### PR TITLE
feat(minikube): minimal install shows one desktop member (the admin), evenfire-branded

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ make install-all && npm --prefix control-ui install
 npm run ui              # Control UI + Profile UI + Desktop App
 ```
 
-Log in as `owner@evenfire.local` using the `ADMIN_PASSWORD` you set in `.env`,
+Log in as `admin@evenfire.local` using the `ADMIN_PASSWORD` you set in `.env`,
 message the `chatllm` agent, and ask it to run a command or generate a PDF —
 then approve the tool call from the chat. The same password logs into the
 Control UI as `admin`. The Desktop App is the client you just used; Control UI

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -61,9 +61,9 @@ It seeds for you:
 
 - an agent: Host `chatllm` + an empty Context `context1` (no MCP servers —
   install connectors from the registry) + a CommunicationChannel
-- one login, using the `ADMIN_PASSWORD` you set in `.env`:
-  **`owner@evenfire.local`** for the Desktop App and **`admin`** for the
-  Control UI
+- one account, using the `ADMIN_PASSWORD` you set in `.env`: username
+  **`admin`** for the Control UI and email **`admin@evenfire.local`** for the
+  Desktop App — the same account, and the sole Desktop App member
 
 Verify:
 
@@ -84,7 +84,7 @@ make install-all && npm --prefix control-ui install
 npm run ui     # runs Control UI (:3000), Profile UI (:3001), and the Desktop App
 ```
 
-Log into the **Desktop App** as `owner@evenfire.local` using the
+Log into the **Desktop App** as `admin@evenfire.local` using the
 `ADMIN_PASSWORD` you set in `.env`, and message the `chatllm` agent. Ask it to
 do something real — _"run `uname -a`"_ or
 _"generate a one-page PDF about Kubernetes NetworkPolicies"_ — and approve the

--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -1016,8 +1016,19 @@ if [ "$SEED_PROFILE" = "e2e" ]; then
   # e2e password.
   ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-changeme123!}"
 else
-  SEED_USER_DEFAULT_EMAIL="owner@evenfire.local"
-  SEED_USER_DEFAULT_NAME="Owner"
+  # Minimal: the Control-UI admin IS the sole Desktop App member — no separate
+  # seeded user. Point both the admin-bootstrap email and the seeded desktop
+  # user at the same evenfire-branded address so the seeder's (idempotent)
+  # user+team step converges on the admin identity that /admin/auth/setup
+  # already provisioned (users row + "<username> team" + chatllm/context1
+  # grants), instead of minting a second member/team. `admin@clerum.io` would
+  # leak the internal code name onto a product surface (the Desktop member
+  # list) — evenfire branding belongs here (docs/concepts/code-names.md). If
+  # the best-effort admin desktop provisioning ever fails, the seeder still
+  # creates this one identity, so the minimal install is never member-less.
+  SEED_USER_DEFAULT_EMAIL="admin@evenfire.local"
+  SEED_USER_DEFAULT_NAME="admin"
+  : "${ADMIN_EMAIL:=admin@evenfire.local}"
 fi
 SEED_USER_EMAIL="${CLERUM_SEED_USER_EMAIL:-${CLERUM_TEST_USER_EMAIL:-${E2E_DEV_LOGIN_EMAIL:-${SEED_USER_DEFAULT_EMAIL}}}}"
 SEED_USER_NAME="${E2E_DEV_LOGIN_NAME:-${SEED_USER_DEFAULT_NAME}}"
@@ -1025,6 +1036,7 @@ log "Seeding test user ${SEED_USER_EMAIL} → agent=chatllm, context=context1"
 SEED_USER_OK=true
 if CONTEXT="${PROFILE}" ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
    SEED_PROFILE="${SEED_PROFILE}" \
+   ADMIN_EMAIL="${ADMIN_EMAIL:-}" \
    E2E_DEV_LOGIN_EMAIL="${SEED_USER_EMAIL}" \
    E2E_DEV_LOGIN_NAME="${SEED_USER_NAME}" \
    bash "${SCRIPT_DIR}/seed-test-data.sh" 2>&1 | tail -15; then

--- a/scripts/minikube/seed-test-data.sh
+++ b/scripts/minikube/seed-test-data.sh
@@ -28,7 +28,10 @@ case "$CONTEXT" in
     ;;
 esac
 
-export ADMIN_PASSWORD E2E_DEV_LOGIN_EMAIL CONTEXT ALLOWED_CONTEXTS
+# ADMIN_EMAIL passes through when the caller sets it (minikube minimal profile
+# points it at admin@evenfire.local); unset/empty lets seed-e2e-data.sh keep
+# its own admin@clerum.io default for the e2e lane and direct callers.
+export ADMIN_PASSWORD E2E_DEV_LOGIN_EMAIL CONTEXT ALLOWED_CONTEXTS ADMIN_EMAIL
 
 bash "${REPO_ROOT}/scripts/e2e/seed-e2e-data.sh" "$@"
 


### PR DESCRIPTION
## What you'll notice

A clean `make minikube-setup` currently shows **two** Desktop App members and **two** teams in the Control UI:

```
Members (2):  admin  admin@clerum.io      Teams (2):  admin team
              Owner  owner@evenfire.local             Owner team
```

This collapses that to one:

```
Members (1):  admin  admin@evenfire.local    Teams (1):  admin team
```

## Why there were two (it's not a seed bug)

The `admin` member + `admin team` are **auto-provisioned**, not seeded: when the Control-UI admin is first created, `provisionAdminDesktopWorkspace` (`control-api/src/routes/admin/auth.ts:174`) best-effort mirrors it into the Desktop directory — a `users` row, a `<username> team`, and `chatllm`/`context1` grants — so one person can drive both apps with one credential. That happens on **every** install, independent of profile. The seed profile then added a *second*, redundant desktop user (`owner@evenfire.local`) on top of it.

## The change

Point both the admin-bootstrap email and the minimal profile's seeded desktop user at the same `admin@evenfire.local`. The seeder's user+team step is idempotent, so it converges on the admin's already-provisioned identity instead of minting a second member. One member, one team, one `ADMIN_PASSWORD` for both apps.

It also cleans up branding — the surviving identity is `admin@evenfire.local`, not `admin@clerum.io`. A Desktop member list is a product surface where evenfire branding belongs (`docs/concepts/code-names.md`), and a repo-wide search shows nothing depends on the `admin@clerum.io` literal except the seeder's own default.

Robustness: if the best-effort admin desktop provisioning ever fails, the seeder still creates this one identity — the minimal install is never member-less.

## Scope / safety

- **e2e profile is byte-identical:** `admin@clerum.io` + `test@clerum.io` + `test2@` + fixtures unchanged, so `validate-all` and the ~26 `control-ui/e2e` specs are unaffected. `ADMIN_EMAIL` passes through `seed-test-data.sh`; unset/empty keeps `seed-e2e-data.sh`'s `admin@clerum.io` default for the e2e lane and the ~9 direct callers.
- Docs updated (`README.md`, `quickstart.md`): desktop login is now `admin@evenfire.local`.
- 4 files, +23/−8.

## Verification

Static: confirmed minimal converges to a single identity (seeded user == bootstrap admin == `admin@evenfire.local`) while e2e stays `test@clerum.io` + `admin@clerum.io`. `bash -n` clean on both scripts.

**Owed:** a from-scratch cluster run to confirm the 1-member/1-team result end-to-end. The admin desktop provisioning is one-shot (gated on `last_login_at IS NULL`), so it can't be re-exercised on the already-seeded dev cluster — it needs `minikube delete` + fresh setup, same as PRs #104/#105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a4PGHXzWZqx6P6T9teWQG