### PR TITLE
docs: ground GlobalFileSystem CRD reference in gfsc broker concepts

### DIFF
--- a/docs/crds/globalfilesystem.md
+++ b/docs/crds/globalfilesystem.md
@@ -8,29 +8,107 @@
 
 ## Purpose
 
-A **brokered global drive** (singleton per cluster intent): PVC plus writer/reader
-deployments and a permission store. Clients do not mount the volume directly;
-they call the GFS HTTP API. Access is authorized and audited (including a
-hash-chained audit log in the controller design).
+A **brokered global drive** — one governed file tree per cluster (singleton
+intent), read and written by both humans and agents under a single
+deny-by-default permission model. It's a distinct storage plane from the
+per-workload PVCs a `WorkflowRecipe` declares and from a
+[SharedFileSystem](sharedfilesystem.md)'s per-team read tree — GFS does not
+replace either.
 
-## Spec fields (summary)
+Nothing mounts the drive's PVC directly. The reconciler provisions a PVC plus
+a single-replica **writer** `gfs-controller` (**gfsc**) Deployment and N
+read-only **reader** replicas; every client — humans through the Control UI,
+agents through built-in tools — reaches the drive exclusively through gfsc's
+HTTP API. gfsc checks every operation against the **permission store** (a
+Postgres-backed grant/share table, not the registry) before allowing it, and
+records it to a hash-chained audit log.
 
-| Area                      | Description                                         |
-| ------------------------- | --------------------------------------------------- |
-| Layout / root directories | Declared intent for governed layout materialization |
-| Storage                   | PVC size / class (see CRD schema)                   |
-| Full schema               | `charts/clerum-crds/crds/globalfilesystem.yaml`     |
+### Concepts
 
-The reconciler owns securityContext, pull policy, and replica wiring — the CRD
-declares intent, not full pod specs.
+- **`gfs://` references.** Every file and folder gets a permanent
+  `gfs://<drive>/<resourceId>` URI (`gfs-controller/src/api/read.ts`), stable
+  across renames/moves — usable for deep links and for sharing one resource
+  with someone who has no access to its parent folder.
+- **Grant vs. share.** A **grant** authorizes a *folder* (and everything
+  under it); a **share** authorizes a single resource by its reference, for
+  someone without folder access. Both are rows in the permission store, not
+  filesystem ACLs (`gfs-controller/src/authz/`).
+- **`manage_acl`.** Holding this permission on a folder makes you able to
+  grant/revoke access to it — a permission, not a fixed "owner" role.
+- **Fail-closed tokens.** A caller's token is a ceiling, not a grant by
+  itself — gfsc re-checks the permission store on every operation
+  (`gfs-controller/src/authz/tokenCeiling.ts`).
+
+## Spec fields
+
+| Field                            | Type     | Required | Default           | Description                                                                                                                                                                                      |
+| --------------------------------- | -------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec.storage.size`               | string   | yes      | --                 | PVC requested storage for the drive's flat blob layout (e.g. `"500Gi"`).                                                                                                                          |
+| `spec.storage.storageClassName`   | string   | no       | `standard-rwo`     | StorageClass for the drive PVC. RWX (`clerum-gcsfuse`) is a deferred escalation — set explicitly only when such a class exists.                                                                  |
+| `spec.storage.accessModes`        | string[] | no       | `[ReadWriteOnce]`  | The single-replica writer and co-located readers work on RWO-only StorageClasses; `ReadWriteMany` requires an RWX-capable class.                                                                 |
+| `spec.layout.rootDirectories`     | string[] | no       | `[]`               | Absolute seed paths (e.g. `/org`), max 64. Materialized as governed resources in the permission store by control-api once the writer reports `Ready` — not written directly by the reconciler. |
+| `spec.security.runAsUser`         | integer  | no       | --                 | POSIX UID applied to the gfsc pods and the init Job.                                                                                                                                              |
+| `spec.security.fsGroup`           | integer  | no       | --                 | Supplemental group applied so gfsc can read/write the mounted drive.                                                                                                                              |
+| `spec.readerReplicas`             | integer  | no       | `2`                | Number of read-only gfsc reader replicas. The writer is always exactly 1 — GFS is a single-writer drive; only readers scale.                                                                     |
+| `spec.retainOnDelete`             | boolean  | no       | `true`             | When `false`, deleting the CRD tears down the Deployments, Service, NetworkPolicies, and PVC (PVC last).                                                                                          |
+
+Full OpenAPI schema: `charts/clerum-crds/crds/globalfilesystem.yaml`. The
+reconciler owns pod-level detail the CRD doesn't expose — securityContext
+defaults beyond the fields above, image pull policy, and replica wiring for
+anything other than `readerReplicas`.
+
+## Status
+
+| Field                 | Type     | Description                                                                                                                    |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `status.phase`         | string   | `Provisioning \| Initializing \| Ready \| Degraded \| Failed`.                                                                    |
+| `status.pvcName`       | string   | The provisioned PVC name.                                                                                                         |
+| `status.serviceName`   | string   | ClusterIP Service serving gfsc **reads** through the writer + readers.                                                            |
+| `status.serviceUrl`    | string   | In-cluster base URL of the read Service (e.g. `http://gfsc.gfs.svc.cluster.local:8087`). Mutations go through a separate writer-only Service, not this URL. |
+| `status.conditions[]`  | object[] | Standard `{type, status, reason, message, lastTransitionTime}` condition list.                                                    |
+
+## Additional Printer Columns
+
+`kubectl get globalfilesystems` displays: Phase, PVC, Service URL.
+
+## Example
+
+```yaml
+apiVersion: clerum.io/v1alpha1
+kind: GlobalFileSystem
+metadata:
+  name: gfs
+  namespace: gfs
+spec:
+  storage:
+    size: 1Gi
+    storageClassName: standard # minikube; GKE overlays use standard-rwo
+    accessModes:
+      - ReadWriteOnce
+  layout:
+    rootDirectories:
+      - /org
+      - /system/published-workflow-artifacts
+  security:
+    runAsUser: 1000
+    fsGroup: 1000
+  readerReplicas: 1 # minikube is resource-constrained; writer is always 1
+  retainOnDelete: true
+```
+
+Working sample:
+[deploy/overlays/minikube/instances/globalfilesystem.yaml](../../deploy/overlays/minikube/instances/globalfilesystem.yaml).
 
 ## Security notes
 
 - Treat GFS as a high-sensitivity data plane.
-- Tokens are a ceiling; permission store is re-checked fail-closed on operations.
+- Tokens are a ceiling; the permission store is re-checked fail-closed on
+  every operation, not just at token-mint time.
 - See root [Security model](../../README.md#security-model).
 
 ## Related
 
+- [SharedFileSystem CRD](sharedfilesystem.md) — the other, per-team read-only
+  storage plane; not replaced by GFS
 - [CRD index](README.md)
 - [gfs-controller](../../gfs-controller/) (service tree)


### PR DESCRIPTION
## Summary
- `docs/crds/globalfilesystem.md` described the CRD only as "PVC plus writer/reader deployments" and was missing about half the shipped schema: `readerReplicas`, `layout.rootDirectories`, `security`, `retainOnDelete`, and the entire `status` block.
- Adds a **Concepts** section explaining the `gfsc` broker, `gfs://` stable references, grant-vs-share, and `manage_acl` — the mental model needed to actually use the CRD, not just its field list.
- Adds the missing `Status` table and `Additional Printer Columns` section, matching the house style used by the other `docs/crds/*.md` files.
- Replaces the placeholder example with the real minikube instance manifest.

## Grounding
Source material for this pass was a Notion draft ("Global File System (gfs) — map & editions index"), but nothing was copied from it directly — it's dated 2026-06-17, still says "Apache 2.0" (repo relicensed to MPL-2.0 on 2026-07-13), and mixes in Enterprise/multi-tenant/pricing content that has no place in the OSS docs tree. Every claim in this PR was instead verified against:
- `charts/clerum-crds/crds/globalfilesystem.yaml` (the actual schema)
- `gfs-controller/src/api/read.ts`, `gfs-controller/src/authz/*.ts` (gfs:// format, grant/share/manage_acl permission strings, token-ceiling behavior)
- `deploy/overlays/minikube/instances/globalfilesystem.yaml` (the real working example, now linked instead of a synthetic one)

Follows `docs/meta/claims-guardrails.md` (every public claim backed by code in this repo) and `docs/meta/docs-roadmap.md`'s non-goals (no commercial/tenant content, no stale license language).

## Test plan
- [x] Diffed against `origin/main` — only this file changed.
- [x] Verified all relative links in the doc resolve (`sharedfilesystem.md`, `README.md`, the minikube example, `gfs-controller/`, root `README.md#security-model`).
- [x] Cross-checked every new field/claim against the CRD YAML and `gfs-controller/src`.
- [ ] Docs-only change — no build/test suite to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)