### PR TITLE
docs: explain how hosted member-registration works

### DIFF
--- a/docs/how-to/member-invitations-self-hosted.md
+++ b/docs/how-to/member-invitations-self-hosted.md
@@ -39,12 +39,91 @@ ignored by design. If you previously configured a remote identity
 control-api refuses to start hosted mode while they are set, and the error
 names them.
 
-If the hub is unreachable, control-api still boots (invitations return a clear
-`503 member_registration_unavailable` until enrollment succeeds — it retries
-automatically on the next invite).
+If something goes wrong, control-api keeps running and invitations fail with
+a clear error instead — see [when things go wrong](#when-things-go-wrong).
 
 To point at a different hub (e.g. staging), set
 `CONTROL_API_MEMBER_REGISTRATION_EXTERNAL_HUB_BASE_URL`.
+
+## How hosted mode works
+
+You don't need any of this to use hosted mode — the section above is the
+whole setup. This explains what actually happens, so nothing about it
+surprises you or your invitees.
+
+### Enrollment happens once, at boot
+
+When control-api starts in hosted mode, it takes the hostnames of
+`CONTROL_API_DESKTOP_PROFILE_UI_BASE_URL` and `CONTROL_API_CONTROL_UI_BASE_URL`
+(deduplicated — ports are ignored) and registers each one with the hub in a
+single call per domain. The hub answers with a credential — a tenant id like
+`ext-…`, a key id, and a signing secret — bound to that domain. There is no
+account to create and no key to copy: **the domain itself is the identity.**
+
+Enrollment runs in the background after control-api is already listening, so
+a slow or unreachable hub never delays startup.
+
+### Credentials live in your own database
+
+The credential is stored AES-256-GCM-encrypted in control-api's own Postgres
+(the `member_registration_credentials` table), under the platform's existing
+at-rest encryption key. Every later boot, restart, or redeploy **reuses** the
+stored credential — control-api never re-registers a domain it already holds
+a credential for, and there is nothing new to back up beyond the database you
+already operate.
+
+If you move a UI to a new domain, control-api enrolls the new domain on its
+next boot (or next invitation) and the old credential simply stops being
+used. To deliberately discard a domain's credential, mark its row revoked
+(`UPDATE member_registration_credentials SET revoked_at = NOW(),
+secret_encrypted = '' WHERE bound_domain = '<host>';`) — the next invitation
+re-enrolls fresh. One honest caveat: local revocation does not invalidate the
+old credential on evenfire's side. If you believe a credential has leaked,
+report it (see [SECURITY.md](../../SECURITY.md)) so it can be revoked at the
+hub as well.
+
+### One credential per destination host
+
+The hub binds each credential to exactly one domain and refuses to send an
+invitation whose link points anywhere else. Member invitations link to your
+Profile UI; admin invitations, email confirmations, and admin password resets
+link to your Control UI — so when those are different hostnames, control-api
+holds one credential for each and signs every request with the credential
+matching that request's destination. This is also *why* both base URLs must
+be real, publicly resolvable domains: the domain is what the credential is
+bound to, and it is where your invitees will be sent.
+
+### What your invitees see
+
+The email arrives from **evenfire's sending address** (at the time of
+writing, `info@joinevenfire.com`) rather than from your domain — that is what
+makes the no-SPF/DKIM-setup promise possible.
+
+The link inside is not a direct link to your Profile UI. It goes to
+`https://registration.evenfire.ai/i/<token>` — a small page that says the
+invitation was sent through Evenfire on behalf of **your** domain, and asks
+for one click to continue. Only then does the browser land on
+`https://<your-profile-ui>/invitations/<token>`. Tell your users to expect
+that hop; it is deliberate:
+
+- it stops evenfire's domain from acting as an open redirect (the page names
+  the destination before navigating anywhere), and
+- it gives evenfire a kill switch against abuse: if a credential is revoked
+  or a destination domain is blocked, already-delivered links stop working at
+  click time instead of living forever in inboxes.
+
+### When things go wrong
+
+Hosted mode never takes control-api down. Every failure degrades to a clear
+error on the invitation endpoints while the rest of the platform keeps
+running:
+
+| Symptom | Cause | What to do |
+|---|---|---|
+| Invitations return `503 member_registration_unavailable` | The hub is unreachable, or enrollment hasn't succeeded yet | Check egress to `registration.evenfire.ai`. Nothing to restart — control-api retries on the next invitation. |
+| Invitations return `503 member_registration_misconfigured`; the boot log says "requires a real, publicly resolvable domain" | A UI base URL points at `localhost`, an IP literal, or a single-word hostname | Set the two UI base URLs to real domains. |
+| control-api refuses to start, naming `CONTROL_API_MEMBER_REGISTRATION_HMAC_KID` / `…_TENANT_ID` | Leftover remote-mode identity from a previous setup | Remove those two variables — hosted mode manages its own identity. |
+| Boot log warns `CONTROL_API_MEMBER_REGISTRATION_HMAC_SECRET is set but IGNORED` | The standard deploy injects this legacy value | Nothing — harmless by design. |
 
 ## The advanced path (remote mode — run your own service)
 

--- a/docs/surfaces/profile-ui.md
+++ b/docs/surfaces/profile-ui.md
@@ -15,18 +15,28 @@ Surfaces](README.md) for how the three consoles divide the platform.
    UI](control-ui.md) (through `control-api`), or by an authenticated
    Profile UI member at `/members/invite`, which posts to `external-rest-api
    POST /api/v1/members/invite`.
-2. **The invited person opens `/invitations/[token]`** — no Profile UI login
+2. **The invitation email reaches the invitee** — sent by evenfire's shared
+   registration hub in [hosted
+   mode](../how-to/member-invitations-self-hosted.md), or by your own
+   `member-registration-service` in remote mode. In hosted mode the emailed
+   link is not a direct link to Profile UI: it goes to a
+   `registration.evenfire.ai/i/<token>` interstitial that names the
+   destination domain and requires one click to continue — see [what your
+   invitees
+   see](../how-to/member-invitations-self-hosted.md#what-your-invitees-see) —
+   before landing on the route below.
+3. **The invited person opens `/invitations/[token]`** — no Profile UI login
    required. The page loads the invitation preview from `external-rest-api
    GET /api/v1/invitations/token/:token` before it renders.
-3. **They accept it**, then **set a password** on the same screen: the
+4. **They accept it**, then **set a password** on the same screen: the
    invitation token, email, invitation id, and new password all go to
    `external-rest-api POST /api/v1/invitations/password`; the invitation
    session token is never returned in the response body or exposed to page
    JavaScript — external-rest-api sets it as an HttpOnly cookie.
-4. **Profile UI offers a Download Evenfire link** — not an automatic
+5. **Profile UI offers a Download Evenfire link** — not an automatic
    handoff. The member installs the [Desktop App](desktop-app.md)
    themselves.
-5. **The Desktop App completes the handoff later**, from its own sign-in
+6. **The Desktop App completes the handoff later**, from its own sign-in
    screen: entering the invited email there makes the Desktop App look up
    the invitation profile and open Profile UI's `/desktop-setup?email=...`
    in the system browser. The member enters their password once more;
@@ -35,11 +45,11 @@ Surfaces](README.md) for how the three consoles divide the platform.
    hands it back to the installed app through the `evenfire://desktop-setup`
    deep link.
 
-Steps 1–3 above don't need a deployed sibling service for this: self-hosted
+Steps 1–4 above don't need a deployed sibling service for this: self-hosted
 control-api can send the invitation email and validate the token itself via
 evenfire's shared registration hub — see [Member invitations on
 self-hosted](../how-to/member-invitations-self-hosted.md) (hosted mode). Step
-5's lookup and completion still depend on `member-registration-service`,
+6's lookup and completion still depend on `member-registration-service`,
 which is **not in this repository** — see the Desktop App page's
 [`member-registration-service` gap](desktop-app.md#the-member-registration-service-gap)
 for what breaks without it.


### PR DESCRIPTION
Follow-up to #91/#92. The feature had a setup recipe but no explanation of how it works — and the one user-visible surprise (the interstitial) was documented in a single clause.

## `docs/how-to/member-invitations-self-hosted.md` — new "How hosted mode works" section

Explanation content, placed between the recipe and the advanced path:

- **Enrollment happens once, at boot** — one call per UI hostname; the domain is the identity; runs in the background so the hub can never delay startup.
- **Credentials live in your own database** — AES-256-GCM in control-api's Postgres, reused across restarts/redeploys, never re-minted. Includes the deliberate-rotation SQL and the honest caveat that local revocation doesn't invalidate the credential hub-side (report leaks via SECURITY.md).
- **One credential per destination host** — why both base URLs must be real domains, and why member vs admin flows sign differently.
- **What your invitees see** — the sender (`info@joinevenfire.com`, hedged "at the time of writing" per the sender decision) and the `registration.evenfire.ai/i/<token>` interstitial: what it looks like, and the two reasons it exists (no open redirect on evenfire's domain; kill switch for already-delivered links). Operators should tell users to expect the hop — without this doc it reads as phishing.
- **When things go wrong** — symptom/cause/fix table for the four failure modes: `503 member_registration_unavailable`, `503 member_registration_misconfigured` (host guard), the `HMAC_KID`/`TENANT_ID` startup refusal, and the harmless ignored-secret warning.

Every row of that table was observed live on 2026-07-17, not derived from source.

## `docs/surfaces/profile-ui.md` — the missing hop in "The invitation flow"

The step list jumped from "an invite is created" straight to "the invited person opens `/invitations/[token]`", skipping the email and the interstitial — the two hops an invitee actually experiences. Inserts the email+interstitial step (with hosted-mode qualifier and a deep link to the new section), renumbers, and fixes the "Steps 1–3"/"Step 5" cross-references to "Steps 1–4"/"Step 6".

Verified: anchors resolve (`#what-your-invitees-see`, `#when-things-go-wrong`), relative links resolve from each file's directory, and no other doc references the old step numbers.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)