### PR TITLE
fix: SSRF via IP-literal targets, profile-ui tab title

### DIFF
--- a/mcp-host/src/core/tools/__tests__/shellAndHttp.test.ts
+++ b/mcp-host/src/core/tools/__tests__/shellAndHttp.test.ts
@@ -86,6 +86,36 @@ describe('HttpRequestTool', () => {
     expect(result.content).toContain('DNS resolution failed')
   })
 
+  // An IP-literal host never reaches DNS (resolve4/resolve6 reject on a literal),
+  // so a guard that only inspects DNS-resolved addresses never runs. The literal
+  // itself must be checked before the DNS step.
+  it.each([
+    ['http://169.254.169.254/latest/meta-data/', 'cloud metadata'],
+    ['http://127.0.0.1/admin', 'loopback'],
+    ['http://10.0.0.1/internal', 'RFC 1918'],
+    ['http://192.168.1.1/router', 'RFC 1918'],
+    ['http://[::1]/admin', 'IPv6 loopback'],
+    ['http://[::ffff:169.254.169.254]/', 'IPv4-mapped metadata'],
+  ])('should block IP-literal host %s (%s) with an empty allowlist', async url => {
+    const tool = new HttpRequestTool([]) // default config: no allowlist
+    const result = await tool.execute({ url })
+
+    expect(result.is_error).toBe(true)
+    // Must be blocked by the guard, not merely fail to connect — a connection
+    // error would also set is_error, so assert on the reason.
+    expect(result.content).toContain('private IP')
+  })
+
+  it('should fail closed when DNS fails and NO allowlist is configured', async () => {
+    const tool = new HttpRequestTool([])
+    const result = await tool.execute({
+      url: 'http://definitely-does-not-exist-12345.example.com/test',
+    })
+
+    expect(result.is_error).toBe(true)
+    expect(result.content).toContain('Cannot verify IP safety')
+  })
+
   it('should detect IPv6 private/loopback addresses (Risk 3.5.3c)', () => {
     expect(isPrivateIp('::1')).toBe(true) // IPv6 loopback
     expect(isPrivateIp('::')).toBe(true) // Unspecified

--- a/mcp-host/src/core/tools/httpRequest.ts
+++ b/mcp-host/src/core/tools/httpRequest.ts
@@ -1,6 +1,7 @@
 import * as dns from 'dns/promises'
 import * as http from 'http'
 import * as https from 'https'
+import * as net from 'net'
 import { URL } from 'url'
 import { Tool } from '../interfaces'
 import { ToolOutput } from '../types'
@@ -79,46 +80,64 @@ export class HttpRequestTool implements Tool {
       }
     }
 
-    // Resolve BOTH A and AAAA in parallel so attackers cannot hide a private
-    // target behind the record type we skip. The first validated address is
-    // pinned into makeRequest to close the DNS-rebinding window between
-    // validation and connect; the Host header (and SNI) keeps the original
-    // hostname intact.
+    // The address we ultimately connect to. For an IP literal it is the literal
+    // itself; for a hostname it is the first DNS-validated address (pinned into
+    // makeRequest to close the DNS-rebinding window between validation and
+    // connect). The Host header (and SNI) always keep the original hostname.
     let resolvedIp: string | undefined
-    try {
-      const [v4, v6] = await Promise.allSettled([
-        dns.resolve4(url.hostname),
-        dns.resolve6(url.hostname),
-      ])
-      const addresses: string[] = []
-      if (v4.status === 'fulfilled') addresses.push(...v4.value)
-      if (v6.status === 'fulfilled') addresses.push(...v6.value)
 
-      if (addresses.length === 0) {
-        throw new Error('no addresses resolved')
-      }
-
-      for (const addr of addresses) {
-        if (isPrivateIp(addr)) {
-          return {
-            content: `Error: Domain resolves to private IP (${addr})`,
-            duration_ms: Date.now() - startTime,
-            is_error: true,
-          }
+    // IP-literal targets never resolve via DNS — dns.resolve4/resolve6 reject a
+    // literal, so the DNS-based guard below would never inspect them. Check the
+    // literal directly (stripping [] brackets and %zone) and skip DNS entirely.
+    // Without this, `http://169.254.169.254/…`, `http://127.0.0.1/…`, etc. slip
+    // straight through to the connect step (SSRF).
+    const bareHost = stripIpv6Decorations(url.hostname)
+    if (net.isIP(bareHost) !== 0) {
+      if (isPrivateIp(url.hostname)) {
+        return {
+          content: `Error: Target is a private IP (${bareHost})`,
+          duration_ms: Date.now() - startTime,
+          is_error: true,
         }
       }
-      resolvedIp = addresses[0]
-    } catch {
-      // DNS resolution failed. If an allowlist is configured, we must block
-      // the request since we can't verify the IP is safe (SSRF protection).
-      if (this.allowlist.length > 0) {
+      resolvedIp = bareHost
+    } else {
+      // Hostname target. Resolve BOTH A and AAAA in parallel so attackers cannot
+      // hide a private target behind the record type we skip.
+      try {
+        const [v4, v6] = await Promise.allSettled([
+          dns.resolve4(url.hostname),
+          dns.resolve6(url.hostname),
+        ])
+        const addresses: string[] = []
+        if (v4.status === 'fulfilled') addresses.push(...v4.value)
+        if (v6.status === 'fulfilled') addresses.push(...v6.value)
+
+        if (addresses.length === 0) {
+          throw new Error('no addresses resolved')
+        }
+
+        for (const addr of addresses) {
+          if (isPrivateIp(addr)) {
+            return {
+              content: `Error: Domain resolves to private IP (${addr})`,
+              duration_ms: Date.now() - startTime,
+              is_error: true,
+            }
+          }
+        }
+        resolvedIp = addresses[0]
+      } catch {
+        // DNS resolution failed — we cannot verify the target is not a
+        // private/internal address, so fail closed. This holds whether or not
+        // an allowlist is configured: an unresolvable name could not have been
+        // reached anyway, and proceeding would be the SSRF hole this guards.
         return {
           content: `Error: DNS resolution failed for "${url.hostname}". Cannot verify IP safety.`,
           duration_ms: Date.now() - startTime,
           is_error: true,
         }
       }
-      // No allowlist — all domains allowed, let HTTP request proceed/fail naturally
     }
 
     try {

--- a/profile-ui/app/layout.tsx
+++ b/profile-ui/app/layout.tsx
@@ -5,7 +5,7 @@ import { ToastProvider } from '@components/Toast'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'Clerum Profile UI',
+  title: 'Evenfire Profile UI',
   description: 'User profile and team membership management',
   icons: {
     icon: '/brand/logo.svg',


### PR DESCRIPTION
## Summary
- Re-applies two fixes that were dropped during the recent git-history reset (they were on branches deleted in that operation, recovered from the pre-reset backup bundle):
  - `fix(mcp-host)`: `http_request` only validated DNS-resolved addresses against the private-IP blocklist. An IP-literal host never resolves via DNS, so the guard was skipped entirely, letting a request reach loopback/RFC 1918/link-local metadata targets by IP. Now checks IP literals directly before the DNS step and fails closed on DNS resolution failure.
  - `fix(profile-ui)`: tab title still read "Clerum Profile UI" instead of the evenfire product name (matches the sibling control-ui title).
- Closes #9, closes #10.

## Test plan
- [x] Regression tests added for IP-literal hosts (IPv4, loopback, RFC 1918, IPv6 `[::1]`, IPv4-mapped metadata) and the DNS-failure fail-closed path.
- [x] profile-ui title change verified against `docs/concepts/code-names.md` naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)