### PR TITLE
fix(control-api): repair the imagePolicy base↔overlay boundary test

### DIFF
--- a/control-api/test/imagePolicy.test.ts
+++ b/control-api/test/imagePolicy.test.ts
@@ -108,12 +108,11 @@ describe('assembled allowlist behavior (deploy/base vs gcp overlay boundary)', (
     'us-central1-docker.pkg.dev/${GCP_PROJECT}/clerum/,example.com/,mongodb/,mcr.microsoft.com/,clerum/'.split(
       ','
     )
-  // PLACEHOLDER mirrors a genericized base that leaked through unoverridden —
-  // the exact bug this boundary guards against.
-  const PLACEHOLDER =
-    'us-central1-docker.pkg.dev/${GCP_PROJECT}/clerum/,example.com/,mongodb/,mcr.microsoft.com/,clerum/'.split(
-      ','
-    )
+  // PLACEHOLDER mirrors the vendor-neutral base default that deploy/base ships
+  // (ghcr.io/evenfire-ai/,mongodb/,mcr.microsoft.com/,clerum/) — the exact list
+  // that leaks through when a gcp overlay fails to patch its AR prefix in. It
+  // has NO us-central1-docker.pkg.dev host, so a real AR image must be rejected.
+  const PLACEHOLDER = 'ghcr.io/evenfire-ai/,mongodb/,mcr.microsoft.com/,clerum/'.split(',')
   const img = 'us-central1-docker.pkg.dev/${GCP_PROJECT}/clerum/mcp-host:sha-5792ba7'
 
   it('accepts a real AR image against the real overlay list', () => {


### PR DESCRIPTION
## Problem

`control-api` CI has been red on `main` (**1 failed / 2590 passed**) since
`e45ca03` ("Propagate base↔overlay genericization fix"). The failing test is
`test/imagePolicy.test.ts › assembled allowlist behavior › rejects the same
image against the genericized placeholder list (the bug)`:

```
AssertionError: expected { ok: true } to deeply equal { ok: false, reason: 'host_not_allowed' }
```

## Root cause

The `describe` block was added in `e45ca03` **already failing**, due to a
copy-paste error in the test fixtures — not a product bug:

- `REAL` and `PLACEHOLDER` were **byte-identical** strings, both containing the
  Artifact-Registry prefix `us-central1-docker.pkg.dev/${GCP_PROJECT}/clerum/`.
- `img` is an AR-host image, so `classifyPluginImage` matched it against **both**
  lists and correctly returned `{ ok: true }`.
- Test 1 asserts `(img, REAL) → ok:true` ✅ and Test 2 asserts `(img, SAME list)
  → ok:false` ❌ — a logical contradiction; both can't pass.

`classifyPluginImage` / `matchesAllowedImagePrefix` are correct — the matcher is
start-anchored (`image.startsWith(prefix)`). Only the fixture was wrong.

## Fix

Set `PLACEHOLDER` to the actual vendor-neutral base default that `deploy/base`
ships — `ghcr.io/evenfire-ai/,mongodb/,mcr.microsoft.com/,clerum/` — which is
named verbatim both in the `e45ca03` commit message and in the `@clerum/image-policy`
source comment. That list has **no** AR host, so a real AR image correctly fails
to match it and the boundary test asserts genuine fail-closed rejection.

## Verification

- `imagePolicy.test.ts`: **12/12 pass** (was 1 failing).
- Controlled local run proves net effect: unmodified suite = 33 failing tests,
  with this fix = 32 — exactly the one target test fixed, nothing else touched.
  (The other 32 local failures are environmental — they need CI's
  `workflow-runtime-core` / control-api build steps; they occur identically
  without this change and do not happen in CI.)
- One-line fixture change; no production code touched.

Unblocks `control-api` CI on `main` (and, once `main` picks this up, the same
check on #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)