### PR TITLE
docs: add "Track usage & set token budgets" how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ each pillar links to its depth.
 - **Cost & governance** — token budgets per scope with block/warn decisions
   (opt-in via `CLERUM_BUDGETS_ENABLED`), usage and LLM-price accounting,
   `WorkflowRecipePolicy`, and a connector-image allowlist. →
-  [docs/crds/workflowrecipepolicy.md](docs/crds/workflowrecipepolicy.md)
+  [docs/crds/workflowrecipepolicy.md](docs/crds/workflowrecipepolicy.md),
+  [track usage & set budgets](docs/how-to/token-budgets-and-usage.md)
 - **Config as code** — the entire fleet is eight `clerum.io` CRDs:
   version-controlled, reviewable, and `kubectl`/GitOps-friendly. →
   [docs/crds/README.md](docs/crds/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Use this index for long-form docs.
 | [Configure approvals](how-to/configure-approvals.md)           | Human-in-the-loop tool gates        |
 | [Add an MCP server](how-to/add-mcp-server.md)                  | Dev-mode JSON or CRD allowlist path |
 | [Desktop setup & updates](how-to/desktop-setup-and-updates.md) | Environments, invitation setup, updates |
+| [Track usage & set budgets](how-to/token-budgets-and-usage.md) | Enable budgets, scope, block vs warn |
 | [Minikube full stack](deploy/minikube.md)                      | Local Kubernetes platform           |
 | [Production notes](deploy/production.md)                       | Checklist and in-repo deploy assets |
 | [WorkflowRecipes operations](deploy/workflow-recipes-guide.md) | Recipe ops, RBAC, debugging         |

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -33,7 +33,8 @@ NetworkPolicies matter.
 1. [Minikube deploy guide](../deploy/minikube.md)
 2. [Configure approvals](../how-to/configure-approvals.md)
 3. [Add an MCP server](../how-to/add-mcp-server.md)
-4. [WorkflowRecipe CRD reference](../crds/workflowrecipe.md) if you need multi-workload recipes
+4. [Track usage & set budgets](../how-to/token-budgets-and-usage.md) — meter and cap what agents spend
+5. [WorkflowRecipe CRD reference](../crds/workflowrecipe.md) if you need multi-workload recipes
 
 **Success looks like:** Control UI up, a Host responding, an approval or
 connector path exercised.

--- a/docs/how-to/token-budgets-and-usage.md
+++ b/docs/how-to/token-budgets-and-usage.md
@@ -1,0 +1,73 @@
+# How to: track usage and set token budgets
+
+Every LLM call evenfire makes is metered — tokens and cost, attributed to the
+agent, team, user, provider, and model behind it. This guide covers where that
+usage shows up, how to turn on **budgets** to cap it, and how a budget's `block`
+vs `warn` decision actually behaves.
+
+## What's tracked
+
+Token usage (input, output, cache) and — once you set prices — cost, rolled up
+by dimension: **agent** (Host), **team**, **user**, **provider**, and **model**.
+Usage is recorded whether or not budgets are enabled.
+
+## Where to see it
+
+In the **Control UI → Cost & Usage → Usage** tab: token totals and a
+stacked-area chart you can break down by agent, team, user, provider, or model.
+See the [Control UI tour](../surfaces/control-ui.md) for the screens. Cost is
+derived from the rates under the **LLM Prices** tab.
+
+## Turn budgets on
+
+Budgets are **off by default**. Set `CLERUM_BUDGETS_ENABLED=true` on
+**`mcp-host`**, which is where enforcement runs. With the flag off, usage is
+still tracked and budgets can still be created — nothing is enforced until the
+flag is on.
+
+## Create a budget
+
+In **Control UI → Cost & Usage → Token Budgets**, add a budget with:
+
+- **Scope** — which usage it covers: any combination of dimensions such as
+  agent (Host), team, user, provider, and model. Leave it empty to cap
+  **everything** (global).
+- **Unit** — `tokens` or `cost`. A `cost` budget needs a currency and **priced
+  models**: add rates under **LLM Prices** first. Creating a cost budget that
+  pins unpriced models is rejected, so it cannot silently under-count.
+- **Limit** and **period** — the cap, over a `daily`, `weekly`, or `monthly`
+  window.
+- **Enforcement** — `block` or `warn` (see below).
+
+## `block` vs `warn`
+
+- **`warn`** — observation only. The agent's call always proceeds; the budget
+  just records that the scope is over its limit.
+- **`block`** — when the scope is over its limit, the agent's next task is
+  denied (`budget_exceeded`) and stops rather than spending more.
+
+## What happens on failure
+
+The two failure modes are deliberately different:
+
+- If **`mcp-host` cannot reach** control-api's budget check at all (a network or
+  service outage), the call **fails open** — the agent proceeds rather than
+  being blocked by infrastructure it cannot control.
+- If control-api **is** reachable but **cannot compute** a `block` budget's
+  spend, it **fails closed** — the task is denied (`budget_eval_error`), because
+  it cannot prove the task is under the cap.
+
+A `warn` budget never blocks in either case.
+
+## What budgets are not
+
+Budgets are **cost control, not a security boundary**. They cap spend; they do
+not authorize, isolate, or gate anything — that is the job of Contexts,
+NetworkPolicies, and [approvals](configure-approvals.md). A cost budget is only
+as accurate as the prices under **LLM Prices**.
+
+## Related
+
+- [Control UI](../surfaces/control-ui.md) — the Cost & Usage, LLM Prices, and Token Budgets screens
+- [Configure approvals](configure-approvals.md) — the other half of governed action
+- [Add an MCP server](add-mcp-server.md) — give an agent tools to spend against

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,6 +33,7 @@
 - Configure approvals: how-to/configure-approvals.md
 - Add MCP server: how-to/add-mcp-server.md
 - Desktop setup & updates (environments, invitation, updates): how-to/desktop-setup-and-updates.md
+- Track usage & set token budgets: how-to/token-budgets-and-usage.md
 - Minikube full stack: deploy/minikube.md
 - Production checklist: deploy/production.md
 - WorkflowRecipes ops: deploy/workflow-recipes-guide.md

--- a/docs/surfaces/control-ui.md
+++ b/docs/surfaces/control-ui.md
@@ -43,7 +43,9 @@ five steps live together.
    choice is the opposite and deliberate: a `block` budget whose spend cannot
    be computed denies the task (`budget_eval_error`) rather than silently
    bypass the cap (`control-api/src/services/budgets/check.ts`), while a `warn`
-   budget that errors is skipped entirely.
+   budget that errors is skipped entirely. For the operator walkthrough —
+   enabling budgets, scoping one, and reading a `block` vs `warn` decision — see
+   [Track usage & set budgets](../how-to/token-budgets-and-usage.md).
 
 3. **Gate it** — `HostApprovalSection` (`components/HostApprovalSection`), on
    the host detail page. A per-tool approval editor with three settings —


### PR DESCRIPTION
PR-4 of the docs improvement plan. A task-oriented operator guide for usage tracking and budgets — the step-by-step behind the Control UI's concise summary.

## New: `docs/how-to/token-budgets-and-usage.md`
- **What's tracked** and **where** (Cost & Usage), independent of budgets.
- **Turn budgets on** — `CLERUM_BUDGETS_ENABLED` (off by default, on `mcp-host`).
- **Create a budget** — scope, unit (tokens/cost; cost needs priced models), limit, period, enforcement.
- **`block` vs `warn`**, and the two failure modes stated precisely.
- **Not a security boundary** (claims-guardrails).

## Verified against code (independent pass, all 7 claims confirmed with file:line)
- Default off — `mcp-host/src/config.ts:619`.
- `block` denies (`budget_exceeded`), `warn` observes — `control-api/src/services/budgets/check.ts`.
- **Fail-open vs fail-closed** — mcp-host unable to reach the check → open (`budgetClient.ts`); a `block` budget whose spend can't be computed → closed, `budget_eval_error` (`check.ts:334`). This nuance is the easy thing to get wrong; it's backed by code and consistent with the Control UI surface doc.
- Cost budgets require priced models or the create is rejected (`BudgetUnpricedModelsError`).

Note: the scope allowlist has 10 dimensions; the how-to surfaces the 5 user-facing ones ("such as …"), deliberately illustrative.

## Wire-up
Root README Cost & governance pillar · Control UI surface doc · docs index · llms.txt · learning path C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)