### PR TITLE
fix(control-api): allow registry.evenfire.ai in the registry URL allowlist

### DIFF
--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -493,7 +493,8 @@ export const config: Config = {
   })(),
   memberRegistrationServiceHmacKid:
     process.env.CONTROL_API_MEMBER_REGISTRATION_HMAC_KID || 'example-dev',
-  memberRegistrationTenantId: process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID || 'example-dev',
+  memberRegistrationTenantId:
+    process.env.CONTROL_API_MEMBER_REGISTRATION_TENANT_ID || 'example-dev',
   desktopExternalRestApiBaseUrl:
     process.env.CONTROL_API_DESKTOP_EXTERNAL_REST_API_BASE_URL || 'http://127.0.0.1:8091',
   desktopRpcProxyBaseUrl:
@@ -797,11 +798,23 @@ if (config.registryAuthEnabled) {
   }
   console.log(`[ControlAPI] Registry connection mode: ${config.registryConnectionMode}`)
 
-  // URL allowlist applies in BOTH modes: self-hosted clerum still points at the
-  // central example.com (spec §14.3 — per-deployment URLs out of scope).
+  // URL allowlist applies in BOTH modes. The shared registry
+  // `registry.evenfire.ai` is the default a self-hoster connects to (see
+  // docs/how-to/connect-to-registry.md); the in-cluster URL covers a
+  // self-hosted registry-api. A deployment that runs its own registry adds its
+  // URL via CLERUM_REGISTRY_URL_ALLOWLIST (comma-separated) rather than editing
+  // this list. `example.com` is the reserved-domain fixture used across the
+  // test suite — inert (no real registry) and kept so tests need no churn.
   const allowed = [
-    'https://example.com',
+    'https://registry.evenfire.ai',
     'http://registry-api.registry.svc.cluster.local:8085',
+    'https://example.com',
+    // Trim-only (NOT parseCsvList, which lowercases) — the entries are compared
+    // verbatim against config.registryUrl, which is not lowercased.
+    ...(process.env.CLERUM_REGISTRY_URL_ALLOWLIST || '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean),
   ]
   if (process.env.CLERUM_DEV_MODE === 'true') {
     allowed.push('http://localhost:8085')

--- a/control-api/test/config.registryConnectionMode.test.ts
+++ b/control-api/test/config.registryConnectionMode.test.ts
@@ -69,3 +69,34 @@ describe('config: REGISTRY_CONNECTION_MODE discriminator', () => {
     expect(lines.some(l => /Registry connection mode: managed/.test(l))).toBe(true)
   })
 })
+
+describe('config: registry URL allowlist', () => {
+  function enableSelfHostedRegistryEnv(): void {
+    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'true'
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+  }
+
+  it('accepts the shared registry.evenfire.ai by default (self-hoster path)', async () => {
+    enableSelfHostedRegistryEnv()
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
+    const { config } = await import('../src/config.js')
+    expect(config.registryUrl).toBe('https://registry.evenfire.ai')
+  })
+
+  it('still rejects a URL outside the allowlist', async () => {
+    enableSelfHostedRegistryEnv()
+    process.env.CLERUM_REGISTRY_URL = 'https://evil.example.org'
+    await expect(import('../src/config.js')).rejects.toThrow(/not in the registry URL allowlist/)
+  })
+
+  it('accepts a URL added via CLERUM_REGISTRY_URL_ALLOWLIST (BYO registry), verbatim/case-sensitive', async () => {
+    enableSelfHostedRegistryEnv()
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.MyCorp.example'
+    process.env.CLERUM_REGISTRY_URL_ALLOWLIST =
+      'https://other.example, https://registry.MyCorp.example'
+    const { config } = await import('../src/config.js')
+    // Non-vacuous: parseCsvList would have lowercased this to a mismatch; the
+    // trim-only split preserves case so the verbatim compare passes.
+    expect(config.registryUrl).toBe('https://registry.MyCorp.example')
+  })
+})


### PR DESCRIPTION
## The bug (found via live minikube test)

The registry URL allowlist (`config.ts`, `validateConfig`, only enforced when `CLERUM_REGISTRY_AUTH_ENABLED=true`) contained only `https://example.com` — an **OSS-sync scrub placeholder** — plus the in-cluster URL, with no env override. So a self-hoster following [connect-to-registry.md](docs/how-to/connect-to-registry.md) and pointing at the shared registry **crashloops control-api at boot**:

```
CLERUM_REGISTRY_URL=https://registry.evenfire.ai is not in the registry URL allowlist:
  https://example.com, http://registry-api.registry.svc.cluster.local:8085
```

Found while testing the self-hosted connect flow on minikube: `register → approve → claim` **succeeds** (allowlist unchecked with auth off, connection reached `connected`), but flipping auth on to actually *use* the connection crashloops. So the OSS build **cannot authenticate to the very registry `open-core-and-hosted.md` advertises connecting to.**

## Fix

- Add `https://registry.evenfire.ai` as the default allowed URL.
- Add `CLERUM_REGISTRY_URL_ALLOWLIST` (comma-separated) so a BYO-registry deployment adds its own URL without editing code — honoring the existing "per-deployment URLs" comment. **Trim-only, not `parseCsvList`** (which lowercases): the entries are compared verbatim against `config.registryUrl`, so lowercasing would silently break a mixed-case override. A test pins that non-vacuously.
- **Keep `example.com`** (IANA-reserved, inert — no real registry there) so the ~15 test files using it as the canonical registry fixture need no churn.

## Tests

New `config: registry URL allowlist` block: default accepts `registry.evenfire.ai`; a non-allowlisted URL still rejected; `CLERUM_REGISTRY_URL_ALLOWLIST` accepts a mixed-case URL verbatim. Full registry test sweep (246 tests) + `tsc` green.

## ⚠️ Same OSS-scrub class as #93 and the sender address

`example.com` arrived via `chore: sync platform source` — the same sync transform that stripped exec bits (#93) and left the member-registration docs asserting `no-reply@evenfire.ai` while the hub sends `info@joinevenfire.com`. **If the sync also scrubs `registry.evenfire.ai`, a future sync could revert this** — the durable fix is a sync-side allowlist exception. Flagging so it's not rediscovered a fourth time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)