### PR TITLE
fix(cla): grant token permissions + store signatures on unprotected branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,16 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, synchronize]
+
+# The CLA Assistant needs to write the signatures file, post/update the PR
+# comment, and set the commit status. The repo default GITHUB_TOKEN is
+# read-only, so grant the required scopes explicitly (least-privilege).
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   cla:
     runs-on: ubuntu-latest
@@ -11,8 +21,12 @@ jobs:
       - uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
         with:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/evenfire-ai/evenfire/blob/main/CLA.md'
-          branch: 'main'
+          # Store signatures on a dedicated UNPROTECTED branch. `main` is
+          # branch-protected, so GITHUB_TOKEN cannot push the signatures file
+          # there ("Make sure the branch where signatures are stored is NOT
+          # protected"). A PERSONAL_ACCESS_TOKEN is only needed if signatures
+          # live in another repo — not our case.
+          branch: 'cla-signatures'


### PR DESCRIPTION
## Problem

The CLA Assistant check fails on every PR with:

```
Error occurred when creating the signed contributors file: Resource not accessible
by integration. Make sure the branch where signatures are stored is NOT protected.
Error occured when creating a pull request comment: Resource not accessible by integration.
```

Three compounding causes:
1. The repo's default `GITHUB_TOKEN` is **read-only** and `cla.yml` declared **no `permissions:`** → the action can't post the PR comment or write the signatures file.
2. Signatures were stored on `branch: main`, which is now **branch-protected** → the token can't push there.
3. `CLA_PAT` secret doesn't exist, so the `PERSONAL_ACCESS_TOKEN` fallback is empty.

## Fix (least-privilege, no new secrets)

- Add a scoped `permissions:` block (`actions`/`contents`/`pull-requests`/`statuses: write`).
- Store signatures on a **dedicated unprotected `cla-signatures` branch** (already created) instead of protected `main`.
- Drop the dead `PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}` env (secret doesn't exist; not needed for same-repo storage).

## Note

`cla.yml` runs on `pull_request_target`, so the fix only takes effect **after this merges to `main`** (the check uses the base-branch workflow). The CLA check is not a required status check, so this can merge on review despite the current red CLA X. The Node 20 deprecation warning in the log is from the action itself (cosmetic), not the failure.