### PR TITLE
chore(license)!: relicense to MPL-2.0 (pure, no additional restriction)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to evenfire
 
-Thanks for your interest. evenfire is **source-available** (Apache-2.0 + a
-no-compete addendum) and requires a signed CLA.
+Thanks for your interest. evenfire is **open source** (MPL-2.0) and requires a
+signed CLA.
 
 ## Before you start
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -11,8 +11,8 @@ suitable. See [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Decision making
 
 Maintainers decide by lazy consensus; the core team has final say on scope and
-roadmap. This is a single-vendor source-available / open-core style project, not
-a foundation.
+roadmap. This is a single-vendor open-source (MPL-2.0) project, not a
+foundation.
 
 ## Security
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,223 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
 
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+1. Definitions
+--------------
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
 
-   1. Definitions.
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+1.5. "Incompatible With Secondary Licenses"
+    means
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+1.8. "License"
+    means this document.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+1.10. "Modifications"
+    means any of the following:
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+2. License Grants and Conditions
+--------------------------------
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+2.1. Grants
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+2.2. Effective Date
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
 
-   END OF TERMS AND CONDITIONS
+2.3. Limitations on Grant Scope
 
-   APPENDIX: How to apply the Apache License to your work.
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+(a) for any code that a Contributor has removed from Covered Software;
+    or
 
-   Copyright [yyyy] [name of copyright owner]
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+2.4. Subsequent Licenses
 
------------------------------------------------------------------------
-ADDITIONAL USE GRANT (evenfire / Clerum — provisional, pending counsel)
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
 
-The Apache License 2.0 above governs your use of this software, with the
-following additional condition:
+2.5. Representation
 
-You may not provide the Software to third parties as a hosted or managed
-service where the service grants third parties access to a multi-tenant
-instance of the Software (a "Competing Managed Service"), without a
-separate commercial license from the copyright holder. A "multi-tenant
-instance" is one that serves two or more tenants whose data and
-configuration are isolated from one another.
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
 
-Self-hosting the Software for your own organization (including internal
-commercial use) and embedding it in your own products is permitted.
+2.6. Fair Use
 
-This is a source-available license; it is NOT an OSI-approved open source
-license. The exact wording of this Additional Use Grant is PROVISIONAL and
-subject to ratification by legal counsel before the public release.
------------------------------------------------------------------------
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > with human-in-the-loop approvals, least-privilege connectors, and default-deny
 > networking built in. Self-hosted, Kubernetes-native, declared as CRDs.
 
-[![License: Apache 2.0 (+ use grant)](https://img.shields.io/badge/License-Apache_2.0%20%2B%20grant-blue.svg)](LICENSE)
+[![License: MPL-2.0](https://img.shields.io/badge/License-MPL--2.0-brightgreen.svg)](LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/evenfire-ai/evenfire/ci-public.yml?branch=main&label=CI)](https://github.com/evenfire-ai/evenfire/actions)
 [![GitHub release](https://img.shields.io/github/v/release/evenfire-ai/evenfire?sort=semver)](https://github.com/evenfire-ai/evenfire/releases)
 
@@ -428,7 +428,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-evenfire is licensed under **Apache-2.0 with an additional use grant** (no
-operating a competing managed multi-tenant service). It is **source-available**,
-not OSI open source. Self-hosting for your own organization and internal
-commercial use are permitted. See [LICENSE](LICENSE) and [TRADEMARK.md](TRADEMARK.md).
+evenfire is **open source** under the [Mozilla Public License 2.0](LICENSE)
+(MPL-2.0) — an OSI-approved, file-level copyleft license. Use it, modify it,
+self-host it, and build commercial products on it; changes to MPL-licensed
+files must remain under MPL when distributed. Trademarks are separate — see
+[TRADEMARK.md](TRADEMARK.md).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,6 +1,6 @@
 # Trademarks
 
 "evenfire" and "Clerum", and associated logos, are trademarks of Keyper Labs.
-The source-available license grants you rights to the code; it does NOT grant
-rights to the names or logos. Forks and derivatives must use a different name
-and must not imply endorsement.
+The MPL-2.0 license grants you rights to the code; it does NOT grant rights to
+the names or logos. Forks and derivatives must use a different name and must
+not imply endorsement.

--- a/channel-reader/package-lock.json
+++ b/channel-reader/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-channel-reader",
       "version": "0.1.63",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^1.0.0",
         "@slack/web-api": "^7.0.0",

--- a/channel-reader/package.json
+++ b/channel-reader/package.json
@@ -21,7 +21,7 @@
     "slack",
     "email"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
     "@slack/web-api": "^7.0.0",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -36,7 +36,8 @@
       },
       "engines": {
         "node": ">=24"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "../packages/image-policy": {
       "name": "@clerum/image-policy",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-control-api",
   "version": "0.1.298",
+  "license": "MPL-2.0",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -27,7 +27,8 @@
         "jsdom": "^28.1.0",
         "typescript": "^5.9.2",
         "vitest": "^4.0.18"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "../packages/workflow-recipe-capability-policy": {
       "name": "@clerum/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-control-ui",
   "version": "0.1.265",
+  "license": "MPL-2.0",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -43,7 +43,8 @@
         "vite": "^7.1.7",
         "vitest": "^3.2.4",
         "wait-on": "^8.0.5"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -2,6 +2,7 @@
   "name": "evenfire",
   "productName": "Evenfire",
   "version": "0.1.253",
+  "license": "MPL-2.0",
   "private": true,
   "description": "Electron desktop client for Clerum RPC access",
   "main": "dist/main.js",

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,7 @@ Use this index for long-form docs.
 | [Claims guardrails](meta/claims-guardrails.md) | Never-overclaim rules for public docs |
 | [Governance](../GOVERNANCE.md)                 | How the project is run                |
 | [Code of conduct](../CODE_OF_CONDUCT.md)       | Community standards                   |
-| [License](../LICENSE)                          | Apache-2.0 + additional use grant     |
+| [License](../LICENSE)                          | MPL-2.0 (open source)                 |
 
 ## Finding things
 

--- a/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
+++ b/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
@@ -1725,7 +1725,7 @@ docker buildx build \
   --platform linux/amd64,linux/arm64 \
   --tag ghcr.io/<org>/<image>:1.0.0 \
   --label org.opencontainers.image.source=https://github.com/<org>/<repo> \
-  --label org.opencontainers.image.licenses=Apache-2.0 \
+  --label org.opencontainers.image.licenses=MPL-2.0 \
   --push \
   .
 ```

--- a/docs/deploy/production.md
+++ b/docs/deploy/production.md
@@ -60,11 +60,12 @@ the target is not minikube: the dependency graph is the same.
 - Treat approval policy as a control, not a UX preference.
 - Report vulnerabilities per [SECURITY.md](../../SECURITY.md).
 
-## License boundary
+## License
 
-Self-hosting for your organization is permitted under the project license.
-Operating a **competing multi-tenant managed service** requires a commercial
-license — see [LICENSE](../../LICENSE) and the root README license section.
+evenfire is open source under **MPL-2.0**: self-hosting, modification, and
+commercial use are permitted; file-level copyleft applies when you distribute
+modified MPL-licensed files. Trademarks are separate
+([TRADEMARK.md](../../TRADEMARK.md)) — see [LICENSE](../../LICENSE).
 
 ## Related
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -10,10 +10,11 @@ declared as Kubernetes CRDs. See [Why evenfire](concepts/why-evenfire.md).
 
 ### Is it “open source”?
 
-It is **source-available** under Apache-2.0 **with an additional use grant**
-(no competing multi-tenant managed service without a commercial license). That
-is **not** an OSI-approved open-source license. Self-hosting for your own
-organization is allowed. See [LICENSE](../LICENSE).
+Yes — **MPL-2.0** (Mozilla Public License 2.0), an OSI-approved, file-level
+copyleft license. You can use, modify, self-host, and build commercial products
+on it; changes to MPL-licensed files must stay under MPL when distributed,
+while larger works that combine with this code may carry their own licenses.
+See [LICENSE](../LICENSE).
 
 ### Why do I keep seeing “clerum”?
 

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -43,7 +43,7 @@ connector path exercised.
 
 1. [Production deploy notes](../deploy/production.md)
 2. Security model + [SECURITY.md](../../SECURITY.md)
-3. License / source-available terms in root [README](../../README.md#license) and [LICENSE](../../LICENSE)
+3. License (MPL-2.0) in root [README](../../README.md#license) and [LICENSE](../../LICENSE)
 
 ## Stuck?
 

--- a/docs/meta/claims-guardrails.md
+++ b/docs/meta/claims-guardrails.md
@@ -24,12 +24,12 @@ caveats over absolute language.
 | SFS multi-writer everywhere                             | Read-only into agents; RWO single-node default unless stated                                                   |
 | First-party Airtable/Mongo MCP images                   | Upstream images + platform packaging                                                                           |
 | Audit-logging for external-rest-api if still future     | Only what the code ships today                                                                                 |
-| OSI open source                                         | Source-available; Apache-2.0 + additional use grant                                                            |
+| “Source-available” / “not open source” / Apache-2.0     | MPL-2.0 since 2026-07-13 — OSI-approved, file-level copyleft                                                   |
 | Stale test counts from service READMEs                  | Recount or use conservative aggregates                                                                         |
 
 ## Always state (when relevant)
 
-- License is **source-available**, not OSI
+- License is **MPL-2.0** (OSI open source; file-level copyleft)
 - Public name **evenfire** / code name **clerum** (`clerum.io`, `CLERUM_*`)
 - Single-service dev mode (`CLERUM_DEV_MODE`) is **not** full platform security
 - Budgets are cost control, not security

--- a/docs/meta/docs-roadmap.md
+++ b/docs/meta/docs-roadmap.md
@@ -29,16 +29,16 @@ slim dev runtime. That is a deliberate trade: higher trust / higher time-to-firs
 
 ### Root README — grade **A-** (launch-ready front door)
 
-| Criterion              | Score | Notes                                                                 |
-| ---------------------- | ----- | --------------------------------------------------------------------- |
-| 30s value prop         | A     | “Build multi-channel LLM agents you own” + real actions               |
-| Differentiator clarity | A     | Capability tour + approvals + NetworkPolicy story                     |
-| Time-to-first-success  | B     | Real success (desktop + JWT API), but **≥10 GB / 6 CPU / 5–10 min**   |
-| Trust / honesty        | A-    | Security caveats improved; CLA still draft; LICENSE provisional       |
-| Code-backed claims     | A-    | Tools tied to `nativeToolRegistry.ts`; seed default zai called out    |
-| Competitor silence     | A     | No product names                                                      |
-| Length / skim          | B     | 434 lines — rich but long for GitHub fold; capability tour is the win |
-| Visual proof           | C     | Still no screenshots / GIF of desktop approval                        |
+| Criterion              | Score | Notes                                                                                 |
+| ---------------------- | ----- | ------------------------------------------------------------------------------------- |
+| 30s value prop         | A     | “Build multi-channel LLM agents you own” + real actions                               |
+| Differentiator clarity | A     | Capability tour + approvals + NetworkPolicy story                                     |
+| Time-to-first-success  | B     | Real success (desktop + JWT API), but **≥10 GB / 6 CPU / 5–10 min**                   |
+| Trust / honesty        | A-    | Security caveats improved; CLA still draft; LICENSE provisional (since resolved — §9) |
+| Code-backed claims     | A-    | Tools tied to `nativeToolRegistry.ts`; seed default zai called out                    |
+| Competitor silence     | A     | No product names                                                                      |
+| Length / skim          | B     | 434 lines — rich but long for GitHub fold; capability tour is the win                 |
+| Visual proof           | C     | Still no screenshots / GIF of desktop approval                                        |
 
 **Strengths**
 
@@ -59,8 +59,9 @@ slim dev runtime. That is a deliberate trade: higher trust / higher time-to-firs
 3. **CLA.md still DRAFT** while `signatures/cla.json` has a signature — the
    document itself says counsel review must precede any signing. Legal
    inconsistency; highest-priority human item.
-4. **LICENSE use grant still PROVISIONAL** — superseded by the 2026-07-13
-   decision to migrate to the latest MPL (see §6 P0 and §9).
+4. **LICENSE use grant still PROVISIONAL** — resolved: the 2026-07-13 MPL
+   migration was **executed** the same day (see §9 status; LICENSE is now
+   canonical MPL-2.0, no additional restriction).
 5. **Default host model `zai`** is correct to document; still a footgun if users
    only set `OPENAI_API_KEY` (mitigated by README warning).
 6. Capability table implies broad enablement; some tools need flags
@@ -99,10 +100,10 @@ warns — it does).
    equal peer without product decision.
 2. **Optional “dev slice” later** only if product wants sub-5-min try-without-K8s;
    if added, label clearly as **incomplete security**.
-3. Finish **trust surfaces**: CLA counsel pass; **license migration to the
-   latest MPL (MPL-2.0)** — decided 2026-07-13, replaces finalizing the
-   Apache-2.0 use grant (see §9); `security@evenfire.ai` mailbox confirmed
-   2026-07-12, GH private reporting to verify.
+3. Finish **trust surfaces**: CLA counsel pass (still open); **license
+   migration to MPL-2.0 executed 2026-07-13** (see §9 status);
+   `security@evenfire.ai` mailbox confirmed 2026-07-12, GH private reporting
+   to verify.
 4. **Service README backlog** (§2 table, §6 P1 rows) — six missing edge/file
    READMEs + control-ui / HCC accuracy pass.
 5. **Visual assets** — 3–5 screenshots (desktop chat + approval, Control UI,
@@ -124,7 +125,8 @@ warns — it does).
 ## 4. Explicit non-goals (for now)
 
 - Competitor comparison pages naming products (keep categories only).
-- Claiming OSI open source.
+- Retaining “source-available” / “not open source” language anywhere — the repo
+  is MPL-2.0 open source since 2026-07-13.
 - Restoring Compose as the default first-run without a product owner decision.
 - Publishing internal phase plans / `docs/superpowers` audits.
 
@@ -150,25 +152,25 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 
 ## 6. Prioritized backlog
 
-| P   | Item                                                                                                                                                                                                  | Owner type       | Depends on                |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------- |
-| P0  | Legal: **migrate license to latest MPL (MPL-2.0)** + CLA counsel pass; align with cla.json (see §9)                                                                                                   | Human / counsel  | decision taken 2026-07-13 |
-| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                                                                       | Human            | —                         |
-| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                                                                                                                            | Docs eng         | —                         |
-| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                                                                                                                   | Docs eng         | —                         |
-| P1  | HCC README: document 4-layer NetworkPolicy model                                                                                                                                                      | Docs eng         | code already exists       |
-| P1  | Screenshots / short demo GIF                                                                                                                                                                          | Design / product | running minikube          |
-| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart                                                                                                      | Eng              | PR #4 merge               |
-| P2  | Automate test counts (make target printing file/case counts; README cites it)                                                                                                                         | Eng              | —                         |
-| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                                                                                                                     | Docs eng         | —                         |
-| P2  | Document-or-mark-experimental the four undocumented `mcp-servers/` dirs (web-search, playwright, doc-generator = real servers referenced from docs; alphavantage = stub) + add to “Available Servers” | Docs eng         | —                         |
-| P2  | Optional README length pass (move ports table to docs)                                                                                                                                                | Docs eng         | —                         |
-| P2  | Docs website                                                                                                                                                                                          | Eng              | —                         |
-| P3  | Fix the zai-default footgun in code: infer provider from whichever single API key is set (`full-setup.sh:571-573`) instead of only warning in docs                                                    | Eng              | —                         |
-| P3  | Resolve or strip TBD placeholders in `docs/crds/workflowrecipe.md` (registry spec “TBD”, unmigrated comparison doc — lines ~177, ~3075, ~4121)                                                        | Docs eng         | —                         |
-| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                                                                                                                          | Docs eng         | —                         |
-| P3  | Lightweight non-K8s path (product decision required)                                                                                                                                                  | Product          | decision                  |
-| P3  | Cloud production tutorial                                                                                                                                                                             | Eng              | production env            |
+| P   | Item                                                                                                                                                                                                  | Owner type       | Depends on          |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------- |
+| P0  | Legal: license migration to MPL-2.0 **executed 2026-07-13** (§9); remaining: CLA counsel pass + align with cla.json                                                                                   | Human / counsel  | —                   |
+| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                                                                       | Human            | —                   |
+| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                                                                                                                            | Docs eng         | —                   |
+| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                                                                                                                   | Docs eng         | —                   |
+| P1  | HCC README: document 4-layer NetworkPolicy model                                                                                                                                                      | Docs eng         | code already exists |
+| P1  | Screenshots / short demo GIF                                                                                                                                                                          | Design / product | running minikube    |
+| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart                                                                                                      | Eng              | PR #4 merge         |
+| P2  | Automate test counts (make target printing file/case counts; README cites it)                                                                                                                         | Eng              | —                   |
+| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                                                                                                                     | Docs eng         | —                   |
+| P2  | Document-or-mark-experimental the four undocumented `mcp-servers/` dirs (web-search, playwright, doc-generator = real servers referenced from docs; alphavantage = stub) + add to “Available Servers” | Docs eng         | —                   |
+| P2  | Optional README length pass (move ports table to docs)                                                                                                                                                | Docs eng         | —                   |
+| P2  | Docs website                                                                                                                                                                                          | Eng              | —                   |
+| P3  | Fix the zai-default footgun in code: infer provider from whichever single API key is set (`full-setup.sh:571-573`) instead of only warning in docs                                                    | Eng              | —                   |
+| P3  | Resolve or strip TBD placeholders in `docs/crds/workflowrecipe.md` (registry spec “TBD”, unmigrated comparison doc — lines ~177, ~3075, ~4121)                                                        | Docs eng         | —                   |
+| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                                                                                                                          | Docs eng         | —                   |
+| P3  | Lightweight non-K8s path (product decision required)                                                                                                                                                  | Product          | decision            |
+| P3  | Cloud production tutorial                                                                                                                                                                             | Eng              | production env      |
 
 > In flight: PR #4 (`fix/minikube-docs-followups`) fixes the pf-mcp-host
 > service name, the e2e-approval-flow default email, canonical bootstrap in the
@@ -183,7 +185,7 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 - [x] Capability tour code-anchored in README
 - [x] Claims guardrails committed
 - [x] 8 CRDs documented at index level
-- [ ] Legal surfaces not marked provisional/draft (MPL migration, §9)
+- [ ] Legal surfaces not marked draft — LICENSE ✅ MPL-2.0 (2026-07-13); CLA.md still DRAFT (counsel)
 - [ ] All platform services have a minimal README
 - [ ] At least one visual proof in README
 - [ ] No known broken public links (currently OK on root README)
@@ -208,7 +210,14 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 
 ---
 
-## 9. License migration — Apache-2.0 + use grant → latest MPL (MPL-2.0)
+## 9. License migration — Apache-2.0 + use grant → MPL-2.0
+
+> **Status: EXECUTED 2026-07-13** (same-day decision by Jose). LICENSE swapped
+> to the canonical mozilla.org MPL-2.0 text (16,726 bytes, verified); all 33
+> `package.json` license fields set to `MPL-2.0` (killing the 2× MIT
+> mislabels); 30 lockfiles synced; every doc surface below flipped from
+> “source-available” to open source. **Pure MPL-2.0 — no additional
+> restriction.** Remaining from this motion: CLA counsel pass only.
 
 **Decision (Jose, 2026-07-13):** replace the current provisional
 “Apache-2.0 + additional use grant” with the **latest Mozilla Public License
@@ -241,4 +250,5 @@ which; docs follow.**
   workflow-approval-request-reader). Lockfile `license` fields follow
 - `TRADEMARK.md` — unchanged (trademarks are independent of MPL)
 
-**Until then:** keep the §4 non-goal (“no OSI claims”) exactly as is.
+**Done:** the former §4 non-goal (“no OSI claims”) is inverted — §4 now
+forbids retaining any “source-available” / “not open source” language.

--- a/external-rest-api/package-lock.json
+++ b/external-rest-api/package-lock.json
@@ -29,7 +29,8 @@
       },
       "engines": {
         "node": ">=24"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/external-rest-api/package.json
+++ b/external-rest-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-external-rest-api",
   "version": "0.1.56",
+  "license": "MPL-2.0",
   "description": "External REST API for profile, team management, and RPC token brokerage",
   "main": "dist/main.js",
   "engines": {

--- a/gfs-controller/package-lock.json
+++ b/gfs-controller/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-gfs-controller",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.13.1"

--- a/gfs-controller/package.json
+++ b/gfs-controller/package.json
@@ -20,7 +20,7 @@
     "global-file-system",
     "broker"
   ],
-  "license": "MIT",
+  "license": "MPL-2.0",
   "dependencies": {
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.13.1"

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-host-context-controller",
       "version": "0.1.113",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MPL-2.0",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -20,7 +20,7 @@
     "mcp",
     "host-context-controller"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@clerum/image-policy": "file:../packages/image-policy",
     "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-mcp-host",
       "version": "0.1.175",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MPL-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
         "@kubernetes/client-node": "^1.0.0",

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -23,7 +23,7 @@
     "claude",
     "llm"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
     "@kubernetes/client-node": "^1.0.0",

--- a/mcp-proxy/package-lock.json
+++ b/mcp-proxy/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-mcp-proxy",
       "version": "0.1.1",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",

--- a/mcp-proxy/package.json
+++ b/mcp-proxy/package.json
@@ -20,7 +20,7 @@
     "proxy",
     "routing"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/mcp-servers/doc-generator/package-lock.json
+++ b/mcp-servers/doc-generator/package-lock.json
@@ -19,7 +19,8 @@
         "@types/node": "^22.13.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",

--- a/mcp-servers/doc-generator/package.json
+++ b/mcp-servers/doc-generator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clerum/doc-generator-mcp",
   "version": "1.0.3",
+  "license": "MPL-2.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -15,7 +15,8 @@
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clerum/mcp-servers",
   "version": "1.0.5",
+  "license": "MPL-2.0",
   "description": "MCP servers for Clerum testing",
   "type": "module",
   "main": "index.ts",

--- a/mcp-servers/web-search/package-lock.json
+++ b/mcp-servers/web-search/package-lock.json
@@ -16,7 +16,8 @@
         "@types/node": "^22.13.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",

--- a/mcp-servers/web-search/package.json
+++ b/mcp-servers/web-search/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clerum/web-search-mcp",
   "version": "1.0.3",
+  "license": "MPL-2.0",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@commitlint/config-conventional": "^19.8.0",
         "@trivago/prettier-plugin-sort-imports": "^5.0.0",
         "prettier": "^3.0.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "channel-reader": {
       "name": "clerum-channel-reader",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "clerum",
+  "license": "MPL-2.0",
   "private": true,
   "scripts": {
     "app": "make local-app",

--- a/packages/image-policy/package.json
+++ b/packages/image-policy/package.json
@@ -12,5 +12,5 @@
       "default": "./index.cjs"
     }
   },
-  "license": "MIT"
+  "license": "MPL-2.0"
 }

--- a/packages/workflow-recipe-capability-policy/package.json
+++ b/packages/workflow-recipe-capability-policy/package.json
@@ -13,5 +13,5 @@
     },
     "./policy.json": "./policy.json"
   },
-  "license": "SEE LICENSE IN LICENSE"
+  "license": "MPL-2.0"
 }

--- a/packages/workflow-runtime-core/package-lock.json
+++ b/packages/workflow-runtime-core/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@clerum/workflow-runtime-core",
       "version": "1.0.0-beta.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",

--- a/packages/workflow-runtime-core/package.json
+++ b/packages/workflow-runtime-core/package.json
@@ -21,7 +21,7 @@
     "runtime",
     "control-plane"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "devDependencies": {
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",

--- a/packages/workflow-sdk/package-lock.json
+++ b/packages/workflow-sdk/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@clerum/workflow-sdk",
       "version": "1.0.26-beta.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MPL-2.0",
       "dependencies": {
         "@clerum/workflow-runtime-core": "file:../workflow-runtime-core"
       },

--- a/packages/workflow-sdk/package.json
+++ b/packages/workflow-sdk/package.json
@@ -27,7 +27,7 @@
     "kubernetes",
     "mcp"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@clerum/workflow-runtime-core": "file:../workflow-runtime-core"
   },

--- a/profile-ui/package-lock.json
+++ b/profile-ui/package-lock.json
@@ -17,7 +17,8 @@
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "typescript": "^5.9.2"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",

--- a/profile-ui/package.json
+++ b/profile-ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-profile-ui",
   "version": "0.1.87",
+  "license": "MPL-2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/rpc-proxy/package-lock.json
+++ b/rpc-proxy/package-lock.json
@@ -27,7 +27,8 @@
       },
       "engines": {
         "node": ">=24"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.0",

--- a/rpc-proxy/package.json
+++ b/rpc-proxy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-rpc-proxy",
   "version": "0.1.36",
+  "license": "MPL-2.0",
   "description": "External-facing RPC proxy for tenant-scoped MCP access",
   "main": "dist/main.js",
   "engines": {

--- a/stdio-bridge/package-lock.json
+++ b/stdio-bridge/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-stdio-bridge",
       "version": "0.1.2",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
       },

--- a/stdio-bridge/package.json
+++ b/stdio-bridge/package.json
@@ -20,7 +20,7 @@
     "bridge",
     "sidecar"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0"
   },

--- a/tests/e2e/fixtures/mock-mcp-server/package-lock.json
+++ b/tests/e2e/fixtures/mock-mcp-server/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",

--- a/tests/e2e/fixtures/mock-mcp-server/package.json
+++ b/tests/e2e/fixtures/mock-mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mock-mcp-server",
   "version": "0.1.4",
+  "license": "MPL-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/fixtures/mock-secrets-server/package-lock.json
+++ b/tests/e2e/fixtures/mock-secrets-server/package-lock.json
@@ -18,7 +18,8 @@
         "tsx": "^4.7.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/tests/e2e/fixtures/mock-secrets-server/package.json
+++ b/tests/e2e/fixtures/mock-secrets-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clerum/mock-secrets-server",
   "version": "1.0.2",
+  "license": "MPL-2.0",
   "description": "Mock HTTP server for providing test secrets in E2E tests",
   "type": "module",
   "main": "index.ts",

--- a/tests/e2e/fixtures/mock-stdio-mcp-server/package-lock.json
+++ b/tests/e2e/fixtures/mock-stdio-mcp-server/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",

--- a/tests/e2e/fixtures/mock-stdio-mcp-server/package.json
+++ b/tests/e2e/fixtures/mock-stdio-mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mock-stdio-mcp-server",
   "version": "0.1.1",
+  "license": "MPL-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/fixtures/package-lock.json
+++ b/tests/e2e/fixtures/package-lock.json
@@ -17,7 +17,8 @@
       },
       "peerDependencies": {
         "vitest": ">=4.0.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/tests/e2e/fixtures/package.json
+++ b/tests/e2e/fixtures/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@clerum/e2e-test-fixtures",
   "version": "1.0.39",
+  "license": "MPL-2.0",
   "description": "E2E test fixtures and utilities for Clerum testing",
   "type": "module",
   "main": "index.ts",

--- a/tests/e2e/fixtures/workflow-plugin-sdk-e2e/package.json
+++ b/tests/e2e/fixtures/workflow-plugin-sdk-e2e/package.json
@@ -1,6 +1,7 @@
 {
   "name": "workflow-plugin-sdk-e2e",
   "version": "0.1.0",
+  "license": "MPL-2.0",
   "private": true,
   "type": "module",
   "description": "Deterministic E2E plugin workload that exercises the Plugin Workload SDK (promptBridge + clientNotifications) from inside a recipe sandbox.",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -13,7 +13,8 @@
         "jsonwebtoken": "^9.0.2",
         "typescript": "^5.6.0",
         "vitest": "^3.0.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-e2e-tests",
   "version": "0.1.40",
+  "license": "MPL-2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/playwright/package-lock.json
+++ b/tests/e2e/playwright/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@playwright/test": "^1.50.0",
         "@types/node": "^22.0.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@playwright/test": {
       "version": "1.58.2",

--- a/tests/e2e/playwright/package.json
+++ b/tests/e2e/playwright/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-playwright-tests",
   "version": "0.1.13",
+  "license": "MPL-2.0",
   "private": true,
   "description": "Playwright E2E tests for Control UI and Desktop App",
   "scripts": {

--- a/webhook-gateway/package-lock.json
+++ b/webhook-gateway/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-webhook-gateway",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",

--- a/webhook-gateway/package.json
+++ b/webhook-gateway/package.json
@@ -20,7 +20,7 @@
     "gateway",
     "clerum"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/webhook-proxy/package-lock.json
+++ b/webhook-proxy/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-webhook-proxy",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",

--- a/webhook-proxy/package.json
+++ b/webhook-proxy/package.json
@@ -20,7 +20,7 @@
     "ingress",
     "clerum"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/workflow-approval-request-reader/package-lock.json
+++ b/workflow-approval-request-reader/package-lock.json
@@ -14,7 +14,8 @@
       },
       "engines": {
         "node": ">=24"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",

--- a/workflow-approval-request-reader/package.json
+++ b/workflow-approval-request-reader/package.json
@@ -1,6 +1,7 @@
 {
   "name": "clerum-workflow-approval-request-reader",
   "version": "0.1.0",
+  "license": "MPL-2.0",
   "description": "Normalizes third-party approval callbacks and submits decisions to workflow runtime mcp-hosts",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "workload-recipes-controller",
       "version": "0.1.241",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MPL-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -25,7 +25,7 @@
     "wrc",
     "workload-recipe"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1009.0",
     "@clerum/image-policy": "file:../packages/image-policy",

--- a/workflow-recipes/tests/e2e/package-lock.json
+++ b/workflow-recipes/tests/e2e/package-lock.json
@@ -11,7 +11,8 @@
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",
         "vitest": "^3.0.0"
-      }
+      },
+      "license": "MPL-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",

--- a/workflow-recipes/tests/e2e/package.json
+++ b/workflow-recipes/tests/e2e/package.json
@@ -1,6 +1,7 @@
 {
   "name": "workflow-recipes-e2e",
   "version": "0.1.16",
+  "license": "MPL-2.0",
   "private": true,
   "description": "E2E tests for Workload Recipes Controller (minikube)",
   "scripts": {

--- a/workspace-files-controller/package-lock.json
+++ b/workspace-files-controller/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "clerum-workspace-files-controller",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "MPL-2.0",
       "dependencies": {
         "express": "^5.2.1",
         "jose": "^6.2.1",

--- a/workspace-files-controller/package.json
+++ b/workspace-files-controller/package.json
@@ -20,7 +20,7 @@
     "clerum",
     "sharedfilesystem"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MPL-2.0",
   "dependencies": {
     "express": "^5.2.1",
     "jose": "^6.2.1",


### PR DESCRIPTION
## Decision

Jose, 2026-07-13: the provisional "Apache-2.0 + additional use grant" (never counsel-ratified, plus two mistaken `MIT` package labels) is replaced by the **Mozilla Public License 2.0**. evenfire is now **OSI-approved open source**; the no-compete use grant is dropped permanently.

## What

- `LICENSE`: canonical mozilla.org MPL-2.0 plain text — **byte-verified against an independently fetched fresh copy** (16,726 bytes)
- **33× package.json** → `"license": "MPL-2.0"` (kills the 2 mistaken MIT labels on `gfs-controller` and `packages/image-policy`, adds 19 missing fields); **30× lockfiles** synced (1-line diffs, no clean-install churn)
- Docs flipped from source-available to open source: README badge + License section, FAQ, CONTRIBUTING, GOVERNANCE, production notes, docs index, learning path, TRADEMARK.md, OCI label example
- `claims-guardrails.md` inverted: "source-available" / "not open source" / Apache-2.0 are now the **banned** phrases
- Roadmap §9 marked EXECUTED; **CLA counsel pass remains the open P0**

## Verification

4-lens adversarial workflow before commit: license-text byte-exactness, metadata consistency (all 33 + 30 checked), docs-language legal accuracy (MPL scope stated correctly — file-level copyleft, no whole-project claims), diff blast-radius (only the intended file set). Two findings it raised were fixed pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)