### PR TITLE
feat(registry): hide the Publisher UI on OSS/self-hosted by default (publisherUiEnabled flag)

### DIFF
--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -75,6 +75,12 @@ type Config = {
   // absence-based: managed = env/Secret, self-hosted = the registry_connection
   // DB row. Required when registryAuthEnabled; logged at boot.
   registryConnectionMode: 'managed' | 'self-hosted'
+  // Publisher UI surface (Sidebar entry + /publisher route) toggle, surfaced
+  // to control-ui on the publish-scope response. Static config value — not
+  // part of resolvePublishScope()'s cached registry-derived fields. Default
+  // OFF for self-hosted deploys, ON for managed; CONTROL_API_PUBLISHER_UI_ENABLED
+  // overrides the default either way.
+  publisherUiEnabled: boolean
   adminAuthMaxFailures: number
   adminAuthLockMinutes: number
   adminBootstrapUsername: string
@@ -435,6 +441,11 @@ if (memberRegistrationMode === 'hosted') {
   }
 }
 
+// Computed once so registryConnectionMode and publisherUiEnabled's mode-based
+// default read the exact same resolved value below (rather than re-parsing
+// REGISTRY_CONNECTION_MODE a second time).
+const registryConnectionMode: 'managed' | 'self-hosted' = parseRegistryConnectionMode()
+
 export const config: Config = {
   port: Number(process.env.CONTROL_API_PORT || 8090),
   jsonBodyLimit: process.env.CONTROL_API_JSON_BODY_LIMIT || '150mb',
@@ -534,7 +545,16 @@ export const config: Config = {
   registryClientId: process.env.CLERUM_REGISTRY_CLIENT_ID ?? '',
   registryClientSecret: process.env.CLERUM_REGISTRY_CLIENT_SECRET ?? '',
   registryAuthEnabled: process.env.CLERUM_REGISTRY_AUTH_ENABLED === 'true',
-  registryConnectionMode: parseRegistryConnectionMode(),
+  registryConnectionMode,
+  // 'true'/'false' wins explicitly; otherwise default OFF for self-hosted,
+  // ON for managed — reuses the registryConnectionMode value above rather
+  // than re-parsing REGISTRY_CONNECTION_MODE.
+  publisherUiEnabled:
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED === 'true'
+      ? true
+      : process.env.CONTROL_API_PUBLISHER_UI_ENABLED === 'false'
+        ? false
+        : registryConnectionMode !== 'self-hosted',
   adminAuthMaxFailures: Number(process.env.CONTROL_API_ADMIN_AUTH_MAX_FAILURES || 5),
   adminAuthLockMinutes: Number(process.env.CONTROL_API_ADMIN_AUTH_LOCK_MINUTES || 15),
   adminBootstrapUsername: requiredOrDevDefault('CONTROL_API_ADMIN_BOOTSTRAP_USERNAME', 'admin'),

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -840,9 +840,12 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
   // GET /admin/registry/publish-scope — Where this control-api's publishes land.
   // The publish UI reads this to show the target ({ curator, orgName, scope }):
   // org-bound clients publish into their own org; curator clients into @clerum.
+  // publisherUiEnabled is merged in from static config (not part of
+  // resolvePublishScope()/its cache) — it gates the Publisher sidebar entry
+  // and /publisher route on control-ui.
   router.get('/admin/registry/publish-scope', async (_req, res, next) => {
     try {
-      res.json(await resolvePublishScope())
+      res.json({ ...(await resolvePublishScope()), publisherUiEnabled: config.publisherUiEnabled })
     } catch (err) {
       next(err)
     }

--- a/control-api/test/app.publisherUiEnabled.test.ts
+++ b/control-api/test/app.publisherUiEnabled.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { MockGateway } from './mockGateway.js'
+
+const ORIGINAL_ENV = { ...process.env }
+
+// Bypass the control-ui auth gate so the supertest request reaches the real
+// publish-scope route (and the real config-driven merge) without a session
+// cookie.
+vi.mock('../src/middleware/controlUIAuth.js', () => ({
+  requireAuthForControlUI: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    ;(req as unknown as { adminAuth: unknown }).adminAuth = {
+      sub: 'admin-1',
+      role: 'admin',
+      typ: 'user',
+    }
+    next()
+  },
+}))
+
+// Partial-mock the registry client: keep every real export (applyPublishScope,
+// RegistryUnavailableError, …) so the admin router still loads, and override
+// only resolvePublishScope so the route returns a fixed org-bound scope
+// regardless of connection mode — this test is about the merged
+// publisherUiEnabled field, not scope resolution itself.
+const registryClient = vi.hoisted(() => ({
+  resolvePublishScope: vi.fn(),
+}))
+vi.mock('../src/services/registryClient.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryClient.js')>()),
+  resolvePublishScope: registryClient.resolvePublishScope,
+}))
+
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+}))
+
+describe('GET /admin/registry/publish-scope: publisherUiEnabled (effective, through the route)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+    delete process.env.CONTROL_API_PUBLISHER_UI_ENABLED
+    delete process.env.REGISTRY_CONNECTION_MODE
+    registryClient.resolvePublishScope.mockReset()
+    registryClient.resolvePublishScope.mockResolvedValue({
+      curator: false,
+      orgName: 'acme',
+      scope: '@acme',
+    })
+  })
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    vi.resetModules()
+  })
+
+  it('is false by default in self-hosted mode', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/publish-scope')
+    expect(res.status).toBe(200)
+    expect(res.body.publisherUiEnabled).toBe(false)
+    // The registry-derived fields still pass through untouched.
+    expect(res.body.scope).toBe('@acme')
+  })
+
+  it('is true by default in managed mode', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'managed'
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/publish-scope')
+    expect(res.status).toBe(200)
+    expect(res.body.publisherUiEnabled).toBe(true)
+  })
+
+  it('env override CONTROL_API_PUBLISHER_UI_ENABLED=true wins on self-hosted', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'true'
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/publish-scope')
+    expect(res.body.publisherUiEnabled).toBe(true)
+  })
+
+  it('env override CONTROL_API_PUBLISHER_UI_ENABLED=false wins on managed', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'managed'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'false'
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app).get('/api/v1/admin/registry/publish-scope')
+    expect(res.body.publisherUiEnabled).toBe(false)
+  })
+})

--- a/control-api/test/config.publisherUiEnabled.test.ts
+++ b/control-api/test/config.publisherUiEnabled.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...ORIGINAL_ENV }
+  delete process.env.CONTROL_API_PUBLISHER_UI_ENABLED
+  delete process.env.REGISTRY_CONNECTION_MODE
+})
+afterEach(() => {
+  process.env = ORIGINAL_ENV
+  vi.resetModules()
+})
+
+describe('config: publisherUiEnabled (mode-based default + env override)', () => {
+  it('defaults to false when REGISTRY_CONNECTION_MODE=self-hosted', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(false)
+  })
+
+  it('defaults to true when REGISTRY_CONNECTION_MODE=managed', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'managed'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(true)
+  })
+
+  it('defaults to true when REGISTRY_CONNECTION_MODE is unset (implicit managed)', async () => {
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(true)
+  })
+
+  it('CONTROL_API_PUBLISHER_UI_ENABLED=true overrides the self-hosted default to true', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'true'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(true)
+  })
+
+  it('CONTROL_API_PUBLISHER_UI_ENABLED=false overrides the managed default to false', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'managed'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'false'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(false)
+  })
+
+  it('an unrecognized CONTROL_API_PUBLISHER_UI_ENABLED value falls back to the mode-based default', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'yes'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(false)
+  })
+})

--- a/control-api/test/routes.registryInstall.test.ts
+++ b/control-api/test/routes.registryInstall.test.ts
@@ -320,24 +320,27 @@ describe('GET /admin/registry/categories', () => {
 
 // ── GET /admin/registry/publish-scope ─────────────────────────────────────────
 describe('GET /admin/registry/publish-scope', () => {
-  it('returns the resolved org-bound publish scope', async () => {
+  it('returns the resolved org-bound publish scope, plus the static publisherUiEnabled flag', async () => {
     const scope: PublishScope = { curator: false, orgName: 'newtenantwf', scope: '@newtenantwf' }
     vi.mocked(resolvePublishScope).mockResolvedValueOnce(scope)
     const app = makeApp()
 
     const res = await request(app).get('/admin/registry/publish-scope').expect(200)
 
-    expect(res.body).toEqual(scope)
+    // publisherUiEnabled is merged in from config at the route boundary, not
+    // part of resolvePublishScope() itself — see config.publisherUiEnabled.test.ts
+    // for the default/override matrix.
+    expect(res.body).toEqual({ ...scope, publisherUiEnabled: config.publisherUiEnabled })
   })
 
-  it('returns the resolved curator publish scope', async () => {
+  it('returns the resolved curator publish scope, plus the static publisherUiEnabled flag', async () => {
     const scope: PublishScope = { curator: true, orgName: 'clerum', scope: null }
     vi.mocked(resolvePublishScope).mockResolvedValueOnce(scope)
     const app = makeApp()
 
     const res = await request(app).get('/admin/registry/publish-scope').expect(200)
 
-    expect(res.body).toEqual(scope)
+    expect(res.body).toEqual({ ...scope, publisherUiEnabled: config.publisherUiEnabled })
   })
 
   it('returns 500 when resolvePublishScope throws', async () => {

--- a/control-ui/components/__tests__/PublisherView.test.tsx
+++ b/control-ui/components/__tests__/PublisherView.test.tsx
@@ -38,6 +38,16 @@ describe('PublisherView', () => {
     expect(screen.getByText(/not available on this deployment/i)).toBeInTheDocument()
   })
 
+  it('renders unavailable when publisherUiEnabled is false (self-hosted default), even for an org-bound non-curator deploy (fails closed)', () => {
+    vi.mocked(hook.usePublishScope).mockReturnValue({
+      scope: { scope: 'acme', curator: false, orgName: 'Acme', publisherUiEnabled: false },
+      loading: false,
+      error: false,
+    })
+    render(<PublisherView activeTab="entries" />)
+    expect(screen.getByText(/not available on this deployment/i)).toBeInTheDocument()
+  })
+
   it('renders the owned-entries panel for an org-bound deploy on the entries tab', async () => {
     vi.mocked(hook.usePublishScope).mockReturnValue({
       scope: { scope: 'acme', curator: false, orgName: 'Acme' },

--- a/control-ui/components/__tests__/Sidebar.test.tsx
+++ b/control-ui/components/__tests__/Sidebar.test.tsx
@@ -23,6 +23,16 @@ describe('Sidebar publisher gating', () => {
     expect(link).toHaveAttribute('href', '/publisher')
   })
 
+  it('hides the Publisher entry when publisherUiEnabled is false (self-hosted default), even for an org-bound non-curator deploy', () => {
+    vi.mocked(hook.usePublishScope).mockReturnValue({
+      scope: { scope: 'acme', curator: false, orgName: 'Acme', publisherUiEnabled: false },
+      loading: false,
+      error: false,
+    })
+    render(<Sidebar currentTab="hosts" />)
+    expect(screen.queryByRole('link', { name: /publisher/i })).toBeNull()
+  })
+
   it('hides the Publisher entry on a curator deploy', () => {
     vi.mocked(hook.usePublishScope).mockReturnValue({
       scope: { scope: null, curator: true, orgName: null },

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -2521,6 +2521,9 @@ export type PublishScope = {
   scope: string | null
   curator: boolean
   orgName: string | null
+  // Static config value (not registry-derived); absent/undefined is treated as
+  // enabled for backward compat with a control-api that doesn't send it yet.
+  publisherUiEnabled?: boolean
 }
 
 export async function getPublishScope(): Promise<PublishScope> {

--- a/control-ui/lib/hooks/__tests__/usePublishScope.test.tsx
+++ b/control-ui/lib/hooks/__tests__/usePublishScope.test.tsx
@@ -34,6 +34,32 @@ describe('usePublishScope / isPublisherEnabled', () => {
     expect(isPublisherEnabled(null)).toBe(false)
   })
 
+  it('isPublisherEnabled: org-bound non-curator, publisherUiEnabled explicitly false → false', () => {
+    expect(
+      isPublisherEnabled({
+        scope: 'acme',
+        curator: false,
+        orgName: 'Acme',
+        publisherUiEnabled: false,
+      })
+    ).toBe(false)
+  })
+
+  it('isPublisherEnabled: org-bound non-curator, publisherUiEnabled explicitly true → true', () => {
+    expect(
+      isPublisherEnabled({
+        scope: 'acme',
+        curator: false,
+        orgName: 'Acme',
+        publisherUiEnabled: true,
+      })
+    ).toBe(true)
+  })
+
+  it('isPublisherEnabled: org-bound non-curator, publisherUiEnabled absent (backward compat) → true', () => {
+    expect(isPublisherEnabled({ scope: 'acme', curator: false, orgName: 'Acme' })).toBe(true)
+  })
+
   it('resolves to enabled for an org-bound scope', async () => {
     vi.mocked(api.getPublishScope).mockResolvedValue({
       scope: 'acme',

--- a/control-ui/lib/hooks/usePublishScope.ts
+++ b/control-ui/lib/hooks/usePublishScope.ts
@@ -40,9 +40,15 @@ export function usePublishScope(): PublishScopeState {
   return state
 }
 
-/** Publisher is available only for an org-bound, non-curator deploy. */
+/**
+ * Publisher is available only for an org-bound, non-curator deploy, and only
+ * when the control-api hasn't explicitly disabled the Publisher UI surface
+ * (self-hosted deployments default this off). `publisherUiEnabled` absent —
+ * an older control-api that doesn't send the field — is treated as enabled,
+ * preserving today's behavior.
+ */
 export function isPublisherEnabled(
   scope: PublishScope | null
 ): scope is PublishScope & { scope: string } {
-  return !!scope && !scope.curator && scope.scope !== null
+  return !!scope && !scope.curator && scope.scope !== null && scope.publisherUiEnabled !== false
 }

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -62,4 +62,10 @@ data:
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
   CLERUM_REGISTRY_AUTH_ENABLED: 'false'
+  # The Publisher UI (Sidebar entry + /publisher route) defaults OFF for
+  # self-hosted deployments (mode-based default, derived from
+  # REGISTRY_CONNECTION_MODE above; ON for managed) — publishing into the
+  # curated registry isn't part of the self-hosted flow. Force it on by
+  # uncommenting the line below.
+  # CONTROL_API_PUBLISHER_UI_ENABLED: 'true'
   CLERUM_ATTACHMENT_MAX_BYTES: '52428800'


### PR DESCRIPTION
## What & why

Hide the **Publisher** UI on OSS / self-hosted deployments by default. The Publisher (self-service UI for managing entries you've published to the shared registry) is a curated/managed surface — prod already hides it because the 1st-party console authenticates as a *curator* (`isPublisherEnabled` is false for curators). This makes the OSS build consistent: self-hosted deployments don't surface the Publisher unless an operator explicitly opts in.

## How

A config flag, mirroring the `authEnabled` pattern:

- **control-api** — new `config.publisherUiEnabled`. Default: `CONTROL_API_PUBLISHER_UI_ENABLED` (`'true'`/`'false'`) wins; otherwise `registryConnectionMode !== 'self-hosted'` — i.e. **OFF for self-hosted, ON for managed**. Surfaced on `GET /admin/registry/publish-scope` (merged at the route; the cached `resolvePublishScope()` is untouched).
- **control-ui** — `isPublisherEnabled` gains `&& scope.publisherUiEnabled !== false`. An *absent* flag stays enabled (backward-compatible with a control-api that doesn't send it). This single gate hides **both** the Sidebar `Publisher` entry and the `/publisher` route (PublisherView).
- **minikube overlay** — a comment documenting the flag + the `CONTROL_API_PUBLISHER_UI_ENABLED: 'true'` opt-in (self-hosted default already hides it, so no key is set).

Only the Publisher surface changes — publishing (`POST /entries`), API keys (`/registry/keys`), and the Marketplace are unaffected.

## Testing

- **control-api** — full suite 2830 passed / 3 skipped / 0 failed. New `config.publisherUiEnabled.test.ts` (unit) + `app.publisherUiEnabled.test.ts` (route via supertest) cover self-hosted→false, managed→true, and both env overrides; the route test also asserts the scope passes through untouched (no cache pollution).
- **control-ui** — full suite 828/830 (the 2 failures are pre-existing, unrelated `DockerCredentials`/`DockerCredentialModal` tests). Updated `usePublishScope`, `Sidebar`, and `PublisherView` tests assert the Publisher is hidden when `publisherUiEnabled:false` (even for an org-bound non-curator) and still shown when the flag is absent.
- Reviewed with real mutation testing: flipping `!== false`→`=== true` fails 8 tests; flipping the self-hosted default fails 3.

## ⚠️ Must be mirrored to the private upstream repo

`control-api/**` and `control-ui/**` are shared with the private repo via the platform→OSS sync. **The source + test changes here must be applied to the private repo too, or the next private→OSS sync will silently revert this feature.** The minikube overlay comment is OSS-only and does not need mirroring.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVekp9KoH9oPvtYepAyNdD
