### PR TITLE
docs: add "Open core: self-host vs hosted" concept page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Use this index for long-form docs.
 | -------------------------------------------------------- | -------------------------------------------------------------------- |
 | [Why evenfire](concepts/why-evenfire.md)                 | Problem, audience, design intent                                     |
 | [When to use evenfire](concepts/when-to-use-evenfire.md) | Fit vs personal assistants / in-process frameworks (categories only) |
+| [Open core: self-host vs hosted](concepts/open-core-and-hosted.md) | What's in this repo vs the managed evenfire hosted service |
 | [Code names](concepts/code-names.md)                     | evenfire vs clerum                                                   |
 | [Architecture overview](architecture/overview.md)        | Services, CRDs, message lifecycle, NetworkPolicy model               |
 | [Platform topology](architecture/platform-topology.md)   | Namespaces, controller split, deny-all baseline                      |

--- a/docs/concepts/open-core-and-hosted.md
+++ b/docs/concepts/open-core-and-hosted.md
@@ -1,0 +1,80 @@
+# Open core: self-host vs evenfire hosted
+
+evenfire is **open core**. This repository is the complete, single-tenant
+platform under **MPL-2.0** — hardened and not feature-gated. A separate
+commercial offering, **evenfire hosted**, runs that platform for you as a
+managed, multi-tenant service. This page draws the line between the two
+honestly, so self-hosting holds no surprises.
+
+## What's in this repo (the open-source platform)
+
+Everything needed to run the full platform yourself — single-tenant, hardened,
+and not held back:
+
+- **Every service**, including the `mcp-host` agent runtime.
+- The **eight `clerum.io` CRDs** and the CRD Helm chart.
+- The **full security model** — default-deny NetworkPolicies, per-workload
+  security contexts, the service-to-service JWT chain, and human-in-the-loop
+  approvals.
+- **One-command local bring-up** (`make minikube-setup`) on minikube, and
+  production on any Kubernetes cluster.
+- **All three UIs** — Control UI, Desktop App, Profile UI — plus `electron-forge`
+  packaging to ship the desktop app to your users.
+- The **registry client**: connect to a registry to install and publish
+  connectors and recipes.
+- The **cluster E2E suites**.
+
+Nothing here is crippled or withheld to force an upgrade. Self-hosting is a
+first-class path, not a trial.
+
+## What's not in this repo
+
+**evenfire hosted** is the commercial, operated, multi-tenant service. A few
+pieces live outside this repo — the multi-tenant machinery, plus one shared
+backend:
+
+- **Multi-tenant provisioning and isolation** — the orchestration that
+  provisions and isolates one tenant from another. Self-hosting is
+  **single-tenant**: one organization per deployment.
+- **The hosted registry control plane** — the operator side of the shared
+  registry at `registry.evenfire.ai`. The registry *client* is in this repo; the
+  control plane that runs the shared service is not.
+- **Member registration** — the invitation-signup backend
+  (`member-registration-service`) is an extracted sibling service, not in this
+  repo. It is needed to complete invitation-based signup in *any* deployment,
+  single-tenant included — you can still log in and drive agents without it, and
+  a self-hoster can point `MEMBER_REGISTRATION_SERVICE_BASE_URL` at their own
+  instance. See the
+  [member-registration gap](../surfaces/desktop-app.md#the-member-registration-service-gap).
+
+These gaps are named, not hidden.
+
+## Connecting to a registry as a self-hoster
+
+The connector/recipe registry is a separate service that `control-api` reaches
+over HTTP, configured with `CLERUM_REGISTRY_URL`. You can point it at a registry
+you operate, or connect to the shared **`registry.evenfire.ai`** after an
+approval step. Either way, browsing, installing, and publishing happen from your
+own Control UI — evenfire's operators never touch your fleet.
+
+## Support
+
+- **Self-host** — community best-effort through GitHub
+  [Issues and Discussions](https://github.com/evenfire-ai/evenfire). There is no
+  SLA; self-host support is never promised.
+- **evenfire hosted** — fully operated, with support and an SLA.
+
+## License
+
+evenfire is licensed under the **Mozilla Public License 2.0 (MPL-2.0)** — an
+OSI-approved, file-level copyleft license. You can use, modify, self-host, and
+build commercial products on it; changes to MPL-licensed files must remain under
+MPL when distributed, while larger works that combine with this code may carry
+their own license. See [LICENSE](../../LICENSE) and the root README's
+[community and license](../../README.md#community-and-license) section.
+
+## Related
+
+- [Why evenfire](why-evenfire.md) — problem, audience, design intent
+- [When to use evenfire](when-to-use-evenfire.md) — category-level fit
+- [Production deploy notes](../deploy/production.md)

--- a/docs/concepts/when-to-use-evenfire.md
+++ b/docs/concepts/when-to-use-evenfire.md
@@ -50,5 +50,6 @@ It does not rank or name competing products.
 ## Related
 
 - [Why evenfire](why-evenfire.md)
+- [Open core: self-host vs hosted](open-core-and-hosted.md)
 - [Security model](../../README.md#security-model)
 - [Code names](code-names.md)

--- a/docs/concepts/why-evenfire.md
+++ b/docs/concepts/why-evenfire.md
@@ -68,3 +68,4 @@ See [When to use evenfire](when-to-use-evenfire.md) for category-level fit.
 - [Quickstart](../get-started/quickstart.md) — try the agent runtime locally
 - [Security model](../../README.md#security-model) — four enforcement layers
 - [Architecture overview](../architecture/overview.md) — services and lifecycle
+- [Open core: self-host vs hosted](open-core-and-hosted.md) — what's in this repo vs the managed service

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,6 +16,14 @@ on it; changes to MPL-licensed files must stay under MPL when distributed,
 while larger works that combine with this code may carry their own licenses.
 See [LICENSE](../LICENSE).
 
+### Is multi-tenancy or hosting included?
+
+No. This repo is the full **single-tenant** platform — one organization per
+deployment. Multi-tenant provisioning, the hosted registry control plane, and
+member registration belong to the managed **evenfire hosted** service and are
+not open source. What you self-host is complete and not feature-gated. See
+[Open core: self-host vs hosted](concepts/open-core-and-hosted.md).
+
 ### Why do I keep seeing “clerum”?
 
 Internal code name. Public name is evenfire. See

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -48,6 +48,7 @@ connector path exercised.
 1. [Production deploy notes](../deploy/production.md)
 2. Security model + [SECURITY.md](../../SECURITY.md)
 3. License (MPL-2.0) in root [README](../../README.md#community-and-license) and [LICENSE](../../LICENSE)
+4. What's OSS vs the managed service: [Open core: self-host vs hosted](../concepts/open-core-and-hosted.md)
 
 ## Stuck?
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -14,6 +14,7 @@
 
 - Why evenfire: concepts/why-evenfire.md
 - When to use evenfire (categories): concepts/when-to-use-evenfire.md
+- Open core (self-host vs evenfire hosted): concepts/open-core-and-hosted.md
 - Claims guardrails: meta/claims-guardrails.md
 - Code names (evenfire vs clerum): concepts/code-names.md
 - Architecture overview: architecture/overview.md


### PR DESCRIPTION
PR-5 of the docs improvement plan. Adds a concept page that sets open-source vs commercial expectations honestly, so self-hosting holds no surprises.

## New: `docs/concepts/open-core-and-hosted.md`
- **What's in this repo** — the full single-tenant platform (every service, 8 CRDs, security model, minikube + any-cluster deploy, all three UIs + electron-forge, registry client, cluster E2E), **MPL-2.0**, not feature-gated.
- **What's not in this repo** — multi-tenant provisioning/isolation, the hosted registry control plane, and the extracted `member-registration-service`. Gaps are **named, not hidden**.
- **Connecting to a registry** as a self-hoster (`CLERUM_REGISTRY_URL`; own registry or `registry.evenfire.ai` after approval).
- **Support tiers** — self-host community best-effort (no SLA) vs operated hosted.
- **License** — MPL-2.0 in plain language.

## Wire-up
docs/README concepts table · llms.txt · learning path E · why-evenfire + when-to-use "related/next" · new FAQ entry "Is multi-tenancy or hosting included?".

## Accuracy / safety
- Independently verified for **private-detail leakage** (clean — no internal infra, repo, or CI/migration details) and **boundary honesty**. One reviewer finding fixed: member-registration was mis-filed as multi-tenant-only; it's now correctly described as needed for invitation signup in any deployment, with the self-host env var.
- Guardrails: **MPL-2.0 only** (no Apache/AGPL/source-available), **minikube-first** (no compose). Every claim corroborated against existing docs (8 CRDs, electron-forge, `CLERUM_REGISTRY_URL`, license).

## Note
Touches `why-evenfire.md` (one "see also" link), which #80 also edits (the approval bullet, a different section) — trivial merge. Independent of #80 otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)