### PR TITLE
docs: add "shared and global files" how-to (PR-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ each pillar links to its depth.
 - **Files** — `SharedFileSystem` team workspaces (read-only to agents) and a
   brokered, audited `GlobalFileSystem` drive. →
   [gfs-controller/README.md](gfs-controller/README.md),
-  [docs/crds/sharedfilesystem.md](docs/crds/sharedfilesystem.md)
+  [docs/crds/sharedfilesystem.md](docs/crds/sharedfilesystem.md),
+  [shared & global files how-to](docs/how-to/shared-and-global-files.md)
 - **Cost & governance** — token budgets per scope with block/warn decisions
   (opt-in via `CLERUM_BUDGETS_ENABLED`), usage and LLM-price accounting,
   `WorkflowRecipePolicy`, and a connector-image allowlist. →

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Use this index for long-form docs.
 | [Track usage & set budgets](how-to/token-budgets-and-usage.md) | Enable budgets, scope, block vs warn |
 | [Connect to the registry](how-to/connect-to-registry.md)       | Self-hosted registry connect flow   |
 | [Publish a plugin](how-to/publish-plugin-to-registry.md)       | Publish under your org with an `efrk_` key |
+| [Shared & global files](how-to/shared-and-global-files.md)     | Team workspaces (SFS) and the brokered drive (GFS) |
 | [Minikube full stack](deploy/minikube.md)                      | Local Kubernetes platform           |
 | [Production notes](deploy/production.md)                       | Checklist and in-repo deploy assets |
 | [WorkflowRecipes operations](deploy/workflow-recipes-guide.md) | Recipe ops, RBAC, debugging         |

--- a/docs/crds/globalfilesystem.md
+++ b/docs/crds/globalfilesystem.md
@@ -33,4 +33,5 @@ declares intent, not full pod specs.
 ## Related
 
 - [CRD index](README.md)
+- [Shared & global files how-to](../how-to/shared-and-global-files.md) — SFS vs GFS, and when to use each
 - [gfs-controller](../../gfs-controller/) (service tree)

--- a/docs/crds/sharedfilesystem.md
+++ b/docs/crds/sharedfilesystem.md
@@ -41,4 +41,5 @@ Working sample:
 ## Related
 
 - [CRD index](README.md)
+- [Shared & global files how-to](../how-to/shared-and-global-files.md) — create an SFS, attach it to a Context, upload
 - [workspace-files-controller](../../workspace-files-controller/) (service tree)

--- a/docs/get-started/learning-path.md
+++ b/docs/get-started/learning-path.md
@@ -36,6 +36,7 @@ NetworkPolicies matter.
 4. [Track usage & set budgets](../how-to/token-budgets-and-usage.md) — meter and cap what agents spend
 5. [WorkflowRecipe CRD reference](../crds/workflowrecipe.md) if you need multi-workload recipes
 6. Self-host the registry: [connect](../how-to/connect-to-registry.md), then [publish a plugin](../how-to/publish-plugin-to-registry.md)
+7. Give agents files: [shared & global files](../how-to/shared-and-global-files.md)
 
 **Success looks like:** Control UI up, a Host responding, an approval or
 connector path exercised.

--- a/docs/how-to/shared-and-global-files.md
+++ b/docs/how-to/shared-and-global-files.md
@@ -1,0 +1,88 @@
+# How to: shared and global files
+
+evenfire has two ways to give agents files, with different trust models:
+
+- **SharedFileSystem (SFS)** — a per-team workspace. Humans and admins write to
+  it; agents in a Context that mounts it get it **read-only**.
+- **GlobalFileSystem (GFS)** — a brokered, audited drive. Nothing mounts the
+  volume except the broker; every read and write goes through an API that
+  authorizes per operation and audits the decision.
+
+## SharedFileSystem — a read-only team workspace
+
+### 1. Create the workspace
+
+Apply a `SharedFileSystem` (or use **Control UI → Shared Files → New**):
+
+```yaml
+apiVersion: clerum.io/v1alpha1
+kind: SharedFileSystem
+metadata:
+  name: team-mission
+  namespace: mcp-host
+spec:
+  size: 20Gi
+```
+
+`host-context-controller` provisions the PVC and a per-SFS
+`workspace-files-controller` that serves the write API. The default PVC is
+`ReadWriteOnce` (single-node); for multi-node, set a `ReadWriteMany`
+StorageClass via `spec.accessModes`.
+
+### 2. Attach it to a Context
+
+A Context mounts SFSes read-only, by name and path
+(`spec.sharedFileSystems`):
+
+```yaml
+spec:
+  sharedFileSystems:
+    - name: team-mission
+      mountPath: /shared/mission
+```
+
+`mountPath` values must be unique within a Context, and each SFS must already
+exist in the `mcp-host` namespace. Every agent (`Host`) using this Context now
+sees the workspace read-only at that path.
+
+### 3. Put files in it
+
+Humans and admins write through the workspace API: in Control UI, open the
+Shared Filesystem and upload — the request is proxied through control-api to the
+per-SFS controller. Agents **cannot** write: their mount is read-only, so an
+agent reads the files with its file tools but never mutates them.
+
+## GlobalFileSystem — a brokered, audited drive
+
+A `GlobalFileSystem` is a drive that **no agent, UI, or service mounts** — only
+its broker (`gfs-controller`) touches the volume. Everyone else goes through an
+HTTP API, and that indirection is the point:
+
+- **Authorized per operation.** Every request is checked against a Postgres
+  permission store, deny-by-default, on every call; the bearer token is an
+  upper bound on authority, never a grant. An absent resource and an
+  unauthorized one are indistinguishable (both `403`).
+- **Audited.** Every decision — allow, deny, or error — is written to an
+  append-only audit log before the operation is served; no operation runs
+  un-audited.
+- **Addressed by URI.** Files are named `gfs://<drive>/<resource>` and resolved
+  through the API; an agent that holds a grant reads (and, where granted,
+  writes) through the broker.
+
+Create one with a `GlobalFileSystem` CRD and manage access from Control UI's
+Global Files area. For the full API, the writer/reader roles, and the
+authorization chain, see [`gfs-controller`](../../gfs-controller/README.md) and
+the [GlobalFileSystem CRD](../crds/globalfilesystem.md).
+
+## Which one?
+
+- Reach for **SharedFileSystem** when a team needs a simple bundle of reference
+  files, mounted read-only into the agent.
+- Reach for **GlobalFileSystem** when access must be brokered and audited per
+  operation, with no volume mounted into the agent at all.
+
+## Related
+
+- [SharedFileSystem CRD](../crds/sharedfilesystem.md) · [GlobalFileSystem CRD](../crds/globalfilesystem.md)
+- [Context CRD](../crds/context.md) — how an agent's Context mounts an SFS
+- [workspace-files-controller](../../workspace-files-controller/README.md) · [gfs-controller](../../gfs-controller/README.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,6 +37,7 @@
 - Track usage & set token budgets: how-to/token-budgets-and-usage.md
 - Connect a self-hosted deployment to the registry: how-to/connect-to-registry.md
 - Publish a plugin to the registry (efrk_ org key): how-to/publish-plugin-to-registry.md
+- Shared & global files (SFS team workspace + brokered GFS drive): how-to/shared-and-global-files.md
 - Minikube full stack: deploy/minikube.md
 - Production checklist: deploy/production.md
 - WorkflowRecipes ops: deploy/workflow-recipes-guide.md


### PR DESCRIPTION
PR-6 of the docs improvement plan — the last item. A task-oriented operator guide for the two file surfaces, since the CRD reference docs are thin (44/36 lines).

## New: `docs/how-to/shared-and-global-files.md`
- **SharedFileSystem** — create the CRD, attach it to a Context **read-only** (`spec.sharedFileSystems: [{name, mountPath}]`), upload through the workspace API (Control UI → Shared Files, proxied by control-api to the per-SFS controller); agents read the mount but never write it. RWO single-node default, RWX via `spec.accessModes`.
- **GlobalFileSystem** — brokered by `gfs-controller` (the only thing that mounts the volume); every op authorized against a Postgres permission store (deny-by-default, token = ceiling, absent vs unauthorized both `403`), append-only audit, `gfs://` URIs. Kept high-level per the plan, linking the service README + CRD.

## Verification
Independent pass confirmed all 5 claim groups with file:line against `gfs-controller/README.md`, `workspace-files-controller/README.md`, `charts/clerum-crds/crds/context.yaml`, and `control-ui`. Two nits fixed pre-commit: dropped "tamper-evident" (the README notes full hash-chaining isn't wired yet — kept the fully-true "append-only"), and corrected the sidebar label to "Shared Files".

Wired into the README Files pillar, docs index, llms.txt, learning path C, and both CRD reference docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)