### PR TITLE
feat(registry): guide operators to enable auth for API keys once connected

### DIFF
--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -88,13 +88,16 @@ export function createRegistryConnectRouter(): Router {
       if (!ctx) return
       const row = await getRegistryConnection()
       if (!row) {
-        res.status(200).json({ state: 'disconnected' })
+        res.status(200).json({ state: 'disconnected', authEnabled: config.registryAuthEnabled })
         return
       }
       if (row.status === 'connected') {
-        res
-          .status(200)
-          .json({ state: 'connected', deploymentId: row.deploymentId, org: row.orgName })
+        res.status(200).json({
+          state: 'connected',
+          deploymentId: row.deploymentId,
+          org: row.orgName,
+          authEnabled: config.registryAuthEnabled,
+        })
         return
       }
       // Not yet connected — poll the registry so an operator approval (or
@@ -115,6 +118,7 @@ export function createRegistryConnectRouter(): Router {
         state,
         deploymentId: row.deploymentId,
         requestedOrgName: row.requestedOrgName,
+        authEnabled: config.registryAuthEnabled,
       })
     } catch (err) {
       next(err)

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -62,14 +62,39 @@ beforeEach(() => {
     status: 'active',
   })
   cfg.registryConnectionMode = 'self-hosted'
+  cfg.registryAuthEnabled = true
 })
 afterEach(() => vi.restoreAllMocks())
 
 describe('registry connect flow', () => {
   it('GET → disconnected when no row', async () => {
+    cfg.registryAuthEnabled = true
     connDb.getRegistryConnection.mockResolvedValue(null)
     const res = await request(app()).get('/admin/registry/connect').expect(200)
     expect(res.body.state).toBe('disconnected')
+    expect(res.body.authEnabled).toBe(true)
+  })
+
+  it('GET connected → includes authEnabled reflecting config (true)', async () => {
+    cfg.registryAuthEnabled = true
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'connected',
+      deploymentId: 'dep-9',
+      orgName: 'acme',
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', org: 'acme', authEnabled: true })
+  })
+
+  it('GET connected → includes authEnabled reflecting config (false)', async () => {
+    cfg.registryAuthEnabled = false
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'connected',
+      deploymentId: 'dep-9',
+      orgName: 'acme',
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', org: 'acme', authEnabled: false })
   })
 
   it('409 not_self_hosted in managed mode', async () => {
@@ -92,7 +117,7 @@ describe('registry connect flow', () => {
       })
     )
     const res = await request(app()).get('/admin/registry/connect').expect(200)
-    expect(res.body).toMatchObject({ state: 'approved', deploymentId: 'dep-9' })
+    expect(res.body).toMatchObject({ state: 'approved', deploymentId: 'dep-9', authEnabled: true })
     // it actually polled the registry status endpoint with a DPoP header
     const [url, init] = fetchSpy.mock.calls[0]
     expect(String(url)).toContain('/api/v1/deployments/dep-9/status')

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -1,20 +1,21 @@
 // control-ui/components/RegistryApiKeysPanel.tsx
 'use client'
+
 import { useCallback, useEffect, useState } from 'react'
 import {
+  type CreateRegistryApiKeyInput,
+  type CreatedRegistryApiKey,
+  type RegistryApiKey,
   createRegistryApiKey,
   listRegistryApiKeys,
   revokeRegistryApiKey,
-  type CreatedRegistryApiKey,
-  type CreateRegistryApiKeyInput,
-  type RegistryApiKey,
 } from '../lib/api'
-import { TableHeaderRow } from './TableHeaderRow'
-import type { TableHeaderColumn } from './TableHeaderRow/types'
-import { TablePanelHeader } from './TablePanelHeader'
 import { useConfirmDialog } from './ConfirmDialog'
 import CreateApiKeyModal from './CreateApiKeyModal'
 import RevealApiKeyModal from './RevealApiKeyModal'
+import { TableHeaderRow } from './TableHeaderRow'
+import type { TableHeaderColumn } from './TableHeaderRow/types'
+import { TablePanelHeader } from './TablePanelHeader'
 import { useToast } from './Toast'
 import { Button } from './ui'
 
@@ -114,12 +115,7 @@ export default function RegistryApiKeysPanel() {
           title={`API keys${isReady ? ` for @${(view as { org: string }).org}` : ''}`}
           actions={
             isReady ? (
-              <Button
-                type="button"
-                variant="primary"
-                size="sm"
-                onClick={() => setCreating(true)}
-              >
+              <Button type="button" variant="primary" size="sm" onClick={() => setCreating(true)}>
                 + Create key
               </Button>
             ) : null
@@ -141,17 +137,16 @@ export default function RegistryApiKeysPanel() {
             </p>
           ) : null}
           {view.kind === 'auth-disabled' ? (
-            <p className="cu-banner">Registry authentication is disabled in this environment.</p>
+            <p className="cu-banner cu-banner--info">
+              Registry authentication is disabled, so API keys can&apos;t be created here. To enable
+              it, set <code>CLERUM_REGISTRY_AUTH_ENABLED=true</code> and restart control-api, then
+              reload this page.
+            </p>
           ) : null}
           {view.kind === 'error' ? (
             <p className="cu-banner cu-banner--warn">
               Could not load API keys.{' '}
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => void load()}
-              >
+              <Button type="button" variant="ghost" size="sm" onClick={() => void load()}>
                 Retry
               </Button>
             </p>
@@ -201,9 +196,7 @@ export default function RegistryApiKeysPanel() {
       {creating ? (
         <CreateApiKeyModal onCreate={handleCreate} onCancel={() => setCreating(false)} />
       ) : null}
-      {revealed ? (
-        <RevealApiKeyModal apiKey={revealed} onClose={() => setRevealed(null)} />
-      ) : null}
+      {revealed ? <RevealApiKeyModal apiKey={revealed} onClose={() => setRevealed(null)} /> : null}
       {confirmDialog}
     </section>
   )

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -18,7 +18,7 @@ type View =
   | { kind: 'pending'; deploymentId?: string; requestedOrgName?: string }
   | { kind: 'approved'; deploymentId?: string; requestedOrgName?: string }
   | { kind: 'rejected'; requestedOrgName?: string }
-  | { kind: 'connected'; org?: string }
+  | { kind: 'connected'; org?: string; authEnabled?: boolean }
   | { kind: 'not-self-hosted' }
   | { kind: 'error' }
 
@@ -41,7 +41,8 @@ export default function RegistryConnectPanel() {
   const load = useCallback(async () => {
     try {
       const s = await getRegistryConnection()
-      if (s.state === 'connected') setView({ kind: 'connected', org: s.org })
+      if (s.state === 'connected')
+        setView({ kind: 'connected', org: s.org, authEnabled: s.authEnabled })
       else if (s.state === 'approved')
         setView({
           kind: 'approved',
@@ -306,6 +307,14 @@ export default function RegistryConnectPanel() {
             <p className="cu-banner cu-banner--ok">
               Connected to the Evenfire Registry{view.org ? ` as @${view.org}` : ''}. This
               deployment can now publish entries and push/pull images.
+            </p>
+          ) : null}
+
+          {view.kind === 'connected' && view.authEnabled === false ? (
+            <p className="cu-banner cu-banner--info" role="status">
+              To create and manage API keys for programmatic publishing, enable registry
+              authentication: set <code>CLERUM_REGISTRY_AUTH_ENABLED=true</code> and restart
+              control-api. See the &quot;connect to registry&quot; guide for details.
             </p>
           ) : null}
         </div>

--- a/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
@@ -68,12 +68,14 @@ describe('RegistryApiKeysPanel', () => {
     expect(await screen.findByText(/not bound to a registry org/i)).toBeInTheDocument()
   })
 
-  it('shows the dev-mode notice on 409 registry_auth_disabled', async () => {
+  it('shows actionable guidance to enable registry auth on 409 registry_auth_disabled', async () => {
     vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
       Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
     )
     render(<RegistryApiKeysPanel />)
     expect(await screen.findByText(/registry authentication is disabled/i)).toBeInTheDocument()
+    expect(screen.getByText('CLERUM_REGISTRY_AUTH_ENABLED=true')).toBeInTheDocument()
+    expect(screen.getByText(/restart/i)).toBeInTheDocument()
   })
 
   it('on create success, shows the reveal modal then refetches', async () => {
@@ -81,7 +83,11 @@ describe('RegistryApiKeysPanel', () => {
       .mockResolvedValueOnce({ org: 'acme', keys: [] })
       .mockResolvedValueOnce({ org: 'acme', keys: [key] })
     vi.mocked(api.createRegistryApiKey).mockResolvedValue({
-      id: 'k1', key: 'efrk_secret', key_prefix: 'efrk_abc', scopes: [], expires_at: null,
+      id: 'k1',
+      key: 'efrk_secret',
+      key_prefix: 'efrk_abc',
+      scopes: [],
+      expires_at: null,
     })
     render(<RegistryApiKeysPanel />)
     fireEvent.click(await screen.findByRole('button', { name: /create key/i }))
@@ -163,8 +169,18 @@ describe('RegistryApiKeysPanel', () => {
   })
 
   it('default sort: two keys with different created_at render newest-first', async () => {
-    const olderKey = { ...key, id: 'k-old', key_prefix: 'efrk_old', created_at: '2026-01-01T00:00:00Z' }
-    const newerKey = { ...key, id: 'k-new', key_prefix: 'efrk_new', created_at: '2026-06-01T00:00:00Z' }
+    const olderKey = {
+      ...key,
+      id: 'k-old',
+      key_prefix: 'efrk_old',
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    const newerKey = {
+      ...key,
+      id: 'k-new',
+      key_prefix: 'efrk_new',
+      created_at: '2026-06-01T00:00:00Z',
+    }
     vi.mocked(api.listRegistryApiKeys).mockResolvedValue({
       org: 'acme',
       keys: [olderKey, newerKey],

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -146,4 +146,32 @@ describe('RegistryConnectPanel', () => {
     render(<RegistryConnectPanel />)
     await waitFor(() => expect(screen.getByText('Disconnect')).toBeInTheDocument())
   })
+
+  it('connected + authEnabled:false → shows guidance to enable registry auth for API keys', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      deploymentId: 'd',
+      org: 'acme',
+      authEnabled: false,
+    })
+    render(<RegistryConnectPanel />)
+    await waitFor(() =>
+      expect(screen.getByText(/enable registry authentication/i)).toBeInTheDocument()
+    )
+    expect(screen.getByText('CLERUM_REGISTRY_AUTH_ENABLED=true')).toBeInTheDocument()
+  })
+
+  it('connected + authEnabled:true → does not show the enable-auth guidance', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      deploymentId: 'd',
+      org: 'acme',
+      authEnabled: true,
+    })
+    render(<RegistryConnectPanel />)
+    await waitFor(() =>
+      expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
+  })
 })

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -3079,6 +3079,7 @@ export type RegistryConnectionStatus = {
   deploymentId?: string
   requestedOrgName?: string
   org?: string
+  authEnabled?: boolean
 }
 
 export async function getRegistryConnection(): Promise<RegistryConnectionStatus> {

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -41,6 +41,26 @@ small state machine — `disconnected → pending → approved → connected`:
   [Publish a plugin to the registry](publish-plugin-to-registry.md).
 - **SSO** to registry API keys from your own Control UI.
 
+## Enable registry authentication (to manage API keys)
+
+Once connected, browsing the public catalog, publishing, and image push/pull all
+work using the credential stored when you claimed the connection — no further
+setup is needed for those.
+
+**Creating and managing API keys** (`efrk_` org keys, used for CI and other
+programmatic publishing) is a separate surface that requires **registry
+authentication** to be enabled. If you see a banner saying registry
+authentication is disabled, or you want to issue org API keys, enable it:
+
+1. Set `CLERUM_REGISTRY_AUTH_ENABLED=true` in the control-api config (e.g. the
+   `control-api-config` ConfigMap, or your env file).
+2. Restart control-api. The flag is read at boot only — there is no hot-reload.
+
+Note the boot guard this enables: with auth on and `REGISTRY_CONNECTION_MODE=self-hosted`,
+control-api requires a completed connection (which you already have once
+claimed) and the registry URL must be in the allowlist — `registry.evenfire.ai`
+is allowed by default; add others via `CLERUM_REGISTRY_URL_ALLOWLIST`.
+
 ## If something goes wrong
 
 - **Already connected** — a deployment has one connection; there is nothing more


### PR DESCRIPTION
## What & why

Follow-up to #103 (registry connect discoverability + clean registry-unavailable error). #103 shipped the on-ramp *to* the connect flow; this closes the loop *after* connecting.

**The gap:** once a self-hosted deployment is connected to the registry, publishing and image push/pull work (they use the machine credential stored at claim time), but **creating and managing API keys** requires `CLERUM_REGISTRY_AUTH_ENABLED=true`. With it off — the OSS default — the API-keys page hit a dead end: a bare banner "Registry authentication is disabled in this environment." with no next step, and nothing anywhere told the operator that enabling the flag is what unlocks API keys.

## Changes

- **control-api** — `GET /admin/registry/connect` now returns `authEnabled` (from `config.registryAuthEnabled`) so the UI can tell "connected but auth off" from "connected and ready".
- **control-ui** —
  - The connect panel's *connected* view keeps its accurate "you can publish / push-pull images" banner and, when `authEnabled === false`, adds a nudge: enable registry auth to create/manage API keys.
  - The API-keys page's `auth-disabled` banner is now actionable: "set `CLERUM_REGISTRY_AUTH_ENABLED=true` and restart control-api, then reload."
- **docs** — `docs/how-to/connect-to-registry.md` gains an "Enable registry authentication" section, correctly scoped: the flag gates **API-key management** (and grants), **not** publishing or image push/pull.

## Accuracy note

All new copy is scoped strictly to API-key management. Nothing claims publishing is broken when auth is off — verified against the boot guard (`config.ts`), the API-keys/grants route guards (`registry.ts`), and `mintToken` (`registryClient.ts`), which supplies the claim-time credential regardless of the flag.

## Testing

- **control-api** — `test/routes.registryConnect.test.ts` 17/17 (added coverage of the `connected` response shape with `authEnabled` true and false; fixed a latent `beforeEach` test-isolation gap where `registryAuthEnabled` wasn't reset).
- **control-ui** — `RegistryConnectPanel.test.tsx` + `RegistryApiKeysPanel.test.tsx` 22/22 (nudge shown only when `authEnabled===false`; the API-keys banner asserts the new actionable copy).
- Reviewed for spec compliance, an accuracy audit (no "publish is broken" wording), code quality, and mutation-tested test guards — all clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD
