### PR TITLE
docs: READMEs for all six undocumented services + control-ui/HCC accuracy + test-count tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,13 @@ test-unit-all: ## Run unit tests across all services
 	fi
 	@echo "All unit tests passed."
 
+.PHONY: test-counts
+test-counts: ## Print unit-test file/case counts (*.test.ts excl. node_modules, tests/e2e, dist)
+	@files=$$(find . -name '*.test.ts' -not -path '*/node_modules/*' -not -path './tests/e2e/*' -not -path '*/dist/*' | wc -l | tr -d ' '); \
+	cases=$$(find . -name '*.test.ts' -not -path '*/node_modules/*' -not -path './tests/e2e/*' -not -path '*/dist/*' -print0 | xargs -0 grep -hE '^[[:space:]]*(it|test)\(' | wc -l | tr -d ' '); \
+	echo "Unit test files: $$files"; \
+	echo "Unit test cases: $$cases"
+
 # ── Build Preflight ──────────────────────────────────────────────────
 .PHONY: build-preflight
 build-preflight: ## Run local build preflight across deployable packages

--- a/control-ui/README.md
+++ b/control-ui/README.md
@@ -1,65 +1,97 @@
-# Control UI (Next.js)
+# Control UI
 
-Internal React/Next.js dashboard for `control-api`.
+Admin dashboard for the control plane. A Next.js (App Router) React app that manages agents, connectors, plugins, files, the marketplace, users/teams, cost, and secrets through `control-api`.
 
-## Features
+## How It Works
 
-- Tabbed explorer for:
-  - Hosts
-  - Connectors
-  - Communication Channels
-  - LLM Secrets
-- Row-style resource listing with click-to-expand details
-- Secret-safe display (redacts secret-like fields in expanded JSON)
-- Guided host creation wizard:
-  1. Host naming
-  2. Context creation + unique connector selection
-  3. Communication channel setup (dropdown + inputs)
-  4. Existing/new LLM secret selection
-  5. Host model/provider config + review (OpenAI, Claude, Z.AI presets + custom model override)
-- Profile admin tab (team/member administration):
-  - users table with row action to load selected user context
-  - explicit `userId` and team selectors
-  - create/rename team
-  - list/delete members
-  - update member role
-  - invite member
-- LLM secrets management:
-  - list host-secret resources
-  - create/update/delete LLM API key secrets
-  - backend-safe behavior (secret values are write-only from UI)
+- The browser only talks to same-origin paths: all API calls go to `/control-api/*` (base overridable via `NEXT_PUBLIC_CONTROL_API_BASE_URL`).
+- A Next.js route handler (`app/control-api/[...path]/route.ts`) proxies those requests server-side to `CONTROL_API_INTERNAL_URL` (default `http://127.0.0.1:8090`), stripping hop-by-hop headers, with a 30 s upstream timeout.
+- Dashboard pages redirect unauthenticated visitors to the login page — most via `<AuthGate>` (`components/AuthGate`), either directly or through a section shell (e.g. `/cost/*` via `CostShell`); the rest use an equivalent `useAuth` redirect.
 
-## Local
+## Authentication
+
+Control UI requires an admin login — it is not an open dashboard.
+
+- The root page (`app/page.tsx`) is a username/password login form with a forgot-password flow.
+- Login posts to control-api `POST /api/v1/admin/auth/login`; the session is a signed admin JWT stored in an HttpOnly cookie set by control-api (`components/AuthContext.tsx`, `lib/api.ts`).
+- control-api seeds a bootstrap admin from `CONTROL_API_ADMIN_BOOTSTRAP_USERNAME` / `CONTROL_API_ADMIN_BOOTSTRAP_PASSWORD_HASH` and locks an account after repeated failed logins (`CONTROL_API_ADMIN_AUTH_MAX_FAILURES`, default 5, for `CONTROL_API_ADMIN_AUTH_LOCK_MINUTES`, default 15).
+- The only unauthenticated routes are the public token flows — admin invitations, password resets, and email confirmations (`/admin-invitations/[token]`, `/admin-password-resets/[token]`, `/admin-email-confirmations/[token]`); the invitation and password-reset form posts are CSRF-protected with an HMAC token (`lib/controlAdminCsrf.ts`) — email confirmation has no form post.
+
+## Sections
+
+Sidebar destinations map to canonical App Router routes (`components/Sidebar/constants.tsx`):
+
+| Sidebar label     | Route                                                    | Contents                                                                         |
+| ----------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Agents            | `/hosts`                                                 | Host list, detail tabs, guided creation wizard, per-tool approval overrides      |
+| Connectors        | `/mcp-servers`                                           | MCP server resources: list, create, edit, egress policy                          |
+| Plugins           | `/workflow-recipes`                                      | Workflow recipes by namespace/name: editor, secrets, integrations, runs          |
+| Shared Files      | `/shared-filesystems`                                    | Shared filesystem resources                                                      |
+| Global Files      | `/gfs`                                                   | Global File System browser and grant delegation                                  |
+| Marketplace       | `/registry`                                              | Registry catalog plus `/registry/install`, `/registry/keys`, `/registry/publish` |
+| Publisher         | `/publisher`                                             | Publisher credentials, entries, shared-with-me                                   |
+| External Channels | `/communication-channels`                                | Communication channel resources                                                  |
+| Users & Teams     | `/profile-admin/users`                                   | Users, teams, and admins administration                                          |
+| Contexts          | `/contexts`                                              | Context resources with per-context tabs                                          |
+| Secrets           | `/secrets`                                               | Secrets by scope, plus recipe secrets (values are write-only from the UI)        |
+| Outputs           | `/outputs`                                               | Generated outputs                                                                |
+| Cost & Usage      | `/cost/usage`, `/cost/llm-prices`, `/cost/token-budgets` | Token usage dashboard, model prices, token budgets                               |
+| Settings          | `/settings`                                              | Control settings panel                                                           |
+
+Routes not in the sidebar: `/control-admins/new` (invite a control admin), `/plugin-workload-sdk` (SDK grants and invocation search), and the public token flows listed above. Old top-level `/usage`, `/llm-prices`, and `/token-budgets` paths permanently redirect under `/cost/*` (`next.config.js`).
+
+## Notable Features
+
+- **UsageDashboard** (`components/UsageDashboard`) — recharts stacked-area chart of input/output tokens over time, with breakdowns including team, model, agent (host), and desktop user (8 group-by dimensions in all — also recipe, provider, LLM secret, and source kind).
+- **LlmPriceTable / TokenBudgetTable** — per-1M-token model prices (input, output, cache read/write) and token budgets with scope and progress. Budgets are cost control, not a security boundary.
+- **RegistryCatalog** (`components/RegistryCatalog.tsx`) — marketplace entries with trust levels (high/mid/low), a guided install flow, and org-scoped publish API keys (create/reveal/revoke) under `/registry/keys`.
+- **HostApprovalSection** (`components/HostApprovalSection`) — per-tool approval editor (Default/Required/Skip) for a host's native tools, with risk hints whenever a setting loosens a required-by-default approval.
+- **EgressEditor** (`components/EgressEditor.tsx`) — egress policy editor with closed-by-default, exact-host, exact-CIDR/IP, and public-web modes; private, metadata, link-local, and reserved IPv4 ranges are rejected (`lib/egressModel.ts`).
+
+## Configuration
+
+| Variable                                    | Explanation                                                                       | Canonical example                                         |
+| ------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `CONTROL_API_INTERNAL_URL`                  | Server-side proxy target for `/control-api/*` requests.                           | `http://control-api.control-plane.svc.cluster.local:8090` |
+| `CONTROL_UI_PUBLIC_TOKEN_CSRF_SECRET`       | HMAC secret for CSRF tokens on public token pages (invitations, password resets). | random string (set via `control-ui-secrets`)              |
+| `NEXT_PUBLIC_CONTROL_API_BASE_URL`          | Browser-side API base path; defaults to the same-origin `/control-api` proxy.     | `/control-api`                                            |
+| `NEXT_PUBLIC_CLERUM_ENABLE_LOCAL_TEMPLATES` | Shows local recipe templates in the recipe editor.                                | `true`                                                    |
+| `PORT`                                      | Inert — the Docker `CMD` runs `next start -p 3000`, and `-p` overrides `PORT`.    | `3000`                                                    |
+
+## Ports
+
+- `3000` — Next.js HTTP server (`npm run start` binds `-p 3000`; the in-cluster Service exposes the same port).
+
+## Local Development
 
 ```bash
 cd control-ui
 npm install
+npm run dev          # needs CONTROL_API_INTERNAL_URL pointing at a control-api
 ```
 
-Then from the repository root:
+Or from the repository root, `npm run web` (→ `make local-web`) port-forwards `control-api` to `localhost:8090`, waits for it to become healthy, then starts the UI with `CONTROL_API_INTERNAL_URL=http://localhost:8090`.
 
-1. Start the UI with:
+### npm scripts
 
-```bash
-npm run web
-```
+| Script       | Command                                       |
+| ------------ | --------------------------------------------- |
+| `dev`        | `NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev`   |
+| `build`      | `NEXT_IGNORE_INCORRECT_LOCKFILE=1 next build` |
+| `start`      | `next start -p 3000`                          |
+| `test`       | `vitest run`                                  |
+| `test:watch` | `vitest`                                      |
 
-This reuses the root `Makefile` to start `control-api` on `localhost:8090`, waits until the port is reachable, then runs `control-ui` locally. When you exit, the port-forward is stopped too.
+## Testing
+
+- **Unit/component tests**: 77 Vitest files (jsdom + Testing Library) — 54 under `components/__tests__/`, 21 under `lib/__tests__/`, 2 under `lib/hooks/__tests__/` — `npm test`.
+- **End-to-end tests**: 25 Playwright specs under `e2e/` (`npx playwright test`), covering operator journeys such as registry install, approval flows, GFS, and workflow runs against a running cluster (`CONTROL_UI_URL` sets the base URL).
 
 ## Deploy
 
 ```bash
 cd control-ui
-make docker-push
-make deploy
+make docker-push     # build + push the image
 ```
 
-In-cluster service URL:
-
-`http://control-ui.control-plane.svc.cluster.local:3000`
-
-Notes:
-
-- Browser requests use same-origin `/control-api/*`.
-- A dedicated Next.js route handler proxies those requests to `CONTROL_API_INTERNAL_URL`.
-- UI assumes cluster-admin trust boundary (for example SSH/VPN access controls) and does not require end-user login.
+Kubernetes manifests live in `deploy/base/control-plane/control-ui.yaml` (namespace `control-plane`); in-cluster service URL: `http://control-ui.control-plane.svc.cluster.local:3000`.

--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -4,7 +4,7 @@
 > All other specification documents reference this document for architectural decisions.
 > When the architecture changes, update THIS document first, then propagate to specs.
 >
-> **Security-First Architecture**: This document defines the 7-namespace architecture,
+> **Security-First Architecture**: This document defines the 12-namespace architecture,
 > the controller architecture (HCC + WRC), the Sandbox Recipes Namespace, the RPC Proxy Namespace,
 > and the **deny-all by default** security posture across all runtime namespaces.
 
@@ -12,7 +12,7 @@
 
 ## Table of Contents
 
-1. [Platform Architecture (7 Namespaces)](#1-platform-architecture-7-namespaces)
+1. [Platform Architecture (12 Namespaces)](#1-platform-architecture-12-namespaces)
 2. [Security Architecture: Deny-All by Default](#2-security-architecture-deny-all-by-default)
 3. [Controller Architecture](#3-controller-architecture)
 4. [CRD Ecosystem](#4-crd-ecosystem)
@@ -33,13 +33,13 @@
 
 ---
 
-## 1. Platform Architecture (7 Namespaces)
+## 1. Platform Architecture (12 Namespaces)
 
 ### 1.1 Platform Overview
 
 evenfire is a Kubernetes-native platform for LLM orchestration with multi-channel communication (Telegram, Email, Slack, Desktop App) and MCP (Model Context Protocol) integration. All configuration is driven by CRDs under the historical `clerum.io/v1alpha1` API group ([code names](../concepts/code-names.md)).
 
-The platform is deployed across **7 namespaces** with a **deny-all by default** security posture. All runtime namespaces (mcp-host, mcp-server, sandbox-recipes, rpc-proxy) deny all ingress/egress by default. Communication is only enabled through explicit NetworkPolicies owned by the component responsible for that selector family: HCC for Context/MCP relationships, WRC for WorkflowRecipe runtime pods, and static deploy overlays for platform infrastructure policies.
+The platform is deployed across **12 namespaces** (declared in `deploy/`) with a **deny-all by default** security posture. All runtime namespaces (mcp-host, mcp-server, sandbox-recipes, rpc-proxy) deny all ingress/egress by default. Communication is only enabled through explicit NetworkPolicies owned by the component responsible for that selector family: HCC for Context/MCP relationships, WRC for WorkflowRecipe runtime pods, and static deploy overlays for platform infrastructure policies.
 
 **Core architectural principle**: Think Linux — **deny everything by default, open only what is needed, with explicit justification for every exception**.
 
@@ -137,15 +137,22 @@ flowchart TB
 
 ### 1.2 Namespace Map
 
-| Namespace           | Purpose                                                  | Deny-All Default | Key Components                                                                           |
-| ------------------- | -------------------------------------------------------- | :--------------: | ---------------------------------------------------------------------------------------- |
-| **profile-plane**   | User identity, profiles, team management, access mapping | No (management)  | profile-ui, external-rest-api                                                            |
-| **control-plane**   | Platform management, CRD lifecycle, controllers          | No (management)  | control-ui, control-api, email intf, HCC Image (3 synchronizers + WRC reconciler module) |
-| **gateway**         | External communication ingress (channels)                |   No (ingress)   | Communication Channel Image (TG/Email/Slack)                                             |
-| **mcp-host**        | LLM orchestration and agent state machine                |     **Yes**      | mcp-host (Agent + MCP Client)                                                            |
-| **mcp-server**      | MCP server runtime and CRD storage                       |     **Yes**      | MCP server pods, McpServer CRDs, Context CRDs                                            |
-| **sandbox-recipes** | Non-MCP workloads from WorkflowRecipes                   |     **Yes**      | StatefulSets, CronJobs, Jobs, Deployments, PVCs                                          |
-| **rpc-proxy**       | Secure external access for Desktop App users             |     **Yes**      | mcpProxy Image (MCP Server Proxy, MCP Host Proxy)                                        |
+| Namespace           | Purpose                                                   | Deny-All Default | Key Components                                                                           |
+| ------------------- | --------------------------------------------------------- | :--------------: | ---------------------------------------------------------------------------------------- |
+| **profiles**        | User identity, profiles, team management, access mapping  | No (management)  | profile-ui, external-rest-api                                                            |
+| **control-plane**   | Platform management, CRD lifecycle, controllers           | No (management)  | control-ui, control-api, email intf, HCC Image (3 synchronizers + WRC reconciler module) |
+| **channels**        | External communication ingress (channels)                 |   No (ingress)   | Communication Channel Image (TG/Email/Slack)                                             |
+| **mcp-host**        | LLM orchestration and agent state machine                 |     **Yes**      | mcp-host (Agent + MCP Client)                                                            |
+| **mcp-server**      | MCP server runtime and CRD storage                        |     **Yes**      | MCP server pods, McpServer CRDs, Context CRDs                                            |
+| **sandbox-recipes** | Non-MCP workloads from WorkflowRecipes                    |     **Yes**      | StatefulSets, CronJobs, Jobs, Deployments, PVCs                                          |
+| **rpc-proxy**       | Secure external access for Desktop App users              |     **Yes**      | mcpProxy Image (MCP Server Proxy, MCP Host Proxy)                                        |
+| **sandbox-ui**      | Untrusted recipe-supplied UI workloads                    |     **Yes**      | Recipe-defined UI workloads (ingress only via rpc-proxy)                                 |
+| **webhook-ingress** | Public webhook termination                                |     **Yes**      | webhook-proxy (HTTP terminator)                                                          |
+| **gfs**             | GFS (Global File System) data plane                       |     **Yes**      | gfsc file-broker pods reconciled from GlobalFileSystem CRDs                              |
+| **ingress**         | Public tunnel ingress                                     |     **Yes**      | cloudflared                                                                              |
+| **registry**        | Recipe registry (declared in the minikube overlay only)   |        No        | registry-api (side-by-side registry server, port 8085)                                   |
+
+> Namespace names above are the ones declared in `deploy/` (`deploy/base/namespaces.yaml`, plus `deploy/base/ingress/` and `deploy/overlays/minikube/registry/`). Diagrams in this document use the historical conceptual names **profile-plane** and **gateway** for the declared namespaces `profiles` and `channels`.
 
 ### 1.3 Service Map
 
@@ -230,7 +237,7 @@ The platform uses a **controller architecture** where all control logic runs in 
 | Workflow Recipe Controller (WRC) | `control-plane` (within HCC) | Pure CRD reconciler for WorkflowRecipe lifecycle                                        |
 | Control-plane triggers deploys   | `control-plane`              | Agents cannot trigger deploys directly                                                  |
 | Non-MCP workloads                | `sandbox-recipes`            | Isolated runtime for non-MCP recipe workloads                                           |
-| 7 namespaces                     | —                            | profile-plane, control-plane, gateway, mcp-host, mcp-server, sandbox-recipes, rpc-proxy |
+| 12 namespaces                    | —                            | channels, control-plane, gfs, ingress, mcp-host, mcp-server, profiles, registry (minikube overlay), rpc-proxy, sandbox-recipes, sandbox-ui, webhook-ingress |
 
 ### 3.2 Where the WRC Fits
 

--- a/docs/meta/docs-roadmap.md
+++ b/docs/meta/docs-roadmap.md
@@ -156,9 +156,9 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------- |
 | P0  | Legal: license migration to MPL-2.0 **executed 2026-07-13** (§9); remaining: CLA counsel pass + align with cla.json                                                                                   | Human / counsel  | —                   |
 | P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                                                                       | Human            | —                   |
-| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security)                                                                                                                            | Docs eng         | —                   |
-| P1  | control-ui README: real route groups + auth story (AuthGate exists)                                                                                                                                   | Docs eng         | —                   |
-| P1  | HCC README: document 4-layer NetworkPolicy model                                                                                                                                                      | Docs eng         | code already exists |
+| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security) *(in PR — this branch)*                                                                                                    | Docs eng         | —                   |
+| P1  | control-ui README: real route groups + auth story (AuthGate exists) *(in PR — this branch)*                                                                                                           | Docs eng         | —                   |
+| P1  | HCC README: document 4-layer NetworkPolicy model *(in PR — this branch)*                                                                                                                              | Docs eng         | code already exists |
 | P1  | Screenshots / short demo GIF                                                                                                                                                                          | Design / product | running minikube    |
 | P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart                                                                                                      | Eng              | PR #4 merge         |
 | P2  | Automate test counts (make target printing file/case counts; README cites it)                                                                                                                         | Eng              | —                   |
@@ -175,6 +175,11 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 > In flight: PR #4 (`fix/minikube-docs-followups`) fixes the pf-mcp-host
 > service name, the e2e-approval-flow default email, canonical bootstrap in the
 > e2e-guide, two stale code comments — and commits this roadmap.
+>
+> Also in flight: `docs/service-readmes` (this branch) — the three P1
+> service-README rows above, plus `make test-counts` (P2 test-count
+> automation), the e2e-guide CLAUDE.md-era unit-test tables (P2), and the
+> platform-topology namespace count (P3).
 
 ---
 
@@ -190,7 +195,7 @@ If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
 - [ ] At least one visual proof in README
 - [ ] No known broken public links (currently OK on root README)
 - [x] Test claims verified by reproducible count (10,260 cases / 882 files, 2026-07-13) — CI automation still open (P2)
-- [ ] Release matches main (v0.1.1 after PR #4)
+- [x] Release matches main (v0.2.0 on e805f47, 2026-07-13)
 
 ---
 

--- a/docs/testing/e2e-guide.md
+++ b/docs/testing/e2e-guide.md
@@ -1,6 +1,6 @@
 # Clerum E2E Testing Guide
 
-> Consolidated 2026-04-13 from CLAUDE.md, scripts/e2e/, and scattered service test docs.
+> Consolidated 2026-04-13 from internal testing notes, scripts/e2e/, and scattered service test docs.
 
 ## Overview
 
@@ -13,7 +13,7 @@ E2E tests validate the full pipeline (CRD reconcile → NetworkPolicy → MCP di
 
 ## Prerequisites
 
-From root `README.md` §Testing prerequisites and CLAUDE.md §Before E2E Testing:
+From root `README.md` §Testing prerequisites:
 
 - **Docker Desktop** running
 - **minikube** installed (`brew install minikube`)
@@ -201,21 +201,15 @@ This ensures E2E tests validate the real production flow, not a weakened test-mo
 
 ## Unit test suites
 
-CLAUDE.md §Testing (test coverage table). Per-service numbers here track the authoritative CLAUDE.md values; actuals can drift — run `npm test` in each directory to confirm.
+Every service in the root Makefile's `TEST_SERVICES` list ships its own vitest suite (mcp-host, workflow-recipes, mcp-servers, control-api, host-context-controller, rpc-proxy, desktop-app, and the rest). Exact per-service counts drift as code changes, so this guide does not pin them — count them yourself, or run the suite:
 
-| Service                 | Tests (CLAUDE.md) | Description                                                                     |
-| ----------------------- | ----------------- | ------------------------------------------------------------------------------- |
-| mcp-host                | 570               | Agent state machine, LLM providers, approval system, MCP client, internal tools |
-| workflow-recipes        | 790               | StatefulSet, Deployment, envSecret, PVC, workflows                              |
-| mcp-servers             | 343 ⚠️            | MongoDB + Airtable config + E2E                                                 |
-| workflow-sdk            | 147               | Workflow SDK primitives                                                         |
-| control-api             | 56                | Admin CRUD, auth, recipes, artifacts                                            |
-| host-context-controller | 38                | McpServer reconciler, NetworkPolicy reconciler, API gateway                     |
-| **Total (CLAUDE.md)**   | **1,944**         |                                                                                 |
+```bash
+make test-counts          # prints unit-test file and case counts
+                          # (it()/test() cases in *.test.ts, excluding
+                          #  node_modules, tests/e2e, and dist)
+```
 
-> ⚠️ **Known discrepancy (mcp-servers)**: CLAUDE.md reports 343 tests; Phase 2 Agent 1 audit (2026-04-11) verified 294 actual tests passing. Likely a counting-methodology difference (e.g. E2E subdirectory vs. unit only). Running `cd mcp-servers && npm test` is the source of truth.
-
-Root `README.md` §2 quotes slightly different (older) per-service counts — 370 workflow-recipes, 404 mcp-host, 37 mcp-proxy, 32 HCC = 843 total. CLAUDE.md is considered more current.
+`npm test` inside each service directory is the source of truth for what actually passes.
 
 Run all unit tests:
 
@@ -238,7 +232,7 @@ cd host-context-controller && npm test
 
 ## Desktop app E2E
 
-From CLAUDE.md §Testing desktop-app. Two-phase test strategy — requires port-forwards to a running cluster.
+Two-phase test strategy — requires port-forwards to a running cluster.
 
 ```bash
 cd desktop-app
@@ -257,15 +251,15 @@ cd tests/e2e && npx vitest run
 
 ## Troubleshooting
 
-Relevant test-related issues from CLAUDE.md §Common issues:
+Common test-related issues:
 
 - **409 on first-time setup** → `make minikube-setup ARGS="--reset-db --skip-build"`
 - **Postgres WAL corruption after cold start** → `make minikube-setup ARGS="--reset-db --skip-build"` (auto-detected)
 - **Pod `ImagePullBackOff`** → `make minikube-setup` (rebuilds images with `:test` tag and `imagePullPolicy: IfNotPresent`)
-- **`401: "Invalid token"` from chatllm** → `make minikube-gen-keys` followed by `make minikube-sync-auth-key` (auto-syncs + restarts). See CLAUDE.md §JWT Auth Chain.
+- **`401: "Invalid token"` from chatllm** → `make minikube-gen-keys` followed by `make minikube-sync-auth-key` (auto-syncs + restarts). See the JWT auth chain notes at the top of the root `Makefile`.
 - **Port-forward drops after pod restart** → re-run `make minikube-pf-desktop`
 - **Desktop app shows no agents after login** → `scripts/minikube/seed-test-data.sh`
-- **NetworkPolicy Phase 6 passes when it shouldn't** → ensure minikube was started with `--cni=calico`; the default `kindnet` CNI silently ignores NetworkPolicy. Cross-check the NetworkPolicy section in root `CLAUDE.md` and the rendered policies from the active overlay.
+- **NetworkPolicy Phase 6 passes when it shouldn't** → ensure minikube was started with `--cni=calico`; the default `kindnet` CNI silently ignores NetworkPolicy. Cross-check the rendered policies from the active overlay (`kubectl kustomize deploy/overlays/minikube`).
 - **Phase 8 times out on approval** → check mcp-host logs for `awaiting_approval` entry; E2E runner uses `userId: "e2e-runner"` and must match the approver identity configured on the Host CRD.
 
 ## Related

--- a/gfs-controller/README.md
+++ b/gfs-controller/README.md
@@ -1,0 +1,119 @@
+# GFS Controller
+
+`gfs-controller` (gfsc) is the brokered HTTP file API over the GlobalFileSystem
+drive. It is the only workload that mounts the drive PVC — every other actor
+(agents, control-api, UIs) reaches the drive through this API, never by
+mounting the volume. Authorization is decided against a Postgres permission
+store on every operation, and every decision is audited.
+
+## How It Works
+
+Two roles, created by the host-context-controller `gfsReconciler` from the
+[GlobalFileSystem CRD](../docs/crds/globalfilesystem.md):
+
+- **writer** — exactly one replica, mounts the PVC read-write, serves the write
+  routes (create / replace / delete).
+- **reader** — `readerReplicas` replicas, mount the PVC read-only. Write verbs
+  are not registered and return 404; the blob store refuses writes outright.
+
+Every request runs a fail-closed chain, in order:
+
+1. **Bearer token** — RS256 JWT verified against `GFS_JWT_PUBLIC_KEY`
+   (`kid`, signature, `aud`, issuer `control-api`, expiry) → 401 on any failure.
+2. **Subject resolution** — the principal is expanded to its subject set
+   (self + teams) from the store; a store error is a 503, never a guess.
+3. **Token ceiling** (`src/authz/tokenCeiling.ts`) — the token is an _upper
+   bound on authority, never a grant_: the op's scope bit (`gfs.read`,
+   `gfs.write`, …) must be present **and**, when the token carries
+   `pathBindings`, some binding must cover the resource path with the matching
+   permission. Neither alone authorizes.
+4. **Permission store** (`src/authz/permissionClient.ts`) — the source of
+   truth, re-checked on every op. Deny by default; a store error is a 503
+   (`gfsc` never falls back to the token's claims).
+
+Steps 3 and 4 must **both** allow. Authorization runs before any metadata is
+revealed, so an absent resource and an unauthorized one are indistinguishable
+(both 403). The `drive` comes from the token claim, never the query string.
+
+**Decision cache** — a short-TTL cache (default 5 s) short-cuts repeated
+identical lookups. It starts **bypassed** and is only enabled once the Postgres
+LISTEN/NOTIFY invalidation fan-out is healthy; any grant/share write flushes it
+(revocation is immediate, not TTL-bound), and a degraded LISTEN connection puts
+it back into bypass. Cache hits are still audited.
+
+**Audit** — every decision (allow, deny, error) is one INSERT-only row in
+`gfs_audit`, written under the least-privilege `gfs_controller` DB role
+(INSERT-only on the audit table; no write on grants/shares). An audit-write
+failure propagates — no un-audited op is served. `src/audit/chain.ts` provides
+the SHA-256 `prevHash → rowHash` chain hashing and verification: the log is
+tamper-**evident**, not WORM. Live rows currently carry a per-row content hash;
+full `prev_hash` chaining of inserted rows is not yet wired into the write path.
+
+Quota primitives (byte/object ceilings, per-subject rate limiter) exist in
+`src/quota/` with a `quota_exceeded` → 429 mapping, but are not yet enforced in
+the serving path.
+
+## Endpoints
+
+| Route                                 | Method | Purpose                                         |
+| ------------------------------------- | ------ | ----------------------------------------------- |
+| `/healthz`                            | GET    | Liveness                                        |
+| `/readyz`                             | GET    | Fail-closed readiness (see below)               |
+| `/metrics`                            | GET    | Prometheus SLIs                                 |
+| `/v1/resources/:rid`                  | GET    | Stat                                            |
+| `/v1/resources/:rid/children`         | GET    | List children                                   |
+| `/v1/resources/:rid/content`          | GET    | Download bytes                                  |
+| `/v1/resolve?uri=gfs://<drive>/<rid>` | GET    | Resolve a `gfs://` URI (drive must match token) |
+| `/v1/accessible`                      | GET    | Resources visible to the caller (paginated)     |
+| `/v1/resources/:parentId/children`    | POST   | Create file/directory (writer only)             |
+| `/v1/resources/:rid/content`          | PUT    | Replace content (writer only)                   |
+| `/v1/resources/:rid`                  | DELETE | Soft-delete (writer only)                       |
+
+Agent principals (`sub` prefixed `host:`) must include an integer `ifMatch`
+field (the resource `version`) in the JSON request body on replace and delete —
+omitting it is a 412. There is no ETag: content responses carry the version in
+the `X-Gfs-Version` response header, and the only request headers the service
+reads are `Authorization` and `x-request-id`. Mutation bodies are capped at
+16 MiB.
+
+## Configuration
+
+Required values fail loud at startup in production; `GFS_DEV_MODE=true`
+relaxes them for local runs only.
+
+| Variable                    | Explanation                                                                                                                    | Default          |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `GFS_PORT`                  | HTTP listen port                                                                                                               | `8087`           |
+| `GFS_STORAGE_PATH`          | Drive PVC mount path (required; dev default `/tmp/gfs-data`)                                                                   | —                |
+| `GFS_STORAGE_ROLE`          | `writer` (RW, single replica) or `reader` (RO)                                                                                 | `writer`         |
+| `GFS_PG_CONNECTION_STRING`  | Permission-store DSN — the least-privilege `gfs_controller` role (required)                                                    | —                |
+| `GFS_JWT_PUBLIC_KEY`        | RS256 public key (PEM) verifying gfs access tokens; required to serve in production. In dev mode an empty key runs probes-only | —                |
+| `GFS_TOKEN_AUDIENCE`        | Expected `aud` on inbound tokens                                                                                               | `gfs-controller` |
+| `GFS_DRIVE_NAME`            | Drive this gfsc serves (a cluster singleton in the open-source release)                                                        | `main`           |
+| `GFS_DECISION_CACHE_TTL_MS` | Decision-cache TTL; bounds staleness even with no invalidation signal                                                          | `5000`           |
+| `GFS_DEV_MODE`              | Relax required vars for local runs and tests                                                                                   | `false`          |
+
+## Readiness
+
+`/readyz` is fail-closed: 200 only when the drive volume is mounted at
+`GFS_STORAGE_PATH` **and** the permission store answers `SELECT 1`. gfsc never
+reports ready when it could not verify the store — it can never serve requests
+it cannot authorize. A fresh checkout ships empty key/DSN placeholders, so gfsc
+stays not-ready until deploy provisioning populates them.
+
+## Testing
+
+```bash
+npm install
+npm test   # vitest — 18 test files (authz, audit, api, db, storage, quota, auth, metrics, server, single-writer)
+```
+
+## Deployment
+
+The writer/reader Deployments, Service, PVC, and workload NetworkPolicies are
+**not** static manifests — HCC's `gfsReconciler` creates them from the
+GlobalFileSystem CRD instance. [`deploy/base/gfs/`](../deploy/base/gfs/) ships
+the namespace default-deny floor plus the config those pods consume: the JWT
+public key ConfigMap (`gfs-config`) and the `gfs-controller-db` Secret (both
+placeholders, populated by `make <env>-gen-keys` / DB provisioning). Agents
+consume this API through mcp-host's `clerum__gfs_*` tools.

--- a/host-context-controller/README.md
+++ b/host-context-controller/README.md
@@ -4,7 +4,7 @@ The Host Context Controller is a Kubernetes operator and REST API service that s
 
 1. **McpServer Operator** — Watches `McpServer` CRDs and automatically manages Deployments and Services for each MCP server, including secret validation.
 2. **Host Operator** — Watches `Host` CRDs and automatically manages one Deployment, one Service, and one PVC per host, including secret validation.
-3. **NetworkPolicy Operator** — Watches `Context` CRDs and generates Kubernetes NetworkPolicies to enforce network-level access control between `mcp-host` pods and MCP server pods.
+3. **NetworkPolicy Operator** — Watches `Context` and `McpServer` CRDs and generates a four-layer NetworkPolicy model (deny-all, infrastructure, context-allow, external-egress) plus recipe binding policies.
 4. **REST API** — Exposes a curated API that `mcp-host` uses to discover available MCP servers, their status, and auth tokens.
 
 ## Architecture
@@ -39,11 +39,11 @@ When an `McpServer` CRD is created, modified, or deleted, the host-context-contr
 
 The reconciler builds Deployments with labels used for pod selection and network policy targeting:
 
-| Label | Value | Purpose |
-|-------|-------|---------|
-| `app` | `<server-name>` | Standard app selector |
-| `clerum.io/managed-by` | `host-context-controller` | Identifies operator-managed pods |
-| `clerum.io/mcpserver` | `<server-name>` | Targets a specific MCP server pod |
+| Label                  | Value                     | Purpose                           |
+| ---------------------- | ------------------------- | --------------------------------- |
+| `app`                  | `<server-name>`           | Standard app selector             |
+| `clerum.io/managed-by` | `host-context-controller` | Identifies operator-managed pods  |
+| `clerum.io/mcpserver`  | `<server-name>`           | Targets a specific MCP server pod |
 
 ### Secret Validation
 
@@ -56,46 +56,57 @@ If the secret is missing or incomplete, the MCP server will **not** be deployed.
 
 ## NetworkPolicy Operator
 
-The host-context-controller enforces **deny-by-default** network isolation for MCP server pods and generates allow policies based on `Context` CRDs.
+The host-context-controller enforces **deny-by-default** network isolation across all runtime namespaces and generates allow policies from `Context` and `McpServer` CRDs. The model has four layers, implemented in `src/networkPolicyReconciler.ts`, plus recipe-scoped binding policies in `src/bindingPolicyReconciler.ts`.
 
-### Policy Model
+### L0 — Default deny
 
-Three types of NetworkPolicies are managed:
+One `deny-all-<namespace>` policy per runtime namespace (default `mcp-server,mcp-host,sandbox-recipes,rpc-proxy`, configurable via `CONTEXT_MAPPER_RUNTIME_NAMESPACES`). Empty pod selector with `policyTypes: [Ingress, Egress]` — all traffic in both directions is blocked unless a higher layer allows it.
 
-| Policy | Name | Purpose |
-|--------|------|---------|
-| **Default deny** | `deny-all-mcp-servers` | Blocks all ingress to pods labeled `clerum.io/managed-by: host-context-controller`. No ingress rules = zero traffic allowed. |
-| **Allow controller API** | `allow-host-context-controller-api` | Allows pods in the host namespace (`mcp-host`) to reach the host-context-controller REST API on its configured port. This ensures `mcp-host` can always discover servers. |
-| **Context allow** | `ctx-<contextId>-<serverName>` | For each MCP server listed in a Context CRD's `spec.mcpServers`, allows ingress from the host namespace to that specific MCP server pod on its transport port. |
+### L1 — Infrastructure
 
-### How It Works
+Baseline plumbing per runtime namespace:
 
-```
-Context CRD (context1)                          NetworkPolicies generated
-┌──────────────────────────┐                    ┌──────────────────────────────────────┐
-│ spec:                    │                    │ deny-all-mcp-servers                 │
-│   contextId: context1    │   ──reconcile──▶   │   - deny all ingress to managed pods │
-│   mcpServers:            │                    │                                      │
-│     - mongodb-server     │                    │ allow-host-context-controller-api      │
-│     - filesystem-server  │                    │   - allow mcp-host → :8081     │
-│                          │                    │                                      │
-│                          │                    │ ctx-context1-mongodb-server           │
-│                          │                    │   - allow mcp-host → :3000     │
-│                          │                    │                                      │
-│                          │                    │ ctx-context1-filesystem-server        │
-│                          │                    │   - allow mcp-host → :3001     │
-└──────────────────────────┘                    └──────────────────────────────────────┘
-```
+| Policy                              | Allows                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow-dns-egress-<ns>`             | DNS (UDP+TCP 53) to `kube-system`; optional extra ipBlock rule for GKE NodeLocal DNSCache via `CONTEXT_MAPPER_NODELOCAL_DNS_CIDR`                                                                                                                                                                                                                 |
+| `allow-hcc-api-egress-<ns>`         | Egress to the `host-context-controller-api-gateway` pod in the control-plane namespace, scoped per namespace to the pod classes that need discovery (managed mcp-host pods, `mcp-proxy`, `rpc-proxy`, workflow MCP hosts)                                                                                                                         |
+| `allow-k8s-api-egress-<ns>`         | Egress to the Kubernetes API server (TCP 443; CIDRs from `CONTEXT_MAPPER_K8S_API_CIDRS`, falling back to `KUBERNETES_SERVICE_HOST`, then to a hardcoded `10.96.0.1/32` when that is unset). **Deny by default** outside `mcp-host`: pods in other runtime namespaces must opt in with the platform-owned label `clerum.io/k8s-api-egress: "true"` |
+| `allow-host-context-controller-api` | Ingress to the controller's own REST API (`app: host-context-controller`) from the `mcp-host` namespace on the configured port                                                                                                                                                                                                                    |
+
+Namespaces listed in `CONTEXT_MAPPER_MINIMAL_INFRA_NAMESPACES` get only deny-all + DNS egress (no HCC-API or K8s-API egress).
+
+### L2 — Context allow
+
+For each MCP server in a `Context` CRD's `spec.mcpServers`, three paired policies open a single route on the server's transport port:
+
+- `ctx-<contextId>-<serverName>` (ingress, MCP server namespace) — the server pod accepts traffic only from mcp-host pods **labeled with that context** (`clerum.io/context`), from `rpc-proxy` pods, and from `mcp-proxy`.
+- `ctx-<contextId>-<serverName>-egress` (egress, `mcp-host` namespace) — the context-labeled mcp-host pods may reach that server (required because L0 also denies egress).
+- `rpc-egress-<contextId>-<serverName>` (egress, `rpc-proxy` namespace) — rpc-proxy pods may reach that server.
+
+Servers removed from a Context lose their policies on the next reconcile; deleting a Context removes all three families.
+
+### L3 — External egress
+
+`McpServer.spec.egressBindings` produce `ext-egress-*` policies in the server's namespace (`reconcileExternalEgress` in `src/networkPolicyReconciler.ts`):
+
+- **`exact-host`** (default) — a CIDR binding, or a public DNS hostname resolved to `/32` ipBlocks, on one declared port/protocol. CIDRs and resolved IPs are rejected if they overlap `PUBLIC_EGRESS_EXCEPT_CIDRS` (RFC1918, CGNAT, loopback, link-local incl. cloud metadata, documentation, benchmarking, multicast, reserved ranges). Hostnames like `localhost`, `metadata.goog`, `*.internal`, `*.svc`, `*.cluster.local` are rejected outright.
+- **`public-web`** — `0.0.0.0/0` on TCP 80/443 with `PUBLIC_EGRESS_EXCEPT_CIDRS` carved out via `except`.
+
+Results are written to the McpServer's `status.conditions` (`ExternalEgressReady`) and `status.resolvedEgressIPs`. A failed binding blocks runtime reconciliation of that server, so a workload cannot start before its egress converges. DNS answers are re-resolved periodically (`HCC_EXTERNAL_EGRESS_RESYNC_SEC`, default 300s).
+
+### Recipe binding policies
+
+McpServers carrying a `clerum.io/recipe-bindings` annotation (set for WorkflowRecipe bindings) get paired `bind-<recipe>-<from>-<to>-{egress,ingress}` policies connecting the MCP workload in the MCP server namespace with its counterpart in `sandbox-recipes` on the declared port/protocol (`src/bindingPolicyReconciler.ts`). Deleting the McpServer removes the recipe's binding policies.
 
 ### Reconciliation Lifecycle
 
-- **Startup** — Loads all `Context` CRDs, creates/updates the default policies and all context-based policies, and cleans up orphaned policies for contexts that no longer exist.
-- **Context ADDED/MODIFIED** — Creates or updates policies for the servers listed in that context. Deletes policies for servers that were removed from the list.
-- **Context DELETED** — Removes all NetworkPolicies labeled with that context ID.
+- **Startup** — Ensures L0/L1 defaults, reconciles all Contexts and all McpServer egress bindings, then deletes orphaned context-allow policies in the MCP server namespace, plus orphaned rpc-proxy-egress and external-egress policies, whose owning CRD no longer exists (`fullReconcile`).
+- **Context ADDED/MODIFIED/DELETED** — Creates, updates, or removes the L2 policy set for that context.
+- **McpServer ADDED/MODIFIED/DELETED** — Reconciles L3 external egress (before the workload Deployment is created) and recipe binding policies.
 
 ### Cross-Namespace Targeting
 
-NetworkPolicies use the built-in `kubernetes.io/metadata.name` namespace label to select traffic from the host namespace:
+Policies select peers with the built-in `kubernetes.io/metadata.name` namespace label combined with pod label selectors, e.g. the L2 ingress rule:
 
 ```yaml
 ingress:
@@ -103,6 +114,10 @@ ingress:
       - namespaceSelector:
           matchLabels:
             kubernetes.io/metadata.name: mcp-host
+        podSelector:
+          matchLabels:
+            clerum.io/managed-by: host-context-controller
+            clerum.io/context: context1
     ports:
       - port: 3000
         protocol: TCP
@@ -121,10 +136,10 @@ When a `Host` CRD is created, modified, or deleted in the host namespace, the ho
 
 Generated resources are labeled for orphan cleanup:
 
-| Label | Value | Purpose |
-|-------|-------|---------|
+| Label                  | Value                     | Purpose                                            |
+| ---------------------- | ------------------------- | -------------------------------------------------- |
 | `clerum.io/managed-by` | `host-context-controller` | Identifies operator-managed host runtime resources |
-| `clerum.io/host` | `<host-name>` | Tracks ownership to a specific Host CRD |
+| `clerum.io/host`       | `<host-name>`             | Tracks ownership to a specific Host CRD            |
 
 On startup, a full host reconciliation pass runs and deletes orphaned host runtime resources whose Host CRD no longer exists.
 
@@ -155,8 +170,15 @@ GET /api/v1/mcpservers
       "name": "mongodb-server",
       "description": "MongoDB MCP Server",
       "contextRef": "context1",
-      "transport": { "type": "sse", "url": "http://mongodb-server.mcp-server.svc.cluster.local:3000/sse" },
-      "auth": { "type": "bearer", "secretRef": "mcp-mongodb-credentials", "secretKey": "auth-token" },
+      "transport": {
+        "type": "sse",
+        "url": "http://mongodb-server.mcp-server.svc.cluster.local:3000/sse"
+      },
+      "auth": {
+        "type": "bearer",
+        "secretRef": "mcp-mongodb-credentials",
+        "secretKey": "auth-token"
+      },
       "enabled": true,
       "status": { "deployed": true, "ready": true, "message": "Running" }
     }
@@ -181,62 +203,64 @@ GET /api/v1/mcpservers/:name/auth
 ```
 
 Response (with auth):
+
 ```json
 { "token": "secret-token-value" }
 ```
 
 Response (no auth configured):
+
 ```json
 { "token": null, "message": "No auth configured for this server" }
 ```
 
 ## Environment Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CLERUM_DEV_MODE` | `false` | Enable dev mode (reads from env vars instead of K8s) |
-| `CONTEXT_MAPPER_PORT` | `8081` | HTTP server port |
-| `CONTEXT_MAPPER_NAMESPACE` | `mcp-server` | Kubernetes namespace where MCP servers and Context CRDs live |
-| `CONTEXT_MAPPER_HOST_NAMESPACE` | `mcp-host` | Namespace where mcp-host pods run (for NetworkPolicy generation) |
-| `CONTEXT_MAPPER_HOST_IMAGE` | `your-registry.example.com/evenfire/mcp-host:0.3.0` | Container image for reconciled host Deployments |
-| `CONTEXT_MAPPER_HOST_IMAGE_PULL_POLICY` | `Always` | Pull policy for reconciled host Deployments |
-| `CONTEXT_MAPPER_HOST_PORT` | `8080` | Container/service port for host runtime |
-| `CONTEXT_MAPPER_HOST_CONFIGMAP_NAME` | `mcp-host-config` | ConfigMap loaded into host containers via `envFrom` |
-| `CONTEXT_MAPPER_HOST_SERVICE_ACCOUNT` | `mcp-host` | Service account used by host Deployments |
-| `CONTEXT_MAPPER_HOST_WORKSPACE_STORAGE_CLASS` | `do-block-storage-retain` | Storage class for per-host workspace PVCs |
-| `CONTEXT_MAPPER_HOST_WORKSPACE_SIZE` | `10Gi` | Requested per-host workspace PVC size |
-| `CONTEXT_MAPPER_HOST_WORKSPACE_PATH` | `/workspace` | Workspace mount path inside host containers |
-| `CONTEXT_MAPPER_HOST_RESOURCES_REQUEST_MEMORY` | `128Mi` | Host container memory request |
-| `CONTEXT_MAPPER_HOST_RESOURCES_REQUEST_CPU` | `100m` | Host container CPU request |
-| `CONTEXT_MAPPER_HOST_RESOURCES_LIMIT_MEMORY` | `512Mi` | Host container memory limit |
-| `CONTEXT_MAPPER_HOST_RESOURCES_LIMIT_CPU` | `500m` | Host container CPU limit |
-| `CLERUM_MCP_SERVERS` | - | (Dev mode) JSON array of McpServer objects |
-| `CLERUM_MCP_AUTH` | - | (Dev mode) JSON object mapping server name to auth token |
+| Variable                                       | Default                                             | Description                                                      |
+| ---------------------------------------------- | --------------------------------------------------- | ---------------------------------------------------------------- |
+| `CLERUM_DEV_MODE`                              | `false`                                             | Enable dev mode (reads from env vars instead of K8s)             |
+| `CONTEXT_MAPPER_PORT`                          | `8081`                                              | HTTP server port                                                 |
+| `CONTEXT_MAPPER_NAMESPACE`                     | `mcp-server`                                        | Kubernetes namespace where MCP servers and Context CRDs live     |
+| `CONTEXT_MAPPER_HOST_NAMESPACE`                | `mcp-host`                                          | Namespace where mcp-host pods run (for NetworkPolicy generation) |
+| `CONTEXT_MAPPER_HOST_IMAGE`                    | `your-registry.example.com/evenfire/mcp-host:0.3.0` | Container image for reconciled host Deployments                  |
+| `CONTEXT_MAPPER_HOST_IMAGE_PULL_POLICY`        | `Always`                                            | Pull policy for reconciled host Deployments                      |
+| `CONTEXT_MAPPER_HOST_PORT`                     | `8080`                                              | Container/service port for host runtime                          |
+| `CONTEXT_MAPPER_HOST_CONFIGMAP_NAME`           | `mcp-host-config`                                   | ConfigMap loaded into host containers via `envFrom`              |
+| `CONTEXT_MAPPER_HOST_SERVICE_ACCOUNT`          | `mcp-host`                                          | Service account used by host Deployments                         |
+| `CONTEXT_MAPPER_HOST_WORKSPACE_STORAGE_CLASS`  | `do-block-storage-retain`                           | Storage class for per-host workspace PVCs                        |
+| `CONTEXT_MAPPER_HOST_WORKSPACE_SIZE`           | `10Gi`                                              | Requested per-host workspace PVC size                            |
+| `CONTEXT_MAPPER_HOST_WORKSPACE_PATH`           | `/workspace`                                        | Workspace mount path inside host containers                      |
+| `CONTEXT_MAPPER_HOST_RESOURCES_REQUEST_MEMORY` | `128Mi`                                             | Host container memory request                                    |
+| `CONTEXT_MAPPER_HOST_RESOURCES_REQUEST_CPU`    | `100m`                                              | Host container CPU request                                       |
+| `CONTEXT_MAPPER_HOST_RESOURCES_LIMIT_MEMORY`   | `512Mi`                                             | Host container memory limit                                      |
+| `CONTEXT_MAPPER_HOST_RESOURCES_LIMIT_CPU`      | `500m`                                              | Host container CPU limit                                         |
+| `CLERUM_MCP_SERVERS`                           | -                                                   | (Dev mode) JSON array of McpServer objects                       |
+| `CLERUM_MCP_AUTH`                              | -                                                   | (Dev mode) JSON object mapping server name to auth token         |
 
 ## Kubernetes RBAC
 
 The host-context-controller requires permissions in both `mcp-server` and `mcp-host` namespaces:
 
-| API Group | Resource | Verbs | Purpose |
-|-----------|----------|-------|---------|
-| `clerum.io` | `mcpservers` | get, list, watch | Watch McpServer CRDs |
-| `clerum.io` | `contexts` | get, list, watch | Watch Context CRDs for NetworkPolicy reconciliation |
-| `clerum.io` | `hosts` | get, list, watch | Watch Host CRDs in host namespace |
-| `networking.k8s.io` | `networkpolicies` | get, list, create, update, delete | Manage generated NetworkPolicies |
-| `apps` | `deployments` | get, list, create, update, delete | Manage MCP server Deployments |
-| `apps` | `deployments` | get, list, create, update, delete | Manage per-host runtime Deployments |
-| _(core)_ | `services` | get, list, create, update, delete | Manage MCP server and host runtime Services |
-| _(core)_ | `persistentvolumeclaims` | get, list, create, update, delete | Manage per-host workspace PVCs |
-| _(core)_ | `secrets` | get | Read auth tokens and validate secret references (`McpServer` + `Host`) |
+| API Group           | Resource                 | Verbs                             | Purpose                                                                |
+| ------------------- | ------------------------ | --------------------------------- | ---------------------------------------------------------------------- |
+| `clerum.io`         | `mcpservers`             | get, list, watch                  | Watch McpServer CRDs                                                   |
+| `clerum.io`         | `contexts`               | get, list, watch                  | Watch Context CRDs for NetworkPolicy reconciliation                    |
+| `clerum.io`         | `hosts`                  | get, list, watch                  | Watch Host CRDs in host namespace                                      |
+| `networking.k8s.io` | `networkpolicies`        | get, list, create, update, delete | Manage generated NetworkPolicies                                       |
+| `apps`              | `deployments`            | get, list, create, update, delete | Manage MCP server Deployments                                          |
+| `apps`              | `deployments`            | get, list, create, update, delete | Manage per-host runtime Deployments                                    |
+| _(core)_            | `services`               | get, list, create, update, delete | Manage MCP server and host runtime Services                            |
+| _(core)_            | `persistentvolumeclaims` | get, list, create, update, delete | Manage per-host workspace PVCs                                         |
+| _(core)_            | `secrets`                | get                               | Read auth tokens and validate secret references (`McpServer` + `Host`) |
 
 ## Namespaces
 
-| Component | Namespace | Purpose |
-|-----------|-----------|---------|
-| host-context-controller | `control-plane` | Operator and API service |
-| MCP server pods + CRDs | `mcp-server` | `McpServer` and `Context` source of truth + managed server workloads |
-| mcp-host | `mcp-host` | Consumer of the REST API, target of NetworkPolicy `from` rules |
-| channel-reader | `channels` | Communication layer |
+| Component               | Namespace       | Purpose                                                              |
+| ----------------------- | --------------- | -------------------------------------------------------------------- |
+| host-context-controller | `control-plane` | Operator and API service                                             |
+| MCP server pods + CRDs  | `mcp-server`    | `McpServer` and `Context` source of truth + managed server workloads |
+| mcp-host                | `mcp-host`      | Consumer of the REST API, target of NetworkPolicy `from` rules       |
+| channel-reader          | `channels`      | Communication layer                                                  |
 
 ## Local Development
 

--- a/nginx-egress-proxy/README.md
+++ b/nginx-egress-proxy/README.md
@@ -1,0 +1,87 @@
+# nginx-egress-proxy
+
+Hardened nginx image that serves as the pinned egress path for **remote** MCP
+servers (McpServer CRDs with `spec.remote.baseUrl`).
+
+**This directory contains only a Dockerfile — there is no application code
+here.** All proxy logic (config generation, URL/header sanitization, deployment)
+lives in [host-context-controller](../host-context-controller/) (`src/reconciler.ts`).
+
+## The image
+
+- Base: `nginx:1.30.1-alpine` — kept because its entrypoint runs `envsubst` on
+  `/etc/nginx/templates/*.template` at startup, which HCC relies on for
+  credential injection.
+- Hardened to run as non-root (`USER 101:101`): the `user` directive is removed
+  from `nginx.conf`, the PID file moves to `/tmp/nginx.pid`, the shipped
+  `default.conf` is removed, and nginx dirs plus `/tmp` temp dirs are chowned
+  to `101:101`.
+
+## How it works
+
+For each remote McpServer, host-context-controller:
+
+1. **Validates and sanitizes `spec.remote.baseUrl`** (`sanitizeRemoteUrl`):
+   HTTPS only; DNS hostnames only (IPv4/IPv6 literals rejected); internal
+   cluster hosts (`*.svc`, `*.svc.cluster.local`, `kubernetes.default`) and
+   private/link-local/loopback patterns rejected; the URL is reconstructed from
+   parsed components so injected characters (e.g. newlines) are stripped.
+2. **Renders a per-server `default.conf.template` ConfigMap** pinning
+   `proxy_pass` to that single external base URL, with TLS to the upstream
+   (`proxy_ssl_verify on`, SNI, system CA bundle), SSE-friendly settings
+   (buffering/cache off, long read timeouts), and a local `/health` endpoint.
+3. **Sanitizes each `spec.remote.authHeaders` entry** (`sanitizeAuthHeader`):
+   header names restricted to `[A-Za-z0-9-]`, values capped at 2048 chars,
+   CR/LF/NUL rejected (HTTP request smuggling / nginx directive-injection
+   defense), backslashes and quotes escaped for nginx's quoted-string context.
+4. **Deploys this image as the only container** (`egress-proxy`) of the
+   per-server Deployment. The ConfigMap mounts at `/etc/nginx/templates`, so
+   `envsubst` resolves `${VAR}` placeholders in auth headers at pod start from
+   env vars sourced from `spec.envSecret` — with `${VAR}` placeholders,
+   credentials never appear in the ConfigMap itself. A literal value inlined in
+   the CRD would be emitted (escaped) into the ConfigMap — always use
+   placeholders.
+
+## Configuration
+
+The image takes no configuration of its own; env vars are injected per-server
+by HCC from the McpServer CRD (`spec.env`, `spec.envSecret`). The image
+reference is platform-controlled:
+
+| Setting                                     | Component                                                             | Default                           |
+| ------------------------------------------- | --------------------------------------------------------------------- | --------------------------------- |
+| `CONTEXT_MAPPER_EGRESS_PROXY_IMAGE`         | host-context-controller                                               | `clerum/nginx-egress-proxy:0.1.0` |
+| `CONTROL_API_REMOTE_MCP_EGRESS_PROXY_IMAGE` | control-api (registry install stamps `spec.image` for remote entries) | `clerum/nginx-egress-proxy:0.1.0` |
+
+HCC additionally canonicalizes `spec.image` of remote McpServers back to the
+platform image (`canonicalizeRemoteEgressProxyImage`) as best-effort cleanup;
+the enforcement is that Deployment rendering always stamps the configured
+platform image, so a CRD's `spec.image` is never what runs.
+
+## Ports
+
+The image `EXPOSE`s **3000**. The actual `listen` port in the generated config
+comes from `spec.transport.port` (default 3000); `/health` answers on it.
+
+## Security
+
+- Deployed as the workload's only container on the remote path: `runAsNonRoot` as `101:101`,
+  all capabilities dropped, `allowPrivilegeEscalation: false`, seccomp
+  `RuntimeDefault`, `automountServiceAccountToken: false` at the pod level.
+- Proxy is pinned to exactly one sanitized external base URL over verified TLS.
+- The broader egress-binding CIDR model (private, metadata, link-local,
+  documentation, multicast, and reserved IPv4 ranges blocked) is validated in
+  [control-ui/lib/egressModel.ts](../control-ui/lib/egressModel.ts).
+
+## Testing
+
+The generated config, sanitization rules, and deployment shape are asserted in
+[host-context-controller/src/\_\_tests\_\_/reconciler.remote.test.ts](../host-context-controller/src/__tests__/reconciler.remote.test.ts).
+
+## Build & deploy
+
+CI builds and publishes the image via
+[.github/workflows/build-publish.yml](../.github/workflows/build-publish.yml)
+(ghcr.io). There are no static manifests for this service: Deployments,
+ConfigMaps, and Services are created dynamically by host-context-controller —
+see its [README](../host-context-controller/README.md).

--- a/webhook-gateway/README.md
+++ b/webhook-gateway/README.md
@@ -1,0 +1,70 @@
+# Webhook Gateway
+
+Per-recipe webhook ingress verifier. The WorkflowRecipe controller (WRC) deploys one gateway per recipe that declares `spec.webhooks[]`; the cluster-edge router (`webhook-proxy/`) forwards `/<webhookId>` requests to it, and the gateway verifies the provider signature before forwarding the untouched raw body to the handler workload. Node builtins only (`crypto`, `http`, `fs`, `url`) — zero runtime dependencies (`"dependencies": {}` in `package.json`).
+
+## How it works
+
+1. `webhook-proxy` forwards `ANY /<webhookId>` to the gateway (port 8090).
+2. The gateway revalidates the id against `^[a-z0-9-]{1,63}$` **before** any config lookup (400), then resolves the entry from its config file (404 if unknown, 410 if dormant).
+3. The raw body is read byte-for-byte (no body-parser middleware — the verifier needs the exact bytes the provider signed), with size and idle-timeout caps enforced as chunks arrive.
+4. The configured verification scheme runs; signature failures return 401 without leaking why (timestamp skew is 408 `timestamp_skew`, verifier misconfiguration is 500 — details below).
+5. On success, headers are sanitised and the request is forwarded to the per-recipe upstream (`host:port/path` from config); the upstream response streams back to the provider.
+
+Setup handshakes are answered inline when configured: `meta-hub-challenge` (GET `hub.challenge` echo, pre-verify; token compared with a length-guarded `timingSafeEqual` — a length mismatch short-circuits, revealing only token length, unlike the padded static-bearer path) and `slack-url-verification` (post-verify, so the challenge payload is still signature-checked). The `stripe-verify` strategy is accepted by the config schema but not implemented yet.
+
+## Verification schemes (`src/verifier.ts`)
+
+| Scheme                       | Mechanism                                                                                                                                                                                                                                                                                                                                         |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hmac-sha256-body`           | HMAC-SHA256 over the raw body; hex or base64 signature header, optional prefix strip.                                                                                                                                                                                                                                                             |
+| `hmac-sha256-timestamp-body` | Stripe/Slack style HMAC over `${timestamp}.${body}` using the wire-exact timestamp string; replay tolerance window (10–3600 s) — out-of-window requests get 408 `timestamp_skew`.                                                                                                                                                                 |
+| `static-bearer`              | Constant-time token compare; defaults to `Authorization: Bearer <token>`, custom header/prefix supported (e.g. Telegram's `x-telegram-bot-api-secret-token`).                                                                                                                                                                                     |
+| `jwt-bearer-jwks`            | JWT verified against a JWKS file on disk. Asymmetric algorithms only (RS/PS/ES\*); `HS*` and `none` are rejected outright — the classic alg-confusion attack. Claims (`exp`, `nbf`, `iss`, `aud`) are checked only **after** signature verification, with 60 s clock skew. Key selection by `kid`, or the sole key when the JWKS has exactly one. |
+
+HMAC and static-bearer comparisons use `crypto.timingSafeEqual` (with equal-length padding on the static-bearer path to keep timing flat); JWT signatures use `crypto.verify`. Duplicate signature headers are rejected, and malformed signatures map to the same 401 as wrong ones so attackers learn nothing from the error shape.
+
+## Configuration
+
+Per-webhook routing/verification config is a JSON file written by the WRC reconciler (secrets are mounted files, never env vars). Runtime knobs come from the environment:
+
+| Variable                       | Default                            | Purpose                                          |
+| ------------------------------ | ---------------------------------- | ------------------------------------------------ |
+| `GATEWAY_RECIPE_NAMESPACE`     | — (required)                       | Recipe namespace, set via Downward API by WRC    |
+| `GATEWAY_RECIPE_NAME`          | — (required)                       | Recipe name, set via Downward API by WRC         |
+| `GATEWAY_CONFIG_PATH`          | `/etc/webhook-gateway/config.json` | Path to the reconciled gateway config            |
+| `GATEWAY_HTTP_PORT`            | `8090`                             | Public `/:webhookId` listener                    |
+| `GATEWAY_METRICS_PORT`         | `9090`                             | Metrics + health listener                        |
+| `GATEWAY_HEADER_TIMEOUT_MS`    | `5000`                             | Slowloris: header-receive timeout                |
+| `GATEWAY_BODY_IDLE_TIMEOUT_MS` | `10000`                            | Slowloris: body idle timeout (also keep-alive)   |
+| `GATEWAY_TOTAL_TIMEOUT_MS`     | `30000`                            | Total request lifetime / upstream forward budget |
+| `GATEWAY_MAX_IN_FLIGHT`        | `256`                              | Per-pod concurrent request cap                   |
+| `GATEWAY_DEBUG`                | `false`                            | Extra debug logging                              |
+
+## Ports
+
+- `8090` — webhook ingress (`ANY /:webhookId`, plus `/healthz` and `/readyz` for probes)
+- `9090` — `/metrics` (Prometheus text format), `/healthz`, `/readyz`
+
+## Security & DoS posture
+
+- **Fail-closed verification** — unverified requests never reach the handler workload; secret-file problems return 500 `verifier_misconfigured`, not a bypass.
+- **Slowloris budgets** at the Node server level (header/total timeouts) plus a body idle timeout inside the streamed reader.
+- **Per-pod in-flight cap** — above `GATEWAY_MAX_IN_FLIGHT`, requests get 503 `gateway_busy`.
+- **Body caps** — declared `Content-Length` is pre-checked and the streamed read is capped per webhook (`maxBodyBytes`, 1 KiB–10 MiB) → 413.
+- **Method allowlist** — only POST (and GET where a handshake requires it) per config → 405 otherwise.
+- **Dormant webhooks** — optional webhooks whose Secret was missing at reconcile time answer 410 Gone (terminal for provider retry storms) with an `X-Clerum-Webhook-State: dormant` header.
+- **Header sanitisation on forward** — `Authorization`, `Cookie`, `Host`, hop-by-hop headers, the scheme's signature/timestamp headers, and _every_ inbound `x-clerum-*` header are stripped; the gateway injects its own `x-clerum-webhook-id` / `-recipe` / `-verified-at`.
+- **Logs never include** request bodies, signatures, or secrets — outcomes only, as single-line JSON.
+- Runs as non-root uid 1001 (`USER nodejs` in the Dockerfile).
+
+## Testing
+
+```bash
+cd webhook-gateway
+npm install
+npm test        # vitest — ~100 test cases across 5 suites (verifier, config, headers, handshake, e2e server)
+```
+
+## Deployment
+
+There is no static Deployment manifest: WRC stamps one gateway Deployment per recipe (image from `WRC_WEBHOOK_GATEWAY_IMAGE`, see `deploy/base/control-plane/workflow-recipes.yaml`) into the `sandbox-recipes` namespace with the `clerum.io/webhook-gateway: "true"` label, alongside per-recipe NetworkPolicies that restrict gateway ingress to `webhook-proxy` (plus the metrics scraper) — see `workflow-recipes/src/reconciler/webhookGatewayBuilder.ts`. The matching webhook-proxy egress policy lives in `deploy/base/webhook-ingress/networkpolicies.yaml`. Build the image with `make docker-build` (see `Makefile`).

--- a/webhook-proxy/README.md
+++ b/webhook-proxy/README.md
@@ -1,0 +1,110 @@
+# Webhook Proxy
+
+Cluster-shared webhook ingress: a stateless, registry-validated router that
+accepts public webhook traffic and forwards it to the right per-recipe
+webhook-gateway. It holds no secrets beyond one control-api service token,
+does no HMAC verification (that is the gateway's job), and buffers no bodies —
+requests are streamed through.
+
+## How it works
+
+1. A request arrives at `ANY /api/v1/webhook/:recipeNs/:recipeName/:webhookId`
+   (TLS is terminated upstream at the cluster edge; the proxy listens on plain
+   HTTP).
+2. The proxy validates the three path segments locally (see
+   [Security](#security)) before doing anything else.
+3. It looks the webhook up in control-api's internal registry
+   (`GET /internal/webhook/registry/:ns/:name/:id`), authenticating with
+   `Authorization: Bearer <service token>` plus `x-service-token:
+webhook-proxy`, with a 5s lookup timeout. Results are cached in memory for
+   `WEBHOOK_PROXY_REGISTRY_CACHE_TTL_MS` (default 5s) — hits **and** misses,
+   so probe bursts against unknown ids don't hammer control-api. Transient
+   `upstream_error` results are never cached.
+4. On a registry hit it enforces the webhook's method allow-list (405
+   otherwise) and a `Content-Length` pre-check against
+   `min(registry maxBodyBytes, WEBHOOK_PROXY_MAX_BODY_BYTES_CEILING)` (413),
+   then streams the request to the gateway service/namespace/port returned by
+   the registry, dropping the `DROP_HEADERS` set from `src/forwarder.ts`
+   (`cookie`, `host`, `connection`, `keep-alive`, `proxy-connection`,
+   `transfer-encoding`) and rewriting `Host`.
+
+Two extra routes bypass the registry entirely and are forwarded to
+workflow-approval-request-reader for provider approval/chat callbacks:
+`/webhooks/telegram` and `/webhooks/slack/:id`.
+
+## Configuration
+
+All configuration is via environment variables (`src/config.ts`):
+
+| Variable                                          | Default                                                                   | Purpose                                                                                                                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `WEBHOOK_PROXY_HTTP_PORT`                         | `8095`                                                                    | Public-facing HTTP port                                                                                                  |
+| `WEBHOOK_PROXY_METRICS_PORT`                      | `9090`                                                                    | Health port (`/healthz`, `/readyz`)                                                                                      |
+| `WEBHOOK_PROXY_CONTROL_API_BASE_URL`              | `http://control-api.control-plane.svc.cluster.local:8090/api/v1`          | Registry lookup endpoint                                                                                                 |
+| `WEBHOOK_PROXY_WORKFLOW_APPROVAL_READER_BASE_URL` | `http://workflow-approval-request-reader.channels.svc.cluster.local:8098` | Upstream for `/webhooks/telegram` and `/webhooks/slack/:id`                                                              |
+| `WEBHOOK_PROXY_CONTROL_API_SERVICE_TOKEN`         | `dev-webhook-proxy-token`                                                 | Service token registered in control-api (rotate in production)                                                           |
+| `WEBHOOK_PROXY_SANDBOX_NAMESPACE`                 | `sandbox-recipes`                                                         | Namespace pin — `:recipeNs` must equal this                                                                              |
+| `WEBHOOK_PROXY_REGISTRY_CACHE_TTL_MS`             | `5000`                                                                    | TTL for cached registry results (positive and negative)                                                                  |
+| `WEBHOOK_PROXY_UPSTREAM_TIMEOUT_MS`               | `30000`                                                                   | Timeout for the gateway/reader forward                                                                                   |
+| `WEBHOOK_PROXY_MAX_BODY_BYTES_CEILING`            | `10485760`                                                                | Declared `Content-Length` pre-check (chunked bodies without `Content-Length` pass through to the gateway's streamed cap) |
+
+## Ports
+
+- `8095` — public webhook traffic (HTTP; TLS terminated at the edge). Also
+  answers `/healthz` and `/readyz`.
+- `9090` — separate health server (`/healthz`, `/readyz`); used by the
+  readiness/liveness probes in the deploy manifests.
+
+## Security
+
+Defense-in-depth, applied in order before any registry lookup:
+
+- **Namespace pin** — `:recipeNs` must equal `WEBHOOK_PROXY_SANDBOX_NAMESPACE`
+  or the request gets a generic 404 `webhook_not_found`.
+- **Segment revalidation** — `:webhookId` is checked against `WEBHOOK_ID_RE`
+  (`src/config.ts`), the same pattern the gateway and CRD use, and the gateway
+  revalidates it independently; `:recipeName` is checked against
+  `RECIPE_NAME_RE`, a proxy-side check only (the gateway never sees the recipe
+  name).
+- **No URL-decoding** — path segments are matched in raw form, so encoded
+  traversal attempts like `%2e%2e` never decode into `..`.
+- **No existence leak via CORS** — per-webhook CORS posture (allowed origins
+  from the registry) is resolved only _after_ the webhook is confirmed to
+  exist; pre-registry failures carry no `Access-Control-Allow-Origin` echo.
+  `OPTIONS` preflights are answered locally (never forwarded), and the
+  `Access-Control-Allow-Headers` echo is clamped to 256 chars.
+- **Minimal trust surface** — zero runtime npm dependencies
+  (`dependencies: {}` in `package.json`), no body buffering, and a fixed
+  drop-list on forward (`cookie`, `host`, `connection`, `keep-alive`,
+  `proxy-connection`, `transfer-encoding`). The proxy injects no identity
+  headers; `X-Clerum-*` handling belongs to the gateway.
+- **Container hardening** — runs as non-root uid 1001 (Dockerfile and deploy
+  manifest), read-only root filesystem, all capabilities dropped,
+  `RuntimeDefault` seccomp.
+- **NetworkPolicies** — `deploy/base/webhook-ingress/networkpolicies.yaml`
+  applies deny-all plus narrow allows: ingress from the cloudflared tunnel on
+  8095 and monitoring on 9090; egress only to control-api, labelled
+  webhook-gateway pods in the sandbox namespace,
+  workflow-approval-request-reader, and DNS (port 53 to kube-system).
+
+## Testing
+
+22 test cases across two vitest suites (`test/registry.test.ts`,
+`test/server.e2e.test.ts`) covering registry caching semantics, route
+validation, method/body-size enforcement, and the CORS matrix:
+
+```bash
+cd webhook-proxy
+npm install
+npm test
+```
+
+## Deploy
+
+Kubernetes manifests live in
+[`deploy/base/webhook-ingress/`](../deploy/base/webhook-ingress/)
+(Deployment, Service, ConfigMap, Secret, NetworkPolicies — namespace
+`webhook-ingress`, 2 replicas). Replace the placeholder
+`WEBHOOK_PROXY_CONTROL_API_SERVICE_TOKEN` secret value before production use;
+it must match the `webhook-proxy` entry in control-api's internal
+service-token config.

--- a/workflow-approval-request-reader/README.md
+++ b/workflow-approval-request-reader/README.md
@@ -1,0 +1,123 @@
+# Workflow Approval Request Reader
+
+The inbound half of channel-based workflow approvals. Approval prompts are
+delivered to Slack/Telegram by other platform components; this service receives
+the provider callbacks that come back — approval button clicks, enrollment
+messages, and Slack chat messages — normalizes them, and submits decisions to
+the right workflow-runtime mcp-host.
+
+## How it works
+
+Endpoints (plain `node:http`, no framework):
+
+- `GET /health`
+- `POST /webhooks/telegram` — Telegram bot webhook updates
+- `POST /webhooks/slack/:targetId` — Slack events / interactivity, per target
+
+In the cluster, provider traffic reaches these routes through `webhook-proxy`
+(`/webhooks/telegram` and `/webhooks/slack/:targetId` are forwarded to this
+service — the path-forwarding rule lives in
+`webhook-proxy/src/server.ts:181-184`; the proxy deployment is
+`../deploy/base/webhook-ingress/webhook-proxy.yaml`).
+
+Each request goes through: rate limit → 1 MB body cap → provider auth →
+parse → normalize → dispatch. Normalized payloads become one of:
+
+- **Decision** — Telegram `callback_query` data or Slack `block_actions` value,
+  in verbose form `approve:<uuid>[:sandbox-recipes/<recipe>][:<channelAlias>]`
+  (also `deny`/`approved`/`denied`/`reject`/`rejected`) or compact form
+  `a:<22-char base64url uuid>:<recipe|~alias>[:<channelAlias>]` (`d:` = deny).
+  The decision is POSTed to
+  `{mcpHost}/v1/runtime/workflow-approvals/decide` with `x-clerum-edge-*`
+  identity headers. Target base URLs come from configured targets
+  (env/file) or are derived from the host ref
+  (`sandbox-recipes/<recipe>` → `wf-<recipe>-mcp-host.sandbox-recipes.svc.cluster.local`,
+  plain agent refs → `<hostRef>.mcp-host.svc.cluster.local`; service names
+  over 63 chars fall back to a truncated stem plus an 8-char hash). Route
+  hints are DNS routing only, never authorization.
+- **Enrollment** — Telegram `/start <nonce>` or Slack `verify <6-digit code>`
+  (or the `workflow_approval_link:<code>` button). Telegram enrollments are
+  confirmed directly on the mcp-host
+  (`/v1/runtime/workflow-approval-mediums/link-sessions/confirm`), resolving
+  the CommunicationChannel ref via control-api first; Slack enrollments are
+  handed off to the per-host channel-reader.
+- **Slack message** — ordinary channel messages for the bot (mention-gated
+  only when the target's `replyOnlyWhenMentioned` flag is set — default false —
+  and DMs bypass the gate; inline `/approve <target>` / `/deny <target>`
+  commands pass the mention gate)
+  are handed off to `channel-reader-{host}:8099/internal/slack/handoff` with a
+  bearer handoff token. Slack `url_verification` challenges are echoed.
+
+Slack button decisions are acknowledged with `200` immediately and submitted in
+the background; the original Slack message is then updated (or a threaded
+failure reply sent) through control-api's slack-target proxy endpoints.
+
+## Configuration
+
+| Variable                                                     | Explanation                                                                                                                                                               | Default                             |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `WORKFLOW_APPROVAL_READER_PORT`                              | HTTP listen port.                                                                                                                                                         | `8098`                              |
+| `WORKFLOW_APPROVAL_READER_ENABLED_MEDIA`                     | Comma-separated media; only `telegram` and `slack` are accepted.                                                                                                          | `telegram,slack`                    |
+| `WORKFLOW_APPROVAL_READER_TELEGRAM_SECRET`                   | Expected `x-telegram-bot-api-secret-token` value; unset means all Telegram requests 401.                                                                                  | —                                   |
+| `WORKFLOW_APPROVAL_READER_MCP_HOST_TARGETS`                  | Semicolon list of `hostRef=baseUrl` workflow-runtime targets.                                                                                                             | —                                   |
+| `WORKFLOW_APPROVAL_READER_MCP_HOST_TARGETS_FILE`             | File with the same `hostRef=baseUrl` format (mounted ConfigMap in-cluster).                                                                                               | —                                   |
+| `WORKFLOW_APPROVAL_READER_MCP_HOST_BASE_URL` / `_REF`        | Primary mcp-host fallback target (`MCP_HOST_BASE_URL`/`MCP_HOST_REF` also read).                                                                                          | —                                   |
+| `WORKFLOW_APPROVAL_READER_MCP_HOST_TIMEOUT_MS`               | Timeout for decision/enrollment calls to mcp-hosts.                                                                                                                       | `5000`                              |
+| `WORKFLOW_APPROVAL_READER_CONTROL_API_BASE_URL`              | control-api base URL for Slack verification, can-approve, and channel-ref resolution.                                                                                     | — (disables control-api calls)      |
+| `WORKFLOW_APPROVAL_READER_CONTROL_API_TOKEN`                 | Static bearer token for control-api internal endpoints.                                                                                                                   | —                                   |
+| `WORKFLOW_APPROVAL_READER_CONTROL_API_TIMEOUT_MS`            | Timeout for control-api calls.                                                                                                                                            | `4000`                              |
+| `WORKFLOW_APPROVAL_READER_RATE_LIMIT_WINDOW_MS`              | Fixed rate-limit window.                                                                                                                                                  | `60000`                             |
+| `WORKFLOW_APPROVAL_READER_RATE_LIMIT_MAX_REQUESTS`           | Max requests per window per key.                                                                                                                                          | `120`                               |
+| `WORKFLOW_APPROVAL_READER_CHANNEL_READER_URL_TEMPLATE`       | Per-host channel-reader URL template (`{host}` is replaced with the host ref).                                                                                            | `http://channel-reader-{host}:8099` |
+| `WORKFLOW_APPROVAL_READER_CHANNEL_READER_HANDOFF_TOKEN`      | Bearer token for channel-reader handoff; unset disables Slack handoff (the internal 503 is only logged — handoff is fire-and-forget, so the Slack caller still gets 200). | —                                   |
+| `WORKFLOW_APPROVAL_READER_CHANNEL_READER_HANDOFF_TIMEOUT_MS` | Timeout for channel-reader handoff calls.                                                                                                                                 | `5000`                              |
+| `WORKFLOW_APPROVAL_READER_SLACK_SIGNING_SECRET`              | Loaded into config but currently unused — Slack verification is delegated to control-api.                                                                                 | —                                   |
+| `WORKFLOW_APPROVAL_READER_MCP_HOST_MESSAGE_TIMEOUT_MS`       | Loaded into config but currently unused by the request path.                                                                                                              | `120000`                            |
+
+## Ports
+
+- `8098` — HTTP: `/health` probes and `/webhooks/*`. Only port exposed.
+
+## Security
+
+- **Telegram auth**: constant-time comparison (`crypto.timingSafeEqual`) of the
+  `x-telegram-bot-api-secret-token` header against the configured secret.
+- **Slack auth**: per-target signature verification is delegated to control-api
+  (timestamp, signature, and raw body are sent to an internal verify endpoint);
+  the verified target's workspace ID is then cross-checked against the payload
+  `team_id` — mismatch returns `403 slack_workspace_mismatch`.
+- **Fail-safe can-approve pre-check**: decisions carrying a `channelAlias`
+  trigger a control-api `can-approve` check before forwarding; `false` or
+  any control-api error means the decision is **not** forwarded (`403`). The
+  check is skipped when control-api is not configured — the authoritative
+  binding is enforced again by control-api at transmission time.
+- **Abuse controls**: fixed-window in-memory rate limit (`429`, keyed per Slack
+  target or per peer IP), 1 MB body cap (`413`), and a 10-minute provider-event
+  dedupe — applied to Slack enrollment events and Slack messages only; decision
+  callbacks (Telegram `callback_query`, Slack `block_actions`) are not deduped
+  by the reader. All three are in-memory and best-effort: they reset on restart, so
+  downstream approval handling must stay idempotent and authorization-backed.
+- **Network**: NetworkPolicy restricts ingress on 8098 to `webhook-proxy` pods
+  and the `ingress-nginx` namespace; dedicated egress policies cover mcp-host,
+  control-api, and channel-reader.
+- **Supply chain**: zero runtime npm dependencies (Node >= 24 stdlib only);
+  runs as non-root with a read-only root filesystem and all capabilities
+  dropped.
+
+## Testing
+
+```bash
+npm install
+npm test   # vitest — 64 test cases across 8 files
+```
+
+Covers provider auth, decision/enrollment/message normalization, rate
+limiting, dedupe, and the control-api / mcp-host / channel-reader clients.
+
+## Deployment
+
+Manifests live in `../deploy/base/channels/workflow-approval-request-reader/`
+(Deployment, Service, ConfigMap, ServiceAccount) with NetworkPolicies in
+`../deploy/base/channels/networkpolicies/`. Secrets (Telegram webhook secret,
+control-api token, channel-reader handoff token) come from the
+`workflow-approval-request-reader-credentials` Secret.

--- a/workspace-files-controller/README.md
+++ b/workspace-files-controller/README.md
@@ -1,0 +1,71 @@
+# Workspace Files Controller
+
+Per-[SharedFileSystem](../docs/crds/sharedfilesystem.md) HTTP file API. Each SharedFileSystem (SFS) gets its own workspace-files-controller (wfc) instance that mounts the SFS PVC at `/workspace` and exposes list/stat/download plus upload/replace/mkdir/move/delete over HTTP. It is the **write path** for a team workspace: host-context-controller mounts the same PVC **read-only** into the mcp-host pods that reference it, so agents read the workspace but never mutate it — humans and admins write through this service (via control-api).
+
+## How It Works
+
+- host-context-controller's SharedFileSystem reconciler provisions, per SFS: a PVC (`sfs-<hash>-files`, default `20Gi`, default access mode `ReadWriteOnce`), a single-replica `Recreate` Deployment (`wfc-<hash>`), a ClusterIP Service on the wfc port, and ingress/egress NetworkPolicies. All `WSF_*` env below is injected by that reconciler, except `WSF_JWT_ISSUER` and `WSF_JWT_AUDIENCE`, which are never injected — the service uses its in-code defaults.
+- The wfc pod's root init container seeds `spec.directories[]` and chowns the fresh PVC to the configured UID/GID (default 1000:1000); the serving container then runs non-root with a read-only root filesystem, all capabilities dropped, and `automountServiceAccountToken: false`.
+- With the default RWO PVC, the wfc is single-node; mcp-host consumer pods co-locate with it via podAffinity. Multi-node `ReadWriteMany` requires an RWX-capable StorageClass set explicitly via `spec.accessModes`.
+- Stack: Express 5, multer (in-memory multipart uploads), jose (JWT verification), pino/pino-http logging.
+
+## API
+
+All non-streaming responses use the envelope `{ ok: true, data }` / `{ ok: false, error: { code, message } }` with stable `error.code` values.
+
+| Route                                   | Scope         | Behavior                                                            |
+| --------------------------------------- | ------------- | ------------------------------------------------------------------- |
+| `GET /v1/files?path=<rel>`              | `files:read`  | List directory entries (capped, `truncated` flag)                   |
+| `GET /v1/files/stat?path=<rel>`         | `files:read`  | File/directory metadata                                             |
+| `GET /v1/files/download?path=<rel>`     | `files:read`  | Stream file contents as attachment                                  |
+| `POST /v1/files/upload` (multipart)     | `files:write` | Create new file — `409 already_exists` if present                   |
+| `PUT /v1/files/replace` (multipart)     | `files:write` | Whole-file replace — `404` if missing                               |
+| `POST /v1/files/mkdir` `{path}`         | `files:write` | `mkdir -p`; idempotent on existing directories                      |
+| `POST /v1/files/move` `{from, to}`      | `files:write` | Rename within the mount; refuses to clobber                         |
+| `DELETE /v1/files?path=<rel>&recursive` | `files:write` | Delete file or directory (`409 not_empty` without `recursive=true`) |
+| `GET /healthz`, `GET /readyz`           | none          | Liveness / readiness (mount present and writable)                   |
+
+`/healthz` and `/readyz` are registered **before** auth — kubelet probes are unauthenticated. Everything under `/v1` requires a valid browsing JWT.
+
+## Configuration
+
+| Variable                          | Explanation                                                                     | Default                      |
+| --------------------------------- | ------------------------------------------------------------------------------- | ---------------------------- |
+| `WSF_PORT`                        | HTTP listen port.                                                               | `8086`                       |
+| `WSF_MOUNT_PATH`                  | Absolute path of the mounted SFS PVC.                                           | `/workspace`                 |
+| `WSF_SHARED_FILESYSTEM_NAME`      | SFS identity this instance serves; the JWT `sharedFileSystem` claim must match. | required                     |
+| `WSF_SHARED_FILESYSTEM_NAMESPACE` | SFS namespace; the JWT `sharedFileSystemNamespace` claim must match.            | required                     |
+| `WSF_JWT_PUBLIC_KEY`              | PEM-encoded RSA public key for verifying browsing JWTs.                         | required                     |
+| `WSF_JWT_ISSUER`                  | Required JWT `iss` claim.                                                       | `control-api`                |
+| `WSF_JWT_AUDIENCE`                | Required JWT `aud` claim.                                                       | `workspace-files-controller` |
+| `WSF_MAX_UPLOAD_BYTES`            | Per-file upload cap; larger uploads get `413 payload_too_large`.                | `104857600` (100 MiB)        |
+| `WSF_MAX_LIST_ENTRIES`            | Max entries returned by a single directory listing.                             | `5000`                       |
+| `WSF_MAX_PATH_DEPTH`              | Max path depth (segments) accepted from clients.                                | `32`                         |
+
+## Security Model
+
+**Auth.** Browsing JWTs are short-lived RS256 tokens minted by control-api (signed with the same keypair as RPC tokens; audience separation keeps the token kinds apart). The wfc rejects any token unless **all** of: `iss` matches, `aud` matches, `sharedFileSystem` and `sharedFileSystemNamespace` claims equal **this** instance's SFS, and `scopes` contains only entries from the closed set `files:read` / `files:write` (unknown or duplicate scopes are rejected outright). Scopes are then enforced per route. Audience or SFS mismatch is `403`; signature/expiry failures are `401`.
+
+**Path safety.** Every client path is validated lexically (reject `..`, backslash, ASCII control chars, excess depth; resolve under the mount root) and physically (each existing segment is `lstat`ed — symlinks are rejected or omitted everywhere: directory listings silently skip symlink entries, and every other operation (listing roots, move sources, delete targets, …) hard-rejects with `path_invalid` — with a `realpath` containment check). Writes re-validate the chain **after** `mkdir`/`rename` to defend against TOCTOU symlink swaps, uploads go to a temp sibling then rename atomically so partial writes never appear at the destination, and the mount root itself can never be written, replaced, moved, or deleted.
+
+**Network.** The HCC-generated NetworkPolicies allow ingress only from control-api pods on the wfc port, and egress to DNS only — a compromised mcp-host pod cannot reach the writable side of its own workspace.
+
+## Development
+
+```bash
+npm install
+WSF_SHARED_FILESYSTEM_NAME=dev WSF_SHARED_FILESYSTEM_NAMESPACE=mcp-host \
+WSF_JWT_PUBLIC_KEY="$(cat public.pem)" npm run dev
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+Five vitest suites cover config loading, JWT verification, path safety, and the read/write route behavior (via supertest against the composed Express app).
+
+## Deployment
+
+There are no static manifests for this service: instances are created dynamically by host-context-controller when a SharedFileSystem CRD is applied. The image, port, JWT public key ConfigMap, and `WSF_MAX_*` limits are configured on HCC via `CONTEXT_MAPPER_WFC_*` env (see [deploy/base/control-plane/host-context-controller.yaml](../deploy/base/control-plane/host-context-controller.yaml) and [host-context-controller/src/config.ts](../host-context-controller/src/config.ts)). See the [SharedFileSystem CRD reference](../docs/crds/sharedfilesystem.md) for the resource that drives it.


### PR DESCRIPTION
Closes the roadmap's P1 service-README backlog and the P2 quick wins.

## New READMEs (previously none)
`gfs-controller` · `workspace-files-controller` · `webhook-gateway` · `webhook-proxy` · `nginx-egress-proxy` (Dockerfile-only dir — documents the image and points at HCC where config generation + SSRF sanitization live) · `workflow-approval-request-reader`

## Accuracy rewrites
- **control-ui**: from "4 tabs, no login" to the real app — 15+ route groups, AuthGate + admin JWT (bootstrap + lockout), usage/cost dashboards, registry catalog, per-tool approval policy editor, egress editor; npm scripts and the 54/21/2 test split quoted verbatim
- **host-context-controller**: NetworkPolicy section upgraded from "three policies" to the real **L0–L3 model** with binding policies and the 18 excluded egress CIDR ranges

## Tooling & hygiene
- `make test-counts` — prints 882 files / 10,260 cases (the README's verified numbers, now reproducible on demand)
- e2e-guide: CLAUDE.md-era test tables removed; platform-topology: 7 → **12** namespaces (recounted from deploy/); roadmap rows updated

## Verification
Every README was written by an agent reading the code, then **adversarially verified by an independent agent** — three of them executed the services' test suites to confirm claimed counts (100/100, 22/22, 64/64). All 29 verifier findings were applied and re-verified before commit (details in the commit message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)