### PR TITLE
fix(control-api): remap registry browse 401 to 502 so control-ui doesn't force-logout

### DIFF
--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -254,6 +254,19 @@ async function registryFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await authedFetch(path, init)
   if (!res.ok) {
     const body = await res.text()
+    // A persistent 401 (authedFetch already evict-retried once) is a registry
+    // machine-token / integration fault — NOT the admin's control-ui session.
+    // Remap to 502 so control-ui's global 401 handler doesn't force-logout the
+    // admin when the registry rejects control-api (e.g. auth off, or a
+    // half-configured/failing connection). Mirrors orgRegistryFetch, which
+    // already does this. Every other status is forwarded verbatim so a
+    // registry 404 stays a 404 (see the e2e-registry-publish-update-remove
+    // failure class below).
+    if (res.status === 401) {
+      throw Object.assign(new Error('Registry 401: registry_integration_error'), {
+        status: 502,
+      })
+    }
     // Attach the upstream status so the global error handler (app.ts) can
     // forward 4xx responses to the API client. Without `.status`, a registry
     // 404 surfaces as a 500 Internal Server Error from control-api — the

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -312,6 +312,36 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     expect(entryCalls.length).toBe(2)
   })
 
+  it('remaps a persistent registry 401 to 502 (so control-ui does not force-logout)', async () => {
+    // authedFetch evict-retries a 401 once; both attempts 401 → registryFetch
+    // remaps to 502. A bare 401 here would trip control-ui's global 401 handler
+    // and force-logout a valid admin session — the "session expires quickly" bug.
+    const fetchMock = entriesQueue([
+      () => new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 }),
+      () => new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 }),
+    ])
+    vi.stubGlobal('fetch', fetchMock)
+    Object.assign(process.env, ENV_OVERRIDE)
+
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & { status?: number }
+    // Load-bearing: status MUST be 502, NOT 401.
+    expect(err.status).toBe(502)
+    expect(err.status).not.toBe(401)
+    expect(err.message).toMatch(/registry_integration_error/)
+  })
+
+  it('still forwards a registry 404 verbatim (not remapped)', async () => {
+    // Guards the 401 remap against over-reach: non-401 statuses must pass through
+    // so a registry 404 stays a 404 (the e2e-registry-publish-update-remove class).
+    const fetchMock = entriesQueue([() => new Response('missing', { status: 404 })])
+    vi.stubGlobal('fetch', fetchMock)
+    Object.assign(process.env, ENV_OVERRIDE)
+
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & { status?: number }
+    expect(err.status).toBe(404)
+    expect(err.message).toMatch(/Registry 404/)
+  })
+
   it('does NOT retry a non-GET (POST publish) on 503', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url.endsWith('/oauth/token')) return Promise.resolve(fakeTokenResponse('tok', 600))


### PR DESCRIPTION
## The bug (reproduced live on minikube)

The registry **browse** path (`registryFetch` → `searchEntries`/`getEntry`, polled app-wide by the control-ui dashboard) forwards an upstream registry 401 **verbatim**. control-ui's global 401 handler (`lib/api.ts` `handleUnauthorized`) then **force-logs-out the admin** — even though their session is perfectly valid; it was the *registry* rejecting control-api. Symptom: **"session expires quickly"**, every few seconds, on every page, whenever `CLERUM_REGISTRY_URL` points at a registry that 401s (auth off, or a half-configured/failing connection).

## Why the fix is here, not in control-ui

A bare 401 at the browser is ambiguous: *"your admin session expired"* vs *"the upstream registry rejected control-api."* **Only control-api can distinguish them.** control-ui logging out on a genuine admin 401 is correct — the bug is control-api emitting a 401 for a registry-integration failure. A control-ui-only fix would have to guess from the URL path, which can't tell a real expired-session-on-a-registry-page from an upstream 401.

## The fix

`registryFetch` now remaps a persistent 401 → **502 `registry_integration_error`**, exactly mirroring **`orgRegistryFetch`**, which already does this with the same rationale in its comment (*"a machine-token/integration fault, NOT the admin's session — remap to 502 so control-ui never force-logs-out on it"*). The remap had been applied to the org/publish helper but **not its sibling browse helper** — this closes that gap. Every other status forwards verbatim, so a registry **404 stays a 404** (new guard test).

## Tests

`registryClient.test.ts`: persistent 401 → asserts thrown `.status === 502` (not 401) — load-bearing, fails against the old code; plus a 404-still-forwards guard. Full registry sweep (233) + `tsc` green. **control-ui unchanged.**

## Scope

Independent of #99 (allowlist lets you *connect*; this keeps you *logged in* while connecting or while the connection is failing). Together they make the self-hosted registry-connect flow usable end-to-end from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)