### PR TITLE
fix(profile-ui): rename tab title to "Evenfire Profile UI"

### DIFF
--- a/profile-ui/app/layout.tsx
+++ b/profile-ui/app/layout.tsx
@@ -5,7 +5,7 @@ import { ToastProvider } from '@components/Toast'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'Clerum Profile UI',
+  title: 'Evenfire Profile UI',
   description: 'User profile and team membership management',
   icons: {
     icon: '/brand/logo.svg',


### PR DESCRIPTION
## What

Fixes #10 — the profile-ui browser tab title still read **"Clerum Profile UI"**.

Per [`docs/concepts/code-names.md`](docs/concepts/code-names.md), user-visible surfaces (product, docs, UI) use **evenfire**; `clerum` is retained only for internal surfaces (`clerum.io` API group, `CLERUM_*` env vars, chart names). A browser tab title is user-visible.

## Change

`profile-ui/app/layout.tsx` — `title: 'Clerum Profile UI'` → `'Evenfire Profile UI'`, matching the sibling `control-ui` title (`'Evenfire Control UI'`). One line.

Base is `oss-wave0-scrub` to match the other in-flight work; retarget if you'd prefer `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)