### PR TITLE
docs: add registry connect + publish how-tos (PR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ each pillar links to its depth.
   governed registry (entries carry trust levels and an `author`); build custom
   coordinator images with `@clerum/workflow-sdk`; install through a governed
   flow. →
-  [packages/workflow-sdk/README.md](packages/workflow-sdk/README.md)
+  [packages/workflow-sdk/README.md](packages/workflow-sdk/README.md),
+  [connect to the registry](docs/how-to/connect-to-registry.md),
+  [publish a plugin](docs/how-to/publish-plugin-to-registry.md)
 - **Teams & access** — profiles, teams, roles (admin / inviter / member),
   invitations, and session → scoped-RPC token brokerage. →
   [external-rest-api/README.md](external-rest-api/README.md),

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,8 @@ Use this index for long-form docs.
 | [Desktop setup & updates](how-to/desktop-setup-and-updates.md) | Environments, invitation setup, updates |
 | [Member invitations on self-hosted](how-to/member-invitations-self-hosted.md) | Hosted mode zero-config emails vs running your own service |
 | [Track usage & set budgets](how-to/token-budgets-and-usage.md) | Enable budgets, scope, block vs warn |
+| [Connect to the registry](how-to/connect-to-registry.md)       | Self-hosted registry connect flow   |
+| [Publish a plugin](how-to/publish-plugin-to-registry.md)       | Publish under your org with an `efrk_` key |
 | [Minikube full stack](deploy/minikube.md)                      | Local Kubernetes platform           |
 | [Production notes](deploy/production.md)                       | Checklist and in-repo deploy assets |
 | [WorkflowRecipes operations](deploy/workflow-recipes-guide.md) | Recipe ops, RBAC, debugging         |

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -35,6 +35,7 @@ NetworkPolicies matter.
 3. [Add an MCP server](../how-to/add-mcp-server.md)
 4. [Track usage & set budgets](../how-to/token-budgets-and-usage.md) — meter and cap what agents spend
 5. [WorkflowRecipe CRD reference](../crds/workflowrecipe.md) if you need multi-workload recipes
+6. Self-host the registry: [connect](../how-to/connect-to-registry.md), then [publish a plugin](../how-to/publish-plugin-to-registry.md)
 
 **Success looks like:** Control UI up, a Host responding, an approval or
 connector path exercised.

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -1,0 +1,57 @@
+# How to: connect a self-hosted deployment to the registry
+
+The Evenfire registry (`registry.evenfire.ai`) is a shared catalog of connectors
+and recipes. A **managed** deployment is connected for you; a **self-hosted**
+deployment connects itself, once — after an Evenfire operator approves the
+request. This guide covers the self-hoster's side of that flow. Once connected
+you can install from the catalog, [publish under your own org](publish-plugin-to-registry.md),
+and use registry SSO from your Control UI.
+
+## Prerequisites
+
+- `REGISTRY_CONNECTION_MODE=self-hosted` on `control-api`. The default is
+  `managed`, and the connect flow only runs in self-hosted mode — a managed
+  deployment is connected automatically, so the panel has nothing to configure.
+- `CLERUM_REGISTRY_URL` set, with outbound HTTPS to the registry.
+- You are an **admin** in your Control UI.
+
+## Connect
+
+Open **Control UI → Registry → Connect** (`/registry/connect`). The panel walks a
+small state machine — `disconnected → pending → approved → connected`:
+
+1. **Request.** Enter a **requested org name** and a **contact email**, and
+   submit. Your control-api generates a signing keypair, registers the request
+   with the registry, and saves it as **pending**. (The keypair is how the
+   registry later confirms the claim really comes from your deployment — you
+   never handle it.) A reserved or blocked org name is refused up front.
+2. **Wait for approval.** An Evenfire operator reviews the request and either
+   approves or rejects it. The panel polls the registry, so the decision appears
+   without you re-submitting.
+3. **Claim.** On approval the operator sends you a **one-time claim token**
+   out-of-band. Paste it into the panel to finish connecting. The token is
+   single-use and short-lived.
+4. **Connected.** The panel shows your bound org. You can now install catalog
+   entries, mint publish keys, and use registry SSO.
+
+## What connecting gives you
+
+- **Install** connectors and recipes from the catalog into your cluster.
+- **Publish** your own connectors and recipes under `@<your-org>/…` — see
+  [Publish a plugin to the registry](publish-plugin-to-registry.md).
+- **SSO** to registry API keys from your own Control UI.
+
+## If something goes wrong
+
+- **Already connected** — a deployment has one connection; there is nothing more
+  to do.
+- **Request rejected** — the operator declined (often an org-name conflict).
+  Adjust the requested name and request again.
+- **Claim token expired or rejected** — ask the operator to re-issue it; tokens
+  are single-use and time-limited.
+
+## Not in this repo
+
+The approval side lives in Evenfire's operator console, which is part of the
+managed service, not this repository — this guide covers only the self-hoster's
+side. See [Open core: self-host vs hosted](../concepts/open-core-and-hosted.md).

--- a/docs/how-to/publish-plugin-to-registry.md
+++ b/docs/how-to/publish-plugin-to-registry.md
@@ -1,0 +1,83 @@
+# How to: publish a plugin to the registry
+
+Once your deployment is [connected](connect-to-registry.md), an **org owner** can
+publish connectors and recipes under your `@<org>/` scope. You can import an
+entry by hand from the Control UI, or — for scripts and CI — publish with an
+**org API key** (`efrk_…`). This guide covers the API-key path.
+
+## Prerequisites
+
+- A [connected deployment](connect-to-registry.md) — publishing is scoped to
+  your org, which connecting establishes.
+- You are an **org owner** (only owners mint publish keys).
+
+## 1. Mint an org API key (`efrk_…`)
+
+In **Control UI → your org → API keys**, create a key. It is:
+
+- **org-scoped** — it can publish only under your `@<org>/` scope;
+- long-lived, opaque, and **revocable** (rotate or revoke on the same screen);
+- sent as `Authorization: Bearer efrk_…`.
+
+Pass the key via an **environment variable or CI secret** only — never a CLI
+flag, a Makefile, a committed file, or logs.
+
+Check the key and learn your org scope:
+
+```bash
+curl -s -H "Authorization: Bearer $REGISTRY_API_KEY" \
+  https://registry.evenfire.ai/api/v1/whoami
+# → {"type":"machine","orgName":"<org>","scopes":["registry:publish", …]}
+```
+
+## 2. Publish — `POST /api/v1/entries`
+
+Required fields: `name` (**`@<org>/<name>`**), `version` (semver), `entryType`
+(`recipe` | `mcp-server`), `description`, `author`, `origin`, `category`,
+`contentCreatorTag`, `configCreatorTag`. For a recipe, also send `recipe` — the
+recipe document as a **string** (≤ 100 KB). Optional: `tags`, `visibility`
+(`public` | `private`).
+
+```bash
+curl -s -X POST https://registry.evenfire.ai/api/v1/entries \
+  -H "Authorization: Bearer $REGISTRY_API_KEY" \
+  -H "Content-Type: application/json" -d @entry.json
+```
+
+Two gotchas for org-key callers:
+
+1. The name **must** be scoped `@<org>/<name>` — a bare name is rejected
+   (`400 scope_required`). `@clerum` / `@evenfire` names are curator-only.
+2. The bare `<name>` **must equal** the recipe's `metadata.name` — a mismatch is
+   `400 INVALID_INPUT`. Use `metadata.name`, not your repo name.
+
+To build the recipe itself, see the
+[`@clerum/workflow-sdk`](../../packages/workflow-sdk/README.md) and the
+[WorkflowRecipe CRD reference](../crds/workflowrecipe.md).
+
+## 3. Verify
+
+A `private` entry is hidden from the default listing — pass `?visibility=all`:
+
+```bash
+curl -s -H "Authorization: Bearer $REGISTRY_API_KEY" \
+  "https://registry.evenfire.ai/api/v1/entries?q=<name>&visibility=all"
+```
+
+## 4. Update
+
+- Re-publishing the **same `name` + `version` → `409 CONFLICT`.** Bump the
+  version to ship a change.
+- Change metadata in place (visibility, tags, description) with
+  `PUT …/entries/@<org>%2F<name>/versions/<version>`; delete a version with
+  `DELETE …/versions/<version>`.
+
+## Scope & visibility
+
+An org key publishes **only** under `@<org>/`. A `@<org>/`-scoped entry — even
+`public` — is surfaced to your org's own clusters and members, not the global
+anonymous marketplace.
+
+> The registry API above (`registry.evenfire.ai`) is the shared registry
+> service, which is not part of this repository; connecting to it is covered in
+> [Connect to the registry](connect-to-registry.md).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -35,6 +35,8 @@
 - Desktop setup & updates (environments, invitation, updates): how-to/desktop-setup-and-updates.md
 - Member invitations on self-hosted (hosted mode vs your own service): how-to/member-invitations-self-hosted.md
 - Track usage & set token budgets: how-to/token-budgets-and-usage.md
+- Connect a self-hosted deployment to the registry: how-to/connect-to-registry.md
+- Publish a plugin to the registry (efrk_ org key): how-to/publish-plugin-to-registry.md
 - Minikube full stack: deploy/minikube.md
 - Production checklist: deploy/production.md
 - WorkflowRecipes ops: deploy/workflow-recipes-guide.md

--- a/docs/surfaces/control-ui.md
+++ b/docs/surfaces/control-ui.md
@@ -90,7 +90,10 @@ five steps live together.
    off (the shipped default), or blocks it and logs a denial when
    enforcement is on. sha256 digest pinning is a different mechanism: it
    applies to custom coordinator images in workflow recipes, not to
-   connector images, and it is required by default there.
+   connector images, and it is required by default there. A self-hosted
+   deployment [connects to the registry](../how-to/connect-to-registry.md) once
+   (operator-approved) before it can install or
+   [publish](../how-to/publish-plugin-to-registry.md) under its own org.
 
    ![Control UI registry catalog at /registry showing trust levels and the install flow](../assets/control-ui-registry-install.webp)
    *Dev cluster, demo tenant.*


### PR DESCRIPTION
PR-3 of the docs improvement plan: registry **connect** (self-host operator) + **publish** (authors/CI) how-tos. **Supersedes #90**, which became conflicting after the repo's history rewrite — this is the same content cleanly rebased onto current `main`.

## New docs
- **`docs/how-to/connect-to-registry.md`** — the Control UI `/registry/connect` flow: `REGISTRY_CONNECTION_MODE=self-hosted`, request → operator approval → one-time claim token → connected. Verified against `config.ts:293` + `registryConnect.ts:85/126/203` on current main.
- **`docs/how-to/publish-plugin-to-registry.md`** — mint an `efrk_` org key (`/admin/registry/keys`), `POST /api/v1/entries` with `@<org>/<name>` + `metadata.name` gotchas, `409` immutability, `?visibility=all`. Matches an end-to-end-verified publish runbook.

## Re-verification after the history rewrite
Confirmed the registry connect code, the `efrk_` surface, and all five wire-up anchors are unchanged on current `main`; the cherry-pick applied cleanly (7 files, +152/−2); all links resolve. Two independent accuracy passes on the original (all connect claims CONFIRMED with file:line; publish consistent with the runbook; no MCC/PoP/secret leakage) still hold — the content is byte-identical.

Wired into the README Plugins pillar, docs index, llms.txt, learning path C, and the Control UI surface doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)