### PR TITLE
fix: minikube docs/tooling follow-ups (pf target, e2e default email, canonical bootstrap)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,12 @@ minikube-pf-rpc-proxy: ## Port-forward RPC Proxy → localhost:8094
 	scripts/dev/resilient-kubectl-port-forward.sh "$(MINIKUBE_PROFILE)" rpc-proxy rpc-proxy 8094 8094
 
 .PHONY: minikube-pf-mcp-host
-minikube-pf-mcp-host: ## Port-forward MCP Host → localhost:8080
-	$(KC) port-forward svc/mcp-host -n mcp-host 8080:8080
+minikube-pf-mcp-host: ## Port-forward MCP Host → localhost:8080 (service is named after the Host CRD, e.g. chatllm)
+	@if $(KC) get svc chatllm -n mcp-host >/dev/null 2>&1; then \
+		$(KC) port-forward svc/chatllm -n mcp-host 8080:8080; \
+	else \
+		$(KC) port-forward svc/mcp-host -n mcp-host 8080:8080; \
+	fi
 
 .PHONY: minikube-pf-desktop
 minikube-pf-desktop: ## Port-forward all services needed by Desktop App (background)

--- a/docs/meta/docs-roadmap.md
+++ b/docs/meta/docs-roadmap.md
@@ -1,0 +1,236 @@
+# Docs & README roadmap (adapted 2026-07-13)
+
+> **Status of main:** `4a13afd` — includes Diátaxis tree (PR #1 lineage) and
+> **minikube-first onboarding + capability tour** (PR #3 `docs/minikube-first`).
+>
+> This document **supersedes** the worktree-only
+> `docs/superpowers/readme-improvement-plan.md` (Wave 1 README rewrite plan).
+> Claim rules still live in [claims-guardrails.md](claims-guardrails.md).
+
+---
+
+## 1. What changed on main (relative to the old plan)
+
+| Old plan assumption                              | Current main                                                                      |
+| ------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Compose quickstart as primary path               | **Removed** `docker-compose.yml`, `.env.quickstart.example`, `quickstart-chat.sh` |
+| ~230-line README, features list                  | **~434-line** README with **capability tour** + architecture depth                |
+| Optional full K8s later                          | **Minikube is the only first-class get-started**                                  |
+| Audience: AI/app developers, K8s as deploy story | Audience still “agents you own,” but **entry barrier is full cluster**            |
+| Competitive naming: none                         | Still category-only (`when-to-use-evenfire.md`) ✅                                |
+| Never-overclaim checklist                        | Committed + tightened (edge headers, digest pinning nuance) ✅                    |
+
+**Decision to lock in:** the product’s public demo is **the real platform**, not a
+slim dev runtime. That is a deliberate trade: higher trust / higher time-to-first-success.
+
+---
+
+## 2. Evaluation snapshot (main @ 4a13afd)
+
+### Root README — grade **A-** (launch-ready front door)
+
+| Criterion              | Score | Notes                                                                 |
+| ---------------------- | ----- | --------------------------------------------------------------------- |
+| 30s value prop         | A     | “Build multi-channel LLM agents you own” + real actions               |
+| Differentiator clarity | A     | Capability tour + approvals + NetworkPolicy story                     |
+| Time-to-first-success  | B     | Real success (desktop + JWT API), but **≥10 GB / 6 CPU / 5–10 min**   |
+| Trust / honesty        | A-    | Security caveats improved; CLA still draft; LICENSE provisional       |
+| Code-backed claims     | A-    | Tools tied to `nativeToolRegistry.ts`; seed default zai called out    |
+| Competitor silence     | A     | No product names                                                      |
+| Length / skim          | B     | 434 lines — rich but long for GitHub fold; capability tour is the win |
+| Visual proof           | C     | Still no screenshots / GIF of desktop approval                        |
+
+**Strengths**
+
+- “What agents can do” is best-in-class for this repo (shell, browser, docs,
+  MCP, memory, workflows, approval wire format).
+- Get started uses **production JWT path** — rare honesty among agent OSS.
+- Architecture section (ports, token flows, L0–L3 networking) matches platform depth.
+- Security model aligns with [claims-guardrails.md](claims-guardrails.md).
+
+**Gaps / risks**
+
+1. **No lightweight path** — developers without Docker Desktop resources bounce.
+2. **Test aggregates** — “10,000+ / ~880 files” is **verified** (10,260
+   `it()`/`test()` cases across 882 `*.test.ts` files, excl. node_modules /
+   tests/e2e / dist; recounted 2026-07-12 and 2026-07-13; the ~950 figure adds
+   `*.spec.ts` Playwright specs). Remaining ask: automate the count (see P2)
+   so it never drifts.
+3. **CLA.md still DRAFT** while `signatures/cla.json` has a signature — the
+   document itself says counsel review must precede any signing. Legal
+   inconsistency; highest-priority human item.
+4. **LICENSE use grant still PROVISIONAL** — superseded by the 2026-07-13
+   decision to migrate to the latest MPL (see §6 P0 and §9).
+5. **Default host model `zai`** is correct to document; still a footgun if users
+   only set `OPENAI_API_KEY` (mitigated by README warning).
+6. Capability table implies broad enablement; some tools need flags
+   (`CLERUM_DESKTOP_BROWSER`, `CLERUM_DESKTOP_X11`, memory flags) — mostly noted.
+
+### Docs hub (`docs/`) — grade **A-**
+
+Diátaxis skeleton is live and consistent with minikube-first:
+
+- Get started / learning path / FAQ
+- Concepts (why, when-to-use, code-names)
+- How-tos (Telegram, approvals, MCP)
+- CRD index (8 CRDs)
+- Production notes, claims guardrails, `llms.txt`
+
+**Minor drift:** learning path / when-to-use still good; no Compose path left to
+document (correct). Feature hubs still contain design-depth docs (OK if index
+warns — it does).
+
+### Service READMEs — grade **B-** (uneven)
+
+| Status              | Components                                                                                                                       |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Solid / long        | mcp-host, channel-reader, control-api, host-context-controller, desktop-app, rpc-proxy                                           |
+| Thin / stale risk   | control-ui (README lists ~4 tabs; app has ~15 route groups; says “no login” but AuthGate + admin JWT exist)                      |
+| Missing entirely    | gfs-controller, workspace-files-controller, webhook-gateway, webhook-proxy, nginx-egress-proxy, workflow-approval-request-reader |
+| Undersells security | host-context-controller NetworkPolicy section still reads simpler than 4-layer model in root README                              |
+
+---
+
+## 3. Goals (adapted)
+
+### Primary (next 1–2 weeks)
+
+1. **Keep minikube-first** as the public path — do not reintroduce Compose as
+   equal peer without product decision.
+2. **Optional “dev slice” later** only if product wants sub-5-min try-without-K8s;
+   if added, label clearly as **incomplete security**.
+3. Finish **trust surfaces**: CLA counsel pass; **license migration to the
+   latest MPL (MPL-2.0)** — decided 2026-07-13, replaces finalizing the
+   Apache-2.0 use grant (see §9); `security@evenfire.ai` mailbox confirmed
+   2026-07-12, GH private reporting to verify.
+4. **§8 service README backlog** — six missing edge/file READMEs + control-ui /
+   HCC accuracy pass.
+5. **Visual assets** — 3–5 screenshots (desktop chat + approval, Control UI,
+   Telegram approve) in README or `docs/assets/`.
+6. **Test number hygiene** — script or Makefile target that prints unit
+   file/case counts so the verified README numbers (10,260 cases / 882 files)
+   never drift silently.
+
+### Secondary (post-launch polish)
+
+7. Docs site (Mintlify/Docusaurus) from existing `docs/` tree + `llms.txt`.
+8. Shorten root README: keep capability tour + get-started + security; move
+   services/ports and layout tables fully into docs (target ~280–320 lines).
+9. Community channel + badge when ready.
+10. Production deploy guide beyond checklist (real cloud walkthrough).
+
+---
+
+## 4. Explicit non-goals (for now)
+
+- Competitor comparison pages naming products (keep categories only).
+- Claiming OSI open source.
+- Restoring Compose as the default first-run without a product owner decision.
+- Publishing internal phase plans / `docs/superpowers` audits.
+
+---
+
+## 5. README structure to preserve (current main)
+
+Do **not** regress these sections without a new decision:
+
+1. Tagline + badges + nav
+2. What is evenfire (+ naming)
+3. **What agents can do** (capability tour — crown jewel)
+4. **Get started (minikube)** with provider warning + desktop + JWT API
+5. Architecture (mermaid + ports + tokens + NetworkPolicy layers)
+6. Security model (4 pillars, claims-aligned)
+7. Beyond the agent
+8. CRDs (8) + providers
+9. Repo layout + testing + docs + community + license
+
+If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
+
+---
+
+## 6. Prioritized backlog
+
+| P   | Item                                                                                                | Owner type       | Depends on                |
+| --- | --------------------------------------------------------------------------------------------------- | ---------------- | ------------------------- |
+| P0  | Legal: **migrate license to latest MPL (MPL-2.0)** + CLA counsel pass; align with cla.json (see §9) | Human / counsel  | decision taken 2026-07-13 |
+| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                     | Human            | —                         |
+| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                          | Docs eng         | —                         |
+| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                 | Docs eng         | —                         |
+| P1  | HCC README: document 4-layer NetworkPolicy model                                                    | Docs eng         | code already exists       |
+| P1  | Screenshots / short demo GIF                                                                        | Design / product | running minikube          |
+| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart    | Eng              | PR #4 merge               |
+| P2  | Automate test counts (make target printing file/case counts; README cites it)                       | Eng              | —                         |
+| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                   | Docs eng         | —                         |
+| P2  | Optional README length pass (move ports table to docs)                                              | Docs eng         | —                         |
+| P2  | Docs website                                                                                        | Eng              | —                         |
+| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                        | Docs eng         | —                         |
+| P3  | Lightweight non-K8s path (product decision required)                                                | Product          | decision                  |
+| P3  | Cloud production tutorial                                                                           | Eng              | production env            |
+
+> In flight: PR #4 (`fix/minikube-docs-followups`) fixes the pf-mcp-host
+> service name, the e2e-approval-flow default email, canonical bootstrap in the
+> e2e-guide, and two stale code comments.
+
+---
+
+## 7. Definition of done for “docs launch”
+
+- [x] Diátaxis index + learning path + FAQ
+- [x] Minikube-first quickstart with felt success (desktop + JWT API)
+- [x] Capability tour code-anchored in README
+- [x] Claims guardrails committed
+- [x] 8 CRDs documented at index level
+- [ ] Legal surfaces not marked provisional/draft (MPL migration, §9)
+- [ ] All platform services have a minimal README
+- [ ] At least one visual proof in README
+- [ ] No known broken public links (currently OK on root README)
+- [x] Test claims machine-verified (10,260 cases / 882 files, 2026-07-13; automate via P2)
+- [ ] Release matches main (v0.1.1 after PR #4)
+
+---
+
+## 8. Process
+
+- **Source of truth for public docs:** `main`
+- **Claim edits:** run [claims-guardrails.md](claims-guardrails.md) checklist
+- **Working notes:** `docs/superpowers/` remains local/gitignored
+- **This roadmap:** update in place when major onboarding decisions change
+
+### Superseded documents
+
+| Document                                           | Disposition                                       |
+| -------------------------------------------------- | ------------------------------------------------- |
+| Worktree `readme-improvement-plan.md` (2026-07-11) | Historical; Wave 1 Compose-era decisions obsolete |
+| Compose-first quickstart narrative                 | Removed on main via PR #3                         |
+
+---
+
+## 9. License migration — Apache-2.0 + use grant → latest MPL (MPL-2.0)
+
+**Decision (Jose, 2026-07-13):** replace the current provisional
+“Apache-2.0 + additional use grant” with the **latest Mozilla Public License
+(MPL-2.0)**. Executed as a **later step** with counsel — not part of the
+current docs waves.
+
+**Why it matters for docs:** MPL-2.0 is an **OSI-approved** license
+(file-level copyleft). If adopted without any additional restriction, every
+“source-available, **not** OSI open source” statement flips to genuinely open
+source — a materially better trust story. If any use-grant-style restriction
+is retained on top, the source-available language must stay. **Counsel decides
+which; docs follow.**
+
+**Touch list when it lands** (single PR, run the claims-guardrails gate):
+
+- `LICENSE` (full text swap; remove provisional addendum)
+- Root `README.md` — License section + license badge
+- `docs/faq.md` — “Is it open source?” answer
+- `docs/meta/claims-guardrails.md` — “OSI open source” row and license lines
+- `CONTRIBUTING.md` (source-available phrasing), `GOVERNANCE.md`
+  (“source-available / open-core style”), `docs/deploy/production.md`
+  (license-boundary section), `docs/README.md` community table
+- `CLA.md` — counsel pass in the same motion (CLA scope depends on final license)
+- Per-service `package.json` `"license": "SEE LICENSE IN LICENSE"` fields —
+  verify they remain accurate; lockfile `license` fields follow
+- `TRADEMARK.md` — unchanged (trademarks are independent of MPL)
+
+**Until then:** keep the §4 non-goal (“no OSI claims”) exactly as is.

--- a/docs/meta/docs-roadmap.md
+++ b/docs/meta/docs-roadmap.md
@@ -103,8 +103,8 @@ warns — it does).
    latest MPL (MPL-2.0)** — decided 2026-07-13, replaces finalizing the
    Apache-2.0 use grant (see §9); `security@evenfire.ai` mailbox confirmed
    2026-07-12, GH private reporting to verify.
-4. **§8 service README backlog** — six missing edge/file READMEs + control-ui /
-   HCC accuracy pass.
+4. **Service README backlog** (§2 table, §6 P1 rows) — six missing edge/file
+   READMEs + control-ui / HCC accuracy pass.
 5. **Visual assets** — 3–5 screenshots (desktop chat + approval, Control UI,
    Telegram approve) in README or `docs/assets/`.
 6. **Test number hygiene** — script or Makefile target that prints unit
@@ -150,26 +150,29 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 
 ## 6. Prioritized backlog
 
-| P   | Item                                                                                                | Owner type       | Depends on                |
-| --- | --------------------------------------------------------------------------------------------------- | ---------------- | ------------------------- |
-| P0  | Legal: **migrate license to latest MPL (MPL-2.0)** + CLA counsel pass; align with cla.json (see §9) | Human / counsel  | decision taken 2026-07-13 |
-| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                     | Human            | —                         |
-| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                          | Docs eng         | —                         |
-| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                 | Docs eng         | —                         |
-| P1  | HCC README: document 4-layer NetworkPolicy model                                                    | Docs eng         | code already exists       |
-| P1  | Screenshots / short demo GIF                                                                        | Design / product | running minikube          |
-| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart    | Eng              | PR #4 merge               |
-| P2  | Automate test counts (make target printing file/case counts; README cites it)                       | Eng              | —                         |
-| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                   | Docs eng         | —                         |
-| P2  | Optional README length pass (move ports table to docs)                                              | Docs eng         | —                         |
-| P2  | Docs website                                                                                        | Eng              | —                         |
-| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                        | Docs eng         | —                         |
-| P3  | Lightweight non-K8s path (product decision required)                                                | Product          | decision                  |
-| P3  | Cloud production tutorial                                                                           | Eng              | production env            |
+| P   | Item                                                                                                                                                                                                  | Owner type       | Depends on                |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------- |
+| P0  | Legal: **migrate license to latest MPL (MPL-2.0)** + CLA counsel pass; align with cla.json (see §9)                                                                                                   | Human / counsel  | decision taken 2026-07-13 |
+| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                                                                       | Human            | —                         |
+| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                                                                                                                            | Docs eng         | —                         |
+| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                                                                                                                   | Docs eng         | —                         |
+| P1  | HCC README: document 4-layer NetworkPolicy model                                                                                                                                                      | Docs eng         | code already exists       |
+| P1  | Screenshots / short demo GIF                                                                                                                                                                          | Design / product | running minikube          |
+| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart                                                                                                      | Eng              | PR #4 merge               |
+| P2  | Automate test counts (make target printing file/case counts; README cites it)                                                                                                                         | Eng              | —                         |
+| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                                                                                                                     | Docs eng         | —                         |
+| P2  | Document-or-mark-experimental the four undocumented `mcp-servers/` dirs (web-search, playwright, doc-generator = real servers referenced from docs; alphavantage = stub) + add to “Available Servers” | Docs eng         | —                         |
+| P2  | Optional README length pass (move ports table to docs)                                                                                                                                                | Docs eng         | —                         |
+| P2  | Docs website                                                                                                                                                                                          | Eng              | —                         |
+| P3  | Fix the zai-default footgun in code: infer provider from whichever single API key is set (`full-setup.sh:571-573`) instead of only warning in docs                                                    | Eng              | —                         |
+| P3  | Resolve or strip TBD placeholders in `docs/crds/workflowrecipe.md` (registry spec “TBD”, unmigrated comparison doc — lines ~177, ~3075, ~4121)                                                        | Docs eng         | —                         |
+| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                                                                                                                          | Docs eng         | —                         |
+| P3  | Lightweight non-K8s path (product decision required)                                                                                                                                                  | Product          | decision                  |
+| P3  | Cloud production tutorial                                                                                                                                                                             | Eng              | production env            |
 
 > In flight: PR #4 (`fix/minikube-docs-followups`) fixes the pf-mcp-host
 > service name, the e2e-approval-flow default email, canonical bootstrap in the
-> e2e-guide, and two stale code comments.
+> e2e-guide, two stale code comments — and commits this roadmap.
 
 ---
 
@@ -184,7 +187,7 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 - [ ] All platform services have a minimal README
 - [ ] At least one visual proof in README
 - [ ] No known broken public links (currently OK on root README)
-- [x] Test claims machine-verified (10,260 cases / 882 files, 2026-07-13; automate via P2)
+- [x] Test claims verified by reproducible count (10,260 cases / 882 files, 2026-07-13) — CI automation still open (P2)
 - [ ] Release matches main (v0.1.1 after PR #4)
 
 ---
@@ -227,10 +230,15 @@ which; docs follow.**
 - `docs/meta/claims-guardrails.md` — “OSI open source” row and license lines
 - `CONTRIBUTING.md` (source-available phrasing), `GOVERNANCE.md`
   (“source-available / open-core style”), `docs/deploy/production.md`
-  (license-boundary section), `docs/README.md` community table
+  (license-boundary section), `docs/README.md` community table,
+  `docs/get-started/learning-path.md` (Path E “source-available terms”)
 - `CLA.md` — counsel pass in the same motion (CLA scope depends on final license)
-- Per-service `package.json` `"license": "SEE LICENSE IN LICENSE"` fields —
-  verify they remain accurate; lockfile `license` fields follow
+- Per-service `package.json` `license` fields — **audit; currently mixed**
+  (2026-07-13 census): 10× `"SEE LICENSE IN LICENSE"`, 2× **`"MIT"`
+  (gfs-controller, packages/image-policy — wrong under the CURRENT license
+  too, reconcile regardless of MPL timing)**, 7× field absent (control-api,
+  control-ui, desktop-app, external-rest-api, rpc-proxy, profile-ui,
+  workflow-approval-request-reader). Lockfile `license` fields follow
 - `TRADEMARK.md` — unchanged (trademarks are independent of MPL)
 
 **Until then:** keep the §4 non-goal (“no OSI claims”) exactly as is.

--- a/docs/testing/e2e-guide.md
+++ b/docs/testing/e2e-guide.md
@@ -47,21 +47,19 @@ minikube start -p clerum-test \
 
 ### 2. Bootstrap infrastructure
 
-```bash
-./scripts/bootstrap-cluster.sh
-```
-
-This performs 10 steps: cluster verify → namespaces (`control-plane`, `mcp-host`, `mcp-server`, `sandbox-recipes`, `rpc-proxy`) → CRDs install → image build+load → deploy HCC + WRC + mcp-host + mcp-proxy → apply Context/Host CRD instances → wait for readiness. API keys are read from `.env` automatically.
-
-Alternatively, the Makefile path is the canonical local setup — it starts the
-`clerum-test` profile, installs CRDs, creates secrets/config, builds images in
-minikube's Docker daemon, deploys manifests, waits for rollouts, and seeds
-local test data:
+The canonical setup is the Makefile path — it starts the `clerum-test`
+profile, installs CRDs, creates secrets/config, builds images in minikube's
+Docker daemon, deploys manifests, waits for rollouts, and seeds local test
+data (12 idempotent steps):
 
 ```bash
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-setup
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-status
+make minikube-setup
+make minikube-status
 ```
+
+> `scripts/bootstrap-cluster.sh` is an older, partial bootstrap (no full JWT
+> chain, UIs, or user seed). E2E suites need the full setup above — do not use
+> the script for E2E runs.
 
 ### 3. Sync a running cluster before a gate
 
@@ -69,25 +67,24 @@ Before any cluster-backed E2E gate, sync the running cluster to the current
 worktree:
 
 ```bash
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-pre-gate-sync GATE=<gate-name>
+make minikube-pre-gate-sync GATE=<gate-name>
 ```
 
 Use `--force-cluster-sync --skip-port-forwards` when deployable code changed
 and your test runner will hold its own port-forwards:
 
 ```bash
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH \
-  make minikube-pre-gate-sync GATE=<gate-name> ARGS="--force-cluster-sync --skip-port-forwards"
+make minikube-pre-gate-sync GATE=<gate-name> ARGS="--force-cluster-sync --skip-port-forwards"
 ```
 
 After the deploy sync, verify a clean state before reading E2E results:
 
 ```bash
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-status
+make minikube-status
 kubectl --context=clerum-test get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
 kubectl --context=clerum-test -n sandbox-recipes get workflowrecipes
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-verify-network-policy
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH CONTEXT=clerum-test scripts/minikube/seed-test-data.sh
+make minikube-verify-network-policy
+CONTEXT=clerum-test scripts/minikube/seed-test-data.sh
 ```
 
 ### 4. Port-forwards and Vitest
@@ -97,7 +94,7 @@ dependencies when missing and keep minikube port-forwards alive for the Vitest
 phase. Direct `npx vitest` runs still require a held port-forward terminal:
 
 ```bash
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make minikube-pf-all
+make minikube-pf-all
 ```
 
 With port-forwards held, verify the localhost ports used by the tests:
@@ -123,13 +120,13 @@ curl -sS http://127.0.0.1:8080/v1/runtime/health
 ./scripts/e2e/e2e-workflow-runtime-gate.sh --cleanup
 
 # Full bash + Vitest E2E
-PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make test-e2e-all
+make test-e2e-all
 ```
 
 The long-running software-creation suites are opt-in:
 
 ```bash
-E2E_RUN_SOFTWARE_CREATION=1 PATH=/usr/local/bin:/opt/homebrew/bin:/Applications/Docker.app/Contents/Resources/bin:$PATH make test-e2e-vitest
+E2E_RUN_SOFTWARE_CREATION=1 make test-e2e-vitest
 ```
 
 ## Individual suites

--- a/mcp-host/src/config.ts
+++ b/mcp-host/src/config.ts
@@ -325,7 +325,8 @@ function getDevHostConfig(): HostSpec | undefined {
 
 /**
  * Parse CLERUM_MCP_SERVERS JSON for dev mode.
- * Format: [{"name": "...", "spec": {"contextRef": "...", "transport": {...}}}]
+ * Format (top-level fields, see McpServerInfo): [{"name": "...", "contextRef": "...",
+ * "transport": {...}, "enabled": true, "status": {"deployed": true, "ready": true}}]
  */
 function parseDevMcpServers(): McpServerInfo[] | undefined {
   const serversJson = process.env.CLERUM_MCP_SERVERS

--- a/mcp-host/src/server/authMiddleware.ts
+++ b/mcp-host/src/server/authMiddleware.ts
@@ -2,7 +2,9 @@
  * JWT scope-based authorization middleware for mcp-host runtime API.
  *
  * Validates RS256 tokens per token-contract.md and enforces scopes per authz-policy.md.
- * Disabled when config.enableAuth is false (default).
+ * Enabled by default (CLERUM_ENABLE_AUTH=true); set config.enableAuth false to disable.
+ * Only wired onto specific control routes (e.g. session-search, compaction-invoke) —
+ * the primary runtime ingress uses edge trust headers (see edgeRuntimeAuth.ts).
  */
 import type { NextFunction, Request, Response } from 'express'
 import jwt from 'jsonwebtoken'

--- a/tests/e2e/e2e-approval-flow.sh
+++ b/tests/e2e/e2e-approval-flow.sh
@@ -77,7 +77,9 @@ warn()   { echo -e "  ${YELLOW}WARN${NC} $*"; }
 detail() { [[ "$VERBOSE" == "true" ]] && echo -e "       $*" || true; }
 
 # ─── Configuration ───────────────────────────────────────────────────
-TEST_EMAIL="${E2E_TEST_EMAIL:-playwright@clerum.io}"
+# Default to the user seeded by `make minikube-setup` (playwright@clerum.io is
+# only present on clusters that ran the Playwright seed separately).
+TEST_EMAIL="${E2E_TEST_EMAIL:-test@clerum.io}"
 HOST_REF="${E2E_HOST_REF:-chatllm}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-changeme123!}"
 EXT_URL="${E2E_EXTERNAL_REST_API_URL:-http://localhost:8091}"


### PR DESCRIPTION
Five small verified fixes from the minikube-first onboarding recon:

1. **`make minikube-pf-mcp-host`** forwarded `svc/mcp-host`, but the deployed Service is named after the Host CRD (`chatllm`) — now tries `chatllm` first with fallback (mirrors `pf-all-stack.sh`).
2. **`tests/e2e/e2e-approval-flow.sh`** defaulted to `playwright@clerum.io`, which `make minikube-setup` never seeds — login failed verbatim. Defaults to the seeded `test@clerum.io`.
3. **e2e-guide**: `make minikube-setup` promoted to the canonical bootstrap (`bootstrap-cluster.sh` is a partial, older path — demoted with an honest note); stale `PATH=` prefixes stripped (the Makefile needs none).
4. **`authMiddleware.ts`** docstring claimed JWT auth is off by default — `CLERUM_ENABLE_AUTH` defaults **true** (config.ts:630); clarified scope.
5. **`config.ts`** `CLERUM_MCP_SERVERS` comment showed an outdated nested shape vs the top-level fields the parser expects.

Comment-only code changes (no behavior change in 4/5); the Makefile and shell changes are behavior fixes verified against `pf-all-stack.sh` and the seed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)