### PR TITLE
fix(dependabot): group majors and pin @types/node — stop the 43-PR flood

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,19 @@ version: 2
 
 # Dependency updates for a repo with ~33 npm workspaces.
 #
-# Two deliberate choices to keep this useful rather than noisy:
-#   - `directories` globs instead of one `updates` block per service. Dependabot
-#     skips any matched directory without a manifest, so this stays correct as
-#     services are added or removed.
-#   - Minor/patch updates are GROUPED into a single PR per ecosystem. Ungrouped,
-#     33 workspaces would open dozens of PRs a week and the signal would be
-#     ignored — which is the same as having no dependency updates at all.
+# THE LESSON THIS FILE ENCODES (learned the hard way, 2026-07-14):
+# Leaving majors ungrouped opened 43 PRs in one run. Across 33 workspaces, a
+# single dev dependency that is one major behind becomes ~19 near-identical PRs.
+# "Majors deserve individual review" is sound advice for a handful of GitHub
+# Actions and actively harmful for a monorepo — the flood is unreviewable, and an
+# unreviewable queue gets ignored, which is the same as having no updates at all.
 #
-# Security updates are NOT grouped: GitHub raises those separately and they should
-# land on their own, reviewable, fast.
+# So: EVERYTHING is grouped, majors included. You still see majors separately from
+# minor/patch (two distinct PRs), so a breaking change is never silently swept in
+# with routine patches — but you get one reviewable PR per class, not 19.
+#
+# Security updates are NOT affected by grouping: GitHub raises those separately
+# and they should land on their own, and fast.
 
 updates:
   - package-ecosystem: npm
@@ -20,16 +23,39 @@ updates:
       - '/*' # every top-level service
       - '/packages/*' # workflow-sdk, workflow-runtime-core, image-policy, …
       - '/mcp-servers/*' # web-search, doc-generator
+
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 10
+
+    # NOTE: with glob `directories`, this limit applies PER DIRECTORY, not
+    # globally — which is why `10` did not cap anything meaningful. The real
+    # defence against a flood is the grouping below, not this number.
+    open-pull-requests-limit: 5
+
+    ignore:
+      # @types/node must track the Node major we actually run, not the newest
+      # published. This repo targets Node 24 (.nvmrc, `engines: >=24`), so a bump
+      # to @types/node@26 would typecheck our code against a runtime we do not
+      # run — surfacing APIs we cannot use and hiding ones we can.
+      # Minor/patch within the 24.x line still flow through normally.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
     groups:
       npm-minor-patch:
         applies-to: version-updates
         update-types:
           - minor
           - patch
+      # Majors grouped too — one reviewable PR, not one per workspace. Kept
+      # separate from minor/patch so a breaking change is never mixed into the
+      # routine batch.
+      npm-major:
+        applies-to: version-updates
+        update-types:
+          - major
+
     commit-message:
       prefix: 'chore(deps)'
       prefix-development: 'chore(deps-dev)'
@@ -39,11 +65,18 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 5
     groups:
-      actions:
+      actions-minor-patch:
         applies-to: version-updates
         update-types:
           - minor
           - patch
+      # Only ~6 actions exist, so an ungrouped major here is a handful of PRs,
+      # not a flood. Grouped anyway for consistency and to keep the queue quiet.
+      actions-major:
+        applies-to: version-updates
+        update-types:
+          - major
     commit-message:
       prefix: 'ci(deps)'


### PR DESCRIPTION
## What happened

My Dependabot config opened **43 PRs in one run.** This is the fix, plus a real bug the flood exposed.

## Cause 1 — majors left ungrouped

I grouped only `minor`/`patch`, reasoning that a **major is a breaking change and should never be swept into a batch nobody reads.** That reasoning is correct for a handful of GitHub Actions. It is **actively harmful across 33 npm workspaces**: one dev dependency a single major behind becomes ~19 near-identical PRs.

The entire flood was **two packages**:

| Package | PRs | Bump |
|---|---|---|
| `typescript` | 19 | 5.9.3 → 7.0.2 |
| `@types/node` | 19 | 20/22/24 → 26.1.1 |

An unreviewable queue gets ignored — which is the same as having no dependency updates at all.

**Fix:** majors are now grouped, but in their **own** group (`npm-major`), separate from `npm-minor-patch`. A breaking change still never rides along with routine patches; you just get one PR per class instead of one per workspace.

Worth noting: **the minor/patch grouping worked perfectly the whole time.** It produced exactly one PR — *"bump the npm-minor-patch group across 21 directories with 41 updates."* The design was right; I just didn't extend it to majors.

## Cause 2 — the limit I trusted does nothing

`open-pull-requests-limit: 10` applies **per directory** when using glob `directories`, not globally. With 33 matched directories it never capped anything. Now documented inline so nobody else trusts it as a flood guard. **Grouping is the real defence.**

## The actual bug the flood exposed

`@types/node@26` is a bump we **must not take**, and Dependabot was offering it in 19 places.

This repo targets **Node 24** (`.nvmrc` = `24`, `engines: ">=24"`, CI runs node 24). Bumping type definitions to Node 26 would typecheck the code against **a runtime we do not run** — surfacing APIs we cannot call and hiding ones we can. `@types/node` must track the Node major actually executed.

Major updates to `@types/node` are now ignored outright. Minor/patch within the 24.x line still flow normally.

`typescript` 7.0 (the native-port rewrite) is not ignored — it will now arrive as **one** reviewable `npm-major` PR, to adopt or reject deliberately rather than 19 times.

## After merge

The 43 stale major PRs get closed; Dependabot reconciles to the grouped shape on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rwv5Q8Lhon5shzjxS8wBYt