### PR TITLE
docs: generalize LLM-provider messaging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ flowchart LR
     CAPI --> CRDS[("clerum.io CRDs")]
     CR --> MH["mcp-host<br/>agent runtime · approval gate"]
     RP --> MH
-    MH <--> LLM[("OpenAI · Claude<br/>Z.AI · Bailian")]
+    MH <--> LLM[("LLM providers")]
     MH --> HCC["host-context-controller<br/>connector discovery"]
     MH --> MP[mcp-proxy] --> MCP["MCP servers<br/>(HTTP · stdio via bridge)"]
     CRDS -.watched by.-> HCC
@@ -297,9 +297,13 @@ Reference: [docs/crds/README.md](docs/crds/README.md).
 | Z.AI             | `zai`            | `glm-5.1`           |
 | Alibaba Bailian  | `bailian`        | `qwen3-coder-plus`  |
 
-Four providers behind one interface; OpenAI-compatible endpoints can plug in as
-registry descriptors where the code supports it. Keys live in a Kubernetes
-Secret you create (dev mode: environment variables). Details:
+One interface across every provider — swap an agent's model, or switch providers
+entirely, by editing two fields on its Host CRD (`spec.model.provider` and
+`spec.model.name`). It's a config change, not a code change, and workflow-recipe
+steps can override the model per step. New providers are added data-first, so the
+list keeps growing; OpenAI-compatible endpoints can plug in as registry
+descriptors where the code supports it. Keys live in a Kubernetes Secret you
+create (dev mode: environment variables). Details:
 [mcp-host/README.md](mcp-host/README.md).
 
 ---


### PR DESCRIPTION
Two related README edits ahead of adding more LLM providers.

## 1. Architecture diagram

Relabel the LLM node from the hardcoded list to a generic label, so it doesn't go stale as providers are added:

```diff
- MH <--> LLM[("OpenAI · Claude<br/>Z.AI · Bailian")]
+ MH <--> LLM[("LLM providers")]
```

Verified the diagram still parses and renders (real Chromium, mermaid 11).

## 2. "Supported LLM providers" prose

Lead with the value prop, grounded in the real mechanism (`docs/crds/host.md`): switching an agent's model or provider is a **two-field edit on its Host CRD** (`spec.model.provider` / `spec.model.name`) — a config change, not a code change — with data-first provider registration so the list keeps growing.

All prior facts are preserved (OpenAI-compatible endpoints, Secret-based keys, the mcp-host link); only the hardcoded "Four providers" count is dropped. The provider reference **table** is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)