### PR TITLE
docs: fix mermaid parse error in Sanitization Sequence diagram

### DIFF
--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -419,11 +419,11 @@ sequenceDiagram
         HCC->>K8s: Ready = True (WrcOwnedRuntimeReady) — WRC built the Deployment
     else spec.managed = true (stdio recipe servers, control-api servers)
         Note over HCC: sanitizeCrdSpec() — coerce, do not reject
-        HCC->>HCC: Drop imagePullPolicy; force non-root gid/fsGroup
+        HCC->>HCC: Drop imagePullPolicy, force non-root gid/fsGroup
         HCC->>HCC: Strip forbidden capabilities and env vars
         HCC->>HCC: Clamp resource limits (unit-naive — see table)
 
-        HCC->>HCC: Validate Secret; classify image against allowlist
+        HCC->>HCC: Validate Secret, classify image against allowlist
 
         alt Secret invalid, or image denied in enforce mode
             HCC->>K8s: status.conditions[Ready] = False (reason + message)


### PR DESCRIPTION
## Problem

The **Sanitization Sequence** `sequenceDiagram` in `docs/architecture/platform-topology.md` fails to render on GitHub:

> Unable to render rich display — Parse error on line 15 … got 'NEWLINE'

## Root cause

Mermaid treats `;` as a statement separator. Two message labels contained semicolons, so each was split mid-message and the trailing fragment was rejected:

- `Drop imagePullPolicy; force non-root gid/fsGroup`
- `Validate Secret; classify image against allowlist`

## Fix

Swap the two semicolons for commas (reads identically). Four characters changed, one file.

## Verification

- ✅ The diagram now **parses and renders** — real headless Chromium, mermaid 11, `securityLevel: strict`.
- ✅ Swept **every mermaid block in the repo** (28 diagrams across 9 files) through an actual render — **28/28 render cleanly, 0 failures**. This was the only broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)