### PR TITLE
docs: add "Desktop setup & updates" how-to

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ Use this index for long-form docs.
 | [Connect Telegram](how-to/connect-telegram.md)                 | Minikube env or CRD channel path    |
 | [Configure approvals](how-to/configure-approvals.md)           | Human-in-the-loop tool gates        |
 | [Add an MCP server](how-to/add-mcp-server.md)                  | Dev-mode JSON or CRD allowlist path |
+| [Desktop setup & updates](how-to/desktop-setup-and-updates.md) | Environments, invitation setup, updates |
 | [Minikube full stack](deploy/minikube.md)                      | Local Kubernetes platform           |
 | [Production notes](deploy/production.md)                       | Checklist and in-repo deploy assets |
 | [WorkflowRecipes operations](deploy/workflow-recipes-guide.md) | Recipe ops, RBAC, debugging         |

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -7,7 +7,9 @@ Pick the path that matches what you want to do.
 1. [Quickstart](quickstart.md) — `make minikube-setup`, then message the seeded
    `chatllm` agent from the desktop app or the API
 2. Tour the [Desktop App](../surfaces/desktop-app.md) — screens, live activity,
-   in-chat approvals, and artifacts, beyond the one message you just sent
+   in-chat approvals, and artifacts, beyond the one message you just sent.
+   To point it at more than one instance or handle updates, see
+   [Desktop setup & updates](../how-to/desktop-setup-and-updates.md)
 3. Optional: connect [Telegram](../how-to/connect-telegram.md)
 4. Read [Why evenfire](../concepts/why-evenfire.md)
 

--- a/docs/how-to/desktop-setup-and-updates.md
+++ b/docs/how-to/desktop-setup-and-updates.md
@@ -1,0 +1,99 @@
+# How to: set up Desktop App environments and updates
+
+The Desktop App is **one packaged build** that any number of people point at any
+number of evenfire instances — your production tenant, a staging tenant, or a
+local `make`-forwarded cluster. This guide covers adding and switching
+**environments**, the three setup paths, and how the app handles **updates**.
+For packaging and shipping the build itself, see
+[Ship it to your users](../surfaces/desktop-app.md#ship-it-to-your-users).
+
+## When you need this
+
+- You run more than one instance (say, staging and production) and want to
+  switch between them in one app.
+- You are onboarding through an **invitation** rather than a shared login.
+- You distribute a **packaged** build and want users to know when a new release
+  requires them to update.
+
+## The environment model
+
+You save only the **External REST API URL** for an instance. The app then asks
+that API for the rest of the environment — the display name and the RPC proxy
+URL — and caches it locally. There is no second URL to type: the RPC proxy is
+**discovered**, not entered.
+
+## Setup paths
+
+Three ways to add an environment; all of them end with the same saved
+environment.
+
+### 1. Manual, from the sign-in screen
+
+Click the **+** beside **Environment**, give it a **name** and the **External
+REST API URL**, and save. Both fields are required. The app discovers the RPC
+proxy, and you can sign in.
+
+For a local minikube cluster, follow the
+[Quickstart](../get-started/quickstart.md) port-forwards and point the
+environment at the forwarded External REST API.
+
+### 2. From Profile UI, by deep link
+
+A member can hand the app its environment from the browser: in **Profile UI →
+Settings → Setup desktop app**, copy the External REST API and click **Open
+desktop app and setup**. That opens an `evenfire://desktop-environment` deep
+link the installed app handles — it saves or updates the environment, and if the
+External REST API was already saved, it updates the name and re-discovers the
+RPC proxy. Fleets can also be pre-seeded with a `CLERUM_DESKTOP_CONFIG_PATH`
+config file (see
+[Ship it to your users](../surfaces/desktop-app.md#ship-it-to-your-users)).
+
+### 3. Through an invitation
+
+When the app starts with **no selected environment**, it runs invitation
+detection. Completing the [Profile UI](../surfaces/profile-ui.md) invitation
+flow hands the app a setup token (an `evenfire://desktop-setup` deep link); the
+app then saves the tenant environment by name and discovers its RPC proxy.
+
+> **Gap:** invitation signup depends on `member-registration-service`, which is
+> not in this repo. See the
+> [member-registration gap](../surfaces/desktop-app.md#the-member-registration-service-gap)
+> for what still works without it.
+
+## Localhost
+
+**Localhost** always sits at the bottom of the environment list. In a packaged
+build it stays **unselected** until you pick it, so invitation detection can run
+on first launch; running through local dev commands selects it by default.
+
+## Updates
+
+After you authenticate, the app checks the **currently selected tenant** for its
+update policy, so different tenants can be on different versions at the same
+time. It asks that tenant's External REST API for its release info, including a
+`minimumDesktopVersion`. If the installed version is **below** that minimum, the
+app shows an **update-required** screen and opens the release page for the new
+build (tag `desktop-app-<version>`) in your browser. (A packaged distribution is
+where this matters most — a source checkout can just pull the latest.)
+
+This is update **detection**, not silent auto-install: the app tells the user an
+update is required and links the release. Code signing, notarization, and
+automatic download/install are not part of this repo — see
+[Ship it to your users](../surfaces/desktop-app.md#ship-it-to-your-users).
+
+## Troubleshooting
+
+- **Wrong instance after switching** — each environment caches its own RPC
+  proxy; re-open the **Environment** screen and confirm which instance is
+  selected.
+- **Stale RPC proxy** — re-running the Profile UI **Setup desktop app** for an
+  already-saved External REST API updates the name and clears the cached RPC
+  proxy so it is re-discovered.
+- **Signed in to the wrong tenant** — authentication is per environment; sign
+  out, reselect the environment, and sign in again.
+
+## Related
+
+- [Desktop App surface](../surfaces/desktop-app.md) — screens, packaging, env vars
+- [Profile UI](../surfaces/profile-ui.md) — the invited-member entry point
+- [Quickstart](../get-started/quickstart.md) — local minikube bring-up

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -32,6 +32,7 @@
 - Connect Telegram: how-to/connect-telegram.md
 - Configure approvals: how-to/configure-approvals.md
 - Add MCP server: how-to/add-mcp-server.md
+- Desktop setup & updates (environments, invitation, updates): how-to/desktop-setup-and-updates.md
 - Minikube full stack: deploy/minikube.md
 - Production checklist: deploy/production.md
 - WorkflowRecipes ops: deploy/workflow-recipes-guide.md

--- a/docs/surfaces/desktop-app.md
+++ b/docs/surfaces/desktop-app.md
@@ -171,7 +171,9 @@ service, a teammate's, or local `make`-forwarded services — from the app's own
 proxy address follows from that environment; there is no second URL to enter.
 Environments can also be pre-seeded for a fleet through Profile UI's
 `evenfire://desktop-environment` deep link or a `CLERUM_DESKTOP_CONFIG_PATH`
-config file.
+config file. Adding and switching environments, the invitation setup path, and
+how a packaged app surfaces a **required** update are covered in
+[Desktop setup & updates](../how-to/desktop-setup-and-updates.md).
 
 Two variables **do** apply to a packaged build, read from the environment or
 the bundled `.env.prod`: `MEMBER_REGISTRATION_SERVICE_BASE_URL` — which has

--- a/docs/surfaces/profile-ui.md
+++ b/docs/surfaces/profile-ui.md
@@ -71,3 +71,4 @@ npm run ui    # Control UI, Desktop App, and Profile UI together
 - [UI Surfaces](README.md) — the persona matrix across all three consoles
 - [Control UI](control-ui.md) — the admin console
 - [Desktop App](desktop-app.md) — the end-user client
+- [Desktop setup & updates](../how-to/desktop-setup-and-updates.md) — environments and the update flow after handoff


### PR DESCRIPTION
PR-2 of the docs improvement plan. A task-oriented how-to for **multi-environment setup and updates** — the flows the Desktop App surface doc explicitly defers ("auto-update not covered here").

## New: `docs/how-to/desktop-setup-and-updates.md`
- **Environment model** — save only the External REST API URL; the app discovers the RPC proxy + app name and caches it.
- **Three setup paths** — manual (`+ Environment`: name + REST API), Profile UI "Setup desktop app" (`evenfire://desktop-environment`), and invitation (`evenfire://desktop-setup`), with the member-registration gap noted.
- **Localhost** list behavior, and **updates** — `GET /desktop/release` + `minimumDesktopVersion` → update-required screen → release page (tag `desktop-app-<version>`), framed as **detection, not auto-install**.

## Verified against shipped code (this mattered)
Independently checked every claim against the code — the source design spec diverges in two places I did **not** propagate:
- The setup deep-link scheme is `evenfire://` (the app also registers `clerum://` for OAuth) — `main.ts:60-61`. Confirmed, not assumed.
- **The update check is *not* packaged-only.** The spec says "only in packaged builds," but the shipped code runs it after auth in dev too (no `isPackaged` gate — `useAppController.ts:585`, `appService.ts:126`). The doc reflects the code, not the spec.
- Confirmed: `/desktop/environment` (public) + `/desktop/release` (auth) shapes, `updateRequired = installed < minimumDesktopVersion`, manual add requires name + REST API only, Profile UI produces the deep link (`SettingsContent.tsx:332`).

Safety: no secrets, no tenant-specific hostnames, all links resolve.

## Wire-up
docs/README how-to table · llms.txt · learning path A · desktop-app + profile-ui surface docs (cross-links; auto-update/signing remain deferred there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)