### PR TITLE
fix(control-ui): default install "Server name" to a valid K8s name

### DIFF
--- a/control-ui/components/RegistryInstallForm/index.tsx
+++ b/control-ui/components/RegistryInstallForm/index.tsx
@@ -9,7 +9,7 @@ import type { CredentialSchema } from '@lib/api'
 import { getContexts, getRegistryCredentialSchema, installFromRegistry } from '@lib/api'
 import { registryEntryToEgressBindings } from '@lib/egressModel'
 import type { EgressBinding, EgressEditorStatus } from '@lib/egressModel'
-import { isValidK8sName } from '@lib/k8sValidation'
+import { isValidK8sName, toK8sName } from '@lib/k8sValidation'
 import { buildPastedValue } from '@lib/pasteUtils'
 import { trustBgColor, trustColor } from '@lib/trustLevel'
 import { getEmbeddedCredentialSchema, getExternalEgressNotice } from '../registryInstallHelpers'
@@ -43,7 +43,9 @@ const STEP_DETAILS = [
 export function RegistryInstallForm({ entry, onCancel, onInstalled }: RegistryInstallFormProps) {
   const { showToast } = useToast()
   const [step, setStep] = useState(0)
-  const [serverName, setServerName] = useState(entry.name)
+  // Default to a K8s-valid name derived from the scoped registry name (e.g.
+  // `@org/name` → `org-name`); `entry.name` itself is not a valid resource name.
+  const [serverName, setServerName] = useState(toK8sName(entry.name))
   const [contextRef, setContextRef] = useState('')
   const [contexts, setContexts] = useState<Array<{ name: string }>>([])
   const [credSchema, setCredSchema] = useState<CredentialSchema | null>(null)
@@ -59,7 +61,7 @@ export function RegistryInstallForm({ entry, onCancel, onInstalled }: RegistryIn
   useEffect(() => {
     installInFlightRef.current = false
     setStep(0)
-    setServerName(entry.name)
+    setServerName(toK8sName(entry.name))
     setError('')
     setCredValues({})
     setEgressBindings(registryInitialEgressBindings)
@@ -306,7 +308,9 @@ export function RegistryInstallForm({ entry, onCancel, onInstalled }: RegistryIn
                     id="ri-name"
                     className="cu-input"
                     value={serverName}
-                    onChange={event => setServerName(event.target.value.toLowerCase())}
+                    onChange={event =>
+                      setServerName(event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
+                    }
                     placeholder="my-mcp-server"
                   />
                   {serverName && !nameValid ? (

--- a/control-ui/components/RegistryInstallModal.tsx
+++ b/control-ui/components/RegistryInstallModal.tsx
@@ -5,7 +5,7 @@ import type { CredentialSchema, RegistryEntry } from '../lib/api'
 import { getContexts, getRegistryCredentialSchema, installFromRegistry } from '../lib/api'
 import { registryEntryToEgressBindings } from '../lib/egressModel'
 import type { EgressBinding, EgressEditorStatus } from '../lib/egressModel'
-import { isValidK8sName } from '../lib/k8sValidation'
+import { isValidK8sName, toK8sName } from '../lib/k8sValidation'
 import { buildPastedValue } from '../lib/pasteUtils'
 import { trustBgColor, trustColor } from '../lib/trustLevel'
 import { EgressEditor } from './EgressEditor'
@@ -21,7 +21,9 @@ interface Props {
 
 export function RegistryInstallModal({ entry, isOpen, onClose, onInstalled }: Props) {
   const { showToast } = useToast()
-  const [serverName, setServerName] = useState(entry.name)
+  // Default to a K8s-valid name derived from the scoped registry name (e.g.
+  // `@org/name` → `org-name`); `entry.name` itself is not a valid resource name.
+  const [serverName, setServerName] = useState(toK8sName(entry.name))
   const [contextRef, setContextRef] = useState('')
   const [contexts, setContexts] = useState<Array<{ name: string }>>([])
   const [credSchema, setCredSchema] = useState<CredentialSchema | null>(null)
@@ -38,7 +40,7 @@ export function RegistryInstallModal({ entry, isOpen, onClose, onInstalled }: Pr
   useEffect(() => {
     if (!isOpen) return
     installInFlightRef.current = false
-    setServerName(entry.name)
+    setServerName(toK8sName(entry.name))
     setError('')
     setCredValues({})
     setEgressBindings(registryInitialEgressBindings)
@@ -338,7 +340,9 @@ export function RegistryInstallModal({ entry, isOpen, onClose, onInstalled }: Pr
                 id="ri-name"
                 className="cu-input"
                 value={serverName}
-                onChange={e => setServerName(e.target.value.toLowerCase())}
+                onChange={e =>
+                  setServerName(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))
+                }
                 placeholder="my-mcp-server"
               />
               {serverName && !nameValid && (

--- a/control-ui/components/__tests__/RegistryInstallForm.test.tsx
+++ b/control-ui/components/__tests__/RegistryInstallForm.test.tsx
@@ -105,3 +105,19 @@ describe('RegistryInstallForm -- pending connector credentials', () => {
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
   })
 })
+
+describe('RegistryInstallForm -- server name default', () => {
+  it('defaults the Server name to a K8s-valid derivation of a scoped registry name', async () => {
+    const scopedEntry = { ...MOCK_ENTRY, name: '@test-oss-jose/helloo' }
+    render(<RegistryInstallForm entry={scopedEntry} onCancel={vi.fn()} onInstalled={vi.fn()} />)
+
+    // Advance from step 0 (review) to step 1 (name & credentials).
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+
+    const nameInput = (await screen.findByLabelText('Server name')) as HTMLInputElement
+    // `@test-oss-jose/helloo` sanitized to a valid RFC 1123 label — no manual fix.
+    expect(nameInput.value).toBe('test-oss-jose-helloo')
+    expect(screen.queryByText(/Must be a valid K8s name/i)).toBeNull()
+  })
+})

--- a/control-ui/lib/__tests__/k8sValidation.test.ts
+++ b/control-ui/lib/__tests__/k8sValidation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { isValidK8sName, toK8sName } from '../k8sValidation'
+
+describe('isValidK8sName', () => {
+  it('accepts RFC 1123 DNS labels', () => {
+    expect(isValidK8sName('test-oss-jose-helloo')).toBe(true)
+    expect(isValidK8sName('a')).toBe(true)
+    expect(isValidK8sName('a1-b2')).toBe(true)
+  })
+  it('rejects scoped registry names, edges, and over-length', () => {
+    expect(isValidK8sName('@test-oss-jose/helloo')).toBe(false)
+    expect(isValidK8sName('-lead')).toBe(false)
+    expect(isValidK8sName('trail-')).toBe(false)
+    expect(isValidK8sName('UPPER')).toBe(false)
+    expect(isValidK8sName('a'.repeat(64))).toBe(false)
+  })
+})
+
+describe('toK8sName', () => {
+  it('derives a valid label from a scoped registry name', () => {
+    expect(toK8sName('@test-oss-jose/helloo')).toBe('test-oss-jose-helloo')
+  })
+
+  it('lowercases, collapses invalid runs, and trims edge hyphens', () => {
+    expect(toK8sName('@Acme//My Server!!')).toBe('acme-my-server')
+    expect(toK8sName('__weird__')).toBe('weird')
+    expect(toK8sName('a---b')).toBe('a-b')
+  })
+
+  it('caps at 63 chars with no trailing hyphen', () => {
+    const out = toK8sName(`@${'x'.repeat(80)}`)
+    expect(out.length).toBe(63)
+    expect(out.endsWith('-')).toBe(false)
+    expect(isValidK8sName(out)).toBe(true)
+  })
+
+  it('always yields a valid K8s name (or empty)', () => {
+    for (const raw of ['@test-oss-jose/helloo', '@Acme//My Server!!', 'a---b']) {
+      expect(isValidK8sName(toK8sName(raw))).toBe(true)
+    }
+    expect(toK8sName('@@@///')).toBe('') // no usable chars → empty (caller handles)
+  })
+})

--- a/control-ui/lib/k8sValidation.ts
+++ b/control-ui/lib/k8sValidation.ts
@@ -9,3 +9,21 @@ const K8S_NAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 export function isValidK8sName(name: string): boolean {
   return K8S_NAME_RE.test(name) && name.length <= 63
 }
+
+/**
+ * Sanitize an arbitrary string into a valid RFC 1123 DNS label for use as a
+ * default K8s resource name: lowercase, runs of non-`[a-z0-9-]` collapsed to a
+ * single hyphen, leading/trailing hyphens trimmed, capped at 63 chars. Used to
+ * derive an install "server name" default from a scoped registry entry name —
+ * e.g. `@test-oss-jose/helloo` → `test-oss-jose-helloo`. May return `""` when
+ * the input has no usable characters (the caller then leaves the field empty).
+ */
+export function toK8sName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-') // non-label chars (@, /, …) → single hyphen
+    .replace(/-+/g, '-') // collapse runs
+    .replace(/^-+|-+$/g, '') // trim edges (labels must start/end alphanumeric)
+    .slice(0, 63)
+    .replace(/-+$/g, '') // re-trim if the 63-cap left a trailing hyphen
+}

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.334",
+  "version": "0.1.335",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.334",
+      "version": "0.1.335",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.334",
+  "version": "0.1.335",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
## What & why

Installing a Marketplace connector seeded the **Server name** field with the raw scoped registry name — e.g. `@test-oss-jose/helloo` — which is **not** a valid RFC 1123 DNS label (`@`, `/` aren't allowed). So every install immediately showed *"Must be a valid K8s name (lowercase, alphanumeric, hyphens, max 63 chars)"* and forced the user to hand-fix the name before proceeding.

Root cause: `RegistryInstallForm` / `RegistryInstallModal` defaulted `serverName` to `entry.name`, and the field's `onChange` only `.toLowerCase()`'d (didn't strip invalid chars).

## Changes

- **`lib/k8sValidation.ts`** — add `toK8sName(raw)`: lowercase → collapse non-`[a-z0-9-]` runs to a hyphen → trim edge hyphens → cap 63. `@test-oss-jose/helloo` → `test-oss-jose-helloo`.
- **`RegistryInstallForm`** + **`RegistryInstallModal`** — default `serverName` to `toK8sName(entry.name)`, and strip invalid chars **as-you-type** (matching `PublishToRegistryForm` / `CreateMcpServerForm`).
- The registry entry name is still sent separately (`registryEntryName: entry.name`), so the image-pull identity is unchanged — this only fixes the K8s **resource** name default.

## Tests

- `toK8sName` unit cases (derivation, collapse/trim, 63-cap, always-valid-or-empty).
- `RegistryInstallForm` defaults a scoped `@org/name` entry to a valid label with no K8s error on load.
- control-ui suite green locally (pre-existing `CostSection`/`RegistryCatalog` failures on `main` are unrelated). Note: control-ui isn't in the CI matrix, so this local run is the coverage.

## Not included (follow-up)
Separate from the `imageRef` repo ↔ entry-name mismatch (the `422` at install review) — that publish-time validation gap is noted but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)