### PR TITLE
feat(registry): add connect discoverability + clean registry-unavailable error

### DIFF
--- a/control-api/src/app.ts
+++ b/control-api/src/app.ts
@@ -26,6 +26,11 @@ import { createRegistryRouter } from './routes/registry.js'
 import { createRpcAccessRouter } from './routes/rpc-access/index.js'
 import { memberRegistrationErrorResponse } from './services/memberRegistrationErrors.js'
 
+// Only errors we construct with these codes are ever forwarded verbatim by the
+// global handler (see below). Keeps the blast radius tight: every other
+// status-less or non-allowlisted error still collapses to a 500.
+const FORWARDABLE_INTEGRATION_CODES = new Set(['registry_unavailable', 'registry_integration_error'])
+
 export function createApp(gateway: K8sGateway) {
   const app = express()
   app.set('trust proxy', 1)
@@ -180,6 +185,36 @@ export function createApp(gateway: K8sGateway) {
       )
       res.status(errStatus as number).json({
         error: err instanceof Error ? err.message : 'Bad Request',
+        correlationId,
+      })
+      return
+    }
+
+    // Allowlisted registry-integration errors carry a safe code + message we set
+    // ourselves (RegistryUnavailableError → 503; the 401 remap → 502). Forward
+    // them so the marketplace shows a clear message instead of a raw 500. The
+    // message is safe because only our own constructors set these codes.
+    const integrationCode = (err as { code?: unknown }).code
+    const integrationStatus = (err as { status?: unknown }).status
+    if (
+      typeof integrationStatus === 'number' &&
+      (integrationStatus === 502 || integrationStatus === 503) &&
+      typeof integrationCode === 'string' &&
+      FORWARDABLE_INTEGRATION_CODES.has(integrationCode)
+    ) {
+      log.warn(
+        {
+          event: 'forwarded_registry_integration_error',
+          correlationId,
+          status: integrationStatus,
+          code: integrationCode,
+          err: err instanceof Error ? err.message : String(err),
+        },
+        'forwarded registry integration error'
+      )
+      res.status(integrationStatus).json({
+        error: integrationCode,
+        message: err instanceof Error ? err.message : 'Registry integration error',
         correlationId,
       })
       return

--- a/control-api/src/app.ts
+++ b/control-api/src/app.ts
@@ -29,7 +29,10 @@ import { memberRegistrationErrorResponse } from './services/memberRegistrationEr
 // Only errors we construct with these codes are ever forwarded verbatim by the
 // global handler (see below). Keeps the blast radius tight: every other
 // status-less or non-allowlisted error still collapses to a 500.
-const FORWARDABLE_INTEGRATION_CODES = new Set(['registry_unavailable', 'registry_integration_error'])
+const FORWARDABLE_INTEGRATION_CODES = new Set([
+  'registry_unavailable',
+  'registry_integration_error',
+])
 
 export function createApp(gateway: K8sGateway) {
   const app = express()

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -258,7 +258,9 @@ async function authedFetch(
 export class RegistryUnavailableError extends Error {
   readonly status = 503
   readonly code = 'registry_unavailable'
-  constructor(message = 'The registry is currently unavailable. Check the connection and try again.') {
+  constructor(
+    message = 'The registry is currently unavailable. Check the connection and try again.'
+  ) {
     super(message)
     this.name = 'RegistryUnavailableError'
   }

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -250,28 +250,58 @@ async function authedFetch(
   return attempt(isGet)
 }
 
+/**
+ * Registry origin/gateway is unreachable (network refusal, timeout, or an
+ * upstream HTTP 5xx). A clean, user-safe error the global handler forwards as a
+ * 503 so the marketplace shows a clear message instead of a raw 500.
+ */
+export class RegistryUnavailableError extends Error {
+  readonly status = 503
+  readonly code = 'registry_unavailable'
+  constructor(message = 'The registry is currently unavailable. Check the connection and try again.') {
+    super(message)
+    this.name = 'RegistryUnavailableError'
+  }
+}
+
 async function registryFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await authedFetch(path, init)
+  let res: Response
+  try {
+    res = await authedFetch(path, init)
+  } catch (err) {
+    // Remap ONLY genuine network/timeout signals to a clean "unavailable":
+    // undici's "fetch failed" (ECONNREFUSED / DNS) surfaces as a TypeError, and
+    // an Abort/Timeout that survives the single GET retry surfaces via
+    // isTransientFetchError. Everything else is rethrown unchanged — critically,
+    // mintToken's status-less "registry credential rejected" (a wrong-secret
+    // misconfig) must keep its own signal rather than be mislabeled "unavailable".
+    if (err instanceof TypeError || isTransientFetchError(err)) {
+      throw new RegistryUnavailableError()
+    }
+    throw err
+  }
   if (!res.ok) {
     const body = await res.text()
     // A persistent 401 (authedFetch already evict-retried once) is a registry
     // machine-token / integration fault — NOT the admin's control-ui session.
-    // Remap to 502 so control-ui's global 401 handler doesn't force-logout the
-    // admin when the registry rejects control-api (e.g. auth off, or a
-    // half-configured/failing connection). Mirrors orgRegistryFetch, which
-    // already does this. Every other status is forwarded verbatim so a
-    // registry 404 stays a 404 (see the e2e-registry-publish-update-remove
-    // failure class below).
+    // Remap to 502 (so control-ui's global 401 handler never force-logs-out the
+    // admin) and carry a machine code + a user-safe message.
     if (res.status === 401) {
-      throw Object.assign(new Error('Registry 401: registry_integration_error'), {
+      throw Object.assign(new Error('The registry could not be reached.'), {
         status: 502,
+        code: 'registry_integration_error',
       })
     }
-    // Attach the upstream status so the global error handler (app.ts) can
-    // forward 4xx responses to the API client. Without `.status`, a registry
-    // 404 surfaces as a 500 Internal Server Error from control-api — the
-    // exact failure class scripts/e2e/e2e-registry-publish-update-remove.sh
-    // is designed to catch.
+    // Registry origin/gateway down — an HTTP 5xx (500/502/503/504 and Cloudflare
+    // 520–524) is the dominant real-world "registry unavailable" signal (edge up,
+    // origin down). Map to a clean 503. Retriable GET statuses already retried
+    // once via RETRIABLE_GET_STATUSES in authedFetch before landing here.
+    if (res.status >= 500) {
+      throw new RegistryUnavailableError()
+    }
+    // Attach the upstream status so the global error handler (app.ts) forwards
+    // 4xx verbatim to the API client (a registry 404 stays a 404 — the
+    // e2e-registry-publish-update-remove failure class).
     throw Object.assign(new Error(`Registry ${res.status}: ${body}`), {
       status: res.status,
     })

--- a/control-api/test/app.registryCatalogUnavailable.test.ts
+++ b/control-api/test/app.registryCatalogUnavailable.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createApp } from '../src/app.js'
+import { RegistryUnavailableError } from '../src/services/registryClient.js'
+import { MockGateway } from './mockGateway.js'
+
+// Bypass the control-ui auth gate so the supertest request reaches the real
+// catalog route (and the real global error handler) without a session cookie.
+vi.mock('../src/middleware/controlUIAuth.js', () => ({
+  requireAuthForControlUI: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    ;(req as unknown as { adminAuth: unknown }).adminAuth = {
+      sub: 'admin-1',
+      role: 'admin',
+      typ: 'user',
+    }
+    next()
+  },
+}))
+
+// Partial-mock the registry client: keep every real export (RegistryProxyError,
+// applyPublishScope, RegistryUnavailableError, …) so the admin router still
+// loads, and override only the two hot catalog reads so we can make them throw.
+const registryClient = vi.hoisted(() => ({
+  searchEntries: vi.fn(),
+  getCategories: vi.fn(),
+}))
+vi.mock('../src/services/registryClient.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryClient.js')>()),
+  searchEntries: registryClient.searchEntries,
+  getCategories: registryClient.getCategories,
+}))
+
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+}))
+
+describe('app: registry-unavailable forwarding at the global error handler (real middleware)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('forwards a RegistryUnavailableError as 503 { error: registry_unavailable, message }', async () => {
+    registryClient.searchEntries.mockRejectedValue(new RegistryUnavailableError())
+    registryClient.getCategories.mockRejectedValue(new RegistryUnavailableError())
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/catalog')
+    expect(res.status).toBe(503)
+    expect(res.body.error).toBe('registry_unavailable')
+    expect(res.body.message).toBe(
+      'The registry is currently unavailable. Check the connection and try again.'
+    )
+  })
+
+  it('collapses a plain status-less Error to 500 Internal Server Error', async () => {
+    registryClient.searchEntries.mockRejectedValue(new Error('boom'))
+    registryClient.getCategories.mockRejectedValue(new Error('boom'))
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/catalog')
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Internal Server Error')
+  })
+
+  it('does NOT forward a 502 with a non-allowlisted code (allowlist enforced) → 500', async () => {
+    registryClient.searchEntries.mockRejectedValue(
+      Object.assign(new Error('nope'), { status: 502, code: 'other' })
+    )
+    registryClient.getCategories.mockRejectedValue(
+      Object.assign(new Error('nope'), { status: 502, code: 'other' })
+    )
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/catalog')
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Internal Server Error')
+  })
+})

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -358,7 +358,9 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     vi.stubGlobal('fetch', fetchMock)
     Object.assign(process.env, ENV_OVERRIDE)
 
-    const err = (await publishEntry({ name: '@clerum/x', version: '0.0.1' }).catch(e => e)) as Error & {
+    const err = (await publishEntry({ name: '@clerum/x', version: '0.0.1' }).catch(
+      e => e
+    )) as Error & {
       status?: number
       code?: string
     }
@@ -417,7 +419,8 @@ describe('registryClient — registry-unavailable remap (Fix 2)', () => {
     // misconfig) — a status-less, non-network Error. It must surface unchanged,
     // NOT collapsed into the "unavailable" message.
     const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (url.endsWith('/oauth/token')) return Promise.resolve(new Response('bad creds', { status: 401 }))
+      if (url.endsWith('/oauth/token'))
+        return Promise.resolve(new Response('bad creds', { status: 401 }))
       return Promise.resolve(
         new Response(JSON.stringify({ data: [], meta: { total: 0, limit: 0, offset: 0 } }), {
           status: 200,

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -296,7 +296,7 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     expect(entryAttempts).toBe(2)
   })
 
-  it('only retries ONCE — a second transient surfaces as an error', async () => {
+  it('only retries ONCE — a second transient surfaces as registry_unavailable', async () => {
     const fetchMock = entriesQueue([
       () => new Response('gw', { status: 503 }),
       () => new Response('gw', { status: 503 }),
@@ -304,7 +304,12 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     vi.stubGlobal('fetch', fetchMock)
     Object.assign(process.env, ENV_OVERRIDE)
 
-    await expect(searchEntries({ q: 'thing' })).rejects.toThrow(/Registry 503/)
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
 
     const entryCalls = fetchMock.mock.calls.filter(
       (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('/entries')
@@ -323,11 +328,14 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     vi.stubGlobal('fetch', fetchMock)
     Object.assign(process.env, ENV_OVERRIDE)
 
-    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & { status?: number }
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
     // Load-bearing: status MUST be 502, NOT 401.
     expect(err.status).toBe(502)
     expect(err.status).not.toBe(401)
-    expect(err.message).toMatch(/registry_integration_error/)
+    expect(err.code).toBe('registry_integration_error')
   })
 
   it('still forwards a registry 404 verbatim (not remapped)', async () => {
@@ -342,7 +350,7 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     expect(err.message).toMatch(/Registry 404/)
   })
 
-  it('does NOT retry a non-GET (POST publish) on 503', async () => {
+  it('does NOT retry a non-GET (POST publish) on 503, and surfaces registry_unavailable', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url.endsWith('/oauth/token')) return Promise.resolve(fakeTokenResponse('tok', 600))
       return Promise.resolve(new Response('gw', { status: 503 }))
@@ -350,9 +358,12 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
     vi.stubGlobal('fetch', fetchMock)
     Object.assign(process.env, ENV_OVERRIDE)
 
-    await expect(publishEntry({ name: '@clerum/x', version: '0.0.1' })).rejects.toThrow(
-      /Registry 503/
-    )
+    const err = (await publishEntry({ name: '@clerum/x', version: '0.0.1' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
 
     const publishCalls = fetchMock.mock.calls.filter(
       (c: unknown[]) =>
@@ -361,6 +372,68 @@ describe('registryClient — GET retry-once (transient resilience)', () => {
         (c[1] as RequestInit | undefined)?.method === 'POST'
     )
     expect(publishCalls.length).toBe(1)
+  })
+})
+
+describe('registryClient — registry-unavailable remap (Fix 2)', () => {
+  it('remaps a TypeError ("fetch failed" = ECONNREFUSED / DNS) to 503 registry_unavailable', async () => {
+    // A TypeError is NOT transient (isTransientFetchError is false for it), so
+    // authedFetch does not retry it — it rethrows, and registryFetch remaps it.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/oauth/token')) return Promise.resolve(fakeTokenResponse('tok', 600))
+      return Promise.reject(new TypeError('fetch failed'))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    Object.assign(process.env, ENV_OVERRIDE)
+
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
+  })
+
+  it('remaps an upstream HTTP 5xx (origin/gateway down) to 503 registry_unavailable', async () => {
+    // The dominant real-world path: the edge is reachable but the origin returns
+    // a 5xx. A GET retries once (RETRIABLE_GET_STATUSES) then maps to unavailable.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/oauth/token')) return Promise.resolve(fakeTokenResponse('tok', 600))
+      return Promise.resolve(new Response('origin down', { status: 503 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    Object.assign(process.env, ENV_OVERRIDE)
+
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
+  })
+
+  it('does NOT relabel a status-less credential-rejected error as registry_unavailable', async () => {
+    // mintToken throws "registry credential rejected: 401 …" (a wrong-secret
+    // misconfig) — a status-less, non-network Error. It must surface unchanged,
+    // NOT collapsed into the "unavailable" message.
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.endsWith('/oauth/token')) return Promise.resolve(new Response('bad creds', { status: 401 }))
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: [], meta: { total: 0, limit: 0, offset: 0 } }), {
+          status: 200,
+        })
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    Object.assign(process.env, ENV_OVERRIDE)
+
+    const err = (await searchEntries({ q: 'thing' }).catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.message).toMatch(/registry credential rejected: 401/)
+    expect(err.code).not.toBe('registry_unavailable')
+    expect(err.status).toBeUndefined()
   })
 })
 
@@ -482,7 +555,7 @@ describe('registryClient — stale-while-error cache', () => {
     expect(second).toEqual({ data: ['ai', 'devtools'] })
   })
 
-  it('throws when the registry errors and there is NO cached value', async () => {
+  it('throws registry_unavailable when the registry errors and there is NO cached value', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {
       if (url.endsWith('/oauth/token')) return Promise.resolve(fakeTokenResponse('tok', 600))
       return Promise.resolve(new Response('down', { status: 503 }))
@@ -490,7 +563,9 @@ describe('registryClient — stale-while-error cache', () => {
     vi.stubGlobal('fetch', fetchMock)
     Object.assign(process.env, ENV_OVERRIDE)
 
-    await expect(getCategories()).rejects.toThrow(/Registry 503/)
+    const err = (await getCategories().catch(e => e)) as Error & { status?: number; code?: string }
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
   })
 
   it('serves last-good default catalog search (limit:200) on error', async () => {

--- a/control-ui/components/RegistryCatalog.tsx
+++ b/control-ui/components/RegistryCatalog.tsx
@@ -11,9 +11,11 @@ import { TablePanelHeader } from '@components/TablePanelHeader'
 import { useToast } from '@components/Toast'
 import { IconPencil, IconX } from '@components/icons'
 import {
+  type RegistryConnectionState,
   type RegistryEntry,
   deleteRegistryEntry,
   getRegistryCatalog,
+  getRegistryConnection,
   installRecipeFromRegistry,
 } from '../lib/api'
 import { trustBgColor, trustColor } from '../lib/trustLevel'
@@ -55,6 +57,17 @@ export default function RegistryCatalog() {
   const [error, setError] = useState<string | null>(null)
   const [installingRecipeKey, setInstallingRecipeKey] = useState('')
   const [installError, setInstallError] = useState('')
+
+  // Registry-connect discoverability: an independent, best-effort fetch that
+  // derives whether this deployment is self-hosted and (if so) its connection
+  // state, so the Marketplace can surface a "Connect" entry point. Initial
+  // mode is 'unknown' (fail-open) so the header button isn't hidden while the
+  // request is in flight or if it errors for a reason other than the
+  // deployment being managed.
+  const [connectionMode, setConnectionMode] = useState<'self-hosted' | 'managed' | 'unknown'>(
+    'unknown'
+  )
+  const [connectionState, setConnectionState] = useState<RegistryConnectionState | null>(null)
 
   // Filters
   const [search, setSearch] = useState('')
@@ -108,7 +121,24 @@ export default function RegistryCatalog() {
 
   useEffect(() => {
     loadData()
+    loadConnectionMode()
   }, [])
+
+  async function loadConnectionMode() {
+    // Independent of the catalog browse: a browse failure must not hide the
+    // connect entry point (see the error early-return below). Fail-open — any
+    // non-managed outcome keeps the entry point available.
+    try {
+      const status = await getRegistryConnection()
+      setConnectionMode('self-hosted')
+      setConnectionState(status.state)
+    } catch (err) {
+      setConnectionMode(
+        (err as { code?: unknown }).code === 'not_self_hosted' ? 'managed' : 'unknown'
+      )
+      setConnectionState(null)
+    }
+  }
 
   async function loadData() {
     setLoading(true)
@@ -165,11 +195,35 @@ export default function RegistryCatalog() {
     return false
   }
 
+  const showConnectBanner =
+    connectionMode === 'self-hosted' &&
+    (connectionState === 'disconnected' || connectionState === 'rejected')
+  // Computed once, rendered in BOTH the error early-return and the normal branch
+  // so the connect prompt survives a catalog browse failure (DRY).
+  const connectBanner = showConnectBanner ? (
+    <div className="cu-banner cu-banner--info" role="status">
+      <span>
+        This deployment isn&apos;t connected to a registry. Connect it to publish and install
+        connectors and plugins.
+      </span>
+      <button
+        type="button"
+        className="cu-btn cu-btn--primary cu-btn--sm"
+        onClick={() => router.push('/registry/connect')}
+      >
+        Connect to registry
+      </button>
+    </div>
+  ) : null
+
   if (error) {
     return (
-      <div className="cu-card cu-card--viewport-fill" style={{ marginBottom: '1.25rem' }}>
-        <div className="cu-card__body">
-          <div className="cu-banner cu-banner--error">Error: {error}</div>
+      <div className="cu-registry-layout">
+        {connectBanner}
+        <div className="cu-card cu-card--viewport-fill" style={{ marginBottom: '1.25rem' }}>
+          <div className="cu-card__body">
+            <div className="cu-banner cu-banner--error">Error: {error}</div>
+          </div>
         </div>
       </div>
     )
@@ -190,6 +244,7 @@ export default function RegistryCatalog() {
           </button>
         </div>
       ) : null}
+      {connectBanner}
       <div className="cu-card cu-card--viewport-fill" style={{ marginBottom: '1.25rem' }}>
         <TablePanelHeader
           title={
@@ -240,6 +295,16 @@ export default function RegistryCatalog() {
                 <span className="cu-registry-count">
                   {filtered.length} of {entries.length} entries
                 </span>
+              ) : null}
+              {connectionMode !== 'managed' ? (
+                <button
+                  type="button"
+                  className="cu-btn cu-btn--ghost cu-btn--sm"
+                  onClick={() => router.push('/registry/connect')}
+                  disabled={isInitialLoad}
+                >
+                  Connect
+                </button>
               ) : null}
               <button
                 type="button"

--- a/control-ui/components/__tests__/RegistryCatalog.test.tsx
+++ b/control-ui/components/__tests__/RegistryCatalog.test.tsx
@@ -918,9 +918,7 @@ describe('RegistryCatalog - connect discoverability (Fix 1)', () => {
     render(<RegistryCatalog />)
     await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
 
-    expect(
-      screen.getByText(/This deployment isn't connected to a registry/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/This deployment isn't connected to a registry/i)).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Connect to registry' }))
     expect(mockPush).toHaveBeenCalledWith('/registry/connect')
@@ -936,9 +934,7 @@ describe('RegistryCatalog - connect discoverability (Fix 1)', () => {
     render(<RegistryCatalog />)
     await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
 
-    expect(
-      screen.getByText(/This deployment isn't connected to a registry/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/This deployment isn't connected to a registry/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument()
   })
 

--- a/control-ui/components/__tests__/RegistryCatalog.test.tsx
+++ b/control-ui/components/__tests__/RegistryCatalog.test.tsx
@@ -362,6 +362,23 @@ describe('RegistryCatalog - loading and error states', () => {
       expect(screen.getByText('Error: 500 Internal Server Error')).toBeInTheDocument()
     })
   })
+
+  it('test_registryCatalog_unavailable_showsFriendlyServerMessage', async () => {
+    vi.mocked(api.getRegistryCatalog).mockRejectedValue(
+      new Error('The registry is currently unavailable. Check the connection and try again.')
+    )
+
+    render(<RegistryCatalog />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Error: The registry is currently unavailable. Check the connection and try again.'
+        )
+      ).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Error: 500 Internal Server Error')).not.toBeInTheDocument()
+  })
 })
 
 describe('RegistryCatalog - entry details', () => {

--- a/control-ui/components/__tests__/RegistryCatalog.test.tsx
+++ b/control-ui/components/__tests__/RegistryCatalog.test.tsx
@@ -930,6 +930,18 @@ describe('RegistryCatalog - connect discoverability (Fix 1)', () => {
     expect(mockPush).toHaveBeenCalledWith('/registry/connect')
   })
 
+  it('self-hosted + rejected → shows connect banner and header Connect button', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'rejected' })
+    render(<RegistryCatalog />)
+    await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
+
+    expect(
+      screen.getByText(/This deployment isn't connected to a registry/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument()
+  })
+
   it('self-hosted + connected → no banner, header Connect button present', async () => {
     mockApiSuccess()
     vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'connected' })

--- a/control-ui/components/__tests__/RegistryCatalog.test.tsx
+++ b/control-ui/components/__tests__/RegistryCatalog.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import * as api from '../../lib/api'
 import type { RegistryEntry, RegistryInstalledState } from '../../lib/api'
@@ -9,6 +9,7 @@ import { ToastProvider } from '../Toast'
 // vi.mock is hoisted before imports, factory runs lazily
 vi.mock('../../lib/api', () => ({
   getRegistryCatalog: vi.fn(),
+  getRegistryConnection: vi.fn(),
   deleteRegistryEntry: vi.fn(),
   installRecipeFromRegistry: vi.fn(),
 }))
@@ -99,6 +100,15 @@ function mockApiSuccess(
     },
   })
 }
+
+beforeEach(() => {
+  // Default: managed deployment (no self-hosted connect surface) so the large
+  // pre-existing catalog suite is undisturbed. Connect-discoverability tests
+  // below override this per case.
+  vi.mocked(api.getRegistryConnection).mockRejectedValue(
+    Object.assign(new Error('409 not_self_hosted'), { code: 'not_self_hosted' })
+  )
+})
 
 afterEach(() => {
   cleanup()
@@ -898,5 +908,81 @@ describe('RegistryCatalog - developer row actions (Edit, Remove)', () => {
     })
     // Modal stays open on error so the user can retry or cancel.
     expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})
+
+describe('RegistryCatalog - connect discoverability (Fix 1)', () => {
+  it('self-hosted + disconnected → shows connect banner and header Connect button; both route to connect', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    render(<RegistryCatalog />)
+    await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
+
+    expect(
+      screen.getByText(/This deployment isn't connected to a registry/i)
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect to registry' }))
+    expect(mockPush).toHaveBeenCalledWith('/registry/connect')
+
+    mockPush.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(mockPush).toHaveBeenCalledWith('/registry/connect')
+  })
+
+  it('self-hosted + connected → no banner, header Connect button present', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'connected' })
+    render(<RegistryCatalog />)
+    await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument()
+    expect(screen.queryByText(/This deployment isn't connected/i)).not.toBeInTheDocument()
+  })
+
+  it('managed deployment (not_self_hosted) → no banner and no header Connect button', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('409 not_self_hosted'), { code: 'not_self_hosted' })
+    )
+    render(<RegistryCatalog />)
+    await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
+
+    // The connection fetch resolves mode → managed, hiding the button.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument()
+    )
+    expect(screen.queryByText(/This deployment isn't connected/i)).not.toBeInTheDocument()
+  })
+
+  it('unknown connection error → header Connect button present (fail-open), no banner', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(new Error('500 Internal Server Error'))
+    render(<RegistryCatalog />)
+    await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument()
+    expect(screen.queryByText(/This deployment isn't connected/i)).not.toBeInTheDocument()
+  })
+
+  it('catalog load error + self-hosted disconnected → connect banner rendered alongside the error banner', async () => {
+    vi.mocked(api.getRegistryCatalog).mockRejectedValue(
+      new Error('The registry is currently unavailable. Check the connection and try again.')
+    )
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    render(<RegistryCatalog />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/This deployment isn't connected to a registry/i)).toBeInTheDocument()
+    )
+    expect(
+      screen.getByText(
+        'Error: The registry is currently unavailable. Check the connection and try again.'
+      )
+    ).toBeInTheDocument()
+
+    // The banner CTA still routes to the connect flow even inside the error branch.
+    fireEvent.click(screen.getByRole('button', { name: 'Connect to registry' }))
+    expect(mockPush).toHaveBeenCalledWith('/registry/connect')
   })
 })

--- a/control-ui/lib/__tests__/registryCatalogApi.test.ts
+++ b/control-ui/lib/__tests__/registryCatalogApi.test.ts
@@ -77,3 +77,23 @@ describe('registry catalog api — tags coercion', () => {
     expect(res.tags).toEqual([])
   })
 })
+
+describe('registry catalog api — registry-unavailable error surface', () => {
+  it('getRegistryCatalog surfaces the server message on a 503 registry_unavailable', async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeRes(503, {
+        error: 'registry_unavailable',
+        message: 'The registry is currently unavailable. Check the connection and try again.',
+      })
+    )
+    const err = (await getRegistryCatalog().catch(e => e)) as Error & {
+      status?: number
+      code?: string
+    }
+    expect(err.message).toBe(
+      'The registry is currently unavailable. Check the connection and try again.'
+    )
+    expect(err.status).toBe(503)
+    expect(err.code).toBe('registry_unavailable')
+  })
+})

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -193,8 +193,28 @@ export async function apiGet(
         }
         handleUnauthorized()
       }
-      const error = new Error(`${res.status} ${res.statusText}`)
-      ;(error as Error & { status?: number }).status = res.status
+      // Prefer a server-provided human-safe `message` (e.g. the 503
+      // registry_unavailable body) so callers surface the clear text instead of
+      // a bare "<status> <statusText>". Bodies carrying only a machine `error`
+      // code (or no JSON) keep the existing status-text message. Also attach the
+      // machine code, mirroring how registryCodedRequest surfaces `.code`.
+      const text = await res.text().catch(() => '')
+      let message = `${res.status} ${res.statusText}`
+      let code: string | undefined
+      try {
+        const parsed = JSON.parse(text) as { error?: unknown; message?: unknown }
+        if (parsed && typeof parsed === 'object') {
+          if (typeof parsed.message === 'string' && parsed.message.trim()) {
+            message = parsed.message
+          }
+          if (typeof parsed.error === 'string') code = parsed.error
+        }
+      } catch {
+        /* non-JSON error body: keep the status-text message */
+      }
+      const error = new Error(message) as Error & { status?: number; code?: string }
+      error.status = res.status
+      if (code) error.code = code
       throw error
     }
     return parseJsonResponse(res)


### PR DESCRIPTION
## What & why

Two small UX gaps surfaced during the self-hosted registry-connect e2e, both fixed here:

### 1. The registry-connect flow was undiscoverable
The connect UI lives at `/registry/connect`, but nothing in the console linked to it — no sidebar item, no button — so a self-hoster following the docs could only reach it by typing the URL. This matters now that `registry.evenfire.ai` is the OSS default and "all self-hosters connect."

**Fix:** `RegistryCatalog.tsx` (the Marketplace) now fetches `getRegistryConnection()` on mount and renders:
- a persistent **"Connect"** header button (beside Publish / Manage API keys), shown whenever the deployment isn't managed;
- a contextual **"Connect to registry"** banner when the deployment is self-hosted and `disconnected`/`rejected`.

Both route to `/registry/connect`. The banner is computed once and rendered in **both** the normal view and the catalog-error branch, so it still shows when the registry is unreachable — exactly when a disconnected operator needs it. Managed deployments (where the connect page shows "nothing to configure") see neither.

### 2. An unreachable registry showed a raw `500 Internal Server Error`
When `CLERUM_REGISTRY_URL` pointed at an unreachable/empty registry, the Marketplace browse returned a bare `500`, rendered as literally "Error: 500 Internal Server Error". Root cause: a network error (or upstream 5xx) was rethrown status-less from `registryFetch` and the global handler only forwards 4xx.

**Fix:**
- `registryClient.ts`: a typed `RegistryUnavailableError` (503, `code: 'registry_unavailable'`). Genuine network/timeout signals **and** any upstream HTTP ≥500 (incl. Cloudflare 520–524) map to it; the persistent-401 remap now carries `code: 'registry_integration_error'` + a user-safe message. Credential-rejected (`mintToken`) errors are deliberately **not** relabeled "unavailable".
- `app.ts`: an allowlisted forward branch (`FORWARDABLE_INTEGRATION_CODES`) surfaces those two codes as clean `503`/`502 { error, message }` instead of collapsing to 500. The allowlist keeps the blast radius tight — only errors we construct with those codes are ever forwarded, with fixed safe messages.
- `apiGet` (control-ui) now surfaces the server-provided `message` (with the existing status-text fallback) so the Marketplace shows "The registry is currently unavailable…".

### 3. Connected-but-auth-off left operators stuck on API keys
Once connected, publishing and image push/pull work (they use the machine credential stored at claim time), but **creating/managing API keys** requires `CLERUM_REGISTRY_AUTH_ENABLED=true`. With it off, the API-keys page showed a dead-end banner ("Registry authentication is disabled in this environment.") and nothing pointed the way forward.

**Fix:**
- `control-api`: the `GET /admin/registry/connect` status endpoint now returns `authEnabled`.
- `control-ui`: the connect panel's "connected" view shows a nudge to enable auth (when `authEnabled===false`) so you can manage API keys; the API-keys page's `auth-disabled` banner is now actionable ("set `CLERUM_REGISTRY_AUTH_ENABLED=true` and restart control-api").
- `docs/how-to/connect-to-registry.md`: documents the enable-auth step, correctly scoped — the flag gates API-key management, not publishing.

## Testing
- **control-api:** full suite green (2818 passed / 3 skipped / 0 failed), including new `registryClient` remap tests (network→503, upstream-5xx→503, credential-rejected not relabeled, 401→502+code) and a new `createApp` supertest asserting the allowlist forward (503 / 500 / 500-non-allowlisted).
- **control-ui:** `RegistryCatalog` + `registryCatalogApi` suites green; full suite 820/822 (the 2 failures are pre-existing, unrelated Docker-credential tests). Acceptance matrix for the banner/button (disconnected, rejected, connected, managed, unknown, catalog-error-survives) all covered.
- Prettier + TypeScript clean.
- Reviewed per-task (spec + quality) and with a whole-branch 3-lens adversarial pass (correctness / security-tenancy / test-integrity) — all clear.

Rebased onto current `main`; integrates cleanly with #102 (member-registration 503 handling) — the only shared file, `control-ui/lib/api.ts`, edits a different function (`apiGet` vs `formatApiError`).

> Live minikube verification (banner/button + clean error in the running UI) is deferred to a rebuild+redeploy pass; the behavior is fully covered by the unit/integration tests above.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD
