### PR TITLE
docs: use the LeadForge plugin sandbox as the README's Desktop App hero shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 [What is evenfire](#what-is-evenfire) · [The platform](#the-platform) · [See it work](#see-it-work) · [Why evenfire](#why-evenfire) · [Get started](#get-started-minikube) · [Architecture](#architecture) · [Security model](#security-model) · [Docs](docs/README.md) · [License](#community-and-license)
 
 <p align="center">
-  <img src="docs/assets/desktop-app-approval.webp" alt="Desktop App: an agent tool call held at an in-chat approval gate with Approve and Deny buttons" width="49%" />
+  <img src="docs/assets/desktop-app-sandbox-ui.webp" alt="Desktop App: the LeadForge prospecting plugin rendered inside the app, with its own dashboard, outreach pipeline, approval queue, and charts" width="49%" />
   <img src="docs/assets/control-ui-usage-dashboard.webp" alt="Control UI: the Cost &amp; Usage console with token totals and a stacked area chart of usage by agent" width="49%" />
 </p>
 
-<p align="center"><sub><b>Left:</b> the Desktop App holds a risky tool call at an in-chat approval gate. <b>Right:</b> the Control UI console governs the fleet — usage, budgets, and model prices. <a href="docs/surfaces/README.md">Tour all three UIs →</a></sub></p>
+<p align="center"><sub><b>Left:</b> a plugin renders its own full UI — the LeadForge prospecting app, approval queue and all — inside the Desktop App. <b>Right:</b> the Control UI console governs the fleet — usage, budgets, and model prices. <a href="docs/surfaces/README.md">Tour all three UIs →</a></sub></p>
 
 ---
 


### PR DESCRIPTION
Follow-up to #77 (already merged). Swaps the README's **left** hero image from the in-chat approval gate to the **LeadForge prospecting app rendered inside the Desktop App**.

## Why
The sandbox shot is denser and higher-impact for a first-time visitor, and it showcases a capability the approval gate can't: a plugin/recipe rendering its **own full UI** inside the Desktop App (the apps platform). The approval story is still covered under **See it work** and the approval gate stays in the Desktop App surface doc.

## What changed
- `README.md` only — 2 lines: the left `<img>` (`desktop-app-approval.webp` → `desktop-app-sandbox-ui.webp`, new alt text) and the caption.
- New caption: *"Left: a plugin renders its own full UI — the LeadForge prospecting app, approval queue and all — inside the Desktop App. Right: the Control UI console governs the fleet…"*
- No new assets — `desktop-app-sandbox-ui.webp` already shipped in #77.

## Notes
- Caption kept factual per `docs/meta/claims-guardrails.md`: "approval queue" refers to LeadForge's own outreach-approval queue (visible in the shot), **not** evenfire's platform approval gate — deliberately not conflated.
- Right image unchanged (Control UI usage dashboard). The two shots are both dark consoles; accepted that mild similarity for the sandbox's higher impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)