### PR TITLE
docs: per-component map in the README (replaces repo-layout table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/evenfire-ai/evenfire/ci-public.yml?branch=main&label=CI)](https://github.com/evenfire-ai/evenfire/actions)
 [![GitHub release](https://img.shields.io/github/v/release/evenfire-ai/evenfire?sort=semver)](https://github.com/evenfire-ai/evenfire/releases)
 
-[What agents can do](#what-agents-can-do) · [Get started](#get-started-minikube) · [Architecture](#architecture) · [Security model](#security-model) · [Docs](docs/README.md) · [License](#license)
+[What agents can do](#what-agents-can-do) · [Get started](#get-started-minikube) · [Architecture](#architecture) · [Security model](#security-model) · [Components](#components) · [Docs](docs/README.md) · [License](#license)
 
 ---
 
@@ -302,7 +302,7 @@ it by default. Four enforcement layers in this repo:
 4. **Authenticated internals.** Service-to-service RS256 tokens with strict
    audience/scope (including short-lived artifact tokens). Shared-file access
    treats the JWT as a ceiling, re-checks a permission store fail-closed, and
-   appends to a tamper-evident audit chain. Inbound webhooks use timing-safe
+   appends to a tamper-evident audit log. Inbound webhooks use timing-safe
    signature checks. Direct `mcp-host` ingress is **layered**: edge trust
    headers from named platform services (in production restricted by
    NetworkPolicy); the host's own JWT middleware guards only specific control
@@ -366,22 +366,183 @@ environment variables). Details: [mcp-host/README.md](mcp-host/README.md).
 
 ---
 
-## Repository layout
+## Components
 
-| Area                    | Component                                                                                                                                              | Role                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
-| **Agent runtime**       | [mcp-host/](mcp-host/README.md)                                                                                                                        | LLM loop, approvals, MCP + native tools |
-|                         | [channel-reader/](channel-reader/README.md)                                                                                                            | Telegram / Email / Slack ingress        |
-|                         | [mcp-proxy/](mcp-proxy/README.md), [stdio-bridge/](stdio-bridge/README.md)                                                                             | MCP routing / stdio bridge              |
-|                         | [mcp-servers/](mcp-servers/README.md)                                                                                                                  | Connector specs (upstream images)       |
-| **Operators**           | [host-context-controller/](host-context-controller/README.md)                                                                                          | CRDs → Deployments + NetworkPolicies    |
-|                         | [workflow-recipes/](workflow-recipes/README.md)                                                                                                        | WorkflowRecipe operator                 |
-|                         | [gfs-controller/](gfs-controller/), [workspace-files-controller/](workspace-files-controller/)                                                         | File planes                             |
-| **Edge & security**     | [rpc-proxy/](rpc-proxy/README.md), [external-rest-api/](external-rest-api/README.md)                                                                   | JWT edge, profiles/tokens               |
-|                         | [webhook-gateway/](webhook-gateway/), [webhook-proxy/](webhook-proxy/), [nginx-egress-proxy/](nginx-egress-proxy/)                                     | Ingress / egress hardening              |
-|                         | [workflow-approval-request-reader/](workflow-approval-request-reader/)                                                                                 | Channel approval callbacks              |
-| **Control plane & UIs** | [control-api/](control-api/README.md), [control-ui/](control-ui/README.md), [profile-ui/](profile-ui/README.md), [desktop-app/](desktop-app/README.md) | Admin, profile, desktop                 |
-| **Platform**            | [charts/clerum-crds/](charts/clerum-crds/README.md), [deploy/](deploy/), [packages/](packages/), [monitoring/](monitoring/README.md)                   | CRDs, manifests, shared libs, log stack |
+Every deployable component in this monorepo has its own README. The map below
+distills the load-bearing facts from each — the folder READMEs are the deep
+dives.
+
+### Agent runtime
+
+- **[mcp-host/](mcp-host/README.md)** — the agent runtime. Runs the task
+  state machine and LLM loop under hard guardrails (per-task tool-call cap,
+  max task duration, bounded queue), executes native and MCP tools behind the
+  approval gate, and serves the versioned `/v1/runtime/*` REST API — messages,
+  approve/deny, task results, cron deliveries. Identity comes from a `Host`
+  CRD plus its referenced Secret, hot-reloaded on change; connector discovery
+  goes through host-context-controller's API, so mcp-host needs no McpServer
+  RBAC. LLM providers are data-first descriptors — an OpenAI-compatible
+  provider is a registry entry, not new code. `Host.spec.approval.tools`
+  overrides per-tool approval defaults (e.g. skip `http_request` approval
+  when `CLERUM_HTTP_ALLOWLIST` is the gate).
+- **[channel-reader/](channel-reader/README.md)** — Telegram (grammY), Email
+  (ImapFlow), and Slack (`@slack/web-api`) ingress. Watches
+  `CommunicationChannel` CRDs filtered by `hostRef` and restarts itself when
+  they change; applies per-sender pre-filters (Telegram user IDs, email
+  addresses, Slack usernames) before a message ever reaches the agent;
+  delivers generated attachments back to the channel under count/size caps.
+- **[mcp-proxy/](mcp-proxy/README.md)** — optional centralized MCP router
+  (`MCP_PROXY_ENABLED`). Polls host-context-controller for the live server
+  list into a diff-logged routing table, forwards with response-size and
+  timeout guards, and fails readiness when its discovery cache expires.
+- **[stdio-bridge/](stdio-bridge/README.md)** — sidecar that turns any
+  stdio-only MCP server (PostgreSQL, Redis, GitHub, …) into a StreamableHTTP
+  endpoint. Injected automatically when a CRD declares
+  `transport.type: stdio`; supervises the child process with
+  exponential-backoff restarts and graceful shutdown.
+- **[mcp-servers/](mcp-servers/README.md)** — the connector catalog. MongoDB
+  and Airtable ship with a 343-case test suite covering CRD config, API
+  behavior, MCP protocol, and generated Kubernetes resources; web-search
+  (Brave), Playwright, and doc-generator are available; Alpha Vantage is a
+  stub. Credentials live in Kubernetes Secrets, never in CRDs.
+
+### Operators
+
+- **[host-context-controller/](host-context-controller/README.md)** — the
+  central operator. Reconciles `McpServer` CRDs into Deployments and Services
+  — refusing to deploy any server whose referenced Secret (or any declared
+  key) is missing — and `Host` CRDs into a per-agent Deployment, Service, and
+  workspace PVC. Owns the four-layer NetworkPolicy model: for external
+  egress, public hostnames are DNS-resolved to `/32` ipBlocks, rejected if
+  they overlap private/link-local/cloud-metadata ranges, and re-resolved
+  periodically (default 5 min) — a failed egress binding blocks the workload
+  from starting at all. Also serves the discovery REST API mcp-host uses to
+  find connectors and their auth tokens, and sweeps orphaned resources on
+  startup.
+- **[workflow-recipes/](workflow-recipes/README.md)** — the operator that
+  owns the `WorkflowRecipe` lifecycle: policy validation against
+  cluster-wide `WorkflowRecipePolicy` CRDs, input and `{{…}}` template
+  resolution, topological dependency ordering, then Deployments,
+  StatefulSets, CronJobs, and Jobs. Recipes advance through a 13-state
+  machine (candidate → … → active, with degraded / rolling-back / failed
+  paths). Transport-enabled workloads become `McpServer` CRDs that
+  host-context-controller picks up. Per-workload security overrides let
+  images like PostgreSQL (uid 70) run under their expected uid while keeping
+  `runAsNonRoot` and all capabilities dropped. Recipes with `steps[]` get a
+  coordinator pod that executes multi-step LLM workflows with crash
+  recovery, per-step model overrides, and LLM-call rate limiting.
+- **[gfs-controller/](gfs-controller/README.md)** — brokered file API over
+  the `GlobalFileSystem` drive, and the only workload that mounts its PVC
+  (one writer replica, read-only readers). Every request runs a fail-closed
+  chain: RS256 JWT → subject expansion → token ceiling (the token is an
+  upper bound on authority, never a grant) → Postgres permission store
+  re-checked on every operation. Unauthorized and non-existent resources are
+  indistinguishable (both 403); every decision — allow, deny, or error — is
+  an INSERT-only audit row, and an audit-write failure means the operation
+  is not served. Agent replace/delete calls carry an integer `ifMatch`
+  version for optimistic concurrency.
+- **[workspace-files-controller/](workspace-files-controller/README.md)** —
+  the write path for `SharedFileSystem` team workspaces, one instance per
+  filesystem. Agents mount the same PVC read-only, and the instance's
+  NetworkPolicy admits only control-api — so a compromised agent pod cannot
+  reach the writable side of its own workspace. Short-lived JWTs are pinned
+  to one filesystem with a closed scope set; paths are validated lexically
+  and physically (symlinks rejected, re-validation after writes against
+  TOCTOU swaps, atomic temp-then-rename uploads).
+
+### Edge & security
+
+- **[rpc-proxy/](rpc-proxy/README.md)** — the external gateway for desktop
+  and tenant traffic. Verifies RS256 RPC tokens — issuer, audience, expiry,
+  scopes, per-host bindings, wildcard `*` rejected — holding a public key
+  only, so it can never mint what it verifies; each user's reachable servers
+  and hosts are resolved through control-api. Status/activity SSE streams
+  are read-only and never include chain-of-thought. Ships hardened
+  manifests: non-root, seccomp `RuntimeDefault`, read-only root filesystem,
+  NetworkPolicy, PodDisruptionBudget.
+- **[external-rest-api/](external-rest-api/README.md)** — public auth and
+  profile facade: password/Google login (session tokens are minted by
+  control-api), team membership and roles (admin / inviter / member),
+  invitations, directory lookup, and RPC-token brokerage. `userId` and
+  `teamId` always derive from verified JWT claims — never from request input
+  — and control-api re-validates the claim binding on every forwarded call.
+- **[webhook-gateway/](webhook-gateway/README.md)** — per-recipe webhook
+  verifier, one per recipe that declares `spec.webhooks[]`. Verifies the
+  exact raw bytes the provider signed: HMAC-SHA256 (plain or timestamped
+  with a replay window), constant-time static bearer, or JWKS-verified JWTs
+  — asymmetric algorithms only, `HS*`/`none` rejected. Slowloris budgets,
+  in-flight caps, per-webhook body caps; strips every inbound `x-clerum-*`
+  header and injects its own verified identity. Zero runtime npm
+  dependencies.
+- **[webhook-proxy/](webhook-proxy/README.md)** — stateless public webhook
+  router in front of the gateways. Path segments are matched raw (encoded
+  `%2e%2e` never decodes into `..`), the recipe namespace is pinned,
+  webhooks are looked up in control-api's registry (hits and misses both
+  cached), and bodies stream through unbuffered with method and size
+  enforcement. Holds no secrets beyond one service token and does no HMAC
+  itself — that is the gateway's job. Zero runtime npm dependencies.
+- **[workflow-approval-request-reader/](workflow-approval-request-reader/README.md)**
+  — the inbound half of channel approvals: normalizes Telegram/Slack
+  callbacks (approve/deny buttons, enrollment, chat handoff) and submits
+  decisions to the right workflow runtime. Telegram auth is a timing-safe
+  secret comparison; Slack signatures are verified via control-api and
+  cross-checked against the workspace ID; a fail-safe `can-approve`
+  pre-check refuses to forward a decision when control-api errors. Zero
+  runtime npm dependencies.
+- **[nginx-egress-proxy/](nginx-egress-proxy/README.md)** — hardened nginx
+  image serving as the pinned egress path for remote (SaaS) connectors.
+  host-context-controller generates its config per server: `proxy_pass`
+  locked to exactly one sanitized HTTPS URL (DNS hostnames only — IP
+  literals, internal and metadata hosts rejected, the URL reconstructed to
+  strip injected characters), upstream TLS verified, auth headers sanitized
+  against CRLF injection, credentials resolved from Secrets at pod start via
+  `${VAR}` placeholders so they never land in the ConfigMap. A remote CRD's
+  `spec.image` is never what runs — the operator always stamps the platform
+  image.
+
+### Control plane & UIs
+
+- **[control-api/](control-api/README.md)** — control-plane backend and the
+  platform's token mint. CRUD for the CRDs, namespace-constrained secret
+  management (listing returns metadata, never payloads), usage/cost
+  accounting, and three separately-keyed RS256 token families: user session
+  JWTs, short-lived scope-narrowed RPC tokens, and admin JWTs
+  (bcrypt-seeded bootstrap admin, lockout after repeated failures).
+  Separate keypairs keep blast radius contained and rotation independent;
+  internal service calls use timing-safe token comparison; token consumers
+  hold public keys only.
+- **[control-ui/](control-ui/README.md)** — the admin dashboard (Next.js).
+  Admin-JWT login in front of 14 sections: agents with a per-tool approval
+  editor that shows risk hints whenever a setting loosens a
+  required-by-default gate, connector egress editing that rejects
+  private/metadata/reserved ranges, a registry marketplace with trust levels
+  and publisher keys, a Global File System browser with grant delegation,
+  token usage with 8 group-by dimensions, budgets, and write-only secrets.
+  The browser talks same-origin only; a server-side handler proxies to
+  control-api.
+- **[profile-ui/](profile-ui/README.md)** — end-user profile and invitation
+  confirmation (Next.js). Invited users accept and set a password through a
+  token route; only the invitation token, email, and password ever leave the
+  browser — the temporary invitation session stays server-side.
+- **[desktop-app/](desktop-app/README.md)** — Electron + React client with a
+  hardened renderer: `contextIsolation` and `sandbox` on, `nodeIntegration`
+  off, all access through validated IPC (`window.clerum.*`). Authenticates
+  via external-rest-api, holds only short-lived scoped RPC tokens (internal
+  service tokens never touch the app), restores sessions from the OS
+  keychain, and consumes the read-only SSE streams. E2E-tested in two
+  phases: real IPC handlers against a live cluster, then Playwright driving
+  the built Electron app.
+
+### Platform directories
+
+| Directory                                           | What's in it                                                                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| [charts/clerum-crds/](charts/clerum-crds/README.md) | Helm chart with all 8 CRDs plus example resources                                                                        |
+| [deploy/](deploy/)                                  | Kubernetes manifests (`deploy/base/…`) for every namespace                                                               |
+| [packages/](packages/)                              | Shared TypeScript libraries                                                                                              |
+| [monitoring/](monitoring/README.md)                 | Optional Grafana + Loki log stack — Helm values and dashboards only, no code; authoritative usage/cost is in control-api |
+| [tests/e2e/](docs/testing/e2e-guide.md)             | 268 end-to-end tests across 8 suites on minikube                                                                         |
+| [docs/](docs/README.md)                             | The documentation tree                                                                                                   |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,11 +45,11 @@ Use this index for long-form docs.
 
 ## Reference
 
-| Doc                         | Description                                                                 |
-| --------------------------- | --------------------------------------------------------------------------- |
-| [CRD index](crds/README.md) | All 8 `clerum.io` CRDs                                                      |
-| [llms.txt](llms.txt)        | Machine-readable doc map for coding agents                                  |
-| Service READMEs             | Linked from root [README repository layout](../README.md#repository-layout) |
+| Doc                         | Description                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| [CRD index](crds/README.md) | All 8 `clerum.io` CRDs                                                               |
+| [llms.txt](llms.txt)        | Machine-readable doc map for coding agents                                           |
+| Service READMEs             | Distilled per component in the root [README components map](../README.md#components) |
 
 ## Feature hubs
 

--- a/docs/meta/docs-roadmap.md
+++ b/docs/meta/docs-roadmap.md
@@ -115,8 +115,11 @@ warns — it does).
 ### Secondary (post-launch polish)
 
 7. Docs site (Mintlify/Docusaurus) from existing `docs/` tree + `llms.txt`.
-8. Shorten root README: keep capability tour + get-started + security; move
-   services/ports and layout tables fully into docs (target ~280–320 lines).
+8. README length: superseded in part on 2026-07-13 — the repo-layout table
+   was deliberately upgraded to a detailed **Components map** (per-component
+   distillation of every folder README) so first-time readers get real depth
+   on the front page. Any future length pass trims architecture/ports
+   duplication, never the capability tour, get-started, or the Components map.
 9. Community channel + badge when ready.
 10. Production deploy guide beyond checklist (real cloud walkthrough).
 
@@ -144,33 +147,35 @@ Do **not** regress these sections without a new decision:
 6. Security model (4 pillars, claims-aligned)
 7. Beyond the agent
 8. CRDs (8) + providers
-9. Repo layout + testing + docs + community + license
+9. Components map (per-component distillation of all folder READMEs, added
+   2026-07-13) + testing + docs + community + license
 
-If length becomes a problem, **trim 5 and 9** first, not 3 or 4.
+If length becomes a problem, **trim 5** first — not 3, not 4, and not the
+Components map in 9 (explicit decision, 2026-07-13).
 
 ---
 
 ## 6. Prioritized backlog
 
-| P   | Item                                                                                                                                                                                                  | Owner type       | Depends on          |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------- |
-| P0  | Legal: license migration to MPL-2.0 **executed 2026-07-13** (§9); remaining: CLA counsel pass + align with cla.json                                                                                   | Human / counsel  | —                   |
-| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                                                                       | Human            | —                   |
-| P1  | Six missing service READMEs (1 screen each: purpose, ports, env, security) *(in PR — this branch)*                                                                                                    | Docs eng         | —                   |
-| P1  | control-ui README: real route groups + auth story (AuthGate exists) *(in PR — this branch)*                                                                                                           | Docs eng         | —                   |
-| P1  | HCC README: document 4-layer NetworkPolicy model *(in PR — this branch)*                                                                                                                              | Docs eng         | code already exists |
-| P1  | Screenshots / short demo GIF                                                                                                                                                                          | Design / product | running minikube    |
-| P1  | Cut **v0.1.1** — v0.1.0 tarball predates PR #3 and still contains the deleted Compose quickstart                                                                                                      | Eng              | PR #4 merge         |
-| P2  | Automate test counts (make target printing file/case counts; README cites it)                                                                                                                         | Eng              | —                   |
-| P2  | e2e-guide internal debt: CLAUDE.md-era test tables (“Total 1,944”) and prose refs                                                                                                                     | Docs eng         | —                   |
-| P2  | Document-or-mark-experimental the four undocumented `mcp-servers/` dirs (web-search, playwright, doc-generator = real servers referenced from docs; alphavantage = stub) + add to “Available Servers” | Docs eng         | —                   |
-| P2  | Optional README length pass (move ports table to docs)                                                                                                                                                | Docs eng         | —                   |
-| P2  | Docs website                                                                                                                                                                                          | Eng              | —                   |
-| P3  | Fix the zai-default footgun in code: infer provider from whichever single API key is set (`full-setup.sh:571-573`) instead of only warning in docs                                                    | Eng              | —                   |
-| P3  | Resolve or strip TBD placeholders in `docs/crds/workflowrecipe.md` (registry spec “TBD”, unmigrated comparison doc — lines ~177, ~3075, ~4121)                                                        | Docs eng         | —                   |
-| P3  | platform-topology.md “7 namespaces” vs 12 declared in deploy/ (pre-existing)                                                                                                                          | Docs eng         | —                   |
-| P3  | Lightweight non-K8s path (product decision required)                                                                                                                                                  | Product          | decision            |
-| P3  | Cloud production tutorial                                                                                                                                                                             | Eng              | production env      |
+| P   | Item                                                                                                                                           | Owner type       | Depends on          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------- |
+| P0  | Legal: license migration to MPL-2.0 **executed 2026-07-13** (§9); remaining: CLA counsel pass + align with cla.json                            | Human / counsel  | —                   |
+| P0  | Verify GH private vulnerability reporting enabled (security@ mailbox confirmed)                                                                | Human            | —                   |
+| P1  | Six missing service READMEs (purpose, ports, env, security) — **done** (PR #7, merged 2026-07-13)                                              | Docs eng         | —                   |
+| P1  | control-ui README: real route groups + auth story — **done** (PR #7)                                                                           | Docs eng         | —                   |
+| P1  | HCC README: document 4-layer NetworkPolicy model — **done** (PR #7)                                                                            | Docs eng         | code already exists |
+| P1  | Screenshots / short demo GIF                                                                                                                   | Design / product | running minikube    |
+| P1  | Cut post-Compose release — **done**: v0.2.0 (2026-07-13) supersedes v0.1.0                                                                     | Eng              | —                   |
+| P2  | Automate test counts — **done**: `make test-counts` (PR #7); README cites it                                                                   | Eng              | —                   |
+| P2  | e2e-guide internal debt (CLAUDE.md-era test tables) — **done** 2026-07-13                                                                      | Docs eng         | —                   |
+| P2  | Four undocumented `mcp-servers/` dirs — **done** 2026-07-13: READMEs + Status column in “Available Servers”                                    | Docs eng         | —                   |
+| P2  | Optional README length pass (move ports table to docs; the Components map is exempt — deliberate 2026-07-13 decision)                          | Docs eng         | —                   |
+| P2  | Docs website                                                                                                                                   | Eng              | —                   |
+| P3  | Fix the zai-default footgun in code — **done**: full-setup.sh infers the provider from the single set API key                                  | Eng              | —                   |
+| P3  | Resolve or strip TBD placeholders in `docs/crds/workflowrecipe.md` (registry spec “TBD”, unmigrated comparison doc — lines ~177, ~3075, ~4121) | Docs eng         | —                   |
+| P3  | platform-topology.md namespace count — **done**: now documents 12 namespaces                                                                   | Docs eng         | —                   |
+| P3  | Lightweight non-K8s path (product decision required)                                                                                           | Product          | decision            |
+| P3  | Cloud production tutorial                                                                                                                      | Eng              | production env      |
 
 > In flight: PR #4 (`fix/minikube-docs-followups`) fixes the pf-mcp-host
 > service name, the e2e-approval-flow default email, canonical bootstrap in the


### PR DESCRIPTION
## What

Replaces the one-line-per-component **Repository layout** table in the root README with a **Components** section: a grouped, per-component distillation of the most load-bearing facts from all twenty folder READMEs (agent runtime · operators · edge & security · control plane & UIs · platform directories). First-time readers now get real technical depth about every component on the front page, with each folder README as the deep dive.

Every claim is drawn from the folder READMEs that were code-verified in the service-README wave (#7).

## Also in this PR

- **Claims fix:** Security model said "tamper-evident audit **chain**"; the verified gfs-controller README states full `prev_hash` chaining is not yet wired into the write path → softened to "audit log".
- **Precision:** gfs `ifMatch` described as applying to replace/delete calls (not all writes).
- **docs/README.md:** reference section now points at the new `#components` anchor.
- **docs-roadmap true-up:** records the Components-map decision (README length-pass guidance updated — the map is exempt from trimming), and marks backlog rows that have since shipped: six service READMEs + control-ui/HCC accuracy (#7), `make test-counts` (#7), e2e-guide CLAUDE.md-era cleanup, mcp-servers READMEs + Status column, zai-footgun code fix in `full-setup.sh`, platform-topology 12-namespace count, and the post-Compose release (v0.2.0 supersedes the v0.1.1 ask).

## Verification

- All 59 relative links in README.md resolve to existing files.
- Prettier-formatted (`npx prettier --write`).
- Roadmap "done" rows each re-verified against the repo (`make test-counts` target, provider-inference block in `full-setup.sh`, no `1,944` relic in e2e-guide, 12 namespaces in platform-topology, v0.2.0 tag, four mcp-servers READMEs present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)