### PR TITLE
docs: fix factual errors and coherence issues from full-tree review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ NetworkPolicy owned by whichever component is responsible for that selector.
 | [mcp-proxy](mcp-proxy/)                   | Optional centralized MCP router (`MCP_PROXY_ENABLED`); discovers servers via HCC       |
 | [stdio-bridge](stdio-bridge/)             | Sidecar translating stdio MCP transport to StreamableHTTP; injected by HCC             |
 | [nginx-egress-proxy](nginx-egress-proxy/) | Image only — the pinned egress path HCC deploys for remote (`spec.remote`) MCP servers |
-| [mcp-servers](mcp-servers/)               | First-party MCP servers (Airtable, MongoDB, Playwright, web-search, …)                 |
+| [mcp-servers](mcp-servers/)               | Platform-packaged MCP servers — first-party (Airtable, web-search) plus upstream images (MongoDB, Playwright, …) |
 
 ### Recipes & sandbox — `sandbox-recipes`, `sandbox-ui` (both deny-all)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,8 +19,8 @@ We aim to **acknowledge within 3 business days** and to keep you informed of
 the fix timeline. Please give us a reasonable window before any public
 disclosure.
 
-If `security@evenfire.ai` is unreachable, use the maintainers listed in
-[GOVERNANCE.md](GOVERNANCE.md) / the GitHub org owners via a private channel.
+If `security@evenfire.ai` is unreachable, reach the core maintainers / GitHub
+org owners via a private channel (see [GOVERNANCE.md](GOVERNANCE.md)).
 
 ## Supported versions
 

--- a/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
+++ b/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
@@ -1580,7 +1580,7 @@ The canonical sandbox-UI shape is "thin static-asset UI pod + sibling credential
 
 `control-api` ServiceAccount needs:
 
-- `mcp-server` ns: Role `control-api-mcp-resources` covering `contexts`, `mcpservers`, `workflowrecipes` — `deploy/base/mcp-server/rbac.yaml`.
+- `mcp-server` ns: Role `control-api-mcp-resources` covering `contexts`, `mcpservers` — `deploy/base/mcp-server/rbac.yaml`.
 - `sandbox-recipes` ns: Role `control-api-workflow-recipes-sandbox` for `workflowrecipes` — `deploy/base/sandbox-recipes/rbac.yaml`.
 
 Both are part of the `deploy/base` kustomize bases (each namespace's `kustomization.yaml` lists `rbac.yaml`) and are applied with the rest of the deployment manifests. Without them, all `/api/v1/admin/recipes` calls return 500.
@@ -1601,17 +1601,19 @@ Same UI handles in-place edits (`/workflow-recipes/[ns]/[name]?edit=1`), uninsta
 > Use this path for CI pipelines, bulk operations, or scripting. For one-off installs, use the Control UI (§13.2). Manual `kubectl` / `curl` paths bypass the UI's pre-flight validation, defaults, and audit trail.
 
 ```bash
-TOKEN=$(curl -s -X POST http://localhost:8090/api/v1/admin/auth/login \
+# Login sets an HttpOnly session cookie (control_ui_admin_session) — it does
+# NOT return a token in the body. Store it in a cookie jar with -c, then send
+# it back with -b; the admin gate ignores the Authorization header.
+curl -s -c /tmp/clerum-admin.jar -X POST http://localhost:8090/api/v1/admin/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"<password>"}' | jq -r '.token')
+  -d '{"username":"admin","password":"<password>"}' | jq .
 
-curl -s -X POST http://localhost:8090/api/v1/admin/recipes \
-  -H "Authorization: Bearer $TOKEN" \
+curl -s -b /tmp/clerum-admin.jar -X POST http://localhost:8090/api/v1/admin/recipes \
   -H "Content-Type: application/json" \
   -d @recipe.json | jq .
 ```
 
-API routes (all require `Authorization: Bearer <admin_jwt>`):
+API routes (all require the `control_ui_admin_session` cookie from login):
 
 | Method | Route |
 |---|---|
@@ -1724,8 +1726,8 @@ kubectl get workflowrecipe <name> -n sandbox-recipes \
 kubectl get workflowrecipe <name> -n sandbox-recipes \
   -o jsonpath='{.status.workflowExecution.phase}'
 
-# Via control-api
-curl -s -H "Authorization: Bearer $TOKEN" \
+# Via control-api (reuse the login cookie jar from §13.3)
+curl -s -b /tmp/clerum-admin.jar \
   http://localhost:8090/api/v1/admin/recipes/<name>/status | jq .
 ```
 
@@ -2118,7 +2120,7 @@ yq -o=json '.' recipe.yaml > recipe.json
 python3 -c 'import sys,yaml,json; json.dump(yaml.safe_load(open("recipe.yaml")),sys.stdout,indent=2)' > recipe.json
 ```
 
-**Recipe naming inside the cluster.** When a recipe is installed from the registry (the Control-UI path), the installed CR is **not** named after your `metadata.name`. (A direct `kubectl apply -f recipe.yaml`, §13, does keep it.) Control-API derives the name from the **registry entry** name and version: `recipe-<entry-name>-v<version-with-dashes>-<hash8>` (e.g. `recipe-sales-crm-v1-0-0-87c8cacc`; `control-api/src/routes/admin/registry.ts`). Your `metadata.name` is not carried over as a label — the only label applied at install is `clerum.io/managed-by: control-api`; the catalog entry name and version are stored as the **annotations** `clerum.io/catalog-id` and `clerum.io/catalog-version` (org-scoped names are illegal label values). So `kubectl get workflowrecipe <metadata.name>` returns `NotFound`. Look it up by substring or by annotation:
+**Recipe naming inside the cluster.** When a recipe is installed from the registry (the Control-UI path), the installed CR is **not** named after your `metadata.name`. (A direct `kubectl apply -f recipe.yaml`, §13, does keep it.) Control-API derives the name from the **registry entry** name and version: `mcp-<entry-name>-v<version-with-dashes>-<hash8>` (e.g. `mcp-sales-crm-v1-0-0-87c8cacc`; `control-api/src/routes/admin/registry.ts`). Your `metadata.name` is not carried over as a label — the only label applied at install is `clerum.io/managed-by: control-api`; the catalog entry name and version are stored as the **annotations** `clerum.io/catalog-id` and `clerum.io/catalog-version` (org-scoped names are illegal label values). So `kubectl get workflowrecipe <metadata.name>` returns `NotFound`. Look it up by substring or by annotation:
 
 ```bash
 kubectl get workflowrecipes -A | grep <your-entry-name>
@@ -2176,14 +2178,14 @@ Steps 4 and 6 are the only operator-action steps; the rest is platform automatio
 
 **Step 2 — `spec.description` spells out every prerequisite.** The Slack OAuth app, the redirect URI to register (`http://<control-api-host>/api/v1/oauth-callback/slack-bot`), and the `kubectl create secret generic slack-oauth-creds ...` command.
 
-**Step 3 — publish via Control UI.** Open **Marketplace** → **Recipes** → **+ Install Recipe** → paste JSON → **Validate** → **Deploy Recipe**. The entry is now in Clerum's centralized registry and visible to every cluster.
+**Step 3 — publish via Control UI.** Open the **Registry → Publish** page (`/registry/publish`) → paste JSON → **Validate** → **Publish**. The entry is now in Clerum's centralized registry and visible to every cluster.
 
 **Step 4 — operators install it.** From any Clerum cluster's Control UI: discover, create the prerequisite Secret, click Install.
 
 **Step 5 — verify on a test install:**
 
 ```bash
-# The installed CR is named recipe-<entry>-v<version>-<hash>, NOT
+# The installed CR is named mcp-<entry>-v<version>-<hash>, NOT
 # "sandbox-ui-oauth-hello" (§14.5) — resolve it first.
 RECIPE=$(kubectl get workflowrecipes -n sandbox-recipes -o name \
   | grep sandbox-ui-oauth-hello)

--- a/docs/architecture/non-mcp-services.md
+++ b/docs/architecture/non-mcp-services.md
@@ -58,7 +58,7 @@ manifest is retargeted out of the recipe's own namespace, WRC strips its
 (`adjustManifestNamespace`, same file). Same-namespace owner refs are kept. A
 finalizer drives cleanup of the cross-namespace resources.
 
-## NetworkPolicy layers (L0–L3)
+## NetworkPolicy layers (L0–L3-egress)
 
 Every runtime namespace is deny-all by default; each layer opens exactly what is
 needed.
@@ -68,9 +68,9 @@ needed.
 | **L0** | Security baseline         | `deny-all` NetworkPolicy — both Ingress and Egress — per runtime namespace                                                                                                                                                                                                                                                       |
 | **L1** | Functional infrastructure | DNS egress (port 53) for **every** pod in the namespace. HCC-API and K8s-API egress are pod-selector-scoped, not namespace-wide: in `sandbox-recipes`, HCC-API egress selects `clerum.io/component=workflow-mcp-host` and K8s-API egress selects `clerum.io/k8s-api-egress=true` — so a plain non-MCP workload gets **DNS only** |
 | **L2** | Context isolation         | Per `(Context, McpServer)` pair: an ingress policy on the McpServer pod in `mcp-server`, plus egress counterparts in `mcp-host` and `rpc-proxy` (without them, L0's egress deny-all would block agents from reaching the server)                                                                                                 |
-| **L3** | Egress control            | External egress per McpServer `egressBindings` (CIDR or DNS)                                                                                                                                                                                                                                                                     |
+| **L3-egress** | Egress control     | External egress per McpServer `egressBindings` (CIDR or DNS)                                                                                                                                                                                                                                                                     |
 
-> **Policy ownership.** L2 and L3 above are HCC's policies for **McpServer**
+> **Policy ownership.** L2 and L3-egress above are HCC's policies for **McpServer**
 > pods. The policies for a _recipe workload's_ `egressBindings` are built by WRC
 > itself, in that workload's own namespace
 > (`buildWorkloadEgressNetworkPolicy` / `buildWorkloadIngressNetworkPolicy`).

--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -748,7 +748,7 @@ flowchart TD
 
 **What it does**: Creates a `NetworkPolicy` in each runtime namespace that selects all pods (`podSelector: {}`) and blocks all ingress and all egress traffic with no exceptions.
 
-**Applied to**: `mcp-server`, `sandbox-recipes`, `rpc-proxy`, `sandbox-ui` — HCC's four runtime namespaces (`CONTEXT_MAPPER_RUNTIME_NAMESPACES`). `mcp-host` is not one of them: it gets an equivalent static `deny-all-mcp-host` policy from `deploy/base/mcp-host/networkpolicies.yaml` instead (see §19.4.3).
+**Applied to**: `mcp-server`, `sandbox-recipes`, `rpc-proxy`, `sandbox-ui` — HCC's four runtime namespaces (`CONTEXT_MAPPER_RUNTIME_NAMESPACES`). `mcp-host` is not one of them: it gets an equivalent static `deny-all-mcp-host` policy from `deploy/base/mcp-host/networkpolicies.yaml` instead (see §19, item 3).
 
 **Why it matters**: This is the foundation of the entire security model. Without L0, any pod deployed into a runtime namespace could immediately communicate with any other pod in the cluster. L0 ensures that the **default state is zero connectivity** — nothing works until a higher layer explicitly opens a path. This is analogous to `iptables -P INPUT DROP` and `iptables -P OUTPUT DROP` in Linux.
 

--- a/docs/architecture/workflow-recipe-naming.md
+++ b/docs/architecture/workflow-recipe-naming.md
@@ -80,15 +80,17 @@ the parent stem, which truncates user-chosen parent names mid-word (e.g.
 `competitive-intel-report` → `competitive-intel-repor`) and erodes
 debuggability.
 
-Truncating the run ID to 8 characters (first octet of the UUID, 32 bits
-of entropy) raises the parent-stem budget to `63 − 8 − 1 = 54` bytes
-while keeping the collision probability inside a single parent at
+Truncating the run ID to 8 characters (the first 8 hex characters of the
+UUID, 32 bits of entropy) raises the parent-stem budget to `63 − 8 − 1 = 54`
+bytes while bounding the collision probability inside a single parent at
 
-> 50 % after roughly 2³² ≈ 4.3 billion runs (birthday bound)
+> ~50 % after roughly 2¹⁶ ≈ 65,000 runs of the **same** parent (birthday
+> bound on a 32-bit suffix)
 
-For reference: even at 1 run/second, that is **136 years** of continuous
-triggering on a single parent recipe. We treat this as safe for both
-development and production.
+This is a per-parent bound — only runs that share one parent recipe draw from
+the same 32-bit suffix space, so the practical risk depends on how often a
+single parent is triggered. Callers that expect high run counts on one parent
+can widen the space with a longer `short-run-id` (below).
 
 If a caller explicitly opts into higher collision resistance they can
 pass a longer `short-run-id` — the function accepts it and shortens the

--- a/docs/crds/communicationchannel.md
+++ b/docs/crds/communicationchannel.md
@@ -18,9 +18,11 @@ Telegram personal approval accounts are verified separately from Profile UI.
 
 ### Core
 
-| Field          | Type   | Required | Description                                                                                                                      |
-| -------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `spec.hostRef` | string | yes      | Reference to the Host this channel configuration belongs to. The channel-reader uses this to filter which channels it processes. |
+| Field                          | Type     | Required | Description                                                                                                                                                                                                                                                            |
+| ------------------------------ | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spec.hostRef`                 | string   | yes      | Reference to the Host this channel configuration belongs to. The channel-reader uses this to filter which channels it processes.                                                                                                                                       |
+| `spec.credentialsSecretRef`    | object   | no       | Reference (`{ name }`) to a Secret in the `channels` namespace holding provider credentials for this channel — keyed by type: `telegram-bot-token`, `slack-bot-token`, `slack-signing-secret`, `email-username`, `email-password`. Auto-created as `cc-<ccname>-credentials` when set via the Control UI; raw YAML may point at a shared Secret. |
+| `spec.access`                  | object   | no       | Users and teams allowed to connect conversations to this channel: `access.users[]` and `access.teams[]` (string lists). The Control UI restricts these to principals that already have access to `hostRef`.                                                            |
 
 ### Telegram
 
@@ -30,7 +32,19 @@ Telegram personal approval accounts are verified separately from Profile UI.
 | `spec.telegram[].channelId`              | string                              | yes      | Identifier for this Telegram private chat, group, or supergroup.                                                                                                                                                                                                                             |
 | `spec.telegram[].chatType`               | `private`, `group`, or `supergroup` | yes      | Explicit Telegram chat type for this operational channel. `channel` cannot identify a personal approver and remains unsupported.                                                                                                                                                             |
 | `spec.telegram[].userIds`                | string[]                            | no       | Optional transport pre-filter for Telegram user IDs. This does not verify personal accounts or authorize workflow actions.                                                                                                                                                                   |
+| `spec.telegram[].title`                  | string                              | no       | Telegram chat title or private-chat display name captured at setup.                                                                                                                                                                                                                          |
+| `spec.telegram[].handle`                 | string                              | no       | Telegram username/handle captured at setup (no secrets).                                                                                                                                                                                                                                     |
+| `spec.telegram[].confirmedByUserId`      | string                              | no       | Clerum user ID that confirmed this conversation. Required for workflow approval authorization (see the upgrade note below).                                                                                                                                                                  |
+| `spec.telegram[].confirmedAt`            | string (date-time)                  | no       | Time this conversation was confirmed.                                                                                                                                                                                                                                                        |
 | `spec.telegram[].replyOnlyWhenMentioned` | boolean                             | no       | If `true`, in groups and supergroups the bot only processes messages that @mention the bot, use a `text_mention` entity for the bot, or reply to the bot. Private chats are unaffected. `/approve` and `/deny` commands are always accepted from verified users after backend authorization. |
+
+#### Telegram global settings
+
+| Field                                          | Type    | Required | Description                                                                                                                        |
+| ---------------------------------------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `spec.telegramSettings`                        | object  | no       | Global Telegram bot behavior for conversations confirmed later.                                                                    |
+| `spec.telegramSettings.botHandle`              | string  | no       | Public Telegram bot handle (pattern `^@?[A-Za-z0-9_]{5,32}$`) shown to users during setup. Not a secret — the token stays in the credentials Secret. |
+| `spec.telegramSettings.replyOnlyWhenMentioned` | boolean | no       | If `true`, group and supergroup messages must mention or reply to the bot.                                                         |
 
 ### Email
 
@@ -56,6 +70,16 @@ Telegram personal approval accounts are verified separately from Profile UI.
 > `workspaceId` (the modern form — required for workflow approvals), **or**
 > `userNames` (the legacy chat-allowlist form). An entry with only `channelId` is
 > rejected at admission.
+
+#### Slack global settings
+
+| Field                                       | Type    | Required | Description                                                                                                        |
+| ------------------------------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `spec.slackSettings`                        | object  | no       | Public Slack app metadata and global bot behavior for conversations confirmed later. App secrets stay in `credentialsSecretRef`. |
+| `spec.slackSettings.workspaceId`            | string  | no       | Slack workspace/team ID (pattern `^T[A-Z0-9]+$`) used while conversations are confirmed.                          |
+| `spec.slackSettings.botHandle`              | string  | no       | Slack App name shown to users during setup.                                                                       |
+| `spec.slackSettings.replyOnlyWhenMentioned` | boolean | no       | If `true`, process Slack messages only when the app is mentioned.                                                 |
+| `spec.slackSettings.replyInThreads`         | boolean | no       | If `true`, app responses are posted in a thread for the triggering message and follow-ups in that thread continue there. |
 
 At least one channel group (`telegram`, `email`, or `slack`) should be defined for the
 CRD to be useful, though the schema does not enforce this.

--- a/docs/crds/mcpserver.md
+++ b/docs/crds/mcpserver.md
@@ -137,7 +137,7 @@ An McpServer with `spec.remote` must declare at least one `egressBinding`.
 | `spec.egressBindings[].egressClass` | string | no | Egress class. `exact-host` is the default for `dns`/`cidr` bindings. `public-web` is explicit public TCP 80/443 egress with private, metadata, cluster-internal, link-local, multicast, and reserved ranges blocked. |
 | `spec.egressBindings[].dns` | string | no | DNS hostname to resolve (e.g. `api.openai.com`). Mutually exclusive with `cidr`. |
 | `spec.egressBindings[].cidr` | string | no | Public IPv4 CIDR range (e.g. `203.0.114.10/32`). Mutually exclusive with `dns`. Must use canonical network notation and must not overlap private, metadata, link-local, documentation, multicast, or reserved IPv4 ranges (this rejects `0.0.0.0/0` and any RFC1918 range such as `10.0.0.0/8`). |
-| `spec.egressBindings[].port` | integer | yes | Destination port number. |
+| `spec.egressBindings[].port` | integer | conditional | Destination port number. Required for `exact-host` bindings; `public-web` bindings must omit it. |
 | `spec.egressBindings[].protocol` | string | no | Network protocol for exact-host bindings. One of: `TCP`, `UDP`. If omitted, the controller treats exact-host as `TCP`; public-web must omit this field. |
 
 Validation rules enforce that exactly one of `dns` or `cidr` must be set per binding, and

--- a/docs/crds/workflowrecipe.md
+++ b/docs/crds/workflowrecipe.md
@@ -642,7 +642,7 @@ workloads:
     # --- DaemonSet-specific (type: daemonset) ---
     # Requires explicit operator annotation (OPA policy: clerum.io/daemonset-approved).
 
-    # --- StatefulSet-specific (type: stateset) ---
+    # --- StatefulSet-specific (type: statefulset) ---
     # A headless Service (clusterIP: None) is auto-created for stable pod DNS.
     # Pod DNS: <recipe>-<workload-id>-N.<recipe>-<workload-id>.<namespace>.svc.cluster.local
     volumeClaimTemplates: # Per-replica PVCs (StatefulSet only).

--- a/docs/deploy/minikube.md
+++ b/docs/deploy/minikube.md
@@ -47,7 +47,7 @@ Ready before E2E results are interpreted.
 - **minikube** v1.30+ (`brew install minikube`)
 - **kubectl** (`brew install kubectl`)
 - **python3** (for JWT key sync)
-- **Node.js** 20+ (for building services and desktop app)
+- **Node.js** 24+ (for building services and desktop app)
 - `.env` file at project root with LLM API keys (optional — uses placeholders if missing)
 
 ---

--- a/docs/how-to/connect-telegram.md
+++ b/docs/how-to/connect-telegram.md
@@ -68,7 +68,7 @@ pre-filter). See [Control UI](../surfaces/control-ui.md).
 ## Approvals over Telegram
 
 When approval policy enables Telegram approvers, approval requests arrive with
-inline **Approve / Deny** buttons (or reply `/approve <target>`); callbacks are
+inline **Approve / Deny** buttons (or reply `/approve` / `/deny`); callbacks are
 signature-checked and authorized before a decision is applied. See
 [Configure approvals](configure-approvals.md).
 

--- a/docs/surfaces/README.md
+++ b/docs/surfaces/README.md
@@ -57,9 +57,9 @@ and an admin's Control UI session cannot invoke agents through `rpc-proxy`.
 Channel users — people talking to an agent over Telegram, Slack, or email —
 never touch any of these UIs. Their messages reach the platform through
 `channel-reader`, and when a tool call needs a human decision, the approval
-arrives right in that same conversation: an inline button on Telegram and
-Slack, or a reply command (`/approve <name>`) on email. See
-[Configure approvals](../how-to/configure-approvals.md).
+arrives right in that same conversation: a reply command (`/approve` /
+`/deny`) on any channel, plus inline Approve/Deny buttons on Telegram and
+Slack. See [Configure approvals](../how-to/configure-approvals.md).
 
 ## Next
 

--- a/workflow-recipes/src/workflow/childRecipeFactory.ts
+++ b/workflow-recipes/src/workflow/childRecipeFactory.ts
@@ -64,8 +64,8 @@ const K8S_LABEL_VALUE_MAX = 63
 
 // Short-form run-id suffix used by buildDbRunChildName. 8 hex chars =
 // 32 bits of entropy, which lifts the parent-stem budget to 54 bytes
-// (63 − 1 separator − 8 suffix). Birthday-bound collision ≈ 2³² runs
-// per parent (~136 years at 1 run/sec). See §2.3 of
+// (63 − 1 separator − 8 suffix). Birthday-bound collision ≈ 2¹⁶ (~65k)
+// runs of the same parent. See §2.3 of
 // docs/architecture/workflow-recipe-naming.md.
 const RUN_ID_SHORT_LEN = 8
 


### PR DESCRIPTION
## Summary

Whole-documentation review pass across `docs/` and the root-level docs. Every finding was verified against the actual code, CRD schemas, scripts, and manifests before fixing. 12 docs files + 1 comment-only code fix.

**Factual errors (would mislead a reader following along):**
- **Admin-API auth was broken** in the recipe guide (§13.3/§13.5): it read a Bearer token from the login response, but `control-api` login sets an HttpOnly cookie (`control_ui_admin_session`) and returns no token — the `Authorization` header is ignored (`controlUIAuth.ts`). Switched to the cookie-jar flow, matching `workflow-recipes-guide.md`.
- **Wrong RBAC scope** — claimed the `mcp-server` `control-api-mcp-resources` role grants `workflowrecipes`; it grants only `contexts`/`mcpservers` (`deploy/base/mcp-server/rbac.yaml`).
- **Wrong installed-CR name prefix** — `recipe-…` → `mcp-…` (`control-api/src/routes/admin/registry.ts` `generateRegistryName`).
- **Birthday-bound math** — a 32-bit suffix reaches ~50% collision at ~2¹⁶ (~65k) runs, not "2³² ≈ 4.3 billion / 136 years". Corrected the doc and the matching comment in `childRecipeFactory.ts`; also "first octet" → "first 8 hex characters".
- **CRD correctness** — `mcpserver` `egressBindings[].port` is conditional (exact-host only), not required; `workflowrecipe` workload-type typo `stateset` → `statefulset`.
- **Provenance overclaim** — MongoDB/Playwright MCP servers use upstream images, so "First-party MCP servers" was inaccurate (also a `claims-guardrails.md` item).
- **Node.js 24+** in `minikube.md` (was stale "20+", contradicting `.nvmrc` and the e2e guide).

**Completeness / coherence:**
- **CommunicationChannel CRD reference** was missing shipped schema fields — added `credentialsSecretRef`, `access`, the Telegram entry `title`/`handle`/`confirmedByUserId`/`confirmedAt`, and the `telegramSettings` / `slackSettings` blocks.
- **Approval command** — docs showed `/approve <name>` for tool-call approvals, but that argument form is workflow-recipe-only; the tool-call command is a bare `/approve` / `/deny` and is channel-agnostic (`channel-reader/src/channels/base.ts`). Fixed in `surfaces/README.md` and `how-to/connect-telegram.md`.
- **NetworkPolicy layer naming** — relabeled `L3` → `L3-egress` in `non-mcp-services.md` to match the "source of truth" `platform-topology.md`.
- Fixed a dangling `§19.4.3` cross-reference (`platform-topology.md`) and a dead-end maintainer reference in `SECURITY.md` (GOVERNANCE lists no named maintainers).

Rebased onto latest `main`; re-verified against the recently merged UI-surfaces docs (#75–78).

## Testing

- [ ] `npm test` passes for changed services — n/a: docs-only change plus one comment-only edit in `childRecipeFactory.ts` (no runtime behavior touched).
- [ ] `npx tsc --noEmit` clean — n/a for the same reason.
- [x] All relative markdown links and image references resolve (checked programmatically across all docs).
- [x] Every corrected claim cross-checked against the CRD YAML, service code, scripts, and manifests it references.

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1G6585jhvSYJr8Xm88Tr9)_