### PR TITLE
docs(quickstart): MINIKUBE_MEMORY workaround for the 10 GB gotcha

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -143,7 +143,7 @@ Details: [Connect Telegram](../how-to/connect-telegram.md).
 | Symptom                                    | Fix                                                                                               |
 | ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
 | Agent never replies                        | No real LLM key in `.env`; with several keys, set `CLERUM_MODEL_PROVIDER` explicitly (see step 1) |
-| `minikube start` fails                     | Docker Desktop has less than 10 GB RAM / 6 CPUs allocated                                         |
+| `minikube start` fails on memory           | Raise Docker Desktop to ≥10 GB RAM / 6 CPUs — or, if you can't spare it, `MINIKUBE_MEMORY=9216 make minikube-setup` (stock Docker Desktop's ~9.9 GB is just under the 10 GB default) |
 | Pods `Pending` early on                    | Calico is still coming up — wait, then `make minikube-status`                                     |
 | postgres CrashLoopBackOff after cold start | `make minikube-setup ARGS="--reset-db --skip-build"`                                              |
 | Port-forwards die                          | re-run `make minikube-pf-all` (it holds them open; Ctrl-C stops)                                  |


### PR DESCRIPTION
A one-row quickstart fix for a real fresh-clone stumble.

`make minikube-setup` defaults `MINIKUBE_MEMORY=10240` (`scripts/minikube/start.sh:10`, `Makefile:114`), but a **stock Docker Desktop** allocates ~9936 MB — just under — so `minikube start` hard-stops with "Docker Desktop has only 9936MB memory but you specified 10240MB", with no hint about the fix.

The troubleshooting table already had a row for this but only named the cause. It now gives the escape hatch: raise Docker Desktop's memory, **or** run `MINIKUBE_MEMORY=9216 make minikube-setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)