### PR TITLE
feat(minikube): default the registry to the shared registry.evenfire.ai

### DIFF
--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -50,6 +50,16 @@ data:
   WORKFLOW_APPROVAL_DEFAULT_TTL_SEC: '86400'
   WORKFLOW_APPROVAL_MAX_TTL_SEC: '172800'
   WORKFLOW_APPROVAL_EXPIRY_INTERVAL_MS: '60000'
-  CLERUM_REGISTRY_URL: 'http://registry-api.registry.svc.cluster.local:8085'
+  # OSS default: point at the shared registry so a self-hoster browses the
+  # public catalog out of the box and can run the connect flow (register →
+  # approve → claim) against it. self-hosted is the only mode that fits an OSS
+  # deployment (managed = MCC-provisioned, not in this repo). Auth stays OFF
+  # until a connection is claimed — the boot guard (assertRegistryConnectionReady)
+  # only requires a connection row when auth is enabled, so this is crashloop-safe.
+  # To run your OWN in-cluster registry instead, set CLERUM_REGISTRY_URL to
+  # http://registry-api.registry.svc.cluster.local:8085 and add it via
+  # CLERUM_REGISTRY_URL_ALLOWLIST if you later enable auth.
+  CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
+  REGISTRY_CONNECTION_MODE: 'self-hosted'
   CLERUM_REGISTRY_AUTH_ENABLED: 'false'
   CLERUM_ATTACHMENT_MAX_BYTES: '52428800'


### PR DESCRIPTION
## Why

The minikube overlay defaulted `CLERUM_REGISTRY_URL` to the **in-cluster** `registry-api` — which OSS doesn't ship (the sibling registry isn't checked out). So on a fresh self-hosted minikube, the **Marketplace returns a 500** (the browse fetch hits an unreachable/empty registry and collapses to Internal Server Error) instead of showing a catalog.

But OSS *is* self-host, and the docs already tell everyone to connect to the shared registry: `open-core-and-hosted.md` ("connect to the shared **registry.evenfire.ai**") and `connect-to-registry.md`. The default should match that reality — a fresh clone should point at `registry.evenfire.ai` with no reconfiguration.

## What

In `deploy/overlays/minikube/configmaps/control-api-config.yaml`:
- **`CLERUM_REGISTRY_URL` → `https://registry.evenfire.ai`** — public catalog browsable out of the box; also fixes the Marketplace 500 (the registry is now reachable).
- **`REGISTRY_CONNECTION_MODE` → `self-hosted`** — the only mode that fits an OSS deployment (managed = MCC-provisioned, not in this repo), so the `register → approve → claim` connect flow works without editing config.
- **`CLERUM_REGISTRY_AUTH_ENABLED` stays `false`** — crashloop-safe: `assertRegistryConnectionReady` only requires a connection row when auth is on. The self-hoster flips auth on after claiming (registry.evenfire.ai is already allowlisted via the earlier fix), and `registryFetch` remaps a pre-connection 401 to 502 (no force-logout) via the other earlier fix.

`minikube-no-uis` inherits `../minikube`, so it's covered too. A comment documents how to point at your own in-cluster registry instead.

## Verification

`kubectl kustomize` renders the new values on **both** overlays. On the live cluster, patching to these values turned the Marketplace 500 into a **200** serving the 7-entry public catalog.

## Note (separate, not fixed here — per owner)

The Marketplace **500 itself** — an unreachable registry should surface a clear "registry unavailable" message, not a 500. Flagged for a follow-up; this PR removes the *trigger* for the default OSS config but the error-handling gap remains for a misconfigured URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)