### PR TITLE
feat(control-api): hosted member-registration — self-enroll with the shared hub

### DIFF
--- a/control-api/src/app.ts
+++ b/control-api/src/app.ts
@@ -24,6 +24,7 @@ import { createMetricsRouter } from './routes/metrics.js'
 import { createRecipeOauthRouter } from './routes/recipeOauth.js'
 import { createRegistryRouter } from './routes/registry.js'
 import { createRpcAccessRouter } from './routes/rpc-access/index.js'
+import { memberRegistrationErrorResponse } from './services/memberRegistrationErrors.js'
 
 export function createApp(gateway: K8sGateway) {
   const app = express()
@@ -139,6 +140,22 @@ export function createApp(gateway: K8sGateway) {
     // synthesize a short tag for legacy paths.
     const correlationId = req.correlationId ?? Math.random().toString(36).slice(2, 10)
     const log = req.log ?? rootLogger
+
+    // Typed member-registration failures map to 503 (spec §8.6) — scoped
+    // instanceof check; the generic 5xx-collapse below stays intact.
+    const memberRegistration = memberRegistrationErrorResponse(err)
+    if (memberRegistration) {
+      log.warn(
+        {
+          event: memberRegistration.error,
+          correlationId,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        'member registration unavailable'
+      )
+      res.status(memberRegistration.status).json({ error: memberRegistration.error, correlationId })
+      return
+    }
 
     // Errors thrown by service-layer code may carry a `.status` field to
     // signal that the upstream response (e.g., registry 404) should be

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -18,6 +18,8 @@ type Config = {
   internalControlJwtWrcHmacSecret: string
   internalControlJwtHccHmacSecret: string
   allowedIssuanceNamespaces: string[]
+  memberRegistrationMode: 'remote' | 'hosted'
+  memberRegistrationExternalHubBaseUrl: string
   memberRegistrationServiceBaseUrl: string
   memberRegistrationServiceHmacSecret: string
   memberRegistrationServiceHmacKid: string
@@ -396,6 +398,43 @@ const RPC_JWT_PUBLIC_KEY = normalizePem(
   process.env.CONTROL_API_RPC_JWT_PUBLIC_KEY || publicKeyFromPrivateKey(RPC_JWT_PRIVATE_KEY)
 )
 
+const memberRegistrationMode: 'remote' | 'hosted' = (() => {
+  const raw = (process.env.CONTROL_API_MEMBER_REGISTRATION_MODE || 'remote').trim()
+  if (raw !== 'remote' && raw !== 'hosted') {
+    throw new Error(
+      `CONTROL_API_MEMBER_REGISTRATION_MODE must be 'remote' or 'hosted' (got '${raw}')`
+    )
+  }
+  return raw
+})()
+
+// "Present" = non-empty after trim: blanking a value in the deploy Secret must
+// count as absent (spec §8.1 — apply-inter-service-tokens.sh re-adds the key).
+function memberRegistrationEnvPresent(name: string): boolean {
+  const value = process.env[name]
+  return typeof value === 'string' && value.trim() !== ''
+}
+
+if (memberRegistrationMode === 'hosted') {
+  // Fail fast on ambiguity — scoped to the DELIBERATELY-set identity vars only.
+  // HMAC_SECRET is excluded: the shipped deploy unconditionally injects it via
+  // the control-api-internal-tokens Secret (spec §8.1), so it is ignorable legacy.
+  const injectedIdentity = [
+    'CONTROL_API_MEMBER_REGISTRATION_HMAC_KID',
+    'CONTROL_API_MEMBER_REGISTRATION_TENANT_ID',
+  ].filter(memberRegistrationEnvPresent)
+  if (injectedIdentity.length > 0) {
+    throw new Error(
+      `[SECURITY] CONTROL_API_MEMBER_REGISTRATION_MODE=hosted is mutually exclusive with an injected remote member-registration identity. Unset: ${injectedIdentity.join(', ')}`
+    )
+  }
+  if (memberRegistrationEnvPresent('CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET')) {
+    console.warn(
+      '[ControlAPI] CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET is set but IGNORED in hosted member-registration mode (deploy-injected legacy value; credentials are self-enrolled and stored in Postgres)'
+    )
+  }
+}
+
 export const config: Config = {
   port: Number(process.env.CONTROL_API_PORT || 8090),
   jsonBodyLimit: process.env.CONTROL_API_JSON_BODY_LIMIT || '150mb',
@@ -429,11 +468,22 @@ export const config: Config = {
   allowedIssuanceNamespaces: parseCsvList(
     process.env.CONTROL_API_ALLOWED_ISSUANCE_NAMESPACES || `${HOSTS_NAMESPACE},${SANDBOX_NAMESPACE}`
   ),
-  memberRegistrationServiceBaseUrl: requiredOrDevDefault(
-    'CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL',
-    'http://member-registration-service.profiles.svc.cluster.local:8092/api/v1'
-  ),
+  memberRegistrationMode,
+  memberRegistrationExternalHubBaseUrl:
+    process.env.CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL ||
+    'https://registration.evenfire.ai/api/v1',
+  memberRegistrationServiceBaseUrl:
+    memberRegistrationMode === 'hosted'
+      ? process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL || ''
+      : requiredOrDevDefault(
+          'CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL',
+          'http://member-registration-service.profiles.svc.cluster.local:8092/api/v1'
+        ),
   memberRegistrationServiceHmacSecret: (() => {
+    if (memberRegistrationMode === 'hosted') {
+      // Hosted mode never signs with the env secret; see the module-scope warning.
+      return ''
+    }
     const value = requiredOrDevDefault(
       'CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET',
       'dev-member-registration-hmac-secret'

--- a/control-api/src/db.ts
+++ b/control-api/src/db.ts
@@ -1,11 +1,11 @@
 import { Pool, type PoolClient } from 'pg'
 import { config } from './config.js'
+import { applyMemberRegistrationCredentialsSchema } from './services/memberRegistrationCredentialsSchema.js'
 import {
   applyPluginWorkloadSdkSchema,
   dropPluginWorkloadSdkSuperAdminApprovedColumn,
 } from './services/pluginWorkloadSdkSchema.js'
 import { applyRegistryConnectionSchema } from './services/registryConnectionSchema.js'
-import { applyMemberRegistrationCredentialsSchema } from './services/memberRegistrationCredentialsSchema.js'
 
 export type DbClient = {
   query: (text: string, values?: unknown[]) => Promise<{ rows: unknown[]; rowCount: number | null }>

--- a/control-api/src/db.ts
+++ b/control-api/src/db.ts
@@ -5,6 +5,7 @@ import {
   dropPluginWorkloadSdkSuperAdminApprovedColumn,
 } from './services/pluginWorkloadSdkSchema.js'
 import { applyRegistryConnectionSchema } from './services/registryConnectionSchema.js'
+import { applyMemberRegistrationCredentialsSchema } from './services/memberRegistrationCredentialsSchema.js'
 
 export type DbClient = {
   query: (text: string, values?: unknown[]) => Promise<{ rows: unknown[]; rowCount: number | null }>
@@ -2649,6 +2650,10 @@ const CONTROL_API_MIGRATIONS: DbMigration[] = [
   {
     version: '0054_workflow_run_completed_notification_download_detection',
     apply: applyWorkflowRunCompletedNotificationTrigger,
+  },
+  {
+    version: '0055_member_registration_credentials',
+    apply: applyMemberRegistrationCredentialsSchema,
   },
 ]
 

--- a/control-api/src/main.ts
+++ b/control-api/src/main.ts
@@ -7,6 +7,7 @@ import {
   startAdminRevokedTokenCleanup,
   stopAdminRevokedTokenCleanup,
 } from './services/adminAuthService.js'
+import { runBootEnrollment } from './services/memberRegistrationEnrollment.js'
 import {
   startBudgetReservationSweepCron,
   stopBudgetReservationSweepCron,
@@ -49,6 +50,10 @@ async function main(): Promise<void> {
   // Self-hosted fail-fast (spec §8 / §14.3): refuse to boot a registry-enabled
   // self-hosted deployment that has no registry_connection identity row.
   await assertRegistryConnectionReady()
+
+  // Hosted member-registration self-enrollment (spec §8.4): degrade, never
+  // block — runBootEnrollment never rejects; failures log and retry on demand.
+  await runBootEnrollment()
 
   startExpiryCron(config.userApprovalRequestExpiryIntervalMs)
   startPluginWorkloadSdkMaintenanceCron()

--- a/control-api/src/main.ts
+++ b/control-api/src/main.ts
@@ -51,10 +51,6 @@ async function main(): Promise<void> {
   // self-hosted deployment that has no registry_connection identity row.
   await assertRegistryConnectionReady()
 
-  // Hosted member-registration self-enrollment (spec §8.4): degrade, never
-  // block — runBootEnrollment never rejects; failures log and retry on demand.
-  await runBootEnrollment()
-
   startExpiryCron(config.userApprovalRequestExpiryIntervalMs)
   startPluginWorkloadSdkMaintenanceCron()
   startRateLimiterCleanup(config.approvalRlCleanupIntervalMs)
@@ -128,6 +124,16 @@ async function main(): Promise<void> {
 
   await server.start()
   console.log('[ControlAPI] Running')
+
+  // Hosted member-registration self-enrollment (spec §8.4): degrade, never
+  // block. Fire-and-forget, and only AFTER the listener is up — the liveness
+  // probe has no startupProbe grace (control-api.yaml: initialDelaySeconds=8,
+  // periodSeconds=12, failureThreshold=3 ≈ 32s), and a silently dropped hub
+  // (egress firewall / default-deny NetworkPolicy) can burn up to 20s of that
+  // budget on its own. Nothing is gained by awaiting it here: the hook never
+  // rejects, every send re-attempts enrollment on demand via ensureEnrollment,
+  // and the in-flight map dedupes any request that races this boot call.
+  void runBootEnrollment()
 }
 
 main().catch(error => {

--- a/control-api/src/main.ts
+++ b/control-api/src/main.ts
@@ -7,11 +7,11 @@ import {
   startAdminRevokedTokenCleanup,
   stopAdminRevokedTokenCleanup,
 } from './services/adminAuthService.js'
-import { runBootEnrollment } from './services/memberRegistrationEnrollment.js'
 import {
   startBudgetReservationSweepCron,
   stopBudgetReservationSweepCron,
 } from './services/budgetReservationSweepCron.js'
+import { runBootEnrollment } from './services/memberRegistrationEnrollment.js'
 import {
   startPluginWorkloadSdkMaintenanceCron,
   stopPluginWorkloadSdkMaintenanceCron,

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -1,12 +1,12 @@
 import { config } from './config.js'
 import {
-  signMemberRegistrationJwt,
-  type MemberRegistrationSigningCredential,
-} from './utils/auth/memberRegistrationSigner.js'
-import {
   ensureEnrollment,
   normalizeEnrollmentHost,
 } from './services/memberRegistrationEnrollment.js'
+import {
+  type MemberRegistrationSigningCredential,
+  signMemberRegistrationJwt,
+} from './utils/auth/memberRegistrationSigner.js'
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -1,28 +1,67 @@
 import { config } from './config.js'
-import { signMemberRegistrationJwt } from './utils/auth/memberRegistrationSigner.js'
+import {
+  signMemberRegistrationJwt,
+  type MemberRegistrationSigningCredential,
+} from './utils/auth/memberRegistrationSigner.js'
+import {
+  ensureEnrollment,
+  normalizeEnrollmentHost,
+} from './services/memberRegistrationEnrollment.js'
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-function buildUrl(path: string): string {
-  const base = config.memberRegistrationServiceBaseUrl.replace(/\/+$/, '')
+function buildUrl(baseUrl: string, path: string): string {
+  const base = baseUrl.replace(/\/+$/, '')
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
   return `${base}${normalizedPath}`
+}
+
+// The single mode seam (spec §8.5): remote signs with the injected env
+// credential against the configured service; hosted resolves the credential
+// bound to the DESTINATION host (the hub 403s on any mismatch) and calls the
+// external hub. destinationBaseUrl is required so no call site can silently
+// sign with the wrong credential.
+async function resolveTarget(destinationBaseUrl: string): Promise<{
+  baseUrl: string
+  credential: MemberRegistrationSigningCredential
+}> {
+  if (config.memberRegistrationMode === 'hosted') {
+    const credential = await ensureEnrollment(normalizeEnrollmentHost(destinationBaseUrl))
+    return {
+      baseUrl: config.memberRegistrationExternalHubBaseUrl,
+      credential: {
+        secret: credential.secret,
+        kid: credential.kid,
+        tenantId: credential.tenantId,
+      },
+    }
+  }
+  return {
+    baseUrl: config.memberRegistrationServiceBaseUrl,
+    credential: {
+      secret: config.memberRegistrationServiceHmacSecret,
+      kid: config.memberRegistrationServiceHmacKid,
+      tenantId: config.memberRegistrationTenantId,
+    },
+  }
 }
 
 export async function memberRegistrationServiceRequest<T>(
   method: RequestMethod,
   path: string,
-  options?: {
+  options: {
     body?: unknown
+    destinationBaseUrl: string
   }
 ): Promise<T> {
-  const response = await fetch(buildUrl(path), {
+  const { baseUrl, credential } = await resolveTarget(options.destinationBaseUrl)
+  const response = await fetch(buildUrl(baseUrl, path), {
     method,
     headers: {
       'content-type': 'application/json',
-      authorization: `Bearer ${signMemberRegistrationJwt()}`,
+      authorization: `Bearer ${signMemberRegistrationJwt(credential)}`,
     },
-    body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
   })
 
   const raw = await response.text()

--- a/control-api/src/routes/admin/auth.ts
+++ b/control-api/src/routes/admin/auth.ts
@@ -36,8 +36,8 @@ import {
   provisionAdminDesktopWorkspace,
   setInvitationPasswordForUser,
 } from '../../services/directory/index.js'
-import { signAdminToken } from '../../utils/auth/adminAuthToken.js'
 import { memberRegistrationErrorResponse } from '../../services/memberRegistrationErrors.js'
+import { signAdminToken } from '../../utils/auth/adminAuthToken.js'
 import {
   CONTROL_UI_ADMIN_SESSION_COOKIE,
   clearHttpOnlySessionCookie,

--- a/control-api/src/routes/admin/auth.ts
+++ b/control-api/src/routes/admin/auth.ts
@@ -37,6 +37,7 @@ import {
   setInvitationPasswordForUser,
 } from '../../services/directory/index.js'
 import { signAdminToken } from '../../utils/auth/adminAuthToken.js'
+import { memberRegistrationErrorResponse } from '../../services/memberRegistrationErrors.js'
 import {
   CONTROL_UI_ADMIN_SESSION_COOKIE,
   clearHttpOnlySessionCookie,
@@ -247,7 +248,7 @@ export function createAdminAuthRouter(): Router {
   router.post(
     '/admin/auth/password-reset/validate',
     publicAdminTokenRateLimit('password_reset_validate'),
-    async (req, res, _next) => {
+    async (req, res, next) => {
       try {
         const token = String(req.body?.token || '').trim()
         const email = String(req.body?.email || '')
@@ -275,6 +276,7 @@ export function createAdminAuthRouter(): Router {
           resetUuid: validation.resetUuid,
         })
       } catch (error) {
+        if (memberRegistrationErrorResponse(error)) return next(error)
         res.status(400).json({ error: 'invalid_password_reset' })
       }
     }
@@ -309,7 +311,8 @@ export function createAdminAuthRouter(): Router {
         let validation: { email: string; resetUuid: string }
         try {
           validation = await validateControlAdminPasswordResetToken(token, email)
-        } catch {
+        } catch (error) {
+          if (memberRegistrationErrorResponse(error)) throw error
           res.status(400).json({ error: 'invalid_password_reset' })
           return
         }
@@ -369,6 +372,7 @@ export function createAdminAuthRouter(): Router {
           desktopAccess,
         })
       } catch (error) {
+        if (memberRegistrationErrorResponse(error)) return next(error)
         res.status(400).json({ error: 'invalid_invitation' })
       }
     }
@@ -469,7 +473,7 @@ export function createAdminAuthRouter(): Router {
   router.post(
     '/admin/auth/control-admin-email-confirmations/validate',
     publicAdminTokenRateLimit('email_confirmation_validate'),
-    async (req, res, _next) => {
+    async (req, res, next) => {
       try {
         const token = String(req.body?.token || '').trim()
         const email = String(req.body?.email || '')
@@ -500,6 +504,7 @@ export function createAdminAuthRouter(): Router {
           confirmationUuid: validation.confirmationUuid,
         })
       } catch (error) {
+        if (memberRegistrationErrorResponse(error)) return next(error)
         res.status(400).json({ error: 'invalid_confirmation' })
       }
     }
@@ -526,7 +531,8 @@ export function createAdminAuthRouter(): Router {
         let validation: { email: string; confirmationUuid: string }
         try {
           validation = await validateControlAdminEmailConfirmationToken(token, email || undefined)
-        } catch {
+        } catch (error) {
+          if (memberRegistrationErrorResponse(error)) throw error
           res.status(400).json({ error: 'invalid_confirmation' })
           return
         }

--- a/control-api/src/routes/external/invitations.ts
+++ b/control-api/src/routes/external/invitations.ts
@@ -18,8 +18,8 @@ import {
   storeDesktopAuthorizationToken,
   validateInvitationFlowToken,
 } from '../../services/invitationFlowRegistrationService.js'
-import { signExternalSessionToken } from '../../utils/auth/externalSessionAuthToken.js'
 import { memberRegistrationErrorResponse } from '../../services/memberRegistrationErrors.js'
+import { signExternalSessionToken } from '../../utils/auth/externalSessionAuthToken.js'
 
 function invitationLookupIpKey(req: {
   ip?: string

--- a/control-api/src/routes/external/invitations.ts
+++ b/control-api/src/routes/external/invitations.ts
@@ -19,6 +19,7 @@ import {
   validateInvitationFlowToken,
 } from '../../services/invitationFlowRegistrationService.js'
 import { signExternalSessionToken } from '../../utils/auth/externalSessionAuthToken.js'
+import { memberRegistrationErrorResponse } from '../../services/memberRegistrationErrors.js'
 
 function invitationLookupIpKey(req: {
   ip?: string
@@ -49,7 +50,8 @@ export function createExternalInvitationsRouter(): Router {
         let validation: { email: string; invitationUuid: string }
         try {
           validation = await validateInvitationFlowToken(token)
-        } catch {
+        } catch (error) {
+          if (memberRegistrationErrorResponse(error)) throw error
           return res.status(400).json({ error: 'invalid_invitation' })
         }
         const invitation = await getInvitationByToken(validation.invitationUuid)
@@ -85,7 +87,8 @@ export function createExternalInvitationsRouter(): Router {
         let validation: { email: string; invitationUuid: string }
         try {
           validation = await validateInvitationFlowToken(token, email)
-        } catch {
+        } catch (error) {
+          if (memberRegistrationErrorResponse(error)) throw error
           return res.status(400).json({ error: 'invalid_invitation' })
         }
         if (validation.invitationUuid !== invitationId) {
@@ -247,7 +250,8 @@ export function createExternalInvitationsRouter(): Router {
       let validation: { email: string; invitationUuid: string }
       try {
         validation = await validateInvitationFlowToken(token, email)
-      } catch {
+      } catch (error) {
+        if (memberRegistrationErrorResponse(error)) throw error
         return res.status(400).json({ error: 'invalid_invitation' })
       }
       const result = await acceptInvitationForEmail(validation.email, validation.invitationUuid)

--- a/control-api/src/routes/external/invitations.ts
+++ b/control-api/src/routes/external/invitations.ts
@@ -207,6 +207,7 @@ export function createExternalInvitationsRouter(): Router {
         try {
           await storeDesktopAuthorizationToken(email, authorizationToken)
         } catch (error) {
+          if (memberRegistrationErrorResponse(error)) throw error
           const message = error instanceof Error ? error.message : ''
           if (message.includes('(404)')) {
             return res.status(404).json({ error: 'not_found' })

--- a/control-api/src/services/controlAdminInvitationRegistrationService.ts
+++ b/control-api/src/services/controlAdminInvitationRegistrationService.ts
@@ -12,6 +12,7 @@ export async function registerAndSendControlAdminInvitation(
     'POST',
     '/control-admin-invitations/invitations',
     {
+      destinationBaseUrl: config.controlUiBaseUrl,
       body: {
         email,
         invitationUuid,
@@ -34,6 +35,7 @@ export async function validateControlAdminInvitationToken(
     email: string
     invitationUuid: string
   }>('POST', '/control-admin-invitations/validate', {
+    destinationBaseUrl: config.controlUiBaseUrl,
     body: {
       token,
       email,
@@ -55,6 +57,7 @@ export async function registerAndSendControlAdminEmailConfirmation(
     'POST',
     '/control-admin-email-confirmations/confirmations',
     {
+      destinationBaseUrl: config.controlUiBaseUrl,
       body: {
         email,
         confirmationUuid,
@@ -76,6 +79,7 @@ export async function validateControlAdminEmailConfirmationToken(
     email: string
     confirmationUuid: string
   }>('POST', '/control-admin-email-confirmations/validate', {
+    destinationBaseUrl: config.controlUiBaseUrl,
     body: {
       token,
       email,
@@ -97,6 +101,7 @@ export async function registerAndSendControlAdminPasswordReset(
     'POST',
     '/control-admin-password-resets/resets',
     {
+      destinationBaseUrl: config.controlUiBaseUrl,
       body: {
         email,
         resetUuid,
@@ -118,6 +123,7 @@ export async function validateControlAdminPasswordResetToken(
     email: string
     resetUuid: string
   }>('POST', '/control-admin-password-resets/validate', {
+    destinationBaseUrl: config.controlUiBaseUrl,
     body: {
       token,
       email,

--- a/control-api/src/services/invitationFlowRegistrationService.ts
+++ b/control-api/src/services/invitationFlowRegistrationService.ts
@@ -16,6 +16,7 @@ export async function registerAndSendInvitation(
     'POST',
     '/invitations-flow/invitations',
     {
+      destinationBaseUrl: config.desktopProfileUiBaseUrl,
       body: {
         email,
         invitationUuid,
@@ -42,6 +43,7 @@ export async function validateInvitationFlowToken(
     email: string
     invitationUuid: string
   }>('POST', '/invitations-flow/validate', {
+    destinationBaseUrl: config.desktopProfileUiBaseUrl,
     body: {
       token,
       email,
@@ -61,6 +63,7 @@ export async function storeDesktopAuthorizationToken(
     'POST',
     '/invitations-flow/desktop-authorizations',
     {
+      destinationBaseUrl: config.desktopProfileUiBaseUrl,
       body: {
         email,
         authorizationToken,

--- a/control-api/src/services/memberRegistrationCredentialsDb.ts
+++ b/control-api/src/services/memberRegistrationCredentialsDb.ts
@@ -1,0 +1,80 @@
+import { config } from '../config.js'
+import { pool } from '../db.js'
+import {
+  decryptOAuthSecret,
+  deriveOAuthEncryptionKey,
+  encryptOAuthSecret,
+} from '../oauth/encryption.js'
+
+// Hosted-mode hub credentials (spec §8.2). Secrets are AES-256-GCM encrypted
+// with the platform's existing envelope key — a Postgres dump yields nothing
+// usable. Rotation is ops-level (revoke + blank); this module never deletes.
+export interface MemberRegistrationCredential {
+  boundDomain: string
+  tenantId: string
+  kid: string
+  secret: string
+}
+
+interface RawRow {
+  bound_domain: string
+  tenant_id: string
+  kid: string
+  secret_encrypted: string
+}
+
+function encryptionKey(): Buffer {
+  return deriveOAuthEncryptionKey(config.oauthEncryptionKey)
+}
+
+export async function getActiveMemberRegistrationCredential(
+  domain: string
+): Promise<MemberRegistrationCredential | null> {
+  const result = await pool.query(
+    `SELECT bound_domain, tenant_id, kid, secret_encrypted
+       FROM member_registration_credentials
+      WHERE bound_domain = $1 AND revoked_at IS NULL
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [domain]
+  )
+  const row = result.rows[0] as RawRow | undefined
+  if (!row) return null
+  let secret: string
+  try {
+    secret = decryptOAuthSecret(encryptionKey(), row.secret_encrypted)
+  } catch {
+    // Lost/rotated envelope key = "no credential" (spec §8.2 fails soft). Revoke
+    // the dead row so it frees the partial-unique slot and the re-mint INSERT
+    // can succeed; keep the row (blanked) as audit trail.
+    await pool.query(
+      `UPDATE member_registration_credentials
+          SET revoked_at = NOW(), secret_encrypted = ''
+        WHERE bound_domain = $1 AND revoked_at IS NULL`,
+      [domain]
+    )
+    return null
+  }
+  return {
+    boundDomain: row.bound_domain,
+    tenantId: row.tenant_id,
+    kid: row.kid,
+    secret,
+  }
+}
+
+export async function insertMemberRegistrationCredential(input: {
+  boundDomain: string
+  tenantId: string
+  kid: string
+  secret: string
+}): Promise<{ inserted: boolean }> {
+  const encrypted = encryptOAuthSecret(encryptionKey(), input.secret)
+  const result = await pool.query(
+    `INSERT INTO member_registration_credentials (bound_domain, tenant_id, kid, secret_encrypted)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (bound_domain) WHERE revoked_at IS NULL DO NOTHING`,
+    [input.boundDomain, input.tenantId, input.kid, encrypted]
+  )
+  return { inserted: (result.rowCount ?? 0) > 0 }
+}

--- a/control-api/src/services/memberRegistrationCredentialsSchema.ts
+++ b/control-api/src/services/memberRegistrationCredentialsSchema.ts
@@ -1,0 +1,31 @@
+import type { DbClient } from '../db.js'
+
+// ─── Hosted member-registration credentials — schema (migration 0055) ──
+// One row per (bound_domain, mint). The hub binds each credential to exactly one
+// destination hostname; hosted mode mints one per configured UI host (spec §8.2).
+// `secret_encrypted` is AES-256-GCM via src/oauth/encryption.ts — never plaintext.
+// Rotation is ops-level: UPDATE ... SET revoked_at = now(), secret_encrypted = ''
+// frees the partial-unique slot; the next send/boot re-mints.
+//
+// Type-only dependency on db.js so db.ts can import it without a runtime cycle —
+// mirrors registryConnectionSchema.ts.
+export async function applyMemberRegistrationCredentialsSchema(db: DbClient): Promise<void> {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS member_registration_credentials (
+      id               BIGSERIAL PRIMARY KEY,
+      bound_domain     TEXT NOT NULL,
+      tenant_id        TEXT NOT NULL,
+      kid              TEXT NOT NULL,
+      secret_encrypted TEXT NOT NULL,
+      created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      revoked_at       TIMESTAMPTZ
+    );
+
+    -- At most one ACTIVE credential per bound domain; revoked rows stay as audit
+    -- trail (with secret_encrypted blanked). The re-mint path relies on the
+    -- WHERE clause: a revoked row must not block a fresh INSERT.
+    CREATE UNIQUE INDEX IF NOT EXISTS member_registration_credentials_active_domain_idx
+      ON member_registration_credentials (bound_domain)
+      WHERE revoked_at IS NULL;
+  `)
+}

--- a/control-api/src/services/memberRegistrationEnrollment.ts
+++ b/control-api/src/services/memberRegistrationEnrollment.ts
@@ -126,11 +126,6 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
   ) {
     throw transientFailure(domain, 'member-registration hub returned a malformed mint response')
   }
-  // Only reset the backoff counter once the mint body is known well-formed —
-  // resetting as soon as response.ok is true (before this check) would let a
-  // hub that keeps returning 2xx with a malformed body re-mint at the 5s base
-  // forever instead of escalating toward BACKOFF_CAP_MS.
-  consecutiveTransientFailures.delete(domain)
 
   let inserted: boolean
   let winner: MemberRegistrationCredential | null
@@ -151,6 +146,14 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
   if (!winner) {
     throw transientFailure(domain, 'credential row missing after insert')
   }
+  // Only reset the backoff counter on genuine full success — after the mint
+  // body is well-formed AND the credential is durably persisted/adopted. The
+  // counter must survive every failure path up to and including a persist
+  // failure or a missing post-insert row, or a sustained outage on any of
+  // those paths would re-mint at the 5s base forever instead of escalating
+  // toward BACKOFF_CAP_MS (the exact orphan storm the design forbids).
+  consecutiveTransientFailures.delete(domain)
+
   if (!inserted) {
     rootLogger.warn(
       {

--- a/control-api/src/services/memberRegistrationEnrollment.ts
+++ b/control-api/src/services/memberRegistrationEnrollment.ts
@@ -110,7 +110,15 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
     throw transientFailure(domain, `member-registration hub error (${response.status})`)
   }
 
-  const minted = (await response.json()) as { tenantId?: unknown; kid?: unknown; secret?: unknown }
+  let minted: { tenantId?: unknown; kid?: unknown; secret?: unknown }
+  try {
+    minted = (await response.json()) as { tenantId?: unknown; kid?: unknown; secret?: unknown }
+  } catch {
+    // Log hygiene: fixed message only — never fold the caught parse error's
+    // text in here, since a JSON.parse SyntaxError can echo body content and
+    // the mint body carries the secret.
+    throw transientFailure(domain, 'member-registration hub returned an unparseable mint response')
+  }
   if (
     typeof minted.tenantId !== 'string' ||
     typeof minted.kid !== 'string' ||
@@ -124,13 +132,22 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
   // forever instead of escalating toward BACKOFF_CAP_MS.
   consecutiveTransientFailures.delete(domain)
 
-  const { inserted } = await insertMemberRegistrationCredential({
-    boundDomain: domain,
-    tenantId: minted.tenantId,
-    kid: minted.kid,
-    secret: minted.secret,
-  })
-  const winner = await getActiveMemberRegistrationCredential(domain)
+  let inserted: boolean
+  let winner: MemberRegistrationCredential | null
+  try {
+    ;({ inserted } = await insertMemberRegistrationCredential({
+      boundDomain: domain,
+      tenantId: minted.tenantId,
+      kid: minted.kid,
+      secret: minted.secret,
+    }))
+    winner = await getActiveMemberRegistrationCredential(domain)
+  } catch {
+    // Same bypass risk as the parse failure above: a persistence throw here
+    // (e.g. Postgres unreachable) must not escape untyped, or every
+    // subsequent request re-mints a fresh hub credential (an orphan storm).
+    throw transientFailure(domain, 'failed to persist the minted credential')
+  }
   if (!winner) {
     throw transientFailure(domain, 'credential row missing after insert')
   }

--- a/control-api/src/services/memberRegistrationEnrollment.ts
+++ b/control-api/src/services/memberRegistrationEnrollment.ts
@@ -1,0 +1,189 @@
+import { config } from '../config.js'
+import { rootLogger } from '../observability/logger.js'
+import {
+  MemberRegistrationMisconfiguredError,
+  MemberRegistrationUnavailableError,
+} from './memberRegistrationErrors.js'
+import {
+  getActiveMemberRegistrationCredential,
+  insertMemberRegistrationCredential,
+  type MemberRegistrationCredential,
+} from './memberRegistrationCredentialsDb.js'
+
+// Hosted-mode self-enrollment against the shared hub (spec §8.3/§8.4).
+// Lock-free: in-flight promise map (per-replica) + the partial unique index
+// with adopt-winner (cross-replica). NO transaction or advisory lock may span
+// the mint fetch. Log hygiene: never log the secret or a raw mint body.
+const MINT_TIMEOUT_MS = 10_000
+const HUB_REJECTION_TTL_MS = 10 * 60 * 1000
+const BACKOFF_BASE_MS = 5_000
+const BACKOFF_CAP_MS = 5 * 60 * 1000
+
+const inFlight = new Map<string, Promise<MemberRegistrationCredential>>()
+const negativeCache = new Map<string, { until: number; message: string }>()
+const consecutiveTransientFailures = new Map<string, number>()
+
+export function __resetMemberRegistrationEnrollmentForTests(): void {
+  inFlight.clear()
+  negativeCache.clear()
+  consecutiveTransientFailures.clear()
+}
+
+export function normalizeEnrollmentHost(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase()
+  } catch {
+    throw new MemberRegistrationMisconfiguredError(
+      `member-registration destination is not a valid URL: ${baseUrl}`
+    )
+  }
+}
+
+const IPV4_RE = /^\d{1,3}(\.\d{1,3}){3}$/
+
+function assertEnrollableHost(host: string): void {
+  const reason =
+    host === 'localhost' || host.endsWith('.localhost')
+      ? 'localhost'
+      : IPV4_RE.test(host)
+        ? 'an IPv4 literal'
+        : host.startsWith('[') || host.includes(':')
+          ? 'an IPv6 literal'
+          : !host.includes('.')
+            ? 'a dotless hostname'
+            : null
+  if (reason) {
+    throw new MemberRegistrationMisconfiguredError(
+      `hosted member-registration requires a real, publicly resolvable domain — '${host}' is ${reason}. Set CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL / CONTROL_API_CONTROL_UI_BASE_URL to real domains.`
+    )
+  }
+}
+
+function hubOrigin(): string {
+  return new URL(config.memberRegistrationExternalHubBaseUrl).origin
+}
+
+export async function ensureEnrollment(domain: string): Promise<MemberRegistrationCredential> {
+  assertEnrollableHost(domain)
+  const cached = negativeCache.get(domain)
+  if (cached) {
+    if (cached.until > Date.now()) throw new MemberRegistrationUnavailableError(cached.message)
+    negativeCache.delete(domain)
+  }
+  const pending = inFlight.get(domain)
+  if (pending) return pending
+  const attempt = enroll(domain).finally(() => inFlight.delete(domain))
+  inFlight.set(domain, attempt)
+  return attempt
+}
+
+async function enroll(domain: string): Promise<MemberRegistrationCredential> {
+  const existing = await getActiveMemberRegistrationCredential(domain)
+  if (existing) return existing
+
+  let response: Response
+  try {
+    response = await fetch(`${hubOrigin()}/public/tenants`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain }),
+      signal: AbortSignal.timeout(MINT_TIMEOUT_MS),
+    })
+  } catch (error) {
+    throw transientFailure(
+      domain,
+      `member-registration hub unreachable: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  if (!response.ok) {
+    // Log hygiene: status only — never stringify the response body.
+    if (response.status >= 400 && response.status < 500) {
+      const message = `member-registration hub rejected enrollment for '${domain}' (${response.status})`
+      negativeCache.set(domain, { until: Date.now() + HUB_REJECTION_TTL_MS, message })
+      rootLogger.error(
+        { event: 'member_registration_enrollment_rejected', domain, status: response.status },
+        message
+      )
+      throw new MemberRegistrationUnavailableError(message)
+    }
+    throw transientFailure(domain, `member-registration hub error (${response.status})`)
+  }
+
+  consecutiveTransientFailures.delete(domain)
+  const minted = (await response.json()) as { tenantId?: unknown; kid?: unknown; secret?: unknown }
+  if (
+    typeof minted.tenantId !== 'string' ||
+    typeof minted.kid !== 'string' ||
+    typeof minted.secret !== 'string'
+  ) {
+    throw transientFailure(domain, 'member-registration hub returned a malformed mint response')
+  }
+
+  const { inserted } = await insertMemberRegistrationCredential({
+    boundDomain: domain,
+    tenantId: minted.tenantId,
+    kid: minted.kid,
+    secret: minted.secret,
+  })
+  const winner = await getActiveMemberRegistrationCredential(domain)
+  if (!winner) {
+    throw transientFailure(domain, 'credential row missing after insert')
+  }
+  if (!inserted) {
+    rootLogger.warn(
+      {
+        event: 'member_registration_enrollment_orphan',
+        domain,
+        kid: winner.kid,
+        tenantId: winner.tenantId,
+      },
+      'lost the cross-replica mint race; adopting the winning credential (orphan minted hub-side)'
+    )
+  } else {
+    rootLogger.info(
+      { event: 'member_registration_enrolled', domain, kid: winner.kid, tenantId: winner.tenantId },
+      'enrolled with the member-registration hub'
+    )
+  }
+  return winner
+}
+
+function transientFailure(domain: string, message: string): MemberRegistrationUnavailableError {
+  const failures = (consecutiveTransientFailures.get(domain) ?? 0) + 1
+  consecutiveTransientFailures.set(domain, failures)
+  const backoffMs = Math.min(BACKOFF_BASE_MS * 2 ** (failures - 1), BACKOFF_CAP_MS)
+  negativeCache.set(domain, { until: Date.now() + backoffMs, message })
+  rootLogger.error(
+    { event: 'member_registration_enrollment_failed', domain, failures, backoffMs },
+    message
+  )
+  return new MemberRegistrationUnavailableError(message)
+}
+
+// Boot hook (spec §8.4): exported and unit-testable; contract = never rejects.
+// main.ts only calls this — do NOT inline a try/catch there.
+export async function runBootEnrollment(): Promise<void> {
+  if (config.memberRegistrationMode !== 'hosted') return
+  const hosts = new Set<string>()
+  for (const base of [config.desktopProfileUiBaseUrl, config.controlUiBaseUrl]) {
+    try {
+      hosts.add(normalizeEnrollmentHost(base))
+    } catch (error) {
+      rootLogger.error(
+        { event: 'member_registration_boot_enrollment_failed', base },
+        error instanceof Error ? error.message : String(error)
+      )
+    }
+  }
+  for (const host of hosts) {
+    try {
+      await ensureEnrollment(host)
+    } catch (error) {
+      rootLogger.error(
+        { event: 'member_registration_boot_enrollment_failed', domain: host },
+        error instanceof Error ? error.message : String(error)
+      )
+    }
+  }
+}

--- a/control-api/src/services/memberRegistrationEnrollment.ts
+++ b/control-api/src/services/memberRegistrationEnrollment.ts
@@ -110,7 +110,6 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
     throw transientFailure(domain, `member-registration hub error (${response.status})`)
   }
 
-  consecutiveTransientFailures.delete(domain)
   const minted = (await response.json()) as { tenantId?: unknown; kid?: unknown; secret?: unknown }
   if (
     typeof minted.tenantId !== 'string' ||
@@ -119,6 +118,11 @@ async function enroll(domain: string): Promise<MemberRegistrationCredential> {
   ) {
     throw transientFailure(domain, 'member-registration hub returned a malformed mint response')
   }
+  // Only reset the backoff counter once the mint body is known well-formed —
+  // resetting as soon as response.ok is true (before this check) would let a
+  // hub that keeps returning 2xx with a malformed body re-mint at the 5s base
+  // forever instead of escalating toward BACKOFF_CAP_MS.
+  consecutiveTransientFailures.delete(domain)
 
   const { inserted } = await insertMemberRegistrationCredential({
     boundDomain: domain,

--- a/control-api/src/services/memberRegistrationEnrollment.ts
+++ b/control-api/src/services/memberRegistrationEnrollment.ts
@@ -1,14 +1,14 @@
 import { config } from '../config.js'
 import { rootLogger } from '../observability/logger.js'
 import {
+  type MemberRegistrationCredential,
+  getActiveMemberRegistrationCredential,
+  insertMemberRegistrationCredential,
+} from './memberRegistrationCredentialsDb.js'
+import {
   MemberRegistrationMisconfiguredError,
   MemberRegistrationUnavailableError,
 } from './memberRegistrationErrors.js'
-import {
-  getActiveMemberRegistrationCredential,
-  insertMemberRegistrationCredential,
-  type MemberRegistrationCredential,
-} from './memberRegistrationCredentialsDb.js'
 
 // Hosted-mode self-enrollment against the shared hub (spec §8.3/§8.4).
 // Lock-free: in-flight promise map (per-replica) + the partial unique index

--- a/control-api/src/services/memberRegistrationErrors.ts
+++ b/control-api/src/services/memberRegistrationErrors.ts
@@ -16,9 +16,10 @@ export class MemberRegistrationMisconfiguredError extends Error {
   }
 }
 
-export function memberRegistrationErrorResponse(
-  err: unknown
-): { status: 503; error: 'member_registration_unavailable' | 'member_registration_misconfigured' } | null {
+export function memberRegistrationErrorResponse(err: unknown): {
+  status: 503
+  error: 'member_registration_unavailable' | 'member_registration_misconfigured'
+} | null {
   if (
     err instanceof MemberRegistrationUnavailableError ||
     err instanceof MemberRegistrationMisconfiguredError

--- a/control-api/src/services/memberRegistrationErrors.ts
+++ b/control-api/src/services/memberRegistrationErrors.ts
@@ -1,0 +1,29 @@
+// Typed member-registration failures (spec §8.6). Routes rethrow these ahead of
+// their bare 400 catch-alls; the app.ts error middleware maps them to 503.
+export class MemberRegistrationUnavailableError extends Error {
+  readonly code = 'member_registration_unavailable' as const
+  constructor(message = 'member registration is temporarily unavailable') {
+    super(message)
+    this.name = 'MemberRegistrationUnavailableError'
+  }
+}
+
+export class MemberRegistrationMisconfiguredError extends Error {
+  readonly code = 'member_registration_misconfigured' as const
+  constructor(message: string) {
+    super(message)
+    this.name = 'MemberRegistrationMisconfiguredError'
+  }
+}
+
+export function memberRegistrationErrorResponse(
+  err: unknown
+): { status: 503; error: 'member_registration_unavailable' | 'member_registration_misconfigured' } | null {
+  if (
+    err instanceof MemberRegistrationUnavailableError ||
+    err instanceof MemberRegistrationMisconfiguredError
+  ) {
+    return { status: 503, error: err.code }
+  }
+  return null
+}

--- a/control-api/src/utils/auth/memberRegistrationSigner.ts
+++ b/control-api/src/utils/auth/memberRegistrationSigner.ts
@@ -1,36 +1,39 @@
 import { createHmac, randomUUID } from 'node:crypto'
-import { config } from '../../config.js'
 
-// Signs the per-tenant HMAC JWT that control-api presents to the centralized
-// member-registration service (on example-hub, example.com) for
-// its three machine-to-machine routes. Mirrors the InternalControl-JWT
-// convention used by WRC/HCC; the member-registration service verifies the
-// signature against this tenant's secret (resolved by `kid`) and binds the
-// request to `sub` = tenantId.
+// Signs the per-tenant HMAC JWT that control-api presents to the member-
+// registration service. Pure: the credential is supplied by the caller —
+// remote mode passes the injected env credential, hosted mode passes the
+// self-enrolled row (spec §8.5). Token shape is unchanged either way.
 const AUDIENCE = 'member-registration-service'
 const ISSUER = 'control-api'
 const TTL_SECONDS = 60
+
+export interface MemberRegistrationSigningCredential {
+  secret: string
+  kid: string
+  tenantId: string
+}
 
 function base64UrlJson(value: unknown): string {
   return Buffer.from(JSON.stringify(value)).toString('base64url')
 }
 
-export function signMemberRegistrationJwt(now: Date = new Date()): string {
-  const secret = config.memberRegistrationServiceHmacSecret
-  const kid = config.memberRegistrationServiceHmacKid
-  const tenantId = config.memberRegistrationTenantId
+export function signMemberRegistrationJwt(
+  credential: MemberRegistrationSigningCredential,
+  now: Date = new Date()
+): string {
   const iat = Math.floor(now.getTime() / 1000)
 
-  const header = base64UrlJson({ alg: 'HS256', typ: 'JWT', kid })
+  const header = base64UrlJson({ alg: 'HS256', typ: 'JWT', kid: credential.kid })
   const payload = base64UrlJson({
     iss: ISSUER,
     aud: AUDIENCE,
-    sub: tenantId,
+    sub: credential.tenantId,
     iat,
     exp: iat + TTL_SECONDS,
     jti: randomUUID(),
   })
   const signingInput = `${header}.${payload}`
-  const signature = createHmac('sha256', secret).update(signingInput).digest('base64url')
+  const signature = createHmac('sha256', credential.secret).update(signingInput).digest('base64url')
   return `${signingInput}.${signature}`
 }

--- a/control-api/test/app.memberRegistrationUnavailable.test.ts
+++ b/control-api/test/app.memberRegistrationUnavailable.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import request from 'supertest'
 import express from 'express'
+import request from 'supertest'
+import { createApp } from '../src/app.js'
+import { MemberRegistrationUnavailableError } from '../src/services/memberRegistrationErrors.js'
+import { MockGateway } from './mockGateway.js'
 
 const adminReg = vi.hoisted(() => ({
   registerAndSendControlAdminInvitation: vi.fn(),
@@ -12,13 +15,10 @@ const adminReg = vi.hoisted(() => ({
 }))
 vi.mock('../src/services/controlAdminInvitationRegistrationService.js', () => adminReg)
 vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
-  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
-    next(),
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
 }))
-
-import { createApp } from '../src/app.js'
-import { MockGateway } from './mockGateway.js'
-import { MemberRegistrationUnavailableError } from '../src/services/memberRegistrationErrors.js'
 
 describe('app: member-registration unavailability maps to 503 (real error middleware)', () => {
   beforeEach(() => {

--- a/control-api/test/app.memberRegistrationUnavailable.test.ts
+++ b/control-api/test/app.memberRegistrationUnavailable.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import request from 'supertest'
+import express from 'express'
+
+const adminReg = vi.hoisted(() => ({
+  registerAndSendControlAdminInvitation: vi.fn(),
+  validateControlAdminInvitationToken: vi.fn(),
+  registerAndSendControlAdminEmailConfirmation: vi.fn(),
+  validateControlAdminEmailConfirmationToken: vi.fn(),
+  registerAndSendControlAdminPasswordReset: vi.fn(),
+  validateControlAdminPasswordResetToken: vi.fn(),
+}))
+vi.mock('../src/services/controlAdminInvitationRegistrationService.js', () => adminReg)
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}))
+
+import { createApp } from '../src/app.js'
+import { MockGateway } from './mockGateway.js'
+import { MemberRegistrationUnavailableError } from '../src/services/memberRegistrationErrors.js'
+
+describe('app: member-registration unavailability maps to 503 (real error middleware)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // /admin/auth/* is mounted at app.ts:46, BEFORE the /admin auth gate at :49,
+  // so this public validate route reaches the real middleware without a token.
+  it('returns 503 member_registration_unavailable through the production app', async () => {
+    adminReg.validateControlAdminPasswordResetToken.mockRejectedValue(
+      new MemberRegistrationUnavailableError()
+    )
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app)
+      .post('/api/v1/admin/auth/password-reset/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('REGRESSION: an untyped error still gets the route catch-all, not the 503 branch', async () => {
+    adminReg.validateControlAdminPasswordResetToken.mockRejectedValue(new Error('boom'))
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app)
+      .post('/api/v1/admin/auth/password-reset/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(400) // the route's own catch-all still owns generic errors
+    expect(res.body.error).toBe('invalid_password_reset')
+  })
+})

--- a/control-api/test/config.memberRegistrationMode.test.ts
+++ b/control-api/test/config.memberRegistrationMode.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { generateKeyPairSync, randomBytes } from 'node:crypto'
+
+function generateNonDevPem(): string {
+  // 3072-bit RSA — 2048 collides with the dev-key fingerprint check in src/config.ts.
+  return generateKeyPairSync('rsa', {
+    modulusLength: 3072,
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+  }).privateKey
+}
+
+/** Mirror of test/config.prod.test.ts applyProdEnv — every env the prod path requires. */
+function applyProdEnv(env: Record<string, string | undefined>): void {
+  env.NODE_ENV = 'production'
+  env.CONTROL_API_RPC_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.CONTROL_API_SESSION_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.CONTROL_API_ADMIN_JWT_PRIVATE_KEY = generateNonDevPem()
+  env.INTERNAL_CONTROL_JWT_WRC_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.INTERNAL_CONTROL_JWT_HCC_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL = 'https://example.com/api/v1'
+  env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID = 'clerum'
+  env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID = 'clerum'
+  env.CONTROL_API_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_JWT_AUDIENCE = 'profile-ui'
+  env.CONTROL_API_RPC_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_RPC_JWT_AUDIENCE = 'rpc-proxy'
+  env.CONTROL_API_GOOGLE_CLIENT_ID = 'prod-google-client-id'
+  env.CONTROL_API_ADMIN_JWT_ISSUER = 'control-api'
+  env.CONTROL_API_ADMIN_JWT_AUDIENCE = 'control-ui'
+  env.CONTROL_API_ADMIN_BOOTSTRAP_USERNAME = 'admin'
+  env.CONTROL_API_ADMIN_BOOTSTRAP_PASSWORD_HASH =
+    '$2b$12$4dm17x2DESCxETGi0MpNruC0KpCev5lbKwqgmUkVLxKsNUxoXXXXXX'
+  env.CONTROL_API_OAUTH_STATE_HMAC_SECRET = randomBytes(32).toString('hex')
+  env.CONTROL_API_OAUTH_ENCRYPTION_KEY = randomBytes(32).toString('hex')
+  env.CONTROL_API_INTERNAL_SERVICE_TOKENS =
+    'external-rest-api=prod-external-rest-api-token,rpc-proxy=prod-rpc-proxy-token,webhook-proxy=prod-webhook-proxy-token'
+}
+
+const MEMBER_REG_VARS = [
+  'CONTROL_API_MEMBER_REGISTRATION_MODE',
+  'CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL',
+  'CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET',
+  'CONTROL_API_MEMBER_REGISTRATION_HMAC_KID',
+  'CONTROL_API_MEMBER_REGISTRATION_TENANT_ID',
+  'CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL',
+] as const
+
+describe('config: member-registration mode', () => {
+  const origEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...origEnv }
+    for (const name of MEMBER_REG_VARS) delete process.env[name]
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    process.env = { ...origEnv }
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('defaults to remote', async () => {
+    const { config } = await import('../src/config.js')
+    expect(config.memberRegistrationMode).toBe('remote')
+  })
+
+  it('parses hosted and defaults the external hub base URL', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    const { config } = await import('../src/config.js')
+    expect(config.memberRegistrationMode).toBe('hosted')
+    expect(config.memberRegistrationExternalHubBaseUrl).toBe(
+      'https://registration.evenfire.ai/api/v1'
+    )
+  })
+
+  it('honors an explicit external hub override (staging hub)', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    process.env.CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL =
+      'https://registration.staging.example.com/api/v1'
+    const { config } = await import('../src/config.js')
+    expect(config.memberRegistrationExternalHubBaseUrl).toBe(
+      'https://registration.staging.example.com/api/v1'
+    )
+  })
+
+  it('hard-errors on unknown mode values (e.g. the abandoned "offline")', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'offline'
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_MODE/
+    )
+  })
+
+  it('fail-fasts hosted + injected HMAC_KID', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID = 'clerum-dev-e6f79032'
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_HMAC_KID/
+    )
+  })
+
+  it('fail-fasts hosted + injected TENANT_ID', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID = 'clerum-dev'
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_TENANT_ID/
+    )
+  })
+
+  it('treats empty/whitespace identity vars as absent (deploy blanking escape hatch)', async () => {
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID = '   '
+    process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID = ''
+    await expect(import('../src/config.js')).resolves.toBeDefined()
+  })
+
+  it('ignores a lone deploy-injected HMAC_SECRET in hosted mode, with a warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET = 'legacy-injected-secret'
+    await expect(import('../src/config.js')).resolves.toBeDefined()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET')
+    )
+  })
+
+  it('hosted relaxes the prod requirement for base URL + secret (non-vacuous direction)', async () => {
+    applyProdEnv(process.env)
+    // A real self-hosted operator flipping hosted: the four legacy vars are gone
+    // except the deploy-injected secret; base URL removed to prove the relaxation.
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'hosted'
+    const { config } = await import('../src/config.js')
+    expect(config.memberRegistrationMode).toBe('hosted')
+  })
+
+  // All four mode × var combinations (spec §8.8): a relaxation gated on env-var
+  // PRESENCE rather than the parsed mode passes a 2-combo suite while booting a
+  // prod remote deploy with no secret.
+  it('NEGATIVE: prod remote (mode unset) still REQUIRES the HMAC secret', async () => {
+    applyProdEnv(process.env)
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET/
+    )
+  })
+
+  it('NEGATIVE: prod remote (explicit) still REQUIRES the HMAC secret', async () => {
+    applyProdEnv(process.env)
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'remote'
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET/
+    )
+  })
+
+  it('NEGATIVE: prod remote (mode unset) still REQUIRES the service base URL', async () => {
+    applyProdEnv(process.env)
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL/
+    )
+  })
+
+  it('NEGATIVE: prod remote (explicit) still REQUIRES the service base URL', async () => {
+    applyProdEnv(process.env)
+    process.env.CONTROL_API_MEMBER_REGISTRATION_MODE = 'remote'
+    delete process.env.CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL
+    await expect(() => import('../src/config.js')).rejects.toThrow(
+      /CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL/
+    )
+  })
+})

--- a/control-api/test/db.memberRegistrationCredentialsMigration.test.ts
+++ b/control-api/test/db.memberRegistrationCredentialsMigration.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const clientQuery = vi.fn()
+const clientRelease = vi.fn()
+const mockConnect = vi.fn()
+const mockPoolCtor = vi.fn(function MockPool() {
+  return { connect: mockConnect, query: vi.fn() }
+})
+vi.mock('pg', () => ({ Pool: mockPoolCtor }))
+
+describe('0055_member_registration_credentials migration', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockConnect.mockResolvedValue({ query: clientQuery, release: clientRelease })
+    clientQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+  })
+
+  it('creates the table with an active-domain partial unique index and encrypted secret column', async () => {
+    const { initDb } = await import('../src/db.js')
+    await initDb()
+    const sqls = clientQuery.mock.calls.map(([sql]) => String(sql))
+    expect(sqls).toContainEqual(
+      expect.stringContaining('CREATE TABLE IF NOT EXISTS member_registration_credentials')
+    )
+    // The rotation re-mint path depends on the LITERAL partial-index predicate (spec §8.8).
+    expect(
+      sqls.some(
+        sql =>
+          /CREATE UNIQUE INDEX IF NOT EXISTS member_registration_credentials_active_domain_idx/.test(
+            sql
+          ) &&
+          /ON member_registration_credentials \(bound_domain\)/.test(sql) &&
+          /WHERE revoked_at IS NULL/.test(sql)
+      )
+    ).toBe(true)
+    expect(sqls.some(sql => /secret_encrypted/.test(sql))).toBe(true)
+    const recordedVersions = clientQuery.mock.calls
+      .filter(([sql]) => String(sql).includes('INSERT INTO schema_migrations'))
+      .map(([, params]) => (Array.isArray(params) ? params[0] : undefined))
+    expect(recordedVersions).toContain('0055_member_registration_credentials')
+  })
+})

--- a/control-api/test/memberRegistrationClient.resolution.test.ts
+++ b/control-api/test/memberRegistrationClient.resolution.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import crypto from 'node:crypto'
+
+const { cfg } = vi.hoisted(() => ({
+  cfg: {
+    memberRegistrationMode: 'hosted',
+    memberRegistrationExternalHubBaseUrl: 'https://registration.evenfire.ai/api/v1',
+    memberRegistrationServiceBaseUrl: '',
+    memberRegistrationServiceHmacSecret: '',
+    memberRegistrationServiceHmacKid: 'example-dev',
+    memberRegistrationTenantId: 'example-dev',
+    desktopProfileUiBaseUrl: 'https://profile.acme.com',
+    controlUiBaseUrl: 'https://control.acme.com',
+    desktopExternalRestApiBaseUrl: 'http://127.0.0.1:8091',
+    desktopRpcProxyBaseUrl: 'http://127.0.0.1:8094',
+    desktopAppName: 'Evenfire',
+    controlUiAppName: 'Evenfire',
+  } as Record<string, unknown>,
+}))
+vi.mock('../src/config.js', () => ({ config: cfg }))
+
+// Per-domain credentials so a transposed wrapper→host mapping is DETECTABLE
+// (spec §8.8 directional assertion).
+const CREDS: Record<string, { boundDomain: string; tenantId: string; kid: string; secret: string }> = {
+  'profile.acme.com': {
+    boundDomain: 'profile.acme.com',
+    tenantId: 'ext-profile',
+    kid: 'kid-profile',
+    secret: 'secret-profile',
+  },
+  'control.acme.com': {
+    boundDomain: 'control.acme.com',
+    tenantId: 'ext-control',
+    kid: 'kid-control',
+    secret: 'secret-control',
+  },
+}
+const enrollment = vi.hoisted(() => ({
+  ensureEnrollment: vi.fn(),
+  normalizeEnrollmentHost: (baseUrl: string) => new URL(baseUrl).hostname.toLowerCase(),
+}))
+vi.mock('../src/services/memberRegistrationEnrollment.js', () => enrollment)
+
+import { registerAndSendInvitation, validateInvitationFlowToken } from '../src/services/invitationFlowRegistrationService.js'
+import {
+  registerAndSendControlAdminInvitation,
+  validateControlAdminInvitationToken,
+} from '../src/services/controlAdminInvitationRegistrationService.js'
+
+function decodeAuthKid(fetchMock: ReturnType<typeof vi.fn>, callIndex: number) {
+  const [, init] = fetchMock.mock.calls[callIndex]
+  const token = String(init.headers.authorization).replace(/^Bearer /, '')
+  const [h, p, sig] = token.split('.')
+  const header = JSON.parse(Buffer.from(h, 'base64url').toString())
+  return { header, signingInput: `${h}.${p}`, sig }
+}
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('member-registration client per-host resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    cfg.memberRegistrationMode = 'hosted'
+    enrollment.ensureEnrollment.mockImplementation(async (domain: string) => {
+      const cred = CREDS[domain]
+      if (!cred) throw new Error(`unexpected domain ${domain}`)
+      return cred
+    })
+  })
+
+  it('member SEND and VALIDATE sign with the profile-ui host credential', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ sent: true, registered: true }))
+      .mockResolvedValueOnce(okJson({ valid: true, email: 'a@b.c', invitationUuid: 'u' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await registerAndSendInvitation('a@b.c', 'uuid-1', 'team', '2026-01-01', '2026-02-01')
+    await validateInvitationFlowToken('tok', 'a@b.c')
+
+    for (const i of [0, 1]) {
+      const { header, signingInput, sig } = decodeAuthKid(fetchMock, i)
+      expect(header.kid).toBe('kid-profile')
+      const expected = crypto
+        .createHmac('sha256', 'secret-profile')
+        .update(signingInput)
+        .digest('base64url')
+      expect(sig).toBe(expected)
+    }
+    // hosted mode routes through the hub base URL
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      'https://registration.evenfire.ai/api/v1/invitations-flow/invitations'
+    )
+  })
+
+  it('admin SEND and VALIDATE sign with the control-ui host credential', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ sent: true, registered: true }))
+      .mockResolvedValueOnce(okJson({ valid: true, email: 'a@b.c', invitationUuid: 'u' }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await registerAndSendControlAdminInvitation('a@b.c', 'uuid-2', '2026-01-01', '2026-02-01')
+    await validateControlAdminInvitationToken('tok', 'a@b.c')
+
+    for (const i of [0, 1]) {
+      const { header, signingInput, sig } = decodeAuthKid(fetchMock, i)
+      expect(header.kid).toBe('kid-control')
+      const expected = crypto
+        .createHmac('sha256', 'secret-control')
+        .update(signingInput)
+        .digest('base64url')
+      expect(sig).toBe(expected)
+    }
+  })
+
+  it('remote mode signs with the env credential, never touches enrollment or /public/tenants', async () => {
+    cfg.memberRegistrationMode = 'remote'
+    cfg.memberRegistrationServiceBaseUrl = 'http://member-registration-service.local:8092/api/v1'
+    cfg.memberRegistrationServiceHmacSecret = 'env-secret'
+    cfg.memberRegistrationServiceHmacKid = 'env-kid'
+    cfg.memberRegistrationTenantId = 'clerum-dev'
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ sent: true, registered: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await registerAndSendInvitation('a@b.c', 'uuid-3', 'team', '2026-01-01', '2026-02-01')
+
+    expect(enrollment.ensureEnrollment).not.toHaveBeenCalled()
+    const [url] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe(
+      'http://member-registration-service.local:8092/api/v1/invitations-flow/invitations'
+    )
+    expect(String(url)).not.toContain('/public/tenants')
+    const { header } = decodeAuthKid(fetchMock, 0)
+    expect(header.kid).toBe('env-kid')
+  })
+})

--- a/control-api/test/memberRegistrationClient.resolution.test.ts
+++ b/control-api/test/memberRegistrationClient.resolution.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import crypto from 'node:crypto'
+import {
+  registerAndSendControlAdminInvitation,
+  validateControlAdminInvitationToken,
+} from '../src/services/controlAdminInvitationRegistrationService.js'
+import {
+  registerAndSendInvitation,
+  validateInvitationFlowToken,
+} from '../src/services/invitationFlowRegistrationService.js'
 
 const { cfg } = vi.hoisted(() => ({
   cfg: {
@@ -21,7 +29,10 @@ vi.mock('../src/config.js', () => ({ config: cfg }))
 
 // Per-domain credentials so a transposed wrapper→host mapping is DETECTABLE
 // (spec §8.8 directional assertion).
-const CREDS: Record<string, { boundDomain: string; tenantId: string; kid: string; secret: string }> = {
+const CREDS: Record<
+  string,
+  { boundDomain: string; tenantId: string; kid: string; secret: string }
+> = {
   'profile.acme.com': {
     boundDomain: 'profile.acme.com',
     tenantId: 'ext-profile',
@@ -40,12 +51,6 @@ const enrollment = vi.hoisted(() => ({
   normalizeEnrollmentHost: (baseUrl: string) => new URL(baseUrl).hostname.toLowerCase(),
 }))
 vi.mock('../src/services/memberRegistrationEnrollment.js', () => enrollment)
-
-import { registerAndSendInvitation, validateInvitationFlowToken } from '../src/services/invitationFlowRegistrationService.js'
-import {
-  registerAndSendControlAdminInvitation,
-  validateControlAdminInvitationToken,
-} from '../src/services/controlAdminInvitationRegistrationService.js'
 
 function decodeAuthKid(fetchMock: ReturnType<typeof vi.fn>, callIndex: number) {
   const [, init] = fetchMock.mock.calls[callIndex]

--- a/control-api/test/memberRegistrationSigner.test.ts
+++ b/control-api/test/memberRegistrationSigner.test.ts
@@ -1,38 +1,39 @@
 import { describe, expect, it } from 'vitest'
 import crypto from 'node:crypto'
-import { config } from '../src/config.js'
 import { signMemberRegistrationJwt } from '../src/utils/auth/memberRegistrationSigner.js'
 
+const CREDENTIAL = {
+  secret: 'test-hmac-secret',
+  kid: 'ext-abc123-deadbeef',
+  tenantId: 'ext-abc123',
+}
+
 describe('signMemberRegistrationJwt', () => {
-  it('produces a verifiable HS256 token with the expected header + claims', () => {
-    const token = signMemberRegistrationJwt(new Date(1_700_000_000_000))
+  it('produces a verifiable HS256 token from the supplied credential', () => {
+    const token = signMemberRegistrationJwt(CREDENTIAL, new Date(1_700_000_000_000))
     const [h, p, sig] = token.split('.')
 
     const expected = crypto
-      .createHmac('sha256', config.memberRegistrationServiceHmacSecret)
+      .createHmac('sha256', CREDENTIAL.secret)
       .update(`${h}.${p}`)
       .digest('base64url')
     expect(sig).toBe(expected)
 
     const header = JSON.parse(Buffer.from(h, 'base64url').toString())
     const payload = JSON.parse(Buffer.from(p, 'base64url').toString())
-    expect(header).toMatchObject({
-      alg: 'HS256',
-      typ: 'JWT',
-      kid: config.memberRegistrationServiceHmacKid,
-    })
+    expect(header).toMatchObject({ alg: 'HS256', typ: 'JWT', kid: CREDENTIAL.kid })
     expect(payload).toMatchObject({
       iss: 'control-api',
       aud: 'member-registration-service',
-      sub: config.memberRegistrationTenantId,
+      sub: CREDENTIAL.tenantId,
     })
     expect(payload.exp - payload.iat).toBe(60)
     expect(typeof payload.jti).toBe('string')
   })
 
   it('mints a fresh jti each call', () => {
-    const a = signMemberRegistrationJwt()
-    const b = signMemberRegistrationJwt()
+    const a = signMemberRegistrationJwt(CREDENTIAL)
+    const b = signMemberRegistrationJwt(CREDENTIAL)
     const jtiA = JSON.parse(Buffer.from(a.split('.')[1], 'base64url').toString()).jti
     const jtiB = JSON.parse(Buffer.from(b.split('.')[1], 'base64url').toString()).jti
     expect(jtiA).not.toBe(jtiB)

--- a/control-api/test/routes.adminAuth.unavailable.test.ts
+++ b/control-api/test/routes.adminAuth.unavailable.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
+import { createAdminAuthRouter } from '../src/routes/admin/auth.js'
+import {
+  MemberRegistrationUnavailableError,
+  memberRegistrationErrorResponse,
+} from '../src/services/memberRegistrationErrors.js'
 
 const adminReg = vi.hoisted(() => ({
   registerAndSendControlAdminInvitation: vi.fn(),
@@ -12,15 +17,10 @@ const adminReg = vi.hoisted(() => ({
 }))
 vi.mock('../src/services/controlAdminInvitationRegistrationService.js', () => adminReg)
 vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
-  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
-    next(),
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
 }))
-
-import { createAdminAuthRouter } from '../src/routes/admin/auth.js'
-import {
-  MemberRegistrationUnavailableError,
-  memberRegistrationErrorResponse,
-} from '../src/services/memberRegistrationErrors.js'
 
 function app(): express.Express {
   const a = express()

--- a/control-api/test/routes.adminAuth.unavailable.test.ts
+++ b/control-api/test/routes.adminAuth.unavailable.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+const adminReg = vi.hoisted(() => ({
+  registerAndSendControlAdminInvitation: vi.fn(),
+  validateControlAdminInvitationToken: vi.fn(),
+  registerAndSendControlAdminEmailConfirmation: vi.fn(),
+  validateControlAdminEmailConfirmationToken: vi.fn(),
+  registerAndSendControlAdminPasswordReset: vi.fn(),
+  validateControlAdminPasswordResetToken: vi.fn(),
+}))
+vi.mock('../src/services/controlAdminInvitationRegistrationService.js', () => adminReg)
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}))
+
+import { createAdminAuthRouter } from '../src/routes/admin/auth.js'
+import {
+  MemberRegistrationUnavailableError,
+  memberRegistrationErrorResponse,
+} from '../src/services/memberRegistrationErrors.js'
+
+function app(): express.Express {
+  const a = express()
+  a.use(express.json())
+  a.use(createAdminAuthRouter())
+  a.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      const mapped = memberRegistrationErrorResponse(err)
+      if (mapped) return res.status(mapped.status).json({ error: mapped.error })
+      res.status(500).json({ error: 'Internal Server Error' })
+    }
+  )
+  return a
+}
+
+describe('admin auth validate routes when the hub is unavailable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('password-reset/validate returns 503, not 400 invalid_password_reset', async () => {
+    adminReg.validateControlAdminPasswordResetToken.mockRejectedValue(
+      new MemberRegistrationUnavailableError()
+    )
+    const res = await request(app())
+      .post('/admin/auth/password-reset/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('control-admin-invitations/validate returns 503, not 400 invalid_invitation', async () => {
+    adminReg.validateControlAdminInvitationToken.mockRejectedValue(
+      new MemberRegistrationUnavailableError()
+    )
+    const res = await request(app())
+      .post('/admin/auth/control-admin-invitations/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('control-admin-email-confirmations/validate returns 503, not 400 invalid_confirmation', async () => {
+    adminReg.validateControlAdminEmailConfirmationToken.mockRejectedValue(
+      new MemberRegistrationUnavailableError()
+    )
+    const res = await request(app())
+      .post('/admin/auth/control-admin-email-confirmations/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('REGRESSION: a generic validation error still maps to 400 invalid_password_reset', async () => {
+    adminReg.validateControlAdminPasswordResetToken.mockRejectedValue(new Error('bad token'))
+    const res = await request(app())
+      .post('/admin/auth/password-reset/validate')
+      .send({ token: 't' })
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('invalid_password_reset')
+  })
+})

--- a/control-api/test/routes.externalInvitations.unavailable.test.ts
+++ b/control-api/test/routes.externalInvitations.unavailable.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
+import { createExternalInvitationsRouter } from '../src/routes/external/invitations.js'
+import {
+  MemberRegistrationUnavailableError,
+  memberRegistrationErrorResponse,
+} from '../src/services/memberRegistrationErrors.js'
 
 const flow = vi.hoisted(() => ({
   validateInvitationFlowToken: vi.fn(),
@@ -19,24 +24,25 @@ const directory = vi.hoisted(() => ({
 vi.mock('../src/services/directory/index.js', () => directory)
 
 vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
-  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
-    next(),
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
 }))
 vi.mock('../src/middleware/externalSessionAuth.js', () => ({
-  rejectBodyUserTeamMismatch: (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
-    next(),
-  requireValidExternalSessionToken: (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
-    next(),
+  rejectBodyUserTeamMismatch: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => next(),
+  requireValidExternalSessionToken: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => next(),
 }))
 vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
   signExternalSessionToken: vi.fn(() => 'session-token'),
 }))
-
-import { createExternalInvitationsRouter } from '../src/routes/external/invitations.js'
-import {
-  MemberRegistrationUnavailableError,
-  memberRegistrationErrorResponse,
-} from '../src/services/memberRegistrationErrors.js'
 
 // Router-level harness: proves the ROUTE GUARDS rethrow instead of swallowing.
 // The real app.ts middleware is covered separately in

--- a/control-api/test/routes.externalInvitations.unavailable.test.ts
+++ b/control-api/test/routes.externalInvitations.unavailable.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+const flow = vi.hoisted(() => ({
+  validateInvitationFlowToken: vi.fn(),
+  storeDesktopAuthorizationToken: vi.fn(),
+}))
+vi.mock('../src/services/invitationFlowRegistrationService.js', () => flow)
+
+const directory = vi.hoisted(() => ({
+  acceptInvitationForEmail: vi.fn(),
+  getInvitationByToken: vi.fn(),
+  listPendingInvitations: vi.fn(),
+  setInvitationPasswordForEmail: vi.fn(),
+  setInvitationPasswordForUser: vi.fn(),
+  verifyUserPassword: vi.fn(),
+}))
+vi.mock('../src/services/directory/index.js', () => directory)
+
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware: () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}))
+vi.mock('../src/middleware/externalSessionAuth.js', () => ({
+  rejectBodyUserTeamMismatch: (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+  requireValidExternalSessionToken: (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+    next(),
+}))
+vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
+  signExternalSessionToken: vi.fn(() => 'session-token'),
+}))
+
+import { createExternalInvitationsRouter } from '../src/routes/external/invitations.js'
+import {
+  MemberRegistrationUnavailableError,
+  memberRegistrationErrorResponse,
+} from '../src/services/memberRegistrationErrors.js'
+
+// Router-level harness: proves the ROUTE GUARDS rethrow instead of swallowing.
+// The real app.ts middleware is covered separately in
+// test/app.memberRegistrationUnavailable.test.ts (Step 1b) — do not treat this
+// local mapper as evidence that app.ts is wired.
+function app(): express.Express {
+  const a = express()
+  a.use(express.json())
+  a.use(createExternalInvitationsRouter())
+  a.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      const mapped = memberRegistrationErrorResponse(err)
+      if (mapped) return res.status(mapped.status).json({ error: mapped.error })
+      res.status(500).json({ error: 'Internal Server Error' })
+    }
+  )
+  return a
+}
+
+describe('external invitation routes when the hub is unavailable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('GET token lookup returns 503 member_registration_unavailable, NOT 400 invalid_invitation', async () => {
+    flow.validateInvitationFlowToken.mockRejectedValue(new MemberRegistrationUnavailableError())
+    const res = await request(app()).get('/external/invitations/token/some-token')
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('POST accept returns 503 when validation hits an unavailable hub', async () => {
+    flow.validateInvitationFlowToken.mockRejectedValue(new MemberRegistrationUnavailableError())
+    const res = await request(app())
+      .post('/external/invitations/accept')
+      .send({ email: 'a@b.c', token: 't' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('REGRESSION: a generic validation error still maps to 400 invalid_invitation', async () => {
+    flow.validateInvitationFlowToken.mockRejectedValue(new Error('invalid_invitation'))
+    const res = await request(app()).get('/external/invitations/token/some-token')
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('invalid_invitation')
+  })
+})

--- a/control-api/test/routes.externalInvitations.unavailable.test.ts
+++ b/control-api/test/routes.externalInvitations.unavailable.test.ts
@@ -89,4 +89,35 @@ describe('external invitation routes when the hub is unavailable', () => {
     expect(res.status).toBe(400)
     expect(res.body.error).toBe('invalid_invitation')
   })
+
+  it('POST desktop-authorization returns 503, NOT 404, when the hub-rejection message shape collides with the "(404)" not_found string match', async () => {
+    // enroll() builds messages like `...rejected enrollment for '<domain>'
+    // (${response.status})`. A hub 404 during boot/on-demand enrollment
+    // therefore produces a MemberRegistrationUnavailableError whose message
+    // contains the literal substring "(404)" — the same substring this
+    // route's catch used to key off of to detect an invitation 404. Without
+    // the memberRegistrationErrorResponse guard, this typed 503 gets
+    // misclassified as a 404 invitation lookup failure.
+    directory.verifyUserPassword.mockResolvedValue(true)
+    flow.storeDesktopAuthorizationToken.mockRejectedValue(
+      new MemberRegistrationUnavailableError(
+        "member-registration hub rejected enrollment for 'x.acme.com' (404)"
+      )
+    )
+    const res = await request(app())
+      .post('/external/invitations/desktop-authorization')
+      .send({ userId: 'u1', email: 'a@b.c', password: 'pw' })
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('member_registration_unavailable')
+  })
+
+  it('REGRESSION: POST desktop-authorization still maps a generic upstream 404 message to 404 not_found', async () => {
+    directory.verifyUserPassword.mockResolvedValue(true)
+    flow.storeDesktopAuthorizationToken.mockRejectedValue(new Error('upstream responded (404)'))
+    const res = await request(app())
+      .post('/external/invitations/desktop-authorization')
+      .send({ userId: 'u1', email: 'a@b.c', password: 'pw' })
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('not_found')
+  })
 })

--- a/control-api/test/services.memberRegistrationCredentialsDb.test.ts
+++ b/control-api/test/services.memberRegistrationCredentialsDb.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deriveOAuthEncryptionKey,
+  encryptOAuthSecret,
+} from '../src/oauth/encryption.js'
+
+const OAUTH_KEY_HEX = 'ab'.repeat(32)
+
+const { cfg } = vi.hoisted(() => ({
+  cfg: { oauthEncryptionKey: 'ab'.repeat(32) } as Record<string, unknown>,
+}))
+vi.mock('../src/config.js', () => ({ config: cfg }))
+
+const db = vi.hoisted(() => ({ pool: { query: vi.fn() } }))
+vi.mock('../src/db.js', () => db)
+
+import {
+  getActiveMemberRegistrationCredential,
+  insertMemberRegistrationCredential,
+} from '../src/services/memberRegistrationCredentialsDb.js'
+
+const KEY = deriveOAuthEncryptionKey(OAUTH_KEY_HEX)
+
+describe('memberRegistrationCredentialsDb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the decrypted active credential', async () => {
+    db.pool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          bound_domain: 'profile.acme.com',
+          tenant_id: 'ext-abc123',
+          kid: 'ext-abc123-deadbeef',
+          secret_encrypted: encryptOAuthSecret(KEY, 'hub-secret'),
+        },
+      ],
+      rowCount: 1,
+    })
+    const row = await getActiveMemberRegistrationCredential('profile.acme.com')
+    expect(row).toEqual({
+      boundDomain: 'profile.acme.com',
+      tenantId: 'ext-abc123',
+      kid: 'ext-abc123-deadbeef',
+      secret: 'hub-secret',
+    })
+    const [sql, params] = db.pool.query.mock.calls[0]
+    expect(String(sql)).toMatch(/revoked_at IS NULL/)
+    expect(params).toEqual(['profile.acme.com'])
+  })
+
+  it('returns null when no active row exists', async () => {
+    db.pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    expect(await getActiveMemberRegistrationCredential('profile.acme.com')).toBeNull()
+  })
+
+  it('self-heals an undecryptable row: revokes it (blanking the secret) and returns null', async () => {
+    db.pool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            bound_domain: 'profile.acme.com',
+            tenant_id: 'ext-abc123',
+            kid: 'ext-abc123-deadbeef',
+            secret_encrypted: 'v1.not.decryptable.garbage',
+          },
+        ],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }) // the revoke UPDATE
+    expect(await getActiveMemberRegistrationCredential('profile.acme.com')).toBeNull()
+    const [updateSql, updateParams] = db.pool.query.mock.calls[1]
+    expect(String(updateSql)).toMatch(/UPDATE member_registration_credentials/)
+    expect(String(updateSql)).toMatch(/revoked_at = NOW\(\)/i)
+    expect(String(updateSql)).toMatch(/secret_encrypted = ''/)
+    expect(updateParams).toEqual(['profile.acme.com'])
+  })
+
+  it('inserts encrypted (never the plaintext secret) with the partial-index conflict target', async () => {
+    db.pool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 })
+    const { inserted } = await insertMemberRegistrationCredential({
+      boundDomain: 'profile.acme.com',
+      tenantId: 'ext-abc123',
+      kid: 'ext-abc123-deadbeef',
+      secret: 'hub-secret',
+    })
+    expect(inserted).toBe(true)
+    const [sql, params] = db.pool.query.mock.calls[0]
+    expect(String(sql)).toMatch(/ON CONFLICT \(bound_domain\) WHERE revoked_at IS NULL DO NOTHING/)
+    expect(params?.[3]).not.toContain('hub-secret')
+    expect(String(params?.[3])).toMatch(/^v1\./) // encryption.ts payload format
+  })
+
+  it('reports inserted:false when the partial unique index rejects (lost race)', async () => {
+    db.pool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+    const { inserted } = await insertMemberRegistrationCredential({
+      boundDomain: 'profile.acme.com',
+      tenantId: 'ext-xyz',
+      kid: 'ext-xyz-1234',
+      secret: 's',
+    })
+    expect(inserted).toBe(false)
+  })
+})

--- a/control-api/test/services.memberRegistrationCredentialsDb.test.ts
+++ b/control-api/test/services.memberRegistrationCredentialsDb.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { deriveOAuthEncryptionKey, encryptOAuthSecret } from '../src/oauth/encryption.js'
 import {
-  deriveOAuthEncryptionKey,
-  encryptOAuthSecret,
-} from '../src/oauth/encryption.js'
+  getActiveMemberRegistrationCredential,
+  insertMemberRegistrationCredential,
+} from '../src/services/memberRegistrationCredentialsDb.js'
 
 const OAUTH_KEY_HEX = 'ab'.repeat(32)
 
@@ -13,11 +14,6 @@ vi.mock('../src/config.js', () => ({ config: cfg }))
 
 const db = vi.hoisted(() => ({ pool: { query: vi.fn() } }))
 vi.mock('../src/db.js', () => db)
-
-import {
-  getActiveMemberRegistrationCredential,
-  insertMemberRegistrationCredential,
-} from '../src/services/memberRegistrationCredentialsDb.js'
 
 const KEY = deriveOAuthEncryptionKey(OAUTH_KEY_HEX)
 

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -204,6 +204,46 @@ describe('memberRegistrationEnrollment', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  it('escalates the backoff on repeated malformed 2xx mint bodies instead of resetting to the 5s base every time', async () => {
+    // If the failure counter is cleared as soon as response.ok is true (before
+    // the body-shape check), a hub that keeps returning 2xx with a malformed
+    // body will re-mint at the 5s base forever — transientFailure() bumps the
+    // counter back to 1 every attempt, so BACKOFF_BASE_MS * 2**(1-1) never
+    // escalates. The network-error/5xx paths don't have this bug because they
+    // never touch the counter before calling transientFailure().
+    const fetchMock = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ nope: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5_000 + 1) // past the 5s base backoff (failures=1)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(5_000 + 1) // still inside the escalated 10s window (failures=2)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2) // served from cache — no re-mint yet
+
+    vi.advanceTimersByTime(5_000 + 1) // now past the escalated 10s window
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
   it('rejects localhost / IP-literal / dotless hosts with the misconfiguration error, never fetching', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -284,6 +284,45 @@ describe('memberRegistrationEnrollment', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it('escalates the backoff on repeated persist failures during a sustained Postgres outage', async () => {
+    // Mirrors 'escalates the backoff on repeated malformed 2xx mint bodies':
+    // a single 5s-window sample isn't enough to prove escalation, because a
+    // counter that gets reset on every attempt (bug: deleting the counter
+    // right after the mint body validates, before the persist block) also
+    // produces a 5s backoff on the FIRST retry — it only diverges from the
+    // correct behavior on the SECOND retry, which must wait 10s, not 5s.
+    const fetchMock = vi.fn().mockImplementation(async () => mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    store.insertMemberRegistrationCredential.mockRejectedValue(new Error('pg down'))
+
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5_000 + 1) // past the 5s base backoff (failures=1)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    vi.advanceTimersByTime(5_000 + 1) // still inside the escalated 10s window (failures=2)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    // Fails against the unfixed code: the counter is deleted before the
+    // persist block, so every failure computes failures=1 and re-mints every
+    // 5s instead of escalating — this call would observe fetchMock called 3
+    // times instead of still being served from the negative cache.
+    expect(fetchMock).toHaveBeenCalledTimes(2) // served from cache — no re-mint yet
+
+    vi.advanceTimersByTime(5_000 + 1) // now past the escalated 10s window
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
   it('rejects localhost / IP-literal / dotless hosts with the misconfiguration error, never fetching', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cfg } = vi.hoisted(() => ({
+  cfg: {
+    memberRegistrationMode: 'hosted',
+    memberRegistrationExternalHubBaseUrl: 'https://registration.evenfire.ai/api/v1',
+    desktopProfileUiBaseUrl: 'https://profile.acme.com',
+    controlUiBaseUrl: 'https://control.acme.com',
+  } as Record<string, unknown>,
+}))
+vi.mock('../src/config.js', () => ({ config: cfg }))
+
+const store = vi.hoisted(() => ({
+  getActiveMemberRegistrationCredential: vi.fn(),
+  insertMemberRegistrationCredential: vi.fn(),
+}))
+vi.mock('../src/services/memberRegistrationCredentialsDb.js', () => store)
+
+const logSink = vi.hoisted(() => ({ lines: [] as string[] }))
+vi.mock('../src/observability/logger.js', () => ({
+  rootLogger: {
+    info: (...args: unknown[]) => logSink.lines.push(JSON.stringify(args)),
+    warn: (...args: unknown[]) => logSink.lines.push(JSON.stringify(args)),
+    error: (...args: unknown[]) => logSink.lines.push(JSON.stringify(args)),
+  },
+}))
+
+import {
+  MemberRegistrationMisconfiguredError,
+  MemberRegistrationUnavailableError,
+} from '../src/services/memberRegistrationErrors.js'
+import {
+  __resetMemberRegistrationEnrollmentForTests,
+  ensureEnrollment,
+  normalizeEnrollmentHost,
+  runBootEnrollment,
+} from '../src/services/memberRegistrationEnrollment.js'
+
+const CRED = {
+  boundDomain: 'profile.acme.com',
+  tenantId: 'ext-abc123',
+  kid: 'ext-abc123-deadbeef',
+  secret: 'hub-secret',
+}
+
+function mintResponse(): Response {
+  return new Response(
+    JSON.stringify({ tenantId: CRED.tenantId, kid: CRED.kid, secret: CRED.secret }),
+    { status: 201, headers: { 'content-type': 'application/json' } }
+  )
+}
+
+describe('memberRegistrationEnrollment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    logSink.lines.length = 0
+    __resetMemberRegistrationEnrollmentForTests()
+    cfg.memberRegistrationMode = 'hosted'
+    cfg.desktopProfileUiBaseUrl = 'https://profile.acme.com'
+    cfg.controlUiBaseUrl = 'https://control.acme.com'
+    store.getActiveMemberRegistrationCredential.mockResolvedValue(null)
+    store.insertMemberRegistrationCredential.mockResolvedValue({ inserted: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('normalizeEnrollmentHost lowercases and strips port/scheme/path', () => {
+    expect(normalizeEnrollmentHost('https://Profile.ACME.com:8443/x/y')).toBe('profile.acme.com')
+  })
+
+  it('mints against the hub ORIGIN (not /api/v1) with a 10s bounded timeout, persists, returns', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    // Observe the BOUND, not merely "some signal": toBeInstanceOf(AbortSignal)
+    // is satisfied by a never-firing controller signal or a 999s timeout.
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+    store.getActiveMemberRegistrationCredential
+      .mockResolvedValueOnce(null) // pre-mint check
+      .mockResolvedValueOnce(CRED) // adopt-winner re-select
+    const cred = await ensureEnrollment('profile.acme.com')
+    expect(cred).toEqual(CRED)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://registration.evenfire.ai/public/tenants')
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000)
+    expect(init.signal).toBe(timeoutSpy.mock.results[0].value)
+    expect(JSON.parse(init.body)).toEqual({ domain: 'profile.acme.com' })
+    expect(store.insertMemberRegistrationCredential).toHaveBeenCalledWith({
+      boundDomain: 'profile.acme.com',
+      tenantId: CRED.tenantId,
+      kid: CRED.kid,
+      secret: CRED.secret,
+    })
+  })
+
+  it('reuses a stored credential without minting', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    store.getActiveMemberRegistrationCredential.mockResolvedValue(CRED)
+    expect(await ensureEnrollment('profile.acme.com')).toEqual(CRED)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('collapses concurrent calls into one mint (in-flight map)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    // STATEFUL store: a `mockResolvedValueOnce(null).mockResolvedValue(CRED)`
+    // sequence would let caller 2's PRE-MINT select consume the persisted CRED
+    // and skip minting, so the test would pass with the in-flight map deleted.
+    // Here both callers see null until an insert happens — only the map can
+    // hold fetch at 1.
+    let stored: typeof CRED | null = null
+    store.getActiveMemberRegistrationCredential.mockImplementation(async () => stored)
+    store.insertMemberRegistrationCredential.mockImplementation(async () => {
+      stored = CRED
+      return { inserted: true }
+    })
+    const [a, b] = await Promise.all([
+      ensureEnrollment('profile.acme.com'),
+      ensureEnrollment('profile.acme.com'),
+    ])
+    expect(a).toEqual(CRED)
+    expect(b).toEqual(CRED)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('adopts the winner on a lost insert race and logs the orphan WITHOUT the secret', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    store.insertMemberRegistrationCredential.mockResolvedValue({ inserted: false })
+    store.getActiveMemberRegistrationCredential
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...CRED, kid: 'ext-winner-kid', secret: 'winner-secret' })
+    const cred = await ensureEnrollment('profile.acme.com')
+    expect(cred.kid).toBe('ext-winner-kid')
+    expect(logSink.lines.join('\n')).toContain('orphan')
+    expect(logSink.lines.join('\n')).not.toContain('hub-secret')
+    expect(logSink.lines.join('\n')).not.toContain('winner-secret')
+  })
+
+  it('negative-caches a hub 4xx for the FULL 10min TTL, not the transient backoff window', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ error: 'domain_blocked' }), { status: 403 }))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1) // second call served from the negative cache
+
+    // Intermediate sample PAST the transient backoff cap (5min) but INSIDE the
+    // 4xx TTL (10min): pins TTL(4xx) > backoff-cap, so routing 4xx through the
+    // transient path (an easy collapse — both write negativeCache) fails here.
+    vi.advanceTimersByTime(5 * 60 * 1000)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1) // now past the 10min TTL
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2) // TTL expired → one fresh attempt
+  })
+
+  it('backs off exponentially on network errors and recovers after the window', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    // within the 5s backoff window: cached, no new fetch
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(5_000 + 1)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats a hub 5xx as transient (5s backoff), NOT as a terminal 4xx rejection', async () => {
+    // Without this, the 5xx branch is dead code: an implementation that treats
+    // every !response.ok as terminal blanks invitations for 10min on a hub 502.
+    const fetchMock = vi.fn().mockResolvedValue(new Response('', { status: 502 }))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(5_000 + 1) // transient window, well inside the 4xx TTL
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects localhost / IP-literal / dotless hosts with the misconfiguration error, never fetching', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    for (const host of ['localhost', '127.0.0.1', '[::1]', 'minikube']) {
+      await expect(ensureEnrollment(host)).rejects.toBeInstanceOf(
+        MemberRegistrationMisconfiguredError
+      )
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('runBootEnrollment enrolls each unique host and NEVER rejects on failure', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError('fetch failed'))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(runBootEnrollment()).resolves.toBeUndefined()
+    expect(fetchMock).toHaveBeenCalledTimes(2) // profile.acme.com + control.acme.com
+    expect(logSink.lines.join('\n')).toContain('member_registration_boot_enrollment_failed')
+  })
+
+  it('runBootEnrollment swallows UNTYPED failures too (the catch is unconditional)', async () => {
+    // The fetch-rejection case above only proves typed errors are caught —
+    // enroll() wraps them. A hook whose catch is narrowed to the typed error
+    // ("rethrow unexpected errors for visibility") would still pass that one,
+    // then crash-loop boot when Postgres is briefly unreachable at startup.
+    vi.stubGlobal('fetch', vi.fn())
+    store.getActiveMemberRegistrationCredential.mockRejectedValue(new Error('db down'))
+    await expect(runBootEnrollment()).resolves.toBeUndefined()
+    expect(logSink.lines.join('\n')).toContain('member_registration_boot_enrollment_failed')
+  })
+
+  it('runBootEnrollment dedupes hosts sharing a hostname and no-ops in remote mode', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    store.getActiveMemberRegistrationCredential
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(CRED)
+    cfg.desktopProfileUiBaseUrl = 'https://apps.acme.com:3001'
+    cfg.controlUiBaseUrl = 'https://apps.acme.com:3000'
+    await runBootEnrollment()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    fetchMock.mockClear()
+    // Assert at the STORE boundary: with a stored credential lingering from the
+    // hosted half, a dropped mode gate would still show fetch=0 while running
+    // enrollment DB reads on every remote (incl. managed/MCC) boot.
+    store.getActiveMemberRegistrationCredential.mockClear()
+    cfg.memberRegistrationMode = 'remote'
+    await runBootEnrollment()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(store.getActiveMemberRegistrationCredential).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -1,4 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __resetMemberRegistrationEnrollmentForTests,
+  ensureEnrollment,
+  normalizeEnrollmentHost,
+  runBootEnrollment,
+} from '../src/services/memberRegistrationEnrollment.js'
+import {
+  MemberRegistrationMisconfiguredError,
+  MemberRegistrationUnavailableError,
+} from '../src/services/memberRegistrationErrors.js'
 
 const { cfg } = vi.hoisted(() => ({
   cfg: {
@@ -24,17 +34,6 @@ vi.mock('../src/observability/logger.js', () => ({
     error: (...args: unknown[]) => logSink.lines.push(JSON.stringify(args)),
   },
 }))
-
-import {
-  MemberRegistrationMisconfiguredError,
-  MemberRegistrationUnavailableError,
-} from '../src/services/memberRegistrationErrors.js'
-import {
-  __resetMemberRegistrationEnrollmentForTests,
-  ensureEnrollment,
-  normalizeEnrollmentHost,
-  runBootEnrollment,
-} from '../src/services/memberRegistrationEnrollment.js'
 
 const CRED = {
   boundDomain: 'profile.acme.com',
@@ -277,9 +276,7 @@ describe('memberRegistrationEnrollment', () => {
   it('runBootEnrollment dedupes hosts sharing a hostname and no-ops in remote mode', async () => {
     const fetchMock = vi.fn().mockResolvedValue(mintResponse())
     vi.stubGlobal('fetch', fetchMock)
-    store.getActiveMemberRegistrationCredential
-      .mockResolvedValueOnce(null)
-      .mockResolvedValue(CRED)
+    store.getActiveMemberRegistrationCredential.mockResolvedValueOnce(null).mockResolvedValue(CRED)
     cfg.desktopProfileUiBaseUrl = 'https://apps.acme.com:3001'
     cfg.controlUiBaseUrl = 'https://apps.acme.com:3000'
     await runBootEnrollment()

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -243,6 +243,47 @@ describe('memberRegistrationEnrollment', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
+  it('negative-caches a 200 response with an unparseable body (proxy/WAF page) instead of re-minting every request', async () => {
+    // response.json() throws SyntaxError on a non-JSON 200 body. Before the
+    // fix this escaped enroll() untyped and unguarded — no negative-cache
+    // entry, so every subsequent request re-minted (the exact amplifier the
+    // cache exists to prevent).
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('<html>proxy error</html>', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Second immediate call must be served from the negative cache, not re-fetch.
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Log hygiene: the parse error must never echo the raw body.
+    expect(logSink.lines.join('\n')).not.toContain('<html>')
+    expect(logSink.lines.join('\n')).not.toContain('proxy error')
+  })
+
+  it('negative-caches a persistence failure after a successful mint instead of re-minting a fresh hub credential every request', async () => {
+    // insertMemberRegistrationCredential throwing (e.g. Postgres unreachable)
+    // after a successful mint was unguarded before the fix — every subsequent
+    // request would mint a brand-new hub credential (an orphan mint storm).
+    const fetchMock = vi.fn().mockResolvedValue(mintResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    store.insertMemberRegistrationCredential.mockRejectedValue(new Error('pg down'))
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Second immediate call must be served from the negative cache, not re-mint.
+    await expect(ensureEnrollment('profile.acme.com')).rejects.toBeInstanceOf(
+      MemberRegistrationUnavailableError
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('rejects localhost / IP-literal / dotless hosts with the misconfiguration error, never fetching', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ Use this index for long-form docs.
 | [Configure approvals](how-to/configure-approvals.md)           | Human-in-the-loop tool gates        |
 | [Add an MCP server](how-to/add-mcp-server.md)                  | Dev-mode JSON or CRD allowlist path |
 | [Desktop setup & updates](how-to/desktop-setup-and-updates.md) | Environments, invitation setup, updates |
+| [Member invitations on self-hosted](how-to/member-invitations-self-hosted.md) | Hosted mode zero-config emails vs running your own service |
 | [Track usage & set budgets](how-to/token-budgets-and-usage.md) | Enable budgets, scope, block vs warn |
 | [Minikube full stack](deploy/minikube.md)                      | Local Kubernetes platform           |
 | [Production notes](deploy/production.md)                       | Checklist and in-repo deploy assets |

--- a/docs/concepts/open-core-and-hosted.md
+++ b/docs/concepts/open-core-and-hosted.md
@@ -41,11 +41,13 @@ backend:
   control plane that runs the shared service is not.
 - **Member registration** — the invitation-signup backend
   (`member-registration-service`) is an extracted sibling service, not in this
-  repo. It is needed to complete invitation-based signup in *any* deployment,
-  single-tenant included — you can still log in and drive agents without it, and
-  a self-hoster can point `MEMBER_REGISTRATION_SERVICE_BASE_URL` at their own
-  instance. See the
-  [member-registration gap](../surfaces/desktop-app.md#the-member-registration-service-gap).
+  repo. Self-hosted deployments don't need to run it: set
+  `CONTROL_API_MEMBER_REGISTRATION_MODE=hosted` and the platform enrolls itself
+  with evenfire's shared registration hub, which sends invitation emails on
+  your behalf — see
+  [member invitations on self-hosted](../how-to/member-invitations-self-hosted.md).
+  Operators who want full control can still run their own instance and point
+  `CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL` at it.
 
 These gaps are named, not hidden.
 

--- a/docs/deploy/minikube.md
+++ b/docs/deploy/minikube.md
@@ -82,6 +82,16 @@ make minikube-pre-gate-sync GATE=<gate-name> ARGS="--force-cluster-sync --skip-p
 this distribution**. There is no `member-registration` overlay, manifest, or deploy
 script in this tree, so `make minikube-setup` cannot deploy it.
 
+> control-api also has a **hosted mode**
+> (`CONTROL_API_MEMBER_REGISTRATION_MODE=hosted`) that sends invitation emails
+> via evenfire's shared registration hub with nothing to deploy — see [Member
+> invitations on self-hosted](../how-to/member-invitations-self-hosted.md).
+> It does not apply here: hosted mode requires real, publicly resolvable
+> `CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL` / `CONTROL_API_CONTROL_UI_BASE_URL`
+> domains and refuses `localhost`/IP literals, so a stock minikube deploy
+> (127.0.0.1 defaults) cannot use it. This section's sibling-checkout path
+> remains the only option for local minikube.
+
 `scripts/minikube/full-setup.sh` looks for a sibling checkout at
 `../evenfire-member-registration` (override with `EVENFIRE_MEMBER_REGISTRATION_DIR`).
 Without it, setup simply prints a warning and continues:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,9 +19,14 @@ See [LICENSE](../LICENSE).
 ### Is multi-tenancy or hosting included?
 
 No. This repo is the full **single-tenant** platform — one organization per
-deployment. Multi-tenant provisioning, the hosted registry control plane, and
-member registration belong to the managed **evenfire hosted** service and are
-not open source. What you self-host is complete and not feature-gated. See
+deployment. Multi-tenant provisioning and the hosted registry control plane
+belong to the managed **evenfire hosted** service and are not open source.
+Member registration is similar — the invitation-signup backend itself is an
+extracted sibling service, not open source — but self-hosted deployments don't
+need to run it: hosted mode sends invitation emails via evenfire's shared
+registration hub with one env var. See [Member invitations on
+self-hosted](how-to/member-invitations-self-hosted.md). What you self-host is
+complete and not feature-gated. See
 [Open core: self-host vs hosted](concepts/open-core-and-hosted.md).
 
 ### Why do I keep seeing “clerum”?

--- a/docs/how-to/desktop-setup-and-updates.md
+++ b/docs/how-to/desktop-setup-and-updates.md
@@ -55,8 +55,11 @@ detection. Completing the [Profile UI](../surfaces/profile-ui.md) invitation
 flow hands the app a setup token (an `evenfire://desktop-setup` deep link); the
 app then saves the tenant environment by name and discovers its RPC proxy.
 
-> **Gap:** invitation signup depends on `member-registration-service`, which is
-> not in this repo. See the
+> **Gap:** the invitation email and the Profile UI signup flow above can now
+> run with nothing extra to deploy, via control-api's **hosted mode** — see
+> [Member invitations on self-hosted](member-invitations-self-hosted.md).
+> Completing the handoff into the Desktop App itself still depends on
+> `member-registration-service`, which is not in this repo. See the
 > [member-registration gap](../surfaces/desktop-app.md#the-member-registration-service-gap)
 > for what still works without it.
 

--- a/docs/how-to/member-invitations-self-hosted.md
+++ b/docs/how-to/member-invitations-self-hosted.md
@@ -1,0 +1,78 @@
+# How to: set up member invitations on a self-hosted deployment
+
+Self-hosted evenfire can send invitation emails **out of the box** using
+evenfire's shared registration hub — no credentials, no SMTP setup, no extra
+service. You opt in with one environment variable; the platform enrolls itself.
+
+## The zero-config path (hosted mode)
+
+Set on the **control-api** container (in your overlay's ConfigMap):
+
+| Variable | Value |
+|---|---|
+| `CONTROL_API_MEMBER_REGISTRATION_MODE` | `hosted` |
+
+Requirements:
+
+- `CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL` and `CONTROL_API_CONTROL_UI_BASE_URL`
+  must point at **real, publicly resolvable domains** (e.g.
+  `https://profile.acme.com`). Hosted mode refuses `localhost`, IP literals, and
+  dotless hostnames — invitation links are emailed to recipients, so they must
+  resolve outside your machine.
+- Outbound HTTPS from control-api to `registration.evenfire.ai`.
+
+What happens: on boot, control-api registers itself with the hub once per UI
+domain, stores the returned credential encrypted in its own Postgres, and
+reuses it forever after. Invitation, admin-invitation, email-confirmation, and
+admin password-reset emails are then sent from `no-reply@evenfire.ai` through
+evenfire's infrastructure. Emailed links pass through a short
+`registration.evenfire.ai/i/…` interstitial that names your domain before
+continuing.
+
+No other configuration is read in hosted mode: the legacy
+`CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL` value in the base ConfigMap
+and the deploy-injected `CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET` are both
+ignored by design. If you previously configured a remote identity
+(`CONTROL_API_MEMBER_REGISTRATION_HMAC_KID` /
+`CONTROL_API_MEMBER_REGISTRATION_TENANT_ID`), remove those two variables —
+control-api refuses to start hosted mode while they are set, and the error
+names them.
+
+If the hub is unreachable, control-api still boots (invitations return a clear
+`503 member_registration_unavailable` until enrollment succeeds — it retries
+automatically on the next invite).
+
+To point at a different hub (e.g. staging), set
+`CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL`.
+
+## The advanced path (remote mode — run your own service)
+
+If you prefer to run your own `member-registration-service` instance (a
+separate repository), leave the mode unset (`remote`) and configure it exactly
+as before:
+
+| Variable | Value |
+|---|---|
+| `CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL` | your instance, e.g. `http://member-registration-service.registration.svc.cluster.local:8092/api/v1` |
+| `CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET` | the per-tenant HMAC secret your instance minted |
+| `CONTROL_API_MEMBER_REGISTRATION_HMAC_KID` | the matching key id |
+| `CONTROL_API_MEMBER_REGISTRATION_TENANT_ID` | the matching tenant id |
+
+Email delivery (SMTP/provider) is configured in that service — see its
+repository's docs.
+
+## Choosing
+
+- **Hosted mode**: zero setup, emails "just work", subject to evenfire's
+  per-domain send quotas and abuse controls. Your instance is identified to the
+  hub by your UI domain.
+- **Remote mode**: full control and your own sender identity, at the cost of
+  deploying and operating the service plus email DNS (SPF/DKIM) yourself.
+
+## Related
+
+- [Open core: self-host vs hosted](../concepts/open-core-and-hosted.md) — why
+  this service lives outside the repo
+- [Desktop setup & updates](desktop-setup-and-updates.md) — the invitation flow
+  these emails feed into
+- [Production notes](../deploy/production.md) — deployment checklist

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -33,6 +33,7 @@
 - Configure approvals: how-to/configure-approvals.md
 - Add MCP server: how-to/add-mcp-server.md
 - Desktop setup & updates (environments, invitation, updates): how-to/desktop-setup-and-updates.md
+- Member invitations on self-hosted (hosted mode vs your own service): how-to/member-invitations-self-hosted.md
 - Track usage & set token budgets: how-to/token-budgets-and-usage.md
 - Minikube full stack: deploy/minikube.md
 - Production checklist: deploy/production.md

--- a/docs/superpowers/specs/2026-07-16-external-member-registration-design.md
+++ b/docs/superpowers/specs/2026-07-16-external-member-registration-design.md
@@ -166,6 +166,13 @@ now resolve to `external` credentials with a `bound_domain`.
 > (3) admin flows are covered by **one credential per destination host**, minted at
 > boot; (4) hub-unreachable **degrades** (boot proceeds, enrollment retries on demand);
 > rotation is schema-supported, no API.
+>
+> Amended the same day after the adversarial deep review (18 confirmed findings, all
+> folded in): the fail-fast is scoped to the deliberately-set identity vars, hosted
+> mode reads its own dedicated hub var, the mint is lock-free with bounded timeouts
+> and a negative cache, secrets are envelope-encrypted with the existing key, the
+> error surface enumerates the real interception sites, and the test list was
+> sharpened to be direction- and regression-proof.
 
 ### 8.1 Mode switch and config
 
@@ -176,18 +183,35 @@ now resolve to `external` credentials with a `bound_domain`.
     required in production, static env credential signs every call. Covers MCC-managed
     tenants (which never set the var) and self-hosters running their own
     member-registration-service.
-  - `hosted` — self-enrollment against the shared hub. `memberRegistrationServiceBaseUrl`
-    defaults to `https://registration.evenfire.ai/api/v1` (env override allowed, e.g. a
-    staging hub). The `CONTROL_API_MEMBER_REGISTRATION_{HMAC_SECRET,HMAC_KID,TENANT_ID}`
+  - `hosted` — self-enrollment against the shared hub. The hub address is read from a
+    **dedicated var** `CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL`
+    (default `https://registration.evenfire.ai/api/v1`; override = staging/test hub
+    only). The legacy `CONTROL_API_MEMBER_REGISTRATION_SERVICE_BASE_URL` is **ignored
+    in hosted mode** — it is a remote-mode concept, and the shipped base configmap
+    (`deploy/base/control-plane/configmaps.yaml:37`) always sets it to the
+    cluster-local URL, so reusing it would silently point enrollment at a nonexistent
+    in-cluster service (permanent 503, no startup signal). In hosted mode this URL is
+    also the **enrollment authority** — mint origin, credential issuer, and receiver
+    of invitation tokens and recipient emails — a trust decision that deserves its own
+    deliberate setting. The `CONTROL_API_MEMBER_REGISTRATION_{HMAC_SECRET,HMAC_KID,TENANT_ID}`
     requirements are dropped — credentials come from the DB (§8.2).
   - Any other value → **hard startup error** listing valid values (nothing in the wild
     sets this var yet; strictness catches e.g. a stale `offline` from the abandoned
     overlay).
-- **Fail fast on ambiguity:** `hosted` + any of
-  `CONTROL_API_MEMBER_REGISTRATION_{HMAC_SECRET,HMAC_KID,TENANT_ID}` present in raw
-  `process.env` (not resolved dev defaults) → startup error: injected credentials and
-  hosted mode are mutually exclusive. Managed tenants are structurally safe — MCC
-  injects credentials and leaves the mode unset (`remote`).
+- **Fail fast on ambiguity — scoped to the deliberately-set identity vars:** `hosted`
+  + either of `CONTROL_API_MEMBER_REGISTRATION_{HMAC_KID,TENANT_ID}` **non-empty
+  (after trim) in raw `process.env`** → startup error: an injected remote identity and
+  hosted mode are mutually exclusive. Those two vars are only ever set deliberately
+  (MCC injection or a BYO remote setup) and live in removable ConfigMaps.
+  `CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET` is **excluded from the check**: the
+  shipped deploy unconditionally injects it
+  (`deploy/scripts/apply-inter-service-tokens.sh` writes it into the
+  `control-api-internal-tokens` Secret, projected via `envFrom` in
+  `deploy/base/control-plane/control-api.yaml` — today's config cannot boot without
+  it, and the script re-adds it on every run), so including it would brick hosted mode
+  on every existing install. A lone secret in hosted mode is ignored with a loud
+  startup warning. Empty-string values never count as present. Managed tenants remain
+  structurally safe — MCC injects credentials and leaves the mode unset (`remote`).
 - **No `NODE_ENV=production` interlock** (unlike offline's): hosted is the intended
   production posture for self-hosters; default-off already keeps throwaway/dev/CI
   deploys from silently provisioning a sender against our Postmark.
@@ -199,12 +223,12 @@ New migration in `control-api/src/db.ts` `CONTROL_API_MIGRATIONS` (next version 
 ```sql
 CREATE TABLE IF NOT EXISTS member_registration_credentials (
   id            BIGSERIAL PRIMARY KEY,
-  bound_domain  TEXT NOT NULL,          -- normalized: lowercase hostname, port stripped (mirrors hub)
-  tenant_id     TEXT NOT NULL,          -- "ext-<hex>" from the hub
-  kid           TEXT NOT NULL,
-  secret        TEXT NOT NULL,
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  revoked_at    TIMESTAMPTZ
+  bound_domain     TEXT NOT NULL,       -- normalized: lowercase hostname, port stripped (mirrors hub)
+  tenant_id        TEXT NOT NULL,       -- "ext-<hex>" from the hub
+  kid              TEXT NOT NULL,
+  secret_encrypted TEXT NOT NULL,       -- envelope-encrypted, never plaintext (see below)
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at       TIMESTAMPTZ
 );
 CREATE UNIQUE INDEX member_registration_credentials_active_domain_idx
   ON member_registration_credentials (bound_domain)
@@ -213,41 +237,83 @@ CREATE UNIQUE INDEX member_registration_credentials_active_domain_idx
 
 - **Persistence is mandatory**, not a nicety: re-minting per boot leaks credentials and
   resets per-credential quota.
+- `secret_encrypted` holds the hub secret **envelope-encrypted with the existing
+  mandatory key** (`encryptOAuthSecret`/`decryptOAuthSecret` over
+  `config.oauthEncryptionKey`) — the same posture as every comparable credential in
+  this DB (`registry_connection`, OAuth grants; see
+  `src/services/registryConnectionSchema.ts`). A Postgres dump leak yields nothing
+  usable, and there is **no new operator key handling**: the envelope key is already
+  provisioned by the standard deploy. If the envelope key is ever lost or rotated,
+  decryption failure is treated as "no credential" and the normal re-mint path
+  recovers — fails soft.
 - **Rotation posture:** schema-supported, no API. Deliberate rotation is an ops action
-  (`UPDATE … SET revoked_at = now()`); the next send/boot re-mints. Old rows remain as
-  audit trail.
-- Secret is stored **plaintext** in control-api's own Postgres — proportionate (this DB
-  already holds far more sensitive material), and an env-key envelope scheme would
-  reintroduce exactly the operator credential handling hosted mode exists to remove.
+  (`UPDATE … SET revoked_at = now(), secret_encrypted = ''`); the next send/boot
+  re-mints. Rows are kept — minus the secret, blanked on revoke — as audit trail.
+  **Local rotation is not compromise remediation:** the hub keeps accepting the old
+  secret's JWTs until it is revoked hub-side (`tenant_credentials.revoked_at`, §9) —
+  an operator who suspects a leak must contact Evenfire. An operator-facing
+  self-revoke endpoint is future work (§13).
 
 ### 8.3 Enrollment service
 
 New `control-api/src/services/memberRegistrationEnrollment.ts`:
 
 - `ensureEnrollment(domain)` — return the active credential row if present; otherwise
-  mint `POST <hub-origin>/public/tenants { domain }` and persist. The mint endpoint is
-  **unauthenticated** and hangs off the hub **origin**, not the `/api/v1` base — derive
-  the origin from the configured base URL; do not route the mint through the signing
-  client.
-- **Concurrency guard, both layers:** an in-process in-flight promise map per domain
-  (no double-mint within a replica), plus `pg_advisory_xact_lock(hash(domain))` around
-  check-mint-insert (no cross-replica mint storm; the advisory-lock pattern exists in
-  `initDb`). The partial unique index is the backstop: if a race still loses, adopt the
-  winner's row and log the orphan. A rare orphan is acceptable; a mint storm is not.
+  mint and persist, **entirely outside any transaction or lock**:
+  1. `SELECT` the active row (`revoked_at IS NULL`); hit → return it.
+  2. Miss → host guard (below), then mint `POST <hub-origin>/public/tenants
+     { domain }` with a **bounded timeout** (`AbortSignal.timeout(~10s)`). The mint
+     endpoint is **unauthenticated** and hangs off the hub **origin**, not the
+     `/api/v1` base — derive the origin from
+     `CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL`; never route the mint
+     through the signing client.
+  3. `INSERT … ON CONFLICT DO NOTHING` (backed by the partial unique index), then
+     re-`SELECT` (filtered `revoked_at IS NULL`) and adopt the winner. A losing race
+     logs the orphan **without secret material** and moves on. A rare orphan is
+     acceptable; a mint storm is not.
+- **Concurrency and repetition guards:** an in-process in-flight promise map per
+  domain collapses concurrent attempts within a replica; the partial unique index +
+  adopt-winner handles cross-replica races. There is **no advisory lock** — holding a
+  pooled connection idle-in-transaction across a network call is a failure mode, not a
+  guard (managed Postgres kills it via `idle_in_transaction_session_timeout`; the
+  `initDb` advisory lock is a boot-only session lock, not a request-path precedent).
+  Repetition is bounded by a **negative cache**: a hub **4xx** mint response is
+  terminal for that domain — cache `{reason, until}` for a TTL (~10 min) and fail
+  sends fast with the typed error instead of re-minting per request; network errors
+  and 5xx retry under **exponential backoff** (capped ~5 min). Without this, an
+  unenrolled instance turns its public unauthenticated routes (invite-token lookup,
+  password-reset) into a per-request mint amplifier against the hub.
+- **Host guard:** refuse to enroll hosts that are `localhost`, IP literals, or dotless
+  names — a typed misconfiguration error (distinct from unavailability; surfaces as
+  `member_registration_misconfigured`, §8.6) and a loud boot log. The hub factually
+  accepts `127.0.0.1` as a domain, and the shipped UI base-URL defaults are exactly
+  that (`config.ts:451-454`) — without this guard, a default-config instance in hosted
+  mode sends real branded emails whose links dead-end, all sharing one global
+  `127.0.0.1` quota bucket on the hub. Hosted mode requires real domains (§8.9).
+- **Log hygiene:** enrollment, orphan-adoption, and failure logs carry only
+  `bound_domain`, `tenant_id`, `kid`, and timestamps — never the secret and never a
+  raw mint response body (the mint response contains the secret; the house pattern of
+  stringifying response bodies into thrown errors must not be applied to it).
 - Domain normalization: `new URL(base).hostname.toLowerCase()` — hostname excludes the
   port, mirroring the hub's normalization.
 
 ### 8.4 Boot integration (degrade, never block)
 
-In `main.ts` after `initDb()` (next to `assertRegistryConnectionReady`): when `hosted`,
-run `ensureEnrollment` for each **unique** normalized host of `desktopProfileUiBaseUrl`
-and `controlUiBaseUrl` (deduped — two UIs on one hostname mint once; subdomain deploys
-like `profile.acme.com` / `control.acme.com` mint two). Hosted mode presumes real,
-publicly meaningful domains; whether the hub accepts IP/localhost hosts is the hub's
-validation call, not something this design relies on. Enrollment failure **logs loudly
-and does not block boot** — the control plane is never hostage to an auxiliary email
-feature. Every later send re-attempts enrollment on demand (§8.5), so the system
-self-heals without a restart. Once enrolled, later boots never need the hub.
+Boot integration is an **exported, unit-testable hook** — `runBootEnrollment(hosts)`
+in the enrollment module, whose contract is **"never rejects: catches, logs,
+returns"** — and `main.ts` (after `initDb()`, next to `assertRegistryConnectionReady`)
+only calls it. Do not inline the try/catch in `main.ts`: no test imports `main.ts`, so
+an inlined swallow is unverifiable, and a dropped `catch` would ship green while
+crash-looping every hub-down boot.
+
+When `hosted`, the hook runs `ensureEnrollment` for each **unique** normalized host of
+`desktopProfileUiBaseUrl` and `controlUiBaseUrl` (deduped — two UIs on one hostname
+mint once; subdomain deploys like `profile.acme.com` / `control.acme.com` mint two).
+Enrollment failure **logs loudly and does not block boot** — the control plane is
+never hostage to an auxiliary email feature — and boot delay is bounded by the mint
+timeout (§8.3), worst case roughly 2 × ~10s before the listener comes up. Every later
+send re-attempts enrollment on demand (§8.5, subject to the negative cache), so the
+system self-heals without a restart. Once enrolled, later boots never need the hub.
 
 ### 8.5 Send-path credential resolution (per-host credentials)
 
@@ -275,10 +341,32 @@ credential).
 
 ### 8.6 Error surface
 
-When enrollment is impossible (hub unreachable, still unenrolled), the wrappers throw a
-typed `MemberRegistrationUnavailableError`, mapped in the calling routes to a clean
-**503 `member_registration_unavailable`** — replacing today's opaque 500. Nothing else
-in the platform blocks or degrades.
+When enrollment is impossible (hub unreachable, still unenrolled), the wrappers throw
+a typed `MemberRegistrationUnavailableError` → **503
+`member_registration_unavailable`**; the host guard throws its own typed error → **503
+`member_registration_misconfigured`** (§8.3). Today's behavior being replaced is **500
+on the send paths and a misleading 400 on the validate paths** — the validate routes
+wrap the wrappers in bare catch-alls that would otherwise convert a hub outage into
+`400 invalid_invitation`, telling an invitee with a perfectly valid link that it is
+invalid, permanently.
+
+A route-level mapper alone therefore does **not** work — the inner catches intercept
+first. The typed errors must be **rethrown (checked via `instanceof`) ahead of each
+existing catch-all**, with a global error-middleware mapping in `app.ts` as the
+backstop. Interception sites (verified):
+
+- `routes/external/invitations.ts` — bare `catch → 400 invalid_invitation` at :52,
+  :88, :250, plus the desktop-authorization string-matching catch (~:204-213).
+- `routes/admin/auth.ts` — `catch → 400 invalid_password_reset`-style at :278, :312,
+  :353, :483, :528 (the completion flow around :420 already forwards via
+  `next(error)` and is covered by the middleware backstop alone).
+- `routes/admin/controlAdmins.ts` — the two send sites; their compensating cleanup
+  (revoke, ~:169-177) must still run before the error surfaces.
+- Sends reached via `services/directory/membership.ts` (from `routes/admin/teams.ts`
+  and `routes/external/members.ts`) — confirm membership does not catch, so the typed
+  error propagates to the route/middleware layer.
+
+Nothing else in the platform blocks or degrades.
 
 ### 8.7 What does not change
 
@@ -290,24 +378,60 @@ in the platform blocks or degrades.
 ### 8.8 Testing (control-api, existing repo patterns)
 
 - config: mode parsing (default `remote`; `hosted`; unknown → error); hosted +
-  explicit env credentials → startup error; hosted relaxes the base-URL/secret
-  requirements under `NODE_ENV=production` **non-vacuously** (mirror
-  `config.prod.test.ts`); remote unchanged.
-- enrollment (mocked `fetch` + mocked `db.js` pool): mints when absent (correct
-  origin-derived URL), persists, reuses without minting; concurrent calls yield one
-  mint; insert conflict adopts the winner; hub failure → typed error and boot
-  continues.
-- resolution: hosted signs member vs admin calls with **different kids** (per-host);
-  remote signs with the env credential and never calls `/public/tenants`.
+  non-empty `HMAC_KID`/`TENANT_ID` → startup error, and **empty-string values do not
+  trip it**; a lone `HMAC_SECRET` in hosted → boots with a warning; hosted relaxes the
+  base-URL/secret requirements under `NODE_ENV=production` **non-vacuously** (mirror
+  `config.prod.test.ts`). **Negative companions — load-bearing for "remote
+  unchanged":** under `applyProdEnv` with the mode unset (and again with
+  `MODE=remote` explicit), deleting `CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET`
+  (and separately `_SERVICE_BASE_URL`) must make the config import **reject, naming
+  the variable** — without these, an implementer who relaxes the requirements
+  unconditionally instead of gating on mode ships green while breaking the
+  managed-tenant fail-fast. (`KID`/`TENANT_ID` are never prod-required today —
+  `config.ts:444-446` — so the relaxation claim is scoped to base URL + secret.)
+- migration DDL (mirror `db.registryConnectionMigration.test.ts`): the emitted SQL
+  contains `CREATE TABLE member_registration_credentials` **and the literal
+  `WHERE revoked_at IS NULL`** on the unique index — the rotation re-mint path
+  depends on that clause, and a mocked-conflict test cannot detect its absence.
+- enrollment (mocked `fetch` + mocked `db.js` pool): mints when absent with the
+  correct origin-derived URL **and a bounded timeout on the request**; persists the
+  secret **encrypted** (the INSERTed value is not the plaintext); reuses without
+  minting; concurrent calls yield one mint (in-flight map); insert conflict adopts
+  the winner via a re-`SELECT` that **filters `revoked_at IS NULL`**; hub 4xx →
+  negative-cached (no re-mint within the TTL, typed error immediately); network/5xx →
+  typed error with backoff; the host guard rejects `localhost`/IP-literal/dotless
+  hosts with the misconfiguration error; **captured log output never contains the
+  secret string**.
+- boot hook: `runBootEnrollment` with `ensureEnrollment` mocked to reject →
+  **resolves** (never rejects) and logs; the enrollment-level rejection is asserted
+  separately. (Asserting this inside `main.ts` is impossible — no test imports it;
+  that is why the hook is exported, §8.4.)
+- resolution — **directional, not just distinct**: the fetch mock mints distinct
+  `{kid, secret, tenantId}` per domain; for each wrapper call capture the
+  `Authorization` header and decode the JWT header; assert member **send and
+  validate** carry the kid minted for the profile-ui host, admin **send and
+  validate** carry the control-ui host's kid, and verify each signature with that
+  host's secret. (A bare "kids differ" assertion stays green when the wrapper→host
+  mapping is transposed — which in production 403s every member send.) Remote mode
+  signs with the env credential and never calls `/public/tenants`.
+- error surface: a validate route (e.g. `GET /external/invitations/token/:token`)
+  whose wrapper throws `MemberRegistrationUnavailableError` returns **503
+  `member_registration_unavailable`, not 400 `invalid_invitation`**.
 - signer: pure-credential signing preserves the existing token shape.
-- Live e2e against the real hub happens in the /verify step, not CI.
+- Live e2e against the real hub happens in the /verify step, not CI — it must
+  provision its **own** throwaway tenant via `/public/tenants` (never borrow a
+  managed credential) and tear down via hub-side revoke.
 
 ### 8.9 Docs (OSS)
 
 Rewrite `docs/how-to/member-invitations-self-hosted.md`: hosted mode as the
-zero-config recommended path (`CONTROL_API_MEMBER_REGISTRATION_MODE=hosted` + real
-domains in the two UI base URLs), BYO member-registration-service (`remote`) kept as
-the advanced path. Touch the member-registration paragraph in
+zero-config recommended path — set `CONTROL_API_MEMBER_REGISTRATION_MODE=hosted` plus
+**real, publicly resolvable domains** in the two UI base URLs (the host guard refuses
+localhost/IP literals, §8.3). **No configmap surgery is needed**: the legacy
+`_SERVICE_BASE_URL` value and the deploy-injected `HMAC_SECRET` are ignored in hosted
+mode by design. BYO member-registration-service (`remote`) stays as the advanced
+path; a BYO operator switching to hosted must remove their `HMAC_KID`/`TENANT_ID` env
+(the §8.1 fail-fast names them). Touch the member-registration paragraph in
 `docs/concepts/open-core-and-hosted.md`.
 
 ## 9. Abuse controls
@@ -383,6 +507,9 @@ Integration (testcontainers Postgres, existing pattern):
   disturbing the rest of the design. Requires the SSRF guard and NetworkPolicy egress
   carve-out noted in §11. Not in this iteration.
 - Orphan-credential GC: TTL-sweep `external` credentials with no sends.
+- Operator-facing self-revoke: a hub endpoint (authenticated by the credential being
+  revoked) so a self-hoster can invalidate a leaked secret without contacting
+  Evenfire. Until it exists, hub-side revocation is an Evenfire ops action (§8.2).
 
 ## 14. Rollout ordering
 

--- a/docs/superpowers/specs/2026-07-16-external-member-registration-design.md
+++ b/docs/superpowers/specs/2026-07-16-external-member-registration-design.md
@@ -1,0 +1,396 @@
+# External Member Registration — Design
+
+**Date:** 2026-07-16
+**Status:** Approved design, pre-implementation
+**Repos affected:** `evenfire-member-registration` (hub, primary) and the OSS control-api (this repo, companion)
+
+> **STATUS NOTE (added on copy into evenfire-open-source, 2026-07-16).**
+> - **Hub half = DONE.** The `evenfire-member-registration` changes in this spec (open `POST /public/tenants` mint, per-credential domain binding, hub-owned `GET /i/:token` redirect + interstitial, per-domain quota/blocklist kill switch, hashed send log, XFF fix, profile-lookup shadowing fix) shipped in hub PR #11 (merged, auto-deployed to `registration.evenfire.ai`).
+> - **This repo implements §8 (control-api self-enrollment)** — the "hosted mode" companion. It is greenfield: control-api is currently a pure client that reads injected env and never self-mints.
+> - **Reconciliation resolved (2026-07-16 brainstorm): hosted replaces offline.** The
+>   offline-mode work (`2026-07-16-offline-member-registration-mode-design.md` + plan,
+>   implemented on `impl/offline-member-registration`, PR #88) was closed unmerged and is
+>   **superseded** by this design. The mode axis is `remote | hosted` — no `offline`
+>   value ships. §8 below was rewritten with the resolved control-api design (mode
+>   semantics, credential store, enrollment, per-host credentials, failure posture).
+
+## 1. Context
+
+The member-registration hub (`registration.evenfire.ai`) currently serves only
+MCC-provisioned tenants. Credentials are minted by MCC via the admin-token-guarded
+`POST /admin/tenant-credentials`, and the tenant's control-api signs per-tenant HS256
+JWTs to call `/api/v1/invitations-flow/*`. An external, self-hosted Evenfire instance
+(e.g. someone running it on their own domain or minikube) has no way to use the hub.
+
+We want any self-hosted Evenfire instance to invite members by email, with the whole
+invite flow handled by us: the email is sent from `no-reply@evenfire.ai` through our
+Postmark account, and it "just works" with **zero credential handling by the operator**.
+
+The hub never calls into a tenant cluster — every flow is either outbound from the
+instance or a public read from an end user's browser — so a self-hosted instance with
+no inbound path works on the network layer today. The gaps are trust, onboarding, and
+a set of latent multi-tenant bugs that become live the moment an untrusted party holds
+a credential.
+
+## 2. Goals
+
+- A self-hosted instance can send member invitations through the hub with no manual
+  credential setup.
+- Emails are sent from `no-reply@evenfire.ai` via our infrastructure.
+- We retain the ability to observe and shut off abuse (per-destination kill switch),
+  without recalling already-delivered mail.
+- Existing MCC-provisioned ("managed") tenants are unaffected and, specifically, cannot
+  be shadowed or impersonated by an external instance.
+
+## 3. Non-goals and explicitly accepted risks
+
+- **No email-DNS setup for the operator.** No SPF/DKIM/DMARC on the operator's domain;
+  we always send as `no-reply@evenfire.ai` signed with our own DKIM.
+- **No domain-ownership verification** (`.well-known`/TXT/callback) in this iteration.
+  The operator's domain is **self-asserted at mint time**. A lazy first-send callback
+  check is deferred as a future flag (§13).
+- **Postmark abuse risk is accepted** (owner decision). A determined actor who buys a
+  domain, runs Evenfire on it, and sends links to that domain can send branded mail
+  from our sender. The controls in §9 reduce and contain this; they do not eliminate it.
+  Because we send from a single account/domain, a severe abuse event can affect
+  deliverability for `clerum` and all managed tenants — this is understood and accepted.
+- **No separate sending identity / IP pool.** Rejected as ineffective containment
+  (subdomains share org reputation; Postmark suspends at the account level) and as a
+  permanent ESP-operations burden.
+
+## 4. Architecture overview
+
+Two coordinated changes:
+
+1. **Hub (`evenfire-member-registration`)** — primary. Adds an open self-service mint,
+   a domain binding on each credential, a hub-owned redirect for every outbound invite
+   link, and abuse controls (revoke, per-domain blocklist, quota, logging). Fixes the
+   public profile-lookup shadowing bug and the `X-Forwarded-For` trust bug.
+2. **OSS control-api (evenfire/clerum monorepo)** — companion. Adds boot-time
+   self-enrollment: when hosted mode is enabled and no credential is stored, it mints
+   one against the hub and persists it in its own Postgres.
+
+There is no zero-manual path that avoids the control-api change: in a pure self-hosted
+deploy, the control-api is the only always-present component that can enroll on the
+operator's behalf.
+
+## 5. Identity model
+
+- **Two populations, one table, namespaced by tenant-id prefix:**
+  - Managed tenants keep `clerum-<slug>`, minted only by `POST /admin/tenant-credentials`.
+  - External instances get `ext-<random>`, minted only by `POST /public/tenants`.
+  - Each endpoint enforces its own prefix and refuses the other's. A public caller can
+    never mint a `clerum-*` id, so an external cannot impersonate a managed tenant.
+- **The credential is the identity.** No operator-chosen slug — no name-squatting.
+- **Each credential is bound to exactly one destination domain**, supplied at mint and
+  stored on the credential row. The hub enforces one-credential-one-domain on every send
+  (§8). The domain is self-asserted (not proven), but bound and locked.
+
+## 6. Data model changes (hub)
+
+New migration (following the existing `applyXxxMigration` pattern in `src/db.ts`):
+
+- `tenant_credentials`: add `tenant_type TEXT NOT NULL DEFAULT 'managed'`
+  (`managed` | `external`), and `bound_domain TEXT` (NULL for managed, the normalized
+  destination host for external). Index on `bound_domain WHERE revoked_at IS NULL`.
+- `invite_redirect_tokens` (new): `token TEXT PRIMARY KEY`, `kid TEXT NOT NULL`,
+  `tenant_id TEXT NOT NULL`, `destination_url TEXT NOT NULL`, `destination_domain TEXT NOT NULL`,
+  `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `clicked_at TIMESTAMPTZ`,
+  `expires_at TIMESTAMPTZ NOT NULL`. Index on `(destination_domain)`.
+- `blocked_domains` (new): `domain TEXT PRIMARY KEY`, `reason TEXT`,
+  `blocked_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`.
+- `invite_send_log` (new): `id`, `kid`, `tenant_id`, `destination_domain`,
+  `recipient_hash TEXT NOT NULL` (SHA-256 of normalized email; never store plaintext
+  recipient), `created_at`. Used for quota accounting and abuse correlation.
+
+Existing `apps`/`app_configs`/`invitation_flow_registrations` are unchanged except as
+needed by the shadowing fix (§10).
+
+## 7. API surface
+
+### New: `POST /public/tenants` (unauthenticated, rate-limited)
+
+Request: `{ "domain": "evenfire.acme.com" }`
+Behavior:
+- Normalize `domain` (lowercase host, strip scheme/port/path); reject empty/invalid.
+- Generate `ext-<random>` tenant id, a `kid`, and a random `hmac_secret`.
+- Insert `tenant_credentials` row with `tenant_type='external'`, `bound_domain=<domain>`.
+- Return `201 { tenantId, kid, secret }` (secret shown once).
+- Rate-limited per real client IP (see §9 XFF fix).
+
+Idempotency: none server-side; the control-api is responsible for minting once and
+persisting (§8). Restart-driven re-mints would leak orphan credentials and, critically,
+would reset any per-credential quota — which is why persistence is mandatory client-side
+and quota is keyed on the stable domain (§9).
+
+### Changed: invite endpoints route links through the hub
+
+All four caller-supplied link builders in `src/services/emailService.ts` —
+`buildInviteUrl` (member), `buildControlAdminInviteUrl`,
+`buildControlAdminEmailConfirmationUrl`, `buildControlAdminPasswordResetUrl` — currently
+email a URL built from a caller-supplied base (`profileUiBaseUrl` / `controlUiBaseUrl`).
+Each must instead:
+1. Build the real destination URL as today.
+2. **For `external` credentials only**, enforce the destination host equals the
+   credential's `bound_domain` (§8); reject otherwise. `managed` credentials have a NULL
+   `bound_domain` and skip this check (their destinations are MCC-controlled).
+3. Store an `invite_redirect_tokens` row and email
+   `https://registration.evenfire.ai/i/<token>` instead of the raw destination.
+
+**Every outbound link must go through the redirect** — a builder that is missed remains
+an open relay. This applies to managed tenants too; verify managed invites still resolve
+end-to-end after the change (§14).
+
+### New: `GET /i/:token` (public, interstitial + redirect)
+
+- Look up the token; expired/unknown → generic "link expired" page.
+- If the credential is revoked OR `destination_domain` is in `blocked_domains` →
+  "this link has been disabled" page (this is the retroactive kill switch — it fires at
+  click time on already-delivered mail).
+- Otherwise render an interstitial naming the destination host in plain text with a
+  single "Continue" control that navigates to `destination_url`. Set `clicked_at`.
+- **Not a bare redirect** — the interstitial is what prevents this from being an open
+  redirect that lends our domain's credibility to an attacker page.
+
+### Unchanged auth surface
+
+External instances reuse the existing `requireTenantJwt` path for
+`/api/v1/invitations-flow/*`. No new signing scheme; the only change is that some `kid`s
+now resolve to `external` credentials with a `bound_domain`.
+
+## 8. Self-enrollment (control-api, companion repo)
+
+> Rewritten 2026-07-16 after the reconciliation brainstorm. Four open questions were
+> resolved with the owner: (1) hosted **replaces** offline — enum is `remote | hosted`;
+> (2) hosted mode + explicitly injected credentials **fail fast** at startup;
+> (3) admin flows are covered by **one credential per destination host**, minted at
+> boot; (4) hub-unreachable **degrades** (boot proceeds, enrollment retries on demand);
+> rotation is schema-supported, no API.
+
+### 8.1 Mode switch and config
+
+- `CONTROL_API_MEMBER_REGISTRATION_MODE` = `remote` (default) | `hosted`
+  (repo-convention `CONTROL_API_` prefix; supersedes this spec's earlier bare
+  `MEMBER_REGISTRATION_MODE` and the abandoned PR #88's `offline` value).
+  - `remote` — today's behavior byte-for-byte: base URL and non-placeholder HMAC secret
+    required in production, static env credential signs every call. Covers MCC-managed
+    tenants (which never set the var) and self-hosters running their own
+    member-registration-service.
+  - `hosted` — self-enrollment against the shared hub. `memberRegistrationServiceBaseUrl`
+    defaults to `https://registration.evenfire.ai/api/v1` (env override allowed, e.g. a
+    staging hub). The `CONTROL_API_MEMBER_REGISTRATION_{HMAC_SECRET,HMAC_KID,TENANT_ID}`
+    requirements are dropped — credentials come from the DB (§8.2).
+  - Any other value → **hard startup error** listing valid values (nothing in the wild
+    sets this var yet; strictness catches e.g. a stale `offline` from the abandoned
+    overlay).
+- **Fail fast on ambiguity:** `hosted` + any of
+  `CONTROL_API_MEMBER_REGISTRATION_{HMAC_SECRET,HMAC_KID,TENANT_ID}` present in raw
+  `process.env` (not resolved dev defaults) → startup error: injected credentials and
+  hosted mode are mutually exclusive. Managed tenants are structurally safe — MCC
+  injects credentials and leaves the mode unset (`remote`).
+- **No `NODE_ENV=production` interlock** (unlike offline's): hosted is the intended
+  production posture for self-hosters; default-off already keeps throwaway/dev/CI
+  deploys from silently provisioning a sender against our Postmark.
+
+### 8.2 Credential store
+
+New migration in `control-api/src/db.ts` `CONTROL_API_MIGRATIONS` (next version slot):
+
+```sql
+CREATE TABLE IF NOT EXISTS member_registration_credentials (
+  id            BIGSERIAL PRIMARY KEY,
+  bound_domain  TEXT NOT NULL,          -- normalized: lowercase hostname, port stripped (mirrors hub)
+  tenant_id     TEXT NOT NULL,          -- "ext-<hex>" from the hub
+  kid           TEXT NOT NULL,
+  secret        TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  revoked_at    TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX member_registration_credentials_active_domain_idx
+  ON member_registration_credentials (bound_domain)
+  WHERE revoked_at IS NULL;
+```
+
+- **Persistence is mandatory**, not a nicety: re-minting per boot leaks credentials and
+  resets per-credential quota.
+- **Rotation posture:** schema-supported, no API. Deliberate rotation is an ops action
+  (`UPDATE … SET revoked_at = now()`); the next send/boot re-mints. Old rows remain as
+  audit trail.
+- Secret is stored **plaintext** in control-api's own Postgres — proportionate (this DB
+  already holds far more sensitive material), and an env-key envelope scheme would
+  reintroduce exactly the operator credential handling hosted mode exists to remove.
+
+### 8.3 Enrollment service
+
+New `control-api/src/services/memberRegistrationEnrollment.ts`:
+
+- `ensureEnrollment(domain)` — return the active credential row if present; otherwise
+  mint `POST <hub-origin>/public/tenants { domain }` and persist. The mint endpoint is
+  **unauthenticated** and hangs off the hub **origin**, not the `/api/v1` base — derive
+  the origin from the configured base URL; do not route the mint through the signing
+  client.
+- **Concurrency guard, both layers:** an in-process in-flight promise map per domain
+  (no double-mint within a replica), plus `pg_advisory_xact_lock(hash(domain))` around
+  check-mint-insert (no cross-replica mint storm; the advisory-lock pattern exists in
+  `initDb`). The partial unique index is the backstop: if a race still loses, adopt the
+  winner's row and log the orphan. A rare orphan is acceptable; a mint storm is not.
+- Domain normalization: `new URL(base).hostname.toLowerCase()` — hostname excludes the
+  port, mirroring the hub's normalization.
+
+### 8.4 Boot integration (degrade, never block)
+
+In `main.ts` after `initDb()` (next to `assertRegistryConnectionReady`): when `hosted`,
+run `ensureEnrollment` for each **unique** normalized host of `desktopProfileUiBaseUrl`
+and `controlUiBaseUrl` (deduped — two UIs on one hostname mint once; subdomain deploys
+like `profile.acme.com` / `control.acme.com` mint two). Hosted mode presumes real,
+publicly meaningful domains; whether the hub accepts IP/localhost hosts is the hub's
+validation call, not something this design relies on. Enrollment failure **logs loudly
+and does not block boot** — the control plane is never hostage to an auxiliary email
+feature. Every later send re-attempts enrollment on demand (§8.5), so the system
+self-heals without a restart. Once enrolled, later boots never need the hub.
+
+### 8.5 Send-path credential resolution (per-host credentials)
+
+The mode branch lives in **one place**: `memberRegistrationServiceRequest` gains a
+**required** `destinationBaseUrl` parameter (all nine call sites live in the two
+wrappers; requiring it means no call site can silently sign with the wrong
+credential).
+
+- The member wrapper (`invitationFlowRegistrationService.ts`) passes
+  `config.desktopProfileUiBaseUrl`; the three admin wrappers
+  (`controlAdminInvitationRegistrationService.ts`) pass `config.controlUiBaseUrl` — on
+  **both send and validate** calls (a validate must be signed by the same tenant
+  credential that registered the token).
+- `remote`: ignore the destination, sign with the static env credential — today's path
+  untouched.
+- `hosted`: `ensureEnrollment(normalizeHost(destinationBaseUrl))` → sign with that row.
+  One credential per destination host means all four flows — member invite, admin
+  invite, admin email confirmation, admin password reset — work in hosted mode with no
+  hub changes and no UI changes (unlike offline, the hub already handles their validate
+  path and the control-ui redeem pages already exist).
+- `signMemberRegistrationJwt` becomes **pure**: takes `{ secret, kid, tenantId }`
+  explicitly. Token shape (HS256, `kid` header, `iss=control-api`,
+  `aud=member-registration-service`, `sub=<tenantId>`, 60s TTL, `jti`) is unchanged —
+  the hub sees identical JWTs.
+
+### 8.6 Error surface
+
+When enrollment is impossible (hub unreachable, still unenrolled), the wrappers throw a
+typed `MemberRegistrationUnavailableError`, mapped in the calling routes to a clean
+**503 `member_registration_unavailable`** — replacing today's opaque 500. Nothing else
+in the platform blocks or degrades.
+
+### 8.7 What does not change
+
+- `remote` mode, byte-for-byte — same required envs, same static signing.
+- Managed/MCC tenants: injected env + mode unset → `remote`.
+- profile-ui, external-rest-api, control-ui, desktop-app: **no changes** — the hub's
+  `/i/<token>` interstitial is transparent and destination URLs are unchanged.
+
+### 8.8 Testing (control-api, existing repo patterns)
+
+- config: mode parsing (default `remote`; `hosted`; unknown → error); hosted +
+  explicit env credentials → startup error; hosted relaxes the base-URL/secret
+  requirements under `NODE_ENV=production` **non-vacuously** (mirror
+  `config.prod.test.ts`); remote unchanged.
+- enrollment (mocked `fetch` + mocked `db.js` pool): mints when absent (correct
+  origin-derived URL), persists, reuses without minting; concurrent calls yield one
+  mint; insert conflict adopts the winner; hub failure → typed error and boot
+  continues.
+- resolution: hosted signs member vs admin calls with **different kids** (per-host);
+  remote signs with the env credential and never calls `/public/tenants`.
+- signer: pure-credential signing preserves the existing token shape.
+- Live e2e against the real hub happens in the /verify step, not CI.
+
+### 8.9 Docs (OSS)
+
+Rewrite `docs/how-to/member-invitations-self-hosted.md`: hosted mode as the
+zero-config recommended path (`CONTROL_API_MEMBER_REGISTRATION_MODE=hosted` + real
+domains in the two UI base URLs), BYO member-registration-service (`remote`) kept as
+the advanced path. Touch the member-registration paragraph in
+`docs/concepts/open-core-and-hosted.md`.
+
+## 9. Abuse controls
+
+- **Revoke a credential** — reuse `tenant_credentials.revoked_at`. Future sends 401;
+  already-sent links dead-end at `GET /i/:token`.
+- **Block a destination domain** — `blocked_domains`. Fastest response: one domain off,
+  blocks future sends and kills pending links to that host at click time.
+- **Daily send quota** — keyed primarily on `destination_domain` (stable across
+  re-mints), accounted from `invite_send_log`. Because each credential is bound to one
+  domain, per-credential and per-domain quota coincide. A speed bump (bypassable by
+  registering more domains), plus an alertable signal.
+- **Abuse correlation** — `invite_send_log` gives per-credential/per-domain history. The
+  one-credential-one-domain invariant means cross-domain fan-out from a single credential
+  is impossible by construction; unusual volume/recipient-spread per domain is the signal
+  to watch.
+- **Rate-limit fix (prerequisite):** `src/middleware/rateLimit.ts:getClientIp` trusts the
+  leftmost `X-Forwarded-For`, which is attacker-controlled behind Cloudflare (CF appends
+  rather than replaces). Switch to `CF-Connecting-IP` (fallback to the last XFF entry).
+  Without this, per-IP limits on `/public/tenants` and public routes are decorative.
+- **Recipient privacy** — store `recipient_hash` (SHA-256 of normalized email), never
+  plaintext, to limit what a hub compromise leaks.
+
+## 10. Profile-lookup shadowing fix (correctness — required regardless)
+
+`getInvitationFlowProfileForEmail` (`src/services/invitationsFlowService.ts:343`) is
+email-only and most-recent-row-wins across **all** tenants
+(`WHERE t.email = $1 ORDER BY created_at DESC LIMIT 1`). Today this is latent among
+trusted tenants; it becomes live once an external holds a credential — a stranger who
+registers `ceo@paying-customer.com` becomes the newest row and hijacks that member's
+public lookup.
+
+Fix: partition by `tenant_type` and make **managed rows always win over external rows**
+for the same email; external lookups are additionally scoped to their own
+`bound_domain`. A stranger can never shadow a managed tenant's member; external instances
+still resolve their own members. Exact query lands in implementation; the invariant is
+"managed-wins, external-scoped-to-own-domain."
+
+## 11. Sender / config prerequisites
+
+- `MEMBER_REGISTRATION_SERVICE_SMTP_FROM_EMAIL` must become `no-reply@evenfire.ai` (live
+  deployment currently sends `no-reply@hypersig.xyz`).
+- **DKIM for `evenfire.ai` must exist in Postmark** before flipping the from-address, or
+  deliverability drops. This is a Postmark/DNS prerequisite, not code.
+- `registration` namespace NetworkPolicies already restrict egress to DNS/SMTP/Postgres.
+  No new egress is required by this design (the hub does not fetch operator domains in
+  this iteration), so the SSRF surface stays closed. If the future callback check (§13)
+  is ever added, it needs the SSRF guard + a NetworkPolicy egress carve-out that excludes
+  loopback/RFC1918/link-local and the GKE metadata IP.
+
+## 12. Testing
+
+Unit:
+- `ext-`/`clerum-` prefix enforcement on both mint endpoints.
+- Credential↔domain binding: send rejected when destination host ≠ `bound_domain`.
+- Redirect token issue/resolve; interstitial gating on revoked credential and blocked
+  domain (kill switch at click time).
+- Quota accounting from `invite_send_log`.
+- `CF-Connecting-IP` rate-limit fix (spoofed `X-Forwarded-For` no longer resets bucket).
+- Shadowing fix: managed row wins over a newer external row for the same email; external
+  lookup scoped to its own domain.
+
+Integration (testcontainers Postgres, existing pattern):
+- Full path: public mint → invite → `GET /i/:token` interstitial → redirect to bound
+  domain.
+- Blocked-domain kill mid-flight: token issued, domain blocked, click now dead-ends.
+
+## 13. Future / deferred
+
+- **Lazy domain verification** as a single flag: on first send for a credential, fetch
+  `https://<bound_domain>/.well-known/evenfire-registration-challenge` and compare a
+  hub-issued token before enabling email. Upgrades self-asserted → proven without
+  disturbing the rest of the design. Requires the SSRF guard and NetworkPolicy egress
+  carve-out noted in §11. Not in this iteration.
+- Orphan-credential GC: TTL-sweep `external` credentials with no sends.
+
+## 14. Rollout ordering
+
+1. Hub: migration + `/public/tenants` + redirect + abuse controls + shadowing fix +
+   XFF fix. Deploy (managed tenants keep working; redirect applies to all outbound links
+   including managed — verify managed invites still resolve end-to-end).
+2. Postmark: verify `evenfire.ai` DKIM; flip `SMTP_FROM_EMAIL`.
+3. Control-api (companion repo): self-enroll behind
+   `CONTROL_API_MEMBER_REGISTRATION_MODE=hosted` (§8).
+4. Document the self-hosted onboarding (real UI domains +
+   `CONTROL_API_MEMBER_REGISTRATION_MODE=hosted`) in the OSS docs (§8.9).

--- a/docs/surfaces/README.md
+++ b/docs/surfaces/README.md
@@ -15,8 +15,12 @@ agents, and the Profile UI is the invited member's front door.
 | Invited member                      | [Profile UI](profile-ui.md)             | `external-rest-api`                                                  | `control-api`, `rpc-proxy`  |
 | Channel user (Telegram/Slack/Email) | no UI — the chat app they already have | `channel-reader`                                                     | everything else             |
 
-Invitation signup depends on `member-registration-service`, which is not in
-this repo — see the
+Invitation signup no longer requires deploying anything extra: self-hosted
+control-api can send the invitation email via evenfire's shared registration
+hub in **hosted mode** — see [Member invitations on
+self-hosted](../how-to/member-invitations-self-hosted.md). The Desktop App's
+own handoff step still calls `member-registration-service` directly, which is
+not in this repo — see the
 [`member-registration-service` gap](desktop-app.md#the-member-registration-service-gap)
 for what still works without it.
 

--- a/docs/surfaces/desktop-app.md
+++ b/docs/surfaces/desktop-app.md
@@ -193,6 +193,13 @@ extracted sibling service, expected in-cluster at
 for one flow: invitation profile lookup and desktop setup completion during
 the invitation/activation flow.
 
+Self-hosted control-api can send and validate the invitation itself with no
+sibling service at all, via **hosted mode** — see [Member invitations on
+self-hosted](../how-to/member-invitations-self-hosted.md). That does not
+close this page's gap: the lookup and setup-completion calls above are made
+by the desktop app directly, not by control-api, so they still need
+`member-registration-service` configured separately.
+
 **Without it, you can still log in and drive agents. You cannot complete an
 invitation-based signup.** Point `MEMBER_REGISTRATION_SERVICE_BASE_URL` at
 your own deployment of it — see [Ship it to your users](#ship-it-to-your-users)

--- a/docs/surfaces/profile-ui.md
+++ b/docs/surfaces/profile-ui.md
@@ -35,7 +35,11 @@ Surfaces](README.md) for how the three consoles divide the platform.
    hands it back to the installed app through the `evenfire://desktop-setup`
    deep link.
 
-Step 5's lookup and completion both depend on `member-registration-service`,
+Steps 1–3 above don't need a deployed sibling service for this: self-hosted
+control-api can send the invitation email and validate the token itself via
+evenfire's shared registration hub — see [Member invitations on
+self-hosted](../how-to/member-invitations-self-hosted.md) (hosted mode). Step
+5's lookup and completion still depend on `member-registration-service`,
 which is **not in this repository** — see the Desktop App page's
 [`member-registration-service` gap](desktop-app.md#the-member-registration-service-gap)
 for what breaks without it.


### PR DESCRIPTION
## Why

Self-hosted evenfire can't send member invitations. `control-api` calls `member-registration-service`, an extracted sibling that **isn't in this repo** — so "Create member" / "Invite" returns a `500` (`TypeError: fetch failed`) and the invitation strands as `draft`. Until now the only fix was "go deploy and operate that service yourself, plus email DNS."

This adds **hosted mode**: set one env var and the platform enrolls *itself* with evenfire's shared registration hub, which sends the emails. **Zero credential handling by the operator.**

```
CONTROL_API_MEMBER_REGISTRATION_MODE=hosted
```

The hub half already shipped (hub PR #11, live at `registration.evenfire.ai`). This is the control-api companion — spec §8.

## What

At boot (hosted mode only), control-api POSTs its UI domain to the hub's unauthenticated `/public/tenants`, gets back `{tenantId, kid, secret}`, and persists it **envelope-encrypted** in its own Postgres. Every later invite signs with the credential bound to that request's destination host.

- **`remote` is the default and is byte-for-byte unchanged** — managed/MCC tenants inject credentials and never set the mode, so they're structurally unaffected. Four negative config tests pin this (they fail if the prod requirement is ever relaxed unconditionally rather than gated on the parsed mode).
- **One credential per destination host.** The hub binds each credential to exactly one domain (403 otherwise). Member invites land on the profile-ui host, the three control-admin flows on the control-ui host — so both get minted and resolved per call. All four flows work; no UI changes needed.
- **Never blocks boot.** Enrollment is fire-and-forget after the listener is up; it never rejects. Hub down → invites return a clean `503 member_registration_unavailable` and retry on demand, instead of the opaque 500 (and the misleading `400 invalid_invitation` the validate routes used to give).
- **Bounded and non-amplifying.** 10s mint timeout; lock-free (in-flight map + partial unique index with adopt-winner — no transaction spans the mint); hub 4xx is terminal for 10 min, network/5xx backs off 5s→5min. Without this, control-api's public unauthenticated routes become a mint amplifier against the hub.
- **Real domains required.** `localhost`/IP-literal/dotless hosts are refused — otherwise a default-config instance emails branded links that dead-end at `127.0.0.1`. (Stock minikube therefore can't use hosted mode; the docs say so.)

Docs: new [how-to](docs/how-to/member-invitations-self-hosted.md), plus the six pages that still told self-hosters invitations were simply broken.

## Verification

- **Live hub contract verified**, which the mocked suite could not do: self-minted a throwaway tenant (never borrowed a credential) → `201` with exactly `{tenantId:"ext-…", kid, secret}`; then signed with our real signer and hit `/invitations-flow/validate` → `400 invalid_invitation`, **not** 401 — the live hub accepts our token shape. No email sent.
- Full control-api suite **2797 passed | 3 skipped**; `tsc` clean; prettier-clean vs `main`.
- Spec + plan each went through an adversarial multi-lens review (18 and 10 verified findings, all folded in); every task got a spec+quality gate; a final whole-branch review found 3 more Important bugs — all fixed and re-reviewed.

## Review notes

- Tests are written to kill plausible wrong implementations, not to pass: the in-flight test uses a stateful store mock (a `mockResolvedValueOnce` sequence passes with the map deleted); the negative-cache test samples past the backoff cap to pin `TTL(4xx) > cap`; the timeout test spies `AbortSignal.timeout` for the actual bound; the resolution test decodes each JWT's `kid` and re-verifies the signature per host, so a transposed wrapper→host mapping fails.
- The fail-fast on `hosted` + injected identity is scoped to `HMAC_KID`/`TENANT_ID`. `HMAC_SECRET` is deliberately **excluded** — the shipped deploy always injects it via `apply-inter-service-tokens.sh`, so including it would brick hosted mode on every existing install; it warns instead.

## Follow-ups (not in this PR)

- Revoke the e2e orphan credential `ext-ce7688af9c6fe0b9` hub-side.
- Operator-facing self-revoke endpoint (spec §13): local rotation is **not** compromise remediation — the hub keeps honoring the old secret until revoked there.
- Domain verification (`.well-known`) and orphan-credential GC remain deferred per spec §13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)