### PR TITLE
ci: run every tested service, add CodeQL + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+# Dependency updates for a repo with ~33 npm workspaces.
+#
+# Two deliberate choices to keep this useful rather than noisy:
+#   - `directories` globs instead of one `updates` block per service. Dependabot
+#     skips any matched directory without a manifest, so this stays correct as
+#     services are added or removed.
+#   - Minor/patch updates are GROUPED into a single PR per ecosystem. Ungrouped,
+#     33 workspaces would open dozens of PRs a week and the signal would be
+#     ignored — which is the same as having no dependency updates at all.
+#
+# Security updates are NOT grouped: GitHub raises those separately and they should
+# land on their own, reviewable, fast.
+
+updates:
+  - package-ecosystem: npm
+    directories:
+      - '/' # root tooling (prettier, commitlint, husky)
+      - '/*' # every top-level service
+      - '/packages/*' # workflow-sdk, workflow-runtime-core, image-policy, …
+      - '/mcp-servers/*' # web-search, doc-generator
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: 'chore(deps)'
+      prefix-development: 'chore(deps-dev)'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: 'ci(deps)'

--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -12,6 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Every service with a `test` script belongs here. Keep in sync with
+        # TEST_SERVICES in the root Makefile — a service in one but not the other
+        # means its tests run in only half the places contributors look.
         service:
           - mcp-host
           - channel-reader
@@ -21,6 +24,16 @@ jobs:
           - workflow-recipes
           - gfs-controller
           - workspace-files-controller
+          - rpc-proxy
+          - webhook-gateway
+          - webhook-proxy
+          - workflow-approval-request-reader
+          - stdio-bridge
+          - external-rest-api
+          - desktop-app
+          - mcp-servers
+          - packages/workflow-runtime-core
+          - packages/workflow-sdk
 
     steps:
       - uses: actions/checkout@v4
@@ -31,17 +44,18 @@ jobs:
           cache: npm
           cache-dependency-path: ${{ matrix.service }}/package-lock.json
 
-      # workflow-recipes and control-api both consume @clerum/workflow-runtime-core
-      # via a `file:../packages/workflow-runtime-core` dependency. Build that package
-      # first so its dist/ exists before the service's `npm ci` links it in — otherwise
-      # the service build fails with TS2307 "Cannot find module '@clerum/workflow-runtime-core'".
+      # workflow-recipes, control-api and packages/workflow-sdk all consume
+      # @clerum/workflow-runtime-core via a `file:../packages/workflow-runtime-core`
+      # dependency. Build that package first so its dist/ exists before the service's
+      # `npm ci` links it in — otherwise the build fails with TS2307
+      # "Cannot find module '@clerum/workflow-runtime-core'".
       - name: Install workflow-runtime-core dependencies
-        if: matrix.service == 'workflow-recipes' || matrix.service == 'control-api'
+        if: matrix.service == 'workflow-recipes' || matrix.service == 'control-api' || matrix.service == 'packages/workflow-sdk'
         working-directory: packages/workflow-runtime-core
         run: npm ci
 
       - name: Build workflow-runtime-core
-        if: matrix.service == 'workflow-recipes' || matrix.service == 'control-api'
+        if: matrix.service == 'workflow-recipes' || matrix.service == 'control-api' || matrix.service == 'packages/workflow-sdk'
         working-directory: packages/workflow-runtime-core
         run: npm run build
 
@@ -59,6 +73,13 @@ jobs:
 
       # Typecheck against the base tsconfig (covers src + test dirs).
       # This catches errors in test files that tsconfig.build.json may exclude.
+      #
+      # mcp-servers is skipped: it has no root tsconfig.json (only the web-search and
+      # doc-generator sub-projects have one), so `tsc --noEmit` there resolves no
+      # project and just prints its help text. Adding a strict root tsconfig surfaces
+      # ~10 pre-existing type errors in its __tests__ — worth fixing, but as its own
+      # change rather than smuggled into a CI-coverage PR.
       - name: Typecheck (tsc --noEmit)
+        if: matrix.service != 'mcp-servers'
         working-directory: ${{ matrix.service }}
         run: npx tsc --noEmit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+# Static analysis for a platform whose pitch is a security model: deny-all
+# networking, approval gates, signature-verified webhooks, scoped RPC tokens.
+# The code enforcing those claims (rpc-proxy's JWT chain, webhook-gateway's HMAC
+# verification, HCC's NetworkPolicy generation) had no SAST gate before this.
+#
+# build-mode: none — CodeQL analyses JS/TS from source and does not need the ~33
+# workspaces built, which keeps this a single job rather than a matrix.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so newly-published CodeQL queries reach the default branch even in
+    # a quiet week. Monday 07:00 UTC.
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write # upload results to the Security tab
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    # Code scanning is FREE on public repositories but requires paid GitHub
+    # Advanced Security on private ones. This repo is still private pending the
+    # public launch, so uploading results fails with:
+    #   "Code Security must be enabled for this repository to use code scanning."
+    #
+    # Rather than leave a permanently-red check (which trains everyone to ignore
+    # CI) or pay for GHAS on a repo that is about to be public anyway, the job is
+    # gated on visibility. It costs nothing today and starts enforcing itself the
+    # moment the repo flips to public — no follow-up commit required.
+    #
+    # Nothing else is needed at that point: just verify the run appears under the
+    # Security tab.
+    if: github.event.repository.visibility == 'public'
+
     permissions:
       security-events: write # upload results to the Security tab
       actions: read


### PR DESCRIPTION
## The gap

CI ran **8 of the 18 services that have tests.** Ten were invisible to it — including the two most security-critical surfaces in the repo:

| Service | Test files | What it guards |
|---|---|---|
| **`rpc-proxy`** | 22 | The RS256 JWT auth chain + scoped-token brokerage between the desktop app and every agent |
| **`webhook-gateway`** | 5 | Provider signature verification — between the public internet and recipe workloads |
| `external-rest-api` | 24 | Auth, teams, invitations, RPC-token issuance |
| `workflow-approval-request-reader` | 8 | Inbound approval callbacks |
| `packages/workflow-runtime-core` | 12 | |
| `mcp-servers` | 8 | |
| `webhook-proxy` | 2 | |
| `packages/workflow-sdk` | 3 | |
| `stdio-bridge` | 1 | |
| `desktop-app` | unit | |

A repo that pitches deny-all networking and human-in-the-loop approvals should not be shipping its JWT auth chain and its HMAC verifier without a CI gate.

## Verified before wiring in

Ran the **exact `ci-public.yml` sequence** (`npm ci` → `build` → `test` → `tsc --noEmit`) against all ten locally. Nine pass outright.

The tenth, `mcp-servers`, has **no root `tsconfig.json`** — only its `web-search` and `doc-generator` sub-projects have one — so `tsc --noEmit` there resolves no project and prints its help text. It now runs build + test with the typecheck step skipped and the reason stated inline. A strict root tsconfig surfaces ~10 pre-existing type errors in its `__tests__`; worth fixing, but as its own change rather than smuggled into a CI-coverage PR.

## Keeping it from drifting again

The matrix is now **exactly** the Makefile's `TEST_SERVICES` (18), with a comment saying so. A service in one but not the other means its tests run in only half the places contributors look — which is precisely how the last gap survived.

Also: `packages/workflow-sdk` consumes `@clerum/workflow-runtime-core` via a `file:` dep, so it needs the same prereq build as `workflow-recipes` and `control-api`, or it fails with TS2307.

## Security automation

The repo had **no Dependabot, no CodeQL, no secret scanning** — while `SECURITY.md` promises a vulnerability policy and safe harbor.

- **CodeQL** — `javascript-typescript`, `security-and-quality`, on PR + weekly. `build-mode: none`, so it stays one job rather than a 33-workspace matrix.
- **Dependabot** — npm across all ~33 workspaces (glob `directories`, so it stays correct as services come and go) plus `github-actions`. Minor/patch are **grouped** into one PR per ecosystem: ungrouped, 33 workspaces would open dozens of PRs a week and get ignored, which is the same as having no dependency updates. Security advisories stay ungrouped so they land on their own, and fast.

## CodeQL is gated on the repo going public — and here is why that matters

The first CodeQL run **failed**, and the failure was informative. The workflow itself is fine: the analysis completed, every query ran, and SARIF exported cleanly. It failed at *upload*:

> `Code Security must be enabled for this repository to use code scanning.`

Root cause: **`evenfire-ai/evenfire` is still `"visibility": "private"`.** Code scanning is free on public repos but requires paid GitHub Advanced Security on private ones.

Rather than buy GHAS for a repo that is about to be public anyway, delete the workflow, or leave a permanently-red check (which just trains everyone to ignore CI), the job is gated on `github.event.repository.visibility == 'public'`. It costs nothing today and starts enforcing itself the moment the repo is flipped — no follow-up commit needed.

**Before flipping public, worth enabling in repo settings** (all currently `disabled`):

| Setting | Status | Note |
|---|---|---|
| `secret_scanning_push_protection` | disabled | **Enable this *before* going public** — it stops a credential being committed in the first place. Free on public repos. |
| `secret_scanning` | disabled | Free on public repos. |
| `code_security` | disabled | What CodeQL's upload needs. Free on public repos. |
| `dependabot_security_updates` | disabled | Complements the version updates added here. |

Dependabot version updates are unaffected by visibility and will open their first grouped batch on Monday.

## Status

**18/18 CI jobs green**, including the ten that had never run. CodeQL skips (private repo); `cla` skips (gate paused pending counsel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwv5Q8Lhon5shzjxS8wBYt
