### PR TITLE
fix(minikube): final-review fixes missed by PR #104 merge (C1 critical + I1/I2 + Step 10 hard-fail)

### DIFF
--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -1004,19 +1004,49 @@ step_header 10 $TOTAL_STEPS "Seed Test User"
 # The minimal profile must not seed anything named test*.
 if [ "$SEED_PROFILE" = "e2e" ]; then
   SEED_USER_DEFAULT_EMAIL="test@clerum.io"
-  : "${ADMIN_PASSWORD:=changeme123!}"
+  SEED_USER_DEFAULT_NAME="Test User"
+  # Force-assign, do NOT defer to .env via `: "${ADMIN_PASSWORD:=...}"`.
+  # .env is sourced with `set -a` above, and this branch requires users to
+  # set a real ADMIN_PASSWORD there — under the `:=` form that real password
+  # would win and override the e2e pin. The E2E specs never read .env: they
+  # hardcode changeme123! (or read ADMIN_PASS), so a leaked .env password
+  # would seed admin/<real password> while the specs still send
+  # admin/changeme123!, turning the whole E2E lane red. E2E_ADMIN_PASSWORD
+  # remains the deliberate escape hatch for callers that need a non-default
+  # e2e password.
+  ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-changeme123!}"
 else
   SEED_USER_DEFAULT_EMAIL="owner@evenfire.local"
+  SEED_USER_DEFAULT_NAME="Owner"
 fi
 SEED_USER_EMAIL="${CLERUM_SEED_USER_EMAIL:-${CLERUM_TEST_USER_EMAIL:-${E2E_DEV_LOGIN_EMAIL:-${SEED_USER_DEFAULT_EMAIL}}}}"
+SEED_USER_NAME="${E2E_DEV_LOGIN_NAME:-${SEED_USER_DEFAULT_NAME}}"
 log "Seeding test user ${SEED_USER_EMAIL} → agent=chatllm, context=context1"
+SEED_USER_OK=true
 if CONTEXT="${PROFILE}" ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
    SEED_PROFILE="${SEED_PROFILE}" \
    E2E_DEV_LOGIN_EMAIL="${SEED_USER_EMAIL}" \
+   E2E_DEV_LOGIN_NAME="${SEED_USER_NAME}" \
    bash "${SCRIPT_DIR}/seed-test-data.sh" 2>&1 | tail -15; then
   ok "Test user seeded"
 else
-  warn "Test user seed encountered errors — check output above"
+  SEED_USER_OK=false
+  if [ "$SEED_PROFILE" = "minimal" ]; then
+    # This step is the only place that both creates the owner user AND
+    # rotates the bootstrap admin credential (POST /admin/auth/setup, called
+    # from seed-test-data.sh → scripts/e2e/seed-e2e-data.sh). generate-keys.sh
+    # bakes a hardcoded bcrypt hash of changeme123! into the admin Secret,
+    # and control-api/src/db.ts auto-inserts a live `admin` row from it on
+    # every fresh DB. If this step fails under the default (minimal)
+    # profile, that publicly-known credential is still live — a green
+    # summary would ship an install that is both unusable and insecure.
+    # Abort instead; setup is idempotent, so re-running after the underlying
+    # issue is fixed recovers cleanly.
+    err "Test user seed failed under SEED_PROFILE=minimal — aborting. The bootstrap admin password may still be the publicly-known default (see generate-keys.sh) until this step succeeds. Fix the error above and re-run setup."
+    exit 1
+  else
+    warn "Test user seed encountered errors — check output above"
+  fi
 fi
 
 # ======================================================================
@@ -1092,16 +1122,37 @@ else
 fi
 echo ""
 echo -e "  ${BOLD}Already done by setup:${NC}"
+# Step 10 (Seed Test User) is what actually rotates the bootstrap admin
+# credential and creates the seed user. If it failed, SEED_USER_OK=false and
+# these lines must say so instead of printing a false ✓ (a failed Step 10
+# under minimal already aborts before reaching here — see Step 10 above —
+# so this else branch is reachable only via the e2e soft-fail path).
 if [ "${SEED_PROFILE:-}" = "e2e" ]; then
-  echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (admin / changeme123!)"
+  if [ "${SEED_USER_OK:-true}" = "true" ]; then
+    echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (admin / changeme123!)"
+  else
+    echo -e "    ${RED}✗${NC} Admin bootstrap NOT confirmed — Step 10 (Seed Test User) failed; admin/changeme123! may not be live"
+  fi
 else
-  echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (admin / your ADMIN_PASSWORD from .env)"
+  if [ "${SEED_USER_OK:-true}" = "true" ]; then
+    echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (admin / your ADMIN_PASSWORD from .env)"
+  else
+    echo -e "    ${RED}✗${NC} Admin bootstrap NOT confirmed — Step 10 (Seed Test User) failed"
+  fi
 fi
 if [ "${SEED_PROFILE:-}" = "e2e" ]; then
-  echo -e "    ${GREEN}✓${NC} Test user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
+  if [ "${SEED_USER_OK:-true}" = "true" ]; then
+    echo -e "    ${GREEN}✓${NC} Test user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
+  else
+    echo -e "    ${RED}✗${NC} Test user seed FAILED (${SEED_USER_EMAIL}) — check Step 10 output above"
+  fi
   echo -e "    ${GREEN}✓${NC} Workflow-trigger E2E recipes seeded"
 else
-  echo -e "    ${GREEN}✓${NC} Owner user seeded (${SEED_USER_EMAIL} → chatllm + context1, password = your ADMIN_PASSWORD)"
+  if [ "${SEED_USER_OK:-true}" = "true" ]; then
+    echo -e "    ${GREEN}✓${NC} Owner user seeded (${SEED_USER_EMAIL} → chatllm + context1, password = your ADMIN_PASSWORD)"
+  else
+    echo -e "    ${RED}✗${NC} Owner user seed FAILED (${SEED_USER_EMAIL}) — check Step 10 output above"
+  fi
 fi
 echo -e "    ${GREEN}✓${NC} Registry catalog seeded (MCP servers + recipes)"
 echo ""


### PR DESCRIPTION
## Why this is a separate PR

PR #104 was merged at `6f458ad`. The final whole-branch review returned **NO** and I pushed the fix as `0db00a8` — but that landed on the branch *after* the merge button was clicked, so **none of these four fixes reached `main`**. This PR is that one commit, cherry-picked onto current `main`. It touches only `scripts/minikube/full-setup.sh`.

## What it fixes

**C1 (Critical) — `.env ADMIN_PASSWORD` leaks into the `e2e` profile and breaks the E2E lane.**
PR #104 made `.env` supply `ADMIN_PASSWORD` (sourced with `set -a`) and now *requires* users to set it. But the e2e branch pinned the test password with `: "${ADMIN_PASSWORD:=changeme123!}"`, which only fills when unset — so a real `.env` password overrode the pin even under `e2e`. The E2E specs never read `.env`; they hardcode `changeme123!` (`control-ui/e2e/artifact-delete.spec.ts:58` and others) or read a different var (`ADMIN_PASS`). So a dev who follows the new README (`ADMIN_PASSWORD=hunter2`) and runs `make validate-all` seeds `admin/hunter2`, then ~26 specs send `changeme123!` → red. Fix: force-assign `ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-changeme123!}"` under `e2e`, restoring `main`'s pre-split deterministic semantics. `E2E_ADMIN_PASSWORD` is the escape hatch.

**I1 (Important) — the clean install still shipped a `Test*` identity.** The split gated the seeded *email* but not the *name*, so `make minikube-setup` created user **"Test User"** and team **"Test User team"** (`seed-e2e-data.sh:55,460`) — visible in the Desktop App on the OSS front door. Fix: thread `E2E_DEV_LOGIN_NAME` (minimal → `Owner`, e2e → `Test User`).

**I2 (Important) — Step 12 lied on failure.** Step 10 soft-fails; Step 12 then printed `✓ admin bootstrap` / `✓ Owner user seeded` unconditionally. Now gated on the recorded Step 10 outcome.

**Security — Step 10 now hard-fails under `minimal`.** `generate-keys.sh` seeds a Secret with a bcrypt hash of `changeme123!`, and `control-api/src/db.ts` auto-inserts a live `admin` from it on every fresh DB. It's rotated only inside Step 10's `POST /admin/auth/setup`. Because Step 10 soft-failed, a failed rotation left a publicly-known admin credential live under a green summary. Under `minimal` that now aborts (soft-fail kept under `e2e`, which the E2E lane depends on).

## Verification

Cherry-pick applied cleanly (no other merged PR touched `full-setup.sh`). `bash -n` clean. C1/I1/I2/security each demonstrated without a cluster in the originating work; a full from-scratch cluster run is in progress this session and will be reported here.

## Follow-up still owed (not in this PR)
Derive the `generate-keys.sh` bootstrap hash from `ADMIN_PASSWORD` so no `changeme123!` hash is committed at all — the deeper fix behind the Step-10 hard-fail mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a4PGHXzWZqx6P6T9teWQG