### PR TITLE
feat: offline member-registration mode (self-hosted invitations)

### DIFF
--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -18,10 +18,12 @@ type Config = {
   internalControlJwtWrcHmacSecret: string
   internalControlJwtHccHmacSecret: string
   allowedIssuanceNamespaces: string[]
+  memberRegistrationMode: 'remote' | 'offline'
   memberRegistrationServiceBaseUrl: string
   memberRegistrationServiceHmacSecret: string
   memberRegistrationServiceHmacKid: string
   memberRegistrationTenantId: string
+  inviteAcceptBaseUrl: string
   desktopExternalRestApiBaseUrl: string
   desktopRpcProxyBaseUrl: string
   desktopProfileUiBaseUrl: string
@@ -396,6 +398,9 @@ const RPC_JWT_PUBLIC_KEY = normalizePem(
   process.env.CONTROL_API_RPC_JWT_PUBLIC_KEY || publicKeyFromPrivateKey(RPC_JWT_PRIVATE_KEY)
 )
 
+const memberRegistrationMode: 'remote' | 'offline' =
+  process.env.CONTROL_API_MEMBER_REGISTRATION_MODE === 'offline' ? 'offline' : 'remote'
+
 export const config: Config = {
   port: Number(process.env.CONTROL_API_PORT || 8090),
   jsonBodyLimit: process.env.CONTROL_API_JSON_BODY_LIMIT || '150mb',
@@ -429,11 +434,18 @@ export const config: Config = {
   allowedIssuanceNamespaces: parseCsvList(
     process.env.CONTROL_API_ALLOWED_ISSUANCE_NAMESPACES || `${HOSTS_NAMESPACE},${SANDBOX_NAMESPACE}`
   ),
-  memberRegistrationServiceBaseUrl: requiredOrDevDefault(
-    'CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL',
-    'http://member-registration-service.profiles.svc.cluster.local:8092/api/v1'
-  ),
+  memberRegistrationMode,
+  memberRegistrationServiceBaseUrl:
+    memberRegistrationMode === 'offline'
+      ? process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL || ''
+      : requiredOrDevDefault(
+          'CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL',
+          'http://member-registration-service.profiles.svc.cluster.local:8092/api/v1'
+        ),
   memberRegistrationServiceHmacSecret: (() => {
+    if (memberRegistrationMode === 'offline') {
+      return process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET || ''
+    }
     const value = requiredOrDevDefault(
       'CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET',
       'dev-member-registration-hmac-secret'
@@ -444,6 +456,10 @@ export const config: Config = {
   memberRegistrationServiceHmacKid:
     process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID || 'example-dev',
   memberRegistrationTenantId: process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID || 'example-dev',
+  inviteAcceptBaseUrl:
+    process.env.CONTROL_API_INVITE_ACCEPT_BASE_URL ||
+    process.env.CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL ||
+    'http://127.0.0.1:3001',
   desktopExternalRestApiBaseUrl:
     process.env.CONTROL_API_DESKTOP_EXTERNAL_REST_API_BASE_URL || 'http://127.0.0.1:8091',
   desktopRpcProxyBaseUrl:
@@ -821,4 +837,15 @@ if (process.env.NODE_ENV === 'production') {
       )
     }
   }
+}
+
+if (
+  process.env.NODE_ENV === 'production' &&
+  memberRegistrationMode === 'offline' &&
+  process.env.CONTROL_API_ALLOW_OFFLINE_IN_PROD !== 'true'
+) {
+  throw new Error(
+    '[SECURITY] offline member-registration mode is not permitted in production. ' +
+      'Set CONTROL_API_ALLOW_OFFLINE_IN_PROD=true to override.'
+  )
 }

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -455,7 +455,8 @@ export const config: Config = {
   })(),
   memberRegistrationServiceHmacKid:
     process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID || 'example-dev',
-  memberRegistrationTenantId: process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID || 'example-dev',
+  memberRegistrationTenantId:
+    process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID || 'example-dev',
   inviteAcceptBaseUrl:
     process.env.CONTROL_API_INVITE_ACCEPT_BASE_URL ||
     process.env.CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL ||
@@ -765,10 +766,7 @@ if (config.registryAuthEnabled) {
 
   // URL allowlist applies in BOTH modes: self-hosted clerum still points at the
   // central example.com (spec §14.3 — per-deployment URLs out of scope).
-  const allowed = [
-    'https://example.com',
-    'http://registry-api.registry.svc.cluster.local:8085',
-  ]
+  const allowed = ['https://example.com', 'http://registry-api.registry.svc.cluster.local:8085']
   if (process.env.CLERUM_DEV_MODE === 'true') {
     allowed.push('http://localhost:8085')
   }

--- a/control-api/src/routes/external/members.ts
+++ b/control-api/src/routes/external/members.ts
@@ -110,6 +110,9 @@ export function createExternalMembersRouter(): Router {
       )
       if ('error' in result) {
         if (result.error === 'forbidden') return res.status(403).json({ error: 'forbidden' })
+        if (result.error === 'member_email_exists') {
+          return res.status(409).json({ error: 'member_email_exists' })
+        }
         return res.status(400).json({ error: 'invalid_payload' })
       }
       return res.status(201).json(result.invitation)

--- a/control-api/src/services/directory/membership.ts
+++ b/control-api/src/services/directory/membership.ts
@@ -1,6 +1,10 @@
 import bcrypt from 'bcryptjs'
+import { config } from '../../config.js'
 import { type DbClient, pool, withTransaction } from '../../db.js'
-import { registerAndSendInvitation } from '../invitationFlowRegistrationService.js'
+import {
+  buildInviteAcceptUrl,
+  registerAndSendInvitation,
+} from '../invitationFlowRegistrationService.js'
 import type { InviteRole, TeamRole } from './types.js'
 import {
   normalizeChannels,
@@ -615,13 +619,16 @@ async function createInvitationForTeamsRecord(
   if (!pending) {
     throw new Error('Failed to activate invitation after registration')
   }
-  return invitationForTeamsResponse(
+  const response = invitationForTeamsResponse(
     {
       ...pending,
       team_name: inserted.invitation.team_name,
     },
     inserted.teams
   )
+  return config.memberRegistrationMode === 'offline'
+    ? { ...response, inviteAcceptUrl: buildInviteAcceptUrl(inserted.invitation.token) }
+    : response
 }
 
 export async function createInvitation(

--- a/control-api/src/services/directory/membership.ts
+++ b/control-api/src/services/directory/membership.ts
@@ -1589,6 +1589,16 @@ export async function createManagedInvitationForUser(
     }
   }
 
+  if (config.memberRegistrationMode === 'offline') {
+    const existing = await pool.query(
+      `SELECT id FROM users WHERE lower(email) = lower($1) LIMIT 1`,
+      [normalizedEmail]
+    )
+    if (existing.rows[0]) {
+      return { error: 'member_email_exists' as const }
+    }
+  }
+
   const fallbackName = normalizedEmail.split('@')[0] || normalizedEmail
   if (normalizedInviteeName) {
     const updatedUser = await pool.query(

--- a/control-api/src/services/invitationFlowRegistrationService.ts
+++ b/control-api/src/services/invitationFlowRegistrationService.ts
@@ -51,6 +51,18 @@ export async function validateInvitationFlowToken(
   token: string,
   email?: string
 ): Promise<{ email: string; invitationUuid: string }> {
+  if (config.memberRegistrationMode === 'offline') {
+    const { getInvitationByToken } = await import('./directory/index.js')
+    const invitation = await getInvitationByToken(token.trim())
+    if (!invitation) {
+      throw new Error('invalid_invitation')
+    }
+    if (email && invitation.email.toLowerCase() !== email.trim().toLowerCase()) {
+      throw new Error('invalid_invitation')
+    }
+    return { email: invitation.email, invitationUuid: token.trim() }
+  }
+
   const result = await memberRegistrationServiceRequest<{
     valid: true
     email: string

--- a/control-api/src/services/invitationFlowRegistrationService.ts
+++ b/control-api/src/services/invitationFlowRegistrationService.ts
@@ -1,5 +1,11 @@
 import { config } from '../config.js'
+import { rootLogger } from '../observability/logger.js'
 import { memberRegistrationServiceRequest } from '../memberRegistrationServiceClient.js'
+
+export function buildInviteAcceptUrl(token: string): string {
+  const base = config.inviteAcceptBaseUrl.replace(/\/+$/, '')
+  return `${base}/invitations/${token}`
+}
 
 export async function registerAndSendInvitation(
   email: string,
@@ -12,6 +18,14 @@ export async function registerAndSendInvitation(
     teamNames?: string[]
   } = {}
 ): Promise<void> {
+  if (config.memberRegistrationMode === 'offline') {
+    rootLogger.info(
+      { event: 'invite_registration_offline', email },
+      'offline member-registration: skipping remote invitation send'
+    )
+    return
+  }
+
   await memberRegistrationServiceRequest<{ sent: true; registered: true }>(
     'POST',
     '/invitations-flow/invitations',
@@ -57,6 +71,14 @@ export async function storeDesktopAuthorizationToken(
   email: string,
   authorizationToken: string
 ): Promise<void> {
+  if (config.memberRegistrationMode === 'offline') {
+    rootLogger.info(
+      { event: 'desktop_authorization_offline', email },
+      'offline member-registration: desktop authorization not persisted'
+    )
+    return
+  }
+
   await memberRegistrationServiceRequest<{ stored: true }>(
     'POST',
     '/invitations-flow/desktop-authorizations',

--- a/control-api/src/services/invitationFlowRegistrationService.ts
+++ b/control-api/src/services/invitationFlowRegistrationService.ts
@@ -1,6 +1,6 @@
 import { config } from '../config.js'
-import { rootLogger } from '../observability/logger.js'
 import { memberRegistrationServiceRequest } from '../memberRegistrationServiceClient.js'
+import { rootLogger } from '../observability/logger.js'
 
 export function buildInviteAcceptUrl(token: string): string {
   const base = config.inviteAcceptBaseUrl.replace(/\/+$/, '')

--- a/control-api/test/config.offline.test.ts
+++ b/control-api/test/config.offline.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateKeyPairSync, randomBytes } from 'node:crypto'
+
+function generateNonDevPem(): string {
+  const { privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 3072,
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  })
+  return privateKey as string
+}
+
+function applyProdEnv(env: Record<string, string | undefined>): void {
+  env.NODE_ENV = 'production'
+  env.CONTROL_API_RPC_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.CONTROL_API_SESSION_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.CONTROL_API_ADMIN_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.INTERNAL_CONTROL_JWT_WRC_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.INTERNAL_CONTROL_JWT_HCC_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL = 'https://example.com/api/v1'
+  env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID = 'clerum'
+  env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID = 'clerum'
+  env.CONTROL_API_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_JWT_AUDIENCE = 'profile-ui'
+  env.CONTROL_API_RPC_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_RPC_JWT_AUDIENCE = 'rpc-proxy'
+  env.CONTROL_API_GOOGLE_CLIENT_ID = 'prod-google-client-id'
+  env.CONTROL_API_ADMIN_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_ADMIN_JWT_AUDIENCE = 'control-ui'
+  env.CONTROL_API_ADMIN_BOOTSTRAP_USERNAME = 'admin'
+  env.CONTROL_API_ADMIN_BOOTSTRAP_PASSWORD_HASH =
+    '$2b$12$4dm17x2DESCxETGi0MpNruC0KpCev5lbKwqgmUkVLxKsNUxoXXXXXX'
+  env.CONTROL_API_OAUTH_STATE_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_OAUTH_ENCRYPTION_KEY = randomBytes(32).toString('hex')
+  env.CONTROL_API_INTERNAL_SERVICE_TOKENS =
+    'external-rest-api=prod-external-rest-api-token,rpc-proxy=prod-rpc-proxy-token,webhook-proxy=prod-webhook-proxy-token'
+}
+
+const origEnv = { ...process.env }
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...origEnv }
+})
+afterEach(() => {
+  process.env = { ...origEnv }
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('config — member registration offline mode', () => {
+  it('defaults to remote and normalizes unknown values to remote', async () => {
+    process.env.NODE_ENV = 'test'
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_MODE
+    const { config: c1 } = await import('../src/config.js')
+    expect(c1.memberRegistrationMode).toBe('remote')
+
+    vi.resetModules()
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'bogus'
+    const { config: c2 } = await import('../src/config.js')
+    expect(c2.memberRegistrationMode).toBe('remote')
+  })
+
+  it('inviteAcceptBaseUrl falls back to the desktop profile-ui base url', async () => {
+    process.env.NODE_ENV = 'test'
+    delete process.env.CONTROL_API_INVITE_ACCEPT_BASE_URL
+    process.env.CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL = 'http://profile.example'
+    const { config } = await import('../src/config.js')
+    expect(config.inviteAcceptBaseUrl).toBe('http://profile.example')
+  })
+
+  it('remote mode in production still requires the member-registration base url', async () => {
+    applyProdEnv(process.env)
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'remote'
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL/
+    )
+  })
+
+  it('offline mode in production relaxes the base-url + HMAC requirements when acknowledged', async () => {
+    applyProdEnv(process.env)
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'offline'
+    process.env.CONTROL_API_ALLOW_OFFLINE_IN_PROD = 'true'
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET
+    const { config } = await import('../src/config.js')
+    expect(config.memberRegistrationMode).toBe('offline')
+    expect(config.memberRegistrationServiceBaseUrl).toBe('')
+  })
+
+  it('offline mode in production is rejected without the ack env var', async () => {
+    applyProdEnv(process.env)
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'offline'
+    delete process.env.CONTROL_API_ALLOW_OFFLINE_IN_PROD
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /offline member-registration mode is not permitted in production/
+    )
+  })
+})

--- a/control-api/test/services.directory.membership.inviteAcceptUrl.test.ts
+++ b/control-api/test/services.directory.membership.inviteAcceptUrl.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createInvitationForTeams } from '../src/services/directory/membership.js'
+
+const mockPoolQuery = vi.fn()
+const mockDbQuery = vi.fn()
+vi.mock('../src/db.js', () => ({
+  pool: { query: (...a: unknown[]) => mockPoolQuery(...a) },
+  withTransaction: async <T>(cb: (db: { query: typeof mockDbQuery }) => Promise<T>) =>
+    cb({ query: mockDbQuery }),
+}))
+
+// vi.mock factories are hoisted above regular `const` declarations, so a plain
+// `const mockConfig = {...}` referenced directly inside the factory below trips a
+// temporal-dead-zone ReferenceError. vi.hoisted() hoists the initializer itself so
+// the value exists by the time the factory runs.
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    memberRegistrationMode: 'offline' as 'remote' | 'offline',
+    inviteAcceptBaseUrl: 'https://p.example',
+  },
+}))
+vi.mock('../src/config.js', () => ({ config: mockConfig }))
+vi.mock('../src/services/invitationFlowRegistrationService.js', () => ({
+  registerAndSendInvitation: vi.fn().mockResolvedValue(undefined),
+  buildInviteAcceptUrl: (t: string) => `https://p.example/invitations/${t}`,
+}))
+
+const draftRow = {
+  id: 'row-1',
+  team_id: null,
+  invitee_name: 'N',
+  email: 'a@b.com',
+  role: 'member',
+  token: 'tok-xyz',
+  status: 'draft',
+  purpose: 'member_invitation',
+  created_at: new Date(),
+  expires_at: new Date(Date.now() + 3600_000),
+  accepted_at: null,
+  accepted_user_id: null,
+  team_name: null,
+}
+const pendingRow = { ...draftRow, status: 'pending' }
+
+beforeEach(() => {
+  mockPoolQuery.mockReset()
+  mockDbQuery.mockReset()
+  mockConfig.memberRegistrationMode = 'offline'
+  // cleanupStaleDraftInvitations() fire-and-forget DELETE
+  mockPoolQuery.mockResolvedValue({ rows: [] })
+  // withTransaction → insertInvitationForTeams: INSERT ... RETURNING (draft), then team inserts/loads
+  mockDbQuery.mockResolvedValue({ rows: [] })
+  mockDbQuery.mockResolvedValueOnce({ rows: [draftRow] }) // INSERT ... RETURNING
+})
+
+describe('createInvitationForTeamsRecord inviteAcceptUrl', () => {
+  it('offline: returns pending invitation carrying inviteAcceptUrl', async () => {
+    // activation UPDATE ... RETURNING pending
+    mockPoolQuery.mockReset()
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] }) // cleanup DELETE
+    mockPoolQuery.mockResolvedValueOnce({ rows: [pendingRow] }) // activate UPDATE RETURNING
+
+    const result = await createInvitationForTeams({
+      inviteeName: 'N',
+      email: 'a@b.com',
+      purpose: 'member_invitation',
+      teamAssignments: [],
+      fallbackRole: 'member',
+    })
+    expect((result as { inviteAcceptUrl?: string }).inviteAcceptUrl).toBe(
+      'https://p.example/invitations/tok-xyz'
+    )
+    expect((result as { status: string }).status).toBe('pending')
+  })
+})

--- a/control-api/test/services.directory.membership.inviteGuard.test.ts
+++ b/control-api/test/services.directory.membership.inviteGuard.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockPoolQuery = vi.fn()
+vi.mock('../src/db.js', () => ({
+  pool: { query: (...a: unknown[]) => mockPoolQuery(...a) },
+  withTransaction: async <T>(cb: (db: { query: typeof mockPoolQuery }) => Promise<T>) =>
+    cb({ query: mockPoolQuery }),
+}))
+
+// vi.mock factories are hoisted above regular `const` declarations, so a plain
+// `const mockConfig = {...}` referenced directly inside the factory below trips a
+// temporal-dead-zone ReferenceError. vi.hoisted() hoists the initializer itself so
+// the value exists by the time the factory runs.
+const { mockConfig } = vi.hoisted(() => ({
+  mockConfig: {
+    memberRegistrationMode: 'offline' as 'remote' | 'offline',
+    inviteAcceptBaseUrl: 'https://p.example',
+  },
+}))
+vi.mock('../src/config.js', () => ({ config: mockConfig }))
+vi.mock('../src/services/invitationFlowRegistrationService.js', () => ({
+  registerAndSendInvitation: vi.fn().mockResolvedValue(undefined),
+  buildInviteAcceptUrl: (t: string) => `https://p.example/invitations/${t}`,
+}))
+
+import { createManagedInvitationForUser } from '../src/services/directory/membership.js'
+
+beforeEach(() => {
+  mockPoolQuery.mockReset()
+  mockConfig.memberRegistrationMode = 'offline'
+})
+
+describe('createManagedInvitationForUser offline existing-user guard', () => {
+  it('offline: rejects inviting a pre-existing user email', async () => {
+    // manager-roles query returns inviter role on the team
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ team_id: 't1', role: 'inviter', team_name: 'T' }] })
+    // existing-user probe returns a row
+    mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 'existing-user' }] })
+    const result = await createManagedInvitationForUser('mgr', 'existing@b.com', [{ teamId: 't1', role: 'member' }], 'Name')
+    expect(result).toEqual({ error: 'member_email_exists' })
+  })
+})

--- a/control-api/test/services.directory.membership.inviteGuard.test.ts
+++ b/control-api/test/services.directory.membership.inviteGuard.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createManagedInvitationForUser } from '../src/services/directory/membership.js'
 
 const mockPoolQuery = vi.fn()
 vi.mock('../src/db.js', () => ({
@@ -23,8 +24,6 @@ vi.mock('../src/services/invitationFlowRegistrationService.js', () => ({
   buildInviteAcceptUrl: (t: string) => `https://p.example/invitations/${t}`,
 }))
 
-import { createManagedInvitationForUser } from '../src/services/directory/membership.js'
-
 beforeEach(() => {
   mockPoolQuery.mockReset()
   mockConfig.memberRegistrationMode = 'offline'
@@ -33,10 +32,17 @@ beforeEach(() => {
 describe('createManagedInvitationForUser offline existing-user guard', () => {
   it('offline: rejects inviting a pre-existing user email', async () => {
     // manager-roles query returns inviter role on the team
-    mockPoolQuery.mockResolvedValueOnce({ rows: [{ team_id: 't1', role: 'inviter', team_name: 'T' }] })
+    mockPoolQuery.mockResolvedValueOnce({
+      rows: [{ team_id: 't1', role: 'inviter', team_name: 'T' }],
+    })
     // existing-user probe returns a row
     mockPoolQuery.mockResolvedValueOnce({ rows: [{ id: 'existing-user' }] })
-    const result = await createManagedInvitationForUser('mgr', 'existing@b.com', [{ teamId: 't1', role: 'member' }], 'Name')
+    const result = await createManagedInvitationForUser(
+      'mgr',
+      'existing@b.com',
+      [{ teamId: 't1', role: 'member' }],
+      'Name'
+    )
     expect(result).toEqual({ error: 'member_email_exists' })
   })
 })

--- a/control-api/test/services.invitationFlowRegistration.test.ts
+++ b/control-api/test/services.invitationFlowRegistration.test.ts
@@ -17,6 +17,7 @@ vi.mock('../src/utils/auth/memberRegistrationSigner.js', () => ({
 import {
   buildInviteAcceptUrl,
   registerAndSendInvitation,
+  storeDesktopAuthorizationToken,
 } from '../src/services/invitationFlowRegistrationService.js'
 
 const fetchSpy = vi.fn()
@@ -52,5 +53,20 @@ describe('registerAndSendInvitation — offline vs remote', () => {
     await registerAndSendInvitation('a@b.com', 'tok-123', 'Team', 'i', 'e', {})
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     expect(String(fetchSpy.mock.calls[0][0])).toContain('/invitations-flow/invitations')
+  })
+})
+
+describe('storeDesktopAuthorizationToken — offline vs remote', () => {
+  it('offline: does not call fetch', async () => {
+    mockConfig.memberRegistrationMode = 'offline'
+    await storeDesktopAuthorizationToken('a@b.com', 'auth-tok')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('remote: calls fetch against the registration service', async () => {
+    mockConfig.memberRegistrationMode = 'remote'
+    await storeDesktopAuthorizationToken('a@b.com', 'auth-tok')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('/invitations-flow/desktop-authorizations')
   })
 })

--- a/control-api/test/services.invitationFlowRegistration.test.ts
+++ b/control-api/test/services.invitationFlowRegistration.test.ts
@@ -18,7 +18,11 @@ import {
   buildInviteAcceptUrl,
   registerAndSendInvitation,
   storeDesktopAuthorizationToken,
+  validateInvitationFlowToken,
 } from '../src/services/invitationFlowRegistrationService.js'
+
+const getInvitationByToken = vi.fn()
+vi.mock('../src/services/directory/index.js', () => ({ getInvitationByToken }))
 
 const fetchSpy = vi.fn()
 beforeEach(() => {
@@ -53,6 +57,31 @@ describe('registerAndSendInvitation — offline vs remote', () => {
     await registerAndSendInvitation('a@b.com', 'tok-123', 'Team', 'i', 'e', {})
     expect(fetchSpy).toHaveBeenCalledTimes(1)
     expect(String(fetchSpy.mock.calls[0][0])).toContain('/invitations-flow/invitations')
+  })
+})
+
+describe('validateInvitationFlowToken — offline', () => {
+  beforeEach(() => {
+    mockConfig.memberRegistrationMode = 'offline'
+    getInvitationByToken.mockReset()
+  })
+
+  it('echoes the input token as invitationUuid for a valid invitation', async () => {
+    // shaped like invitationResponse — intentionally has NO `token` field
+    getInvitationByToken.mockResolvedValue({ id: 'row-id', email: 'a@b.com', status: 'pending' })
+    const result = await validateInvitationFlowToken('  tok-123  ', 'A@B.com')
+    expect(getInvitationByToken).toHaveBeenCalledWith('tok-123')
+    expect(result).toEqual({ email: 'a@b.com', invitationUuid: 'tok-123' })
+  })
+
+  it('throws when the invitation is missing/invalid', async () => {
+    getInvitationByToken.mockResolvedValue(null)
+    await expect(validateInvitationFlowToken('nope')).rejects.toThrow()
+  })
+
+  it('throws when the supplied email does not match', async () => {
+    getInvitationByToken.mockResolvedValue({ id: 'row-id', email: 'a@b.com', status: 'pending' })
+    await expect(validateInvitationFlowToken('tok-123', 'other@b.com')).rejects.toThrow()
   })
 })
 

--- a/control-api/test/services.invitationFlowRegistration.test.ts
+++ b/control-api/test/services.invitationFlowRegistration.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockConfig = vi.hoisted(() => ({
+  memberRegistrationMode: 'offline' as 'remote' | 'offline',
+  memberRegistrationServiceBaseUrl: 'https://reg.example/api/v1',
+  inviteAcceptBaseUrl: 'https://profile.example/',
+  desktopExternalRestApiBaseUrl: 'http://x',
+  desktopRpcProxyBaseUrl: 'http://x',
+  desktopProfileUiBaseUrl: 'http://x',
+  desktopAppName: 'Evenfire',
+}))
+vi.mock('../src/config.js', () => ({ config: mockConfig }))
+vi.mock('../src/utils/auth/memberRegistrationSigner.js', () => ({
+  signMemberRegistrationJwt: () => 'test-jwt',
+}))
+
+import {
+  buildInviteAcceptUrl,
+  registerAndSendInvitation,
+} from '../src/services/invitationFlowRegistrationService.js'
+
+const fetchSpy = vi.fn()
+beforeEach(() => {
+  fetchSpy.mockReset()
+  fetchSpy.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({ sent: true, registered: true }),
+  })
+  vi.stubGlobal('fetch', fetchSpy)
+  mockConfig.memberRegistrationMode = 'offline'
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('buildInviteAcceptUrl', () => {
+  it('joins the accept base url and token, trimming trailing slashes', () => {
+    expect(buildInviteAcceptUrl('tok-123')).toBe('https://profile.example/invitations/tok-123')
+  })
+})
+
+describe('registerAndSendInvitation — offline vs remote', () => {
+  it('offline: does not call fetch and logs no token', async () => {
+    mockConfig.memberRegistrationMode = 'offline'
+    await registerAndSendInvitation('a@b.com', 'tok-123', 'Team', 'i', 'e', {})
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('remote: calls fetch against the registration service', async () => {
+    mockConfig.memberRegistrationMode = 'remote'
+    await registerAndSendInvitation('a@b.com', 'tok-123', 'Team', 'i', 'e', {})
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('/invitations-flow/invitations')
+  })
+})

--- a/control-api/test/services.invitationFlowRegistration.test.ts
+++ b/control-api/test/services.invitationFlowRegistration.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildInviteAcceptUrl,
+  registerAndSendInvitation,
+  storeDesktopAuthorizationToken,
+  validateInvitationFlowToken,
+} from '../src/services/invitationFlowRegistrationService.js'
 
 const mockConfig = vi.hoisted(() => ({
   memberRegistrationMode: 'offline' as 'remote' | 'offline',
@@ -13,13 +19,6 @@ vi.mock('../src/config.js', () => ({ config: mockConfig }))
 vi.mock('../src/utils/auth/memberRegistrationSigner.js', () => ({
   signMemberRegistrationJwt: () => 'test-jwt',
 }))
-
-import {
-  buildInviteAcceptUrl,
-  registerAndSendInvitation,
-  storeDesktopAuthorizationToken,
-  validateInvitationFlowToken,
-} from '../src/services/invitationFlowRegistrationService.js'
 
 const getInvitationByToken = vi.fn()
 vi.mock('../src/services/directory/index.js', () => ({ getInvitationByToken }))

--- a/control-ui/app/profile-admin/users/new/page.tsx
+++ b/control-ui/app/profile-admin/users/new/page.tsx
@@ -14,6 +14,7 @@ import { IconTrash } from '@components/icons'
 import { Button, CheckboxField, Field, TextInput } from '@components/ui'
 import { createMemberFromControlAdmin, getAdminTeams, inviteAdminTeamMember } from '@lib/api'
 import type { TeamRole } from '@lib/api'
+import { copyTextToClipboard } from '@lib/clipboard'
 import { permissionsForTeamRole, setDeletePermission, setInvitePermission } from '@lib/teamRoles'
 
 const STEPS = ['Member', 'Team'] as const
@@ -65,6 +66,7 @@ export default function CreateMemberPage() {
   const [loadingTeams, setLoadingTeams] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [inviteAcceptUrl, setInviteAcceptUrl] = useState('')
   const hasTeams = teams.length > 0
   const teamOptions = useMemo(
     () =>
@@ -133,10 +135,21 @@ export default function CreateMemberPage() {
     return !loadingTeams && isMemberIdentityValid()
   }
 
+  async function copyInviteAcceptUrl() {
+    const copied = await copyTextToClipboard(inviteAcceptUrl)
+    showToast(
+      copied
+        ? 'Invitation link copied.'
+        : 'Could not copy to clipboard. Select the link and copy it manually.',
+      { tone: copied ? 'success' : 'error' }
+    )
+  }
+
   async function handleCreateMember() {
     if (!canSubmit) return
     setSaving(true)
     setError('')
+    setInviteAcceptUrl('')
     try {
       const payload = {
         name: name.trim(),
@@ -155,7 +168,14 @@ export default function CreateMemberPage() {
         window.sessionStorage.removeItem(`control-admin-member-reuse-password:${sourceAdminId}`)
         showToast(`Member created for ${payload.email}.`, { tone: 'success' })
       } else {
-        await inviteAdminTeamMember(null, payload)
+        const created = await inviteAdminTeamMember(null, payload)
+        if (created?.inviteAcceptUrl) {
+          setInviteAcceptUrl(created.inviteAcceptUrl)
+          showToast(`Invitation created for ${payload.email}. Copy the link to share it.`, {
+            tone: 'success',
+          })
+          return // stay on the page so the admin can copy the link
+        }
         showToast(`Invitation sent to ${payload.email}.`, { tone: 'success' })
       }
       router.push('/profile-admin/users')
@@ -362,6 +382,17 @@ export default function CreateMemberPage() {
                   </div>
                 )}
               </div>
+            ) : null}
+
+            {inviteAcceptUrl ? (
+              <Field label="Invitation link" htmlFor="invite-accept-url">
+                <div className="cu-team-member-picker">
+                  <TextInput id="invite-accept-url" value={inviteAcceptUrl} readOnly />
+                  <Button variant="ghost" size="sm" onClick={() => void copyInviteAcceptUrl()}>
+                    Copy link
+                  </Button>
+                </div>
+              </Field>
             ) : null}
 
             {error ? <div className="cu-banner cu-banner--error">{error}</div> : null}

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -1641,6 +1641,7 @@ export async function inviteAdminTeamMember(
       token: string
       status: 'pending'
       created_at: string
+      inviteAcceptUrl?: string
     }>
   }
   return apiSend(
@@ -1656,6 +1657,7 @@ export async function inviteAdminTeamMember(
     token: string
     status: 'pending'
     created_at: string
+    inviteAcceptUrl?: string
   }>
 }
 

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -25,6 +25,8 @@ data:
   # control-api authenticates with a per-tenant HMAC JWT — the dev-default
   # kid/tenant/secret seeded into the sibling postgres tenant_credentials table.
   CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL: 'http://member-registration-service.registration.svc.cluster.local:8092/api/v1'
+  CONTROL_API_MEMBER_REGISTRATION_MODE: 'offline'
+  CONTROL_API_INVITE_ACCEPT_BASE_URL: 'http://127.0.0.1:3001'
   CONTROL_API_DESKTOP_EXTERNAL_REST_API_BASE_URL: 'http://127.0.0.1:8091'
   CONTROL_API_DESKTOP_RPC_PROXY_BASE_URL: 'http://127.0.0.1:8094'
   CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL: 'http://127.0.0.1:3001'

--- a/external-rest-api/test/routes.members.test.ts
+++ b/external-rest-api/test/routes.members.test.ts
@@ -66,6 +66,20 @@ describe('routes/members', () => {
     )
   })
 
+  it('passes through inviteAcceptUrl from the managed invitation service', async () => {
+    authTokenMock.verifyToken.mockReturnValueOnce(claims)
+    memberManagementMock.inviteManagedMember.mockResolvedValueOnce({
+      id: 'inv-1',
+      inviteAcceptUrl: 'https://profile.example/invitations/tok-xyz',
+    })
+
+    await request(makeApp())
+      .post('/members/invite')
+      .set('authorization', 'Bearer good-token')
+      .send({ email: 'x@example.com', name: 'X', teams: [{ teamId: 'team-1', role: 'member' }] })
+      .expect(201, { id: 'inv-1', inviteAcceptUrl: 'https://profile.example/invitations/tok-xyz' })
+  })
+
   it('rejects overlong invitee names', async () => {
     authTokenMock.verifyToken.mockReturnValueOnce(claims)
 

--- a/profile-ui/app/members/invite/page.tsx
+++ b/profile-ui/app/members/invite/page.tsx
@@ -50,6 +50,7 @@ export default function InviteMemberPage() {
   const [loadingTeams, setLoadingTeams] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [inviteAcceptUrl, setInviteAcceptUrl] = useState('')
   const emailValid = EMAIL_PATTERN.test(email.trim())
   const nameValid = Boolean(name.trim())
   const selectedTeamIds = useMemo(() => Object.keys(inviteRoles), [inviteRoles])
@@ -121,12 +122,24 @@ export default function InviteMemberPage() {
     setInviteRoles(current => ({ ...current, [team.id]: nextRole }))
   }
 
+  async function copyInviteAcceptUrl() {
+    try {
+      await navigator.clipboard.writeText(inviteAcceptUrl)
+      showToast('Invitation link copied.', { tone: 'success' })
+    } catch {
+      showToast('Could not copy to clipboard. Select the link and copy it manually.', {
+        tone: 'error',
+      })
+    }
+  }
+
   async function sendInvite() {
     if (!canSubmit) return
     setSaving(true)
     setError('')
+    setInviteAcceptUrl('')
     try {
-      await inviteManagedMember(
+      const created = await inviteManagedMember(
         email.trim().toLowerCase(),
         name.trim(),
         selectedTeams.map(team => ({
@@ -134,6 +147,11 @@ export default function InviteMemberPage() {
           role: inviteRoles[team.id] || 'member',
         }))
       )
+      if (created?.inviteAcceptUrl) {
+        setInviteAcceptUrl(created.inviteAcceptUrl)
+        showToast('Invitation created. Copy the link to share it.', { tone: 'success' })
+        return // stay on the page so the admin can copy the link
+      }
       showToast('Invitation sent.', { tone: 'success' })
       router.push('/members')
     } catch (nextError) {
@@ -241,6 +259,17 @@ export default function InviteMemberPage() {
                     </div>
                   )}
                 </div>
+              ) : null}
+
+              {inviteAcceptUrl ? (
+                <FormField label="Invitation link">
+                  <div className="cu-team-member-picker">
+                    <TextInput id="invite-accept-url" value={inviteAcceptUrl} readOnly />
+                    <Button variant="ghost" onClick={() => void copyInviteAcceptUrl()}>
+                      Copy link
+                    </Button>
+                  </div>
+                </FormField>
               ) : null}
 
               {error ? <div className="message message--error">{error}</div> : null}

--- a/profile-ui/lib/api.ts
+++ b/profile-ui/lib/api.ts
@@ -272,8 +272,10 @@ export async function inviteManagedMember(
   email: string,
   name: string,
   teams: Array<{ teamId: string; role: Role }>
-) {
-  return apiSend('POST', '/api/v1/members/invite', { email, name, teams })
+): Promise<{ inviteAcceptUrl?: string }> {
+  return apiSend('POST', '/api/v1/members/invite', { email, name, teams }) as Promise<{
+    inviteAcceptUrl?: string
+  }>
 }
 
 export async function updateManagedMemberRole(userId: string, teamId: string, role: Role) {


### PR DESCRIPTION
## Why

The member-invitation flow ("Create member" / "Invite") returns **500 Internal Server Error** on self-hosted (minikube/OSS) deployments: `control-api` makes an unconditional outbound `fetch` to `member-registration-service`, which is a hosted-only extracted sibling **not shipped in this repo** (see `docs/concepts/open-core-and-hosted.md`). In minikube that DNS name has no endpoint → `TypeError: fetch failed` → 500, and the invitation is stranded as `draft`.

## What

Adds an **`offline` mode** (default `remote`, so hosted is unchanged) that runs the full web member-invitation flow with no `member-registration-service`.

- **config** — `CONTROL_API_MEMBER_REGISTRATION_MODE` (`remote`|`offline`, default `remote`); production interlock (`offline` rejected under `NODE_ENV=production` unless `CONTROL_API_ALLOW_OFFLINE_IN_PROD=true`); `CONTROL_API_INVITE_ACCEPT_BASE_URL`. Remote-only requirements (service base URL, HMAC placeholder assertion) are relaxed only in offline mode.
- **create side** — `registerAndSendInvitation` and `storeDesktopAuthorizationToken` become no-ops offline (no `fetch`), and the create response carries an `inviteAcceptUrl` the admin can share.
- **accept side** — `validateInvitationFlowToken` resolves the token against the local `invitations` table (echoing the input token, which every consumer resolves by), so `create → GET /token → /accept → /password → login` works offline.
- **security** — offline existing-user guard on the inviter path (`member_email_exists` → 409), preventing an in-band invite token from being minted for a pre-existing account; tokens are never logged.
- **UI** — control-ui + profile-ui surface a copyable invite link when the response includes `inviteAcceptUrl`.
- **deploy** — the minikube overlay flips to `offline`; base/production overlays untouched.

## Testing

- New/updated unit tests for config (incl. prod semantics), the create/accept offline branches (fetch-spy load-bearing; validate proven to echo the input token via a `token`-less mock), the `inviteAcceptUrl` response, the existing-user guard, and external-rest-api passthrough.
- Full **control-api** (2763 passed / 3 skipped) and **external-rest-api** (106 passed) suites green; both UIs `tsc --noEmit` clean; prettier clean.
- Live end-to-end (deploy to minikube + drive the invite flow) intentionally deferred to the deployer.

## Scope / follow-ups (deliberately out of this PR)

- **Control-admin flows** (invitation / email-change / admin password-reset) stay on the remote path offline — they route through a separate wrapper with no local token column; offline support is a follow-up **PR 2** that reuses this flag.
- **Desktop-app** offline activation (`storeDesktopAuthorizationToken` is a non-500 stub for now).
- Minor: profile-ui invite-link uses a `cu-team-member-picker` class only defined in control-ui (pre-existing, cosmetic); a couple of test-coverage/comment nits.

## Base note

Targets the open sync branch `chore/sync-dev-e51b5b21b` (PR #87), since the invitation source it modifies lives there and not yet on `main`. Diff is exactly the 10 feature commits (rebased onto the sync tip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)