### PR TITLE
docs: consistency pack — Node 24, UI install, approval model, seed disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ npm run ui              # Control UI + Profile UI + Desktop App
 
 Log in as `test@clerum.io` / `changeme123!`, message the `chatllm` agent, and
 ask it to run a command or generate a PDF — then approve the tool call from the
-chat. The Desktop App is the client you just used; Control UI is the admin
-console for the same fleet — both are toured in
+chat. These are seeded local-minikube credentials — change them before any
+shared or production-like environment. The Desktop App is the client you just
+used; Control UI is the admin console for the same fleet — both are toured in
 [docs/surfaces/](docs/surfaces/README.md).
 
 Prefer the API path? The full curl walkthrough exercises the real session →

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1138,7 +1138,7 @@ The MCP servers maintain comprehensive test coverage validating CRD configuratio
 | **Total Test Files** | 8 files       |
 | **Total Unit Tests** | ~110 tests    |
 | **Test Framework**   | Vitest 4.0.18 |
-| **Environment**      | Node.js 20.x+ |
+| **Environment**      | Node.js 24.x+ |
 
 #### Test Organization
 

--- a/docs/concepts/why-evenfire.md
+++ b/docs/concepts/why-evenfire.md
@@ -26,8 +26,10 @@ runtime and multi-channel surfaces.
 
 ## What evenfire optimizes for
 
-1. **Human-in-the-loop by default** — MCP tool calls pause for explicit
-   approve/deny; pending approvals survive restarts.
+1. **Human-in-the-loop by default** — with the approval system on (the default),
+   MCP tool calls always pause for explicit approve/deny, as do the risky native
+   tools (`shell_exec`, `http_request`, `cron_manage`, `browser_open`,
+   `browser_navigate`); pending approvals survive restarts.
 2. **Least privilege at the network layer** — a `Context` allowlists MCP
    servers; unlisted servers are unreachable via default-deny NetworkPolicies.
 3. **Declarative fleet** — Hosts, channels, connectors, and workflows are

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -15,7 +15,7 @@ named `chatllm` you can message immediately.
 - **minikube** v1.30+ (`brew install minikube`)
 - **kubectl**
 - **python3** (used by the JWT key sync)
-- **Node.js 20+** (service builds; desktop app)
+- **Node.js 24+** (service builds; desktop app)
 - One LLM API key: OpenAI, Anthropic Claude, Z.AI, or Alibaba Bailian
 
 ## 1. Configure
@@ -51,6 +51,8 @@ minikube's Docker → deploy → readiness wait with auto-recovery → seed → 
 
 It seeds for you:
 
+> Seeded credentials below are for local minikube only — change them before any shared or production-like environment.
+
 - an agent: Host `chatllm` + Context `context1` + a CommunicationChannel
 - a desktop/API login: **`test@clerum.io` / `changeme123!`**
 - a Control UI admin: **`admin` / `changeme123!`**
@@ -68,6 +70,7 @@ Useful re-runs: `make minikube-setup ARGS="--skip-build"` (redeploy in ~1 min) �
 ## 3. Say hello — desktop app
 
 ```bash
+make install-all && npm --prefix control-ui install
 npm run ui     # runs Control UI (:3000), Profile UI (:3001), and the Desktop App
 ```
 

--- a/docs/how-to/configure-approvals.md
+++ b/docs/how-to/configure-approvals.md
@@ -1,8 +1,13 @@
 # How to: configure human-in-the-loop approvals
 
-evenfire treats tool execution as untrusted by default. MCP tool calls can
-**suspend** until an explicit approve or deny. Pending approvals are persisted
-so they survive pod restarts.
+The approval system is **on by default** (`CLERUM_ENABLE_APPROVAL` defaults to
+`true`). **MCP tool calls always require approval** — they **suspend** until an
+explicit approve or deny, and the per-tool overrides below do not apply to them.
+Among **native** tools, five require approval by default — `shell_exec`,
+`http_request`, `cron_manage`, `browser_open`, and `browser_navigate` — while
+every other native tool runs without prompting; each native tool can be flipped
+with a per-tool override on `Host.spec.approval`. Pending approvals are
+persisted so they survive pod restarts.
 
 ## Mental model
 
@@ -12,7 +17,7 @@ so they survive pod restarts.
    configured).
 4. Runtime continues or aborts.
 
-## Dev / Compose
+## Dev mode (no cluster)
 
 Environment knobs on `mcp-host` (see [mcp-host README](../../mcp-host/README.md)):
 

--- a/docs/meta/claims-guardrails.md
+++ b/docs/meta/claims-guardrails.md
@@ -33,7 +33,7 @@ caveats over absolute language.
 - Public name **evenfire** / code name **clerum** (`clerum.io`, `CLERUM_*`)
 - Single-service dev mode (`CLERUM_DEV_MODE`) is **not** full platform security
 - Budgets are cost control, not security
-- Approvals default-on for **MCP** tools (native tool overrides exist)
+- Approvals default-on for **MCP** tools (always) and for the five risky **native** tools (`shell_exec`, `http_request`, `cron_manage`, `browser_open`, `browser_navigate`); per-tool overrides on `Host.spec.approval` apply to native tools only
 
 ## Review checklist
 

--- a/docs/surfaces/control-ui.md
+++ b/docs/surfaces/control-ui.md
@@ -49,9 +49,9 @@ five steps live together.
    the host detail page. A per-tool approval editor with three settings —
    **Default / Required / Skip** — and a risk hint whenever an override
    loosens a tool whose built-in default is Required (for example, setting
-   `shell_exec` or `http_request` to Skip). Approvals are default-on for MCP
-   tools; native tools carry per-tool overrides, and the safe default per
-   native tool is baked into `mcp-host`. Of the always-on native tools the
+   `shell_exec` or `http_request` to Skip). MCP tools always require approval;
+   native tools carry per-tool overrides, and the safe default per native tool
+   is baked into `mcp-host`. Of the always-on native tools the
    editor lists, only `http_request` and `shell_exec` default to Required and
    the rest to Skip; conditionally-registered tools carry their own defaults
    (`cron_manage` and the desktop `browser_open` / `browser_navigate` tools
@@ -163,6 +163,7 @@ invitation and password-reset form posts — is in
 ## Run it
 
 ```bash
+make install-all && npm --prefix control-ui install
 npm run web   # port-forwards control-api to :8090, waits for health, starts Control UI alone
 npm run ui    # starts Control UI, Desktop App, and Profile UI together
 ```

--- a/docs/surfaces/desktop-app.md
+++ b/docs/surfaces/desktop-app.md
@@ -124,6 +124,7 @@ process handlers before any privileged call runs.
 From the repository root:
 
 ```bash
+make install-all && npm --prefix control-ui install
 npm run app   # desktop app only
 npm run ui    # Control UI, Desktop App, and Profile UI together
 ```

--- a/docs/surfaces/profile-ui.md
+++ b/docs/surfaces/profile-ui.md
@@ -62,6 +62,7 @@ overlays (`make minikube-deploy-all`). There is no per-service
 `make deploy`.
 
 ```bash
+make install-all && npm --prefix control-ui install
 npm run ui    # Control UI, Desktop App, and Profile UI together
 ```
 


### PR DESCRIPTION
PR-1 of the docs improvement plan — the "consistency pack". Fixes the first-hour contradictions from the plan's §1 Still-open table, **each verified against the code** (not just cross-doc diffing).

## Changes

| Area | Fix |
|---|---|
| **Node version** | `quickstart.md` and `architecture/overview.md` said Node **20**; bumped to **24** (matches `.nvmrc` and README). |
| **UI install** | `quickstart.md` + the three surfaces docs showed a bare `npm run ui`, which **fails** — neither `make minikube-setup` nor `npm run ui` installs node deps (verified in `full-setup.sh` / `make local-ui`). Added the required `make install-all && npm --prefix control-ui install`. |
| **Approval model** | Stated accurately and consistently across `why-evenfire`, `configure-approvals`, `claims-guardrails`, and `control-ui`. |
| **Stale heading** | `configure-approvals.md`: `## Dev / Compose` → `## Dev mode (no cluster)`. |
| **Seed creds** | `README.md` + `quickstart.md`: label `test@clerum.io` / `changeme123!` as local-minikube only. |

## The verified approval model

Confirmed against `UnifiedApprovalGateController` (`mcp-host/src/core/extensions/mcpApprovalGateController.ts:77`) and `taskExecutor.ts:1351`:

- Approval system **on by default** (`CLERUM_ENABLE_APPROVAL`, default `true`).
- **MCP tool calls always require approval** — suspended by naming convention before `requiresApproval()` is consulted. The `Host.spec.approval.tools` override map covers **native tools only**.
- **Five native tools** gated by default: `shell_exec`, `http_request`, `cron_manage`, `browser_open`, `browser_navigate`; every other native tool runs without prompting; each configurable per-tool.
- Cron-fired tasks are not re-gated at fire time.

> **Note on process:** the approval wording went through a self-correction. An initial draft inverted the MCP default (based on a misleading `requiresApproval=false` comment on the MCP wrapper). The workflow's independent verify phase flagged an inconsistency in `control-ui.md`, which led to reading the actual gate controller and fixing the wording to the model above. Every approval claim here is now backed by the controller code.

## How this was produced

An 8-file edit + independent per-file verification pass (each edit re-checked against `mcp-host`), then a repo-wide sweep that caught two extras the per-file pass couldn't see: a residual `Node.js 20.x+` in `architecture/overview.md` and the backwards approval claim in `control-ui.md`.

Acceptance: no `Node.js 20` in docs · no `Dev / Compose` heading · no doc claims MCP tools are ungated · quickstart install path matches README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)