### PR TITLE
ci: guard against tracked superpowers docs and stripped exec bits

### DIFF
--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -6,6 +6,36 @@ on:
   pull_request:
 
 jobs:
+  repo-hygiene:
+    name: Repo hygiene (no internal working artifacts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No superpowers docs may be tracked
+        # docs/superpowers/ holds per-developer working artifacts (brainstorm
+        # specs, implementation plans) that are gitignored by convention. The
+        # gitignore cannot stop a `git add -f`, so this gate can: any tracked
+        # file under a superpowers directory fails CI. If you hit this, the
+        # file belongs in the brain or your local tree, not the distribution.
+        run: |
+          tracked=$(git ls-files | grep -E '(^|/)(docs/(archive/)?superpowers|superpowers)/' || true)
+          if [ -n "$tracked" ]; then
+            echo "::error::Tracked superpowers working artifacts found:"
+            echo "$tracked"
+            exit 1
+          fi
+      - name: Shipped shell scripts must be executable
+        # The sync-to-OSS pipeline has stripped exec bits before (every .sh at
+        # mode 100644), which breaks `make minikube-setup` with Permission
+        # denied on a fresh clone. Regression gate for the PR #93 fix.
+        run: |
+          bad=$(git ls-files -s '*.sh' | awk '$1 != "100755" {print $4}' || true)
+          if [ -n "$bad" ]; then
+            echo "::error::Non-executable shell scripts (mode must be 100755):"
+            echo "$bad"
+            exit 1
+          fi
+
   test:
     name: Build / test / typecheck (${{ matrix.service }})
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,9 @@ docs/diagrams/
 docs/security/
 docs/superpowers/
 docs/archive/superpowers/
+# Belt-and-braces: a superpowers working-artifact directory is local no matter
+# where it appears (CI also fails the build if one is ever force-added).
+**/superpowers/
 
 # Git worktrees — isolated feature workspaces, never tracked.
 .worktrees/


### PR DESCRIPTION
Closes the loop on two incidents:

**Guard 1 — no tracked superpowers docs.** `docs/superpowers/` is gitignored per-developer working space, but gitignore can't stop `git add -f` — which is exactly how the hosted member-registration design spec briefly entered the tree (untracked in #92, **purged from all reachable history today**; the canonical copy lives in the brain). CI now fails on any tracked path under a `superpowers/` directory anywhere in the repo, and `.gitignore` gains a `**/superpowers/` belt-and-braces rule. This is the protection layer that works against humans *and* agents.

**Guard 2 — shipped `.sh` must be `100755`.** The sync-to-OSS pipeline has stripped exec bits before (all 187 scripts at `100644` → `make minikube-setup` died with Permission denied on every fresh clone; fixed in #93). Since the root cause lives in the sync pipeline outside this repo, this gate ensures the regression can't ship silently again: the next mode-stripping sync fails CI instead of breaking every new user.

Both checks dry-ran clean against the current tree. Docs-free, code-free — one workflow job + one gitignore line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)