### PR TITLE
fix: return a typed 503 instead of an opaque 500 when member registration is unreachable

### DIFF
--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -100,14 +100,37 @@ export async function memberRegistrationServiceRequest<T>(
   // by routes/external/invitations.ts:212, routes/admin/teams.ts:42 and
   // routes/external/teams.ts:36 (spec §4.1).
   if (response.status >= 500) {
+    // NOTE: this message must NOT contain the exact string "Member registration
+    // service" (capital M) — routes/admin/teams.ts:97,157 and
+    // routes/external/teams.ts:55 call sendInvitationServiceError(res, error)
+    // before next(error), which matches via message.includes('Member
+    // registration service'). If this 5xx message matched that string, a typed
+    // MemberRegistrationUnavailableError would be silently swallowed into a
+    // 502 invitation_service_unavailable instead of the intended 503.
     throw unavailable(
       { ...context, upstreamStatus: response.status },
       `member-registration service ${method} ${path} failed (${response.status})`
     )
   }
 
-  const raw = await response.text()
+  // A stalled body (headers sent, body never completes) or a mid-body reset
+  // throws here (raw AbortError / TypeError: terminated) even though the
+  // fetch() above already resolved. Without this try/catch that throw escapes
+  // untyped and collapses to a generic 500 — the exact failure this file
+  // exists to prevent.
+  let raw: string
+  try {
+    raw = await response.text()
+  } catch (cause) {
+    throw unavailable(
+      { ...context, upstreamStatus: response.status },
+      'member-registration service response could not be read',
+      cause
+    )
+  }
+
   let parsed: unknown = null
+  let nonJsonBody = false
   if (raw) {
     try {
       parsed = JSON.parse(raw) as unknown
@@ -119,13 +142,18 @@ export async function memberRegistrationServiceRequest<T>(
           cause
         )
       }
+      nonJsonBody = true
       parsed = null
     }
   }
 
   if (!response.ok) {
-    let errorMessage =
-      parsed && typeof parsed === 'object' && 'error' in parsed
+    // A non-JSON 4xx body must never be interpolated verbatim: it's echoed to
+    // callers by routes/admin/teams.ts:44, so an intermediary's HTML error
+    // page (possibly containing internal hostnames) must not leak through.
+    let errorMessage = nonJsonBody
+      ? '<non-JSON response>'
+      : parsed && typeof parsed === 'object' && 'error' in parsed
         ? String((parsed as { error: unknown }).error)
         : raw
     if (parsed && typeof parsed === 'object' && 'message' in parsed) {

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -12,7 +12,14 @@ import {
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-const SEND_TIMEOUT_MS = 10_000
+// This bounds a stalled hub, but does not guarantee the send didn't happen:
+// if the hub's synchronous send exceeds it, we abort and return 503 while the
+// hub may already have sent the mail — leaving the invitation in `draft`
+// (which cleanupStaleDraftInvitations later deletes) and the invitee holding
+// a dead link. 30s is chosen over the enrollment path's MINT_TIMEOUT_MS
+// (10_000, memberRegistrationEnrollment.ts) to give a loaded SMTP send room
+// to finish.
+const SEND_TIMEOUT_MS = 30_000
 
 function buildUrl(baseUrl: string, path: string): string {
   const base = baseUrl.replace(/\/+$/, '')
@@ -101,12 +108,9 @@ export async function memberRegistrationServiceRequest<T>(
   // routes/external/teams.ts:36 (spec §4.1).
   if (response.status >= 500) {
     // NOTE: this message must NOT contain the exact string "Member registration
-    // service" (capital M) — routes/admin/teams.ts:97,157 and
-    // routes/external/teams.ts:55 call sendInvitationServiceError(res, error)
-    // before next(error), which matches via message.includes('Member
-    // registration service'). If this 5xx message matched that string, a typed
-    // MemberRegistrationUnavailableError would be silently swallowed into a
-    // 502 invitation_service_unavailable instead of the intended 503.
+    // service" (capital M) — that exact string is reserved for the untyped 4xx
+    // path below, which routes/external/invitations.ts:212 and the
+    // sendInvitationServiceError helpers match on.
     throw unavailable(
       { ...context, upstreamStatus: response.status },
       `member-registration service ${method} ${path} failed (${response.status})`

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -12,14 +12,17 @@ import {
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-// This bounds a stalled hub, but does not guarantee the send didn't happen:
-// if the hub's synchronous send exceeds it, we abort and return 503 while the
-// hub may already have sent the mail — leaving the invitation in `draft`
-// (which cleanupStaleDraftInvitations later deletes) and the invitee holding
-// a dead link. 30s is chosen over the enrollment path's MINT_TIMEOUT_MS
-// (10_000, memberRegistrationEnrollment.ts) to give a loaded SMTP send room
-// to finish.
-const SEND_TIMEOUT_MS = 30_000
+// Bounds a stalled hub (otherwise the request hangs indefinitely). Must stay
+// below control-ui's API_REQUEST_TIMEOUT_MS (30000), otherwise the browser
+// aborts first and shows "Request timed out. Check that Control API is
+// reachable" (blaming the wrong component) instead of
+// member_registration_unavailable. Leaving headroom lets the 503 reach the
+// browser. Also larger than enrollment path's MINT_TIMEOUT_MS (10_000,
+// memberRegistrationEnrollment.ts) to give a loaded SMTP send room. Tradeoff:
+// if the hub's send exceeds this timeout, we abort and return 503 while the
+// hub may have already sent the mail, leaving the invitation in draft
+// (cleanupStaleDraftInvitations later deletes it).
+const SEND_TIMEOUT_MS = 20_000
 
 function buildUrl(baseUrl: string, path: string): string {
   const base = baseUrl.replace(/\/+$/, '')
@@ -109,8 +112,8 @@ export async function memberRegistrationServiceRequest<T>(
   if (response.status >= 500) {
     // NOTE: this message must NOT contain the exact string "Member registration
     // service" (capital M) — that exact string is reserved for the untyped 4xx
-    // path below, which routes/external/invitations.ts:212 and the
-    // sendInvitationServiceError helpers match on.
+    // path below, which the sendInvitationServiceError helpers
+    // (routes/admin/teams.ts:42, routes/external/teams.ts:36) match on.
     throw unavailable(
       { ...context, upstreamStatus: response.status },
       `member-registration service ${method} ${path} failed (${response.status})`

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -1,14 +1,18 @@
 import { config } from './config.js'
+import { rootLogger } from './observability/logger.js'
 import {
   ensureEnrollment,
   normalizeEnrollmentHost,
 } from './services/memberRegistrationEnrollment.js'
+import { MemberRegistrationUnavailableError } from './services/memberRegistrationErrors.js'
 import {
   type MemberRegistrationSigningCredential,
   signMemberRegistrationJwt,
 } from './utils/auth/memberRegistrationSigner.js'
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+
+const SEND_TIMEOUT_MS = 10_000
 
 function buildUrl(baseUrl: string, path: string): string {
   const base = baseUrl.replace(/\/+$/, '')
@@ -46,6 +50,24 @@ async function resolveTarget(destinationBaseUrl: string): Promise<{
   }
 }
 
+// Log hygiene (mirrors memberRegistrationEnrollment.ts:100): status only —
+// never stringify the upstream response body into the log or the error.
+function unavailable(
+  context: { baseUrl: string; method: string; path: string; upstreamStatus?: number },
+  message: string,
+  cause?: unknown
+): MemberRegistrationUnavailableError {
+  rootLogger.error(
+    {
+      event: 'member_registration_request_failed',
+      ...context,
+      cause: cause instanceof Error ? cause.message : undefined,
+    },
+    message
+  )
+  return new MemberRegistrationUnavailableError(message)
+}
+
 export async function memberRegistrationServiceRequest<T>(
   method: RequestMethod,
   path: string,
@@ -55,17 +77,51 @@ export async function memberRegistrationServiceRequest<T>(
   }
 ): Promise<T> {
   const { baseUrl, credential } = await resolveTarget(options.destinationBaseUrl)
-  const response = await fetch(buildUrl(baseUrl, path), {
-    method,
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${signMemberRegistrationJwt(credential)}`,
-    },
-    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
-  })
+  const context = { baseUrl, method, path }
+
+  let response: Response
+  try {
+    response = await fetch(buildUrl(baseUrl, path), {
+      method,
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${signMemberRegistrationJwt(credential)}`,
+      },
+      body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+      signal: AbortSignal.timeout(SEND_TIMEOUT_MS),
+    })
+  } catch (cause) {
+    throw unavailable(context, 'member-registration service is unreachable', cause)
+  }
+
+  // Upstream 5xx is an availability problem: typed, so the app.ts middleware
+  // returns 503. 4xx is a domain answer from the hub and keeps the legacy
+  // message verbatim — `Member registration service` and `(status)` are matched
+  // by routes/external/invitations.ts:212, routes/admin/teams.ts:42 and
+  // routes/external/teams.ts:36 (spec §4.1).
+  if (response.status >= 500) {
+    throw unavailable(
+      { ...context, upstreamStatus: response.status },
+      `member-registration service ${method} ${path} failed (${response.status})`
+    )
+  }
 
   const raw = await response.text()
-  const parsed = raw ? (JSON.parse(raw) as unknown) : null
+  let parsed: unknown = null
+  if (raw) {
+    try {
+      parsed = JSON.parse(raw) as unknown
+    } catch (cause) {
+      if (response.ok) {
+        throw unavailable(
+          { ...context, upstreamStatus: response.status },
+          'member-registration service returned a non-JSON response',
+          cause
+        )
+      }
+      parsed = null
+    }
+  }
 
   if (!response.ok) {
     let errorMessage =

--- a/control-api/src/memberRegistrationServiceClient.ts
+++ b/control-api/src/memberRegistrationServiceClient.ts
@@ -136,10 +136,13 @@ export async function memberRegistrationServiceRequest<T>(
       parsed = JSON.parse(raw) as unknown
     } catch (cause) {
       if (response.ok) {
+        // The parse error is NOT passed as cause here: V8 embeds ~10 chars of
+        // the offending input in SyntaxError.message, so passing cause would
+        // leak the upstream body into the log — contradicting this file's
+        // status-only rule (line 53). The message + upstreamStatus is sufficient.
         throw unavailable(
           { ...context, upstreamStatus: response.status },
-          'member-registration service returned a non-JSON response',
-          cause
+          'member-registration service returned a non-JSON response'
         )
       }
       nonJsonBody = true

--- a/control-api/test/memberRegistrationClient.errors.test.ts
+++ b/control-api/test/memberRegistrationClient.errors.test.ts
@@ -26,6 +26,13 @@ const enrollment = vi.hoisted(() => ({
 }))
 vi.mock('../src/services/memberRegistrationEnrollment.js', () => enrollment)
 
+const logger = vi.hoisted(() => ({
+  rootLogger: {
+    error: vi.fn(),
+  },
+}))
+vi.mock('../src/observability/logger.js', () => logger)
+
 function send(): Promise<void> {
   return registerAndSendInvitation('a@b.c', 'uuid-1', 'team', '2026-01-01', '2026-02-01')
 }
@@ -137,5 +144,24 @@ describe('member-registration client failure classification', () => {
     expect(error.message).toContain('Member registration service')
     expect(error.message).toContain('(404)')
     expect(error.message).not.toContain('upstream-internal-host.local')
+  })
+
+  it('REGRESSION: a non-JSON 2xx does not leak body snippet from SyntaxError.message into logs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html>SECRET_BODY_MARKER</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        })
+      )
+    )
+    const error = await caught()
+    expect(error).toBeInstanceOf(MemberRegistrationUnavailableError)
+    // Verify the logger.error was called
+    expect(logger.rootLogger.error).toHaveBeenCalled()
+    // Verify the logged object does not contain the body snippet
+    const [loggedObject] = logger.rootLogger.error.mock.calls[0]
+    expect(JSON.stringify(loggedObject)).not.toContain('SECRET_BODY_MARKER')
   })
 })

--- a/control-api/test/memberRegistrationClient.errors.test.ts
+++ b/control-api/test/memberRegistrationClient.errors.test.ts
@@ -96,6 +96,12 @@ describe('member-registration client failure classification', () => {
     expect(error).toBeInstanceOf(MemberRegistrationUnavailableError)
     expect(error.message).not.toContain('SECRET_BODY')
     expect(error.message).toContain('500')
+    // Pins the invariant the comment above the 5xx throw documents: this
+    // message must never collide with the untyped 4xx prefix, or a typed
+    // MemberRegistrationUnavailableError would be matched by
+    // sendInvitationServiceError's message.includes('Member registration
+    // service') check.
+    expect(error.message).not.toContain('Member registration service')
   })
 
   it('REGRESSION: an upstream 404 keeps the legacy plain Error and message so routes still match (spec §4.1)', async () => {
@@ -147,10 +153,14 @@ describe('member-registration client failure classification', () => {
   })
 
   it('REGRESSION: a non-JSON 2xx does not leak body snippet from SyntaxError.message into logs', async () => {
+    // V8 embeds only the first ~10 characters of the offending input in
+    // SyntaxError.message (e.g. JSON.parse('<html>...') -> "...\"<html>SECR\"...
+    // is not valid JSON"). The marker must sit inside that window, or this
+    // assertion passes regardless of whether the bug is present.
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        new Response('<html>SECRET_BODY_MARKER</html>', {
+        new Response('SECRETMARKER-not-json', {
           status: 200,
           headers: { 'content-type': 'text/html' },
         })
@@ -162,6 +172,9 @@ describe('member-registration client failure classification', () => {
     expect(logger.rootLogger.error).toHaveBeenCalled()
     // Verify the logged object does not contain the body snippet
     const [loggedObject] = logger.rootLogger.error.mock.calls[0]
-    expect(JSON.stringify(loggedObject)).not.toContain('SECRET_BODY_MARKER')
+    expect(JSON.stringify(loggedObject)).not.toContain('SECRETMARK')
+    // Verify directly that no cause was threaded through at all on this path
+    // -- the parse SyntaxError must never be passed to unavailable() here.
+    expect(loggedObject.cause).toBeUndefined()
   })
 })

--- a/control-api/test/memberRegistrationClient.errors.test.ts
+++ b/control-api/test/memberRegistrationClient.errors.test.ts
@@ -112,4 +112,30 @@ describe('member-registration client failure classification', () => {
     expect(error.message).toContain('Member registration service')
     expect(error.message).toContain('(403)')
   })
+
+  it('a body read failure (stalled body / mid-body reset) becomes Unavailable, not a raw AbortError', async () => {
+    const response = new Response('{"ok":true}', { status: 200 })
+    vi.spyOn(response, 'text').mockRejectedValue(
+      new DOMException('The user aborted a request.', 'AbortError')
+    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response))
+    await expect(send()).rejects.toBeInstanceOf(MemberRegistrationUnavailableError)
+  })
+
+  it('REGRESSION: a non-JSON 404 keeps the legacy plain Error but does not leak the raw body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html><body>upstream-internal-host.local error</body></html>', {
+          status: 404,
+          headers: { 'content-type': 'text/html' },
+        })
+      )
+    )
+    const error = await caught()
+    expect(error).not.toBeInstanceOf(MemberRegistrationUnavailableError)
+    expect(error.message).toContain('Member registration service')
+    expect(error.message).toContain('(404)')
+    expect(error.message).not.toContain('upstream-internal-host.local')
+  })
 })

--- a/control-api/test/memberRegistrationClient.errors.test.ts
+++ b/control-api/test/memberRegistrationClient.errors.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerAndSendInvitation } from '../src/services/invitationFlowRegistrationService.js'
+import { MemberRegistrationUnavailableError } from '../src/services/memberRegistrationErrors.js'
+
+const { cfg } = vi.hoisted(() => ({
+  cfg: {
+    memberRegistrationMode: 'remote',
+    memberRegistrationExternalHubBaseUrl: 'https://registration.evenfire.ai/api/v1',
+    memberRegistrationServiceBaseUrl: 'http://member-registration-service.local:8092/api/v1',
+    memberRegistrationServiceHmacSecret: 'env-secret',
+    memberRegistrationServiceHmacKid: 'env-kid',
+    memberRegistrationTenantId: 'clerum-dev',
+    desktopProfileUiBaseUrl: 'https://profile.acme.com',
+    controlUiBaseUrl: 'https://control.acme.com',
+    desktopExternalRestApiBaseUrl: 'http://127.0.0.1:8091',
+    desktopRpcProxyBaseUrl: 'http://127.0.0.1:8094',
+    desktopAppName: 'Evenfire',
+    controlUiAppName: 'Evenfire',
+  } as Record<string, unknown>,
+}))
+vi.mock('../src/config.js', () => ({ config: cfg }))
+
+const enrollment = vi.hoisted(() => ({
+  ensureEnrollment: vi.fn(),
+  normalizeEnrollmentHost: (baseUrl: string) => new URL(baseUrl).hostname.toLowerCase(),
+}))
+vi.mock('../src/services/memberRegistrationEnrollment.js', () => enrollment)
+
+function send(): Promise<void> {
+  return registerAndSendInvitation('a@b.c', 'uuid-1', 'team', '2026-01-01', '2026-02-01')
+}
+
+async function caught(): Promise<Error> {
+  return send().then(
+    () => {
+      throw new Error('expected send() to reject')
+    },
+    (error: unknown) => error as Error
+  )
+}
+
+describe('member-registration client failure classification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    cfg.memberRegistrationMode = 'remote'
+  })
+
+  it('fetch rejecting (minikube: no registration namespace) becomes Unavailable, not a raw TypeError', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')))
+    await expect(send()).rejects.toBeInstanceOf(MemberRegistrationUnavailableError)
+  })
+
+  it('a timeout/abort becomes Unavailable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new DOMException('aborted due to timeout', 'TimeoutError'))
+    )
+    await expect(send()).rejects.toBeInstanceOf(MemberRegistrationUnavailableError)
+  })
+
+  it('passes an AbortSignal so a stalled hub cannot hang the request forever', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{"sent":true}', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    await send()
+    const [, init] = fetchMock.mock.calls[0]
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('a non-JSON 2xx body becomes Unavailable, not a raw SyntaxError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html>gateway</html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        })
+      )
+    )
+    await expect(send()).rejects.toBeInstanceOf(MemberRegistrationUnavailableError)
+  })
+
+  it('an upstream 5xx becomes Unavailable and never leaks the response body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{"error":"SECRET_BODY"}', { status: 500 }))
+    )
+    const error = await caught()
+    expect(error).toBeInstanceOf(MemberRegistrationUnavailableError)
+    expect(error.message).not.toContain('SECRET_BODY')
+    expect(error.message).toContain('500')
+  })
+
+  it('REGRESSION: an upstream 404 keeps the legacy plain Error and message so routes still match (spec §4.1)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{"error":"nope"}', { status: 404 }))
+    )
+    const error = await caught()
+    expect(error).not.toBeInstanceOf(MemberRegistrationUnavailableError)
+    expect(error.message).toContain('Member registration service')
+    expect(error.message).toContain('(404)')
+  })
+
+  it('REGRESSION: an upstream 403 keeps the legacy plain Error (teams routes sniff this message)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('{"error":"forbidden"}', { status: 403 }))
+    )
+    const error = await caught()
+    expect(error).not.toBeInstanceOf(MemberRegistrationUnavailableError)
+    expect(error.message).toContain('Member registration service')
+    expect(error.message).toContain('(403)')
+  })
+})

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -101,7 +101,11 @@ function formatApiError(res: Response, text: string): Error {
             ? 'Desktop App password must be between 8 and 256 characters.'
             : detail === 'password must be between 8 and 256 characters'
               ? 'Password must be between 8 and 256 characters.'
-              : detail
+              : detail === 'member_registration_unavailable'
+                ? "Invitations are unavailable — the member-registration service isn't configured or can't be reached. Check the server logs for details."
+                : detail === 'member_registration_misconfigured'
+                  ? 'Invitations are unavailable — member registration is misconfigured. Check the server logs for details.'
+                  : detail
   const error = new Error(`${res.status} ${res.statusText} - ${friendlyDetail}`)
   ;(error as Error & { status?: number }).status = res.status
   // Preserve the machine-readable error code and full JSON body so callers can

--- a/profile-ui/lib/api.ts
+++ b/profile-ui/lib/api.ts
@@ -129,6 +129,16 @@ export async function apiSend(
     } catch {
       detail = text
     }
+    if (detail === 'member_registration_unavailable') {
+      throw new Error(
+        "Invitations are unavailable — the member-registration service isn't configured or can't be reached. Check the server logs for details."
+      )
+    }
+    if (detail === 'member_registration_misconfigured') {
+      throw new Error(
+        'Invitations are unavailable — member registration is misconfigured. Check the server logs for details.'
+      )
+    }
     throw new Error(`${res.status} ${res.statusText} - ${detail}`)
   }
   if (res.status === 204) {

--- a/profile-ui/lib/api.ts
+++ b/profile-ui/lib/api.ts
@@ -129,12 +129,12 @@ export async function apiSend(
     } catch {
       detail = text
     }
-    if (detail === 'member_registration_unavailable') {
+    if (detail.includes('member_registration_unavailable')) {
       throw new Error(
         "Invitations are unavailable — the member-registration service isn't configured or can't be reached. Check the server logs for details."
       )
     }
-    if (detail === 'member_registration_misconfigured') {
+    if (detail.includes('member_registration_misconfigured')) {
       throw new Error(
         'Invitations are unavailable — member registration is misconfigured. Check the server logs for details.'
       )


### PR DESCRIPTION
## The problem

A self-hosted/minikube operator clicking **Create member** got an opaque `500 {"error":"Internal Server Error"}` with no indication of why.

`memberRegistrationServiceClient.ts` used a bare `fetch`. A stock minikube has no `registration` namespace, so DNS for `member-registration-service.registration.svc.cluster.local` fails, `fetch` throws `TypeError: fetch failed`, nothing catches it, and the error middleware collapses it to a generic 500.

## Why this is small

The typed-error contract already existed — PR #91 shipped `MemberRegistrationUnavailableError` and the `503` mapping at `app.ts:144-158`, but wired them **only to the enrollment path**. In `remote` mode (minikube's default) enrollment never runs, so nothing ever constructed a typed error and the 500 was untouched.

This PR points the *request* path at that existing contract. No new error classes, no middleware change, no route change.

## What changed

| failure | result |
|---|---|
| `fetch` throws (DNS/ECONNREFUSED — the minikube case) | `503 member_registration_unavailable` |
| request timeout (new — `SEND_TIMEOUT_MS = 20_000`) | `503 member_registration_unavailable` |
| body read fails (stalled body / mid-body reset) | `503 member_registration_unavailable` |
| non-JSON 2xx body | `503 member_registration_unavailable` |
| upstream 5xx | `503 member_registration_unavailable` |
| **upstream 4xx** | **unchanged** — see below |

Both UIs now map `member_registration_unavailable` / `member_registration_misconfigured` to human copy (the latter also covers PR #91's enrollment errors, which previously rendered as a bare code).

## Upstream 4xx is deliberately frozen

The 4xx branch keeps its message byte-for-byte, including the `Member registration service` prefix and the `(${status})` fragment, because three call sites match on it:

- `routes/external/invitations.ts:211` matches `(404)` → `404 not_found`. Typing hub 404s would make that branch dead code and turn a legitimate "not found" into a 503.
- `routes/admin/teams.ts:42` and `routes/external/teams.ts:36` match the prefix.

A 4xx on the send path is a domain answer from the hub, not an availability problem — unlike enrollment, where a hub 4xx genuinely means "you cannot enroll". Two regression tests pin this.

Consequence, and it's the desired one: transport/5xx messages deliberately **don't** contain that prefix, so `sendInvitationServiceError` no longer matches and the routes' existing `next(error)` carries them to the middleware → 503, with no edit to those files.

## Timeout choice

`SEND_TIMEOUT_MS = 20_000` sits **below** control-ui's `API_REQUEST_TIMEOUT_MS = 30000` (`control-ui/lib/api.ts:57`) on purpose. control-api does its lookup and insert *before* the fetch starts, so a 30s send timeout always lost the race to the browser — a stalled hub showed *"Check that Control API is reachable"* (wrong component) instead of this PR's copy. 20s still gives a loaded SMTP send double the enrollment path's `MINT_TIMEOUT_MS = 10_000`.

Residual tradeoff: if the hub's send exceeds 20s we return 503 while it may already have sent the mail, leaving the invitation `draft` for `cleanupStaleDraftInvitations` to delete.

## Testing

- 7 new tests covering every failure class, plus regression tests pinning the frozen 4xx message and the 5xx/4xx prefix distinction.
- Full control-api suite: **2812 passed / 3 skipped**. Both UIs typecheck clean; prettier clean.
- Every fix in this PR was verified by **mutation** — reintroducing each bug makes its test fail.

## Known gaps (not addressed here)

- **`external-rest-api` does not forward 503** (`app.ts:59-75` forwards only 4xx), so profile-ui matches the code by substring inside the flattened 500 message. The copy renders today, but the status itself doesn't survive that hop.
- **Empty/`null` 2xx body still escapes untyped** → `validateInvitationFlowToken` throws `TypeError: Cannot read properties of null` → 500. Same bug class, pre-existing, on a path this PR doesn't touch. Worth a tracked issue.
- **A 204/empty send resolves silently** → `membership.ts:600` flips `draft`→`pending` with nothing sent. Pre-existing.
- 5xx response body left unread (bounded by the abort signal); no route-level test for `POST /admin/invitations` → 503 (needs admin-auth mocking); `profile-ui` `apiGet` never parses the body; the UI copy says "check the server logs" but drops the `correlationId` the API returns; no reciprocal note at `control-ui/lib/api.ts:57` warning against lowering the browser timeout below 20s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)