### PR TITLE
fix(control-api): reject imageRef↔name mismatch at publish, not just install

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.359",
+  "version": "0.1.360",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.359",
+      "version": "0.1.360",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.359",
+  "version": "0.1.360",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -127,8 +127,7 @@ type SecretSnapshot = {
 }
 
 type CredentialPayloadValidation =
-  | { ok: true; secretData: Record<string, string> }
-  | { ok: false; body: Record<string, unknown> }
+  { ok: true; secretData: Record<string, string> } | { ok: false; body: Record<string, unknown> }
 
 function looksLikeCredentialPlaceholder(value: string): boolean {
   const normalized = value.trim().toLowerCase()
@@ -786,7 +785,28 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
       // clients publish unscoped and the registry maps them to @clerum, so the
       // name is left untouched there.
       const scope = await resolvePublishScope()
-      const body = { ...req.body, name: applyPublishScope(req.body?.name, scope) }
+      const scopedName = applyPublishScope(req.body?.name, scope)
+
+      // Phase 2.5 parity: reject an evenfire-hosted local connector whose imageRef
+      // repo != its scoped name AT PUBLISH, not only at install/upgrade (the same
+      // check runs there — see registryImageRefIdentity). Otherwise the publish
+      // succeeds but every install 422s later (cross-org pull would be denied),
+      // which is exactly the surprise we want to surface up front.
+      const mcp = req.body?.mcpServer as Record<string, unknown> | undefined
+      const imageRefIdentity = checkEvenfireImageRefMatchesEntry({
+        isLocal: req.body?.entryType === 'mcp-server' && mcp?.serverMode === 'local',
+        entryName: scopedName,
+        image: mcp?.imageRef,
+        registryUrl: config.registryUrl,
+      })
+      if (!imageRefIdentity.ok) {
+        res.status(422).json({
+          error: `Registry entry imageRef repo "${imageRefIdentity.actual}" must equal the entry name "${imageRefIdentity.expected}" for evenfire-hosted plugins; cross-org pull would be denied.`,
+        })
+        return
+      }
+
+      const body = { ...req.body, name: scopedName }
       const result = await publishEntry(body)
       res.status(201).json(result)
     } catch (err) {
@@ -1055,9 +1075,7 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
         }
 
         const transport = (entry.transport ?? 'streamableHttp') as
-          | 'streamableHttp'
-          | 'sse'
-          | 'stdio'
+          'streamableHttp' | 'sse' | 'stdio'
         const port = (meta?.port as number | undefined) ?? 3000
         const secretName = `${serverName}-credentials`
 
@@ -2379,9 +2397,7 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
       const limit = toPageNum(req.query.limit)
       const offset = toPageNum(req.query.offset)
       const raw = (await listOrgEntries(ctx.orgName, { limit, offset })) as
-        | { data?: unknown[]; entries?: unknown[]; meta?: unknown }
-        | null
-        | undefined
+        { data?: unknown[]; entries?: unknown[]; meta?: unknown } | null | undefined
       const data = raw?.data ?? raw?.entries ?? []
       res.status(200).json(raw?.meta !== undefined ? { data, meta: raw.meta } : { data })
     } catch (err) {

--- a/control-api/test/app.publishImageRefIdentity.test.ts
+++ b/control-api/test/app.publishImageRefIdentity.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { MockGateway } from './mockGateway.js'
+
+const ORIGINAL_ENV = { ...process.env }
+
+// Bypass the control-ui auth gate so supertest reaches the real POST /entries route.
+vi.mock('../src/middleware/controlUIAuth.js', () => ({
+  requireAuthForControlUI: (
+    req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => {
+    ;(req as unknown as { adminAuth: unknown }).adminAuth = {
+      sub: 'admin-1',
+      role: 'admin',
+      typ: 'user',
+    }
+    next()
+  },
+}))
+
+// Partial-mock the registry client: keep every real export (applyPublishScope,
+// checkEvenfireImageRefMatchesEntry is a separate module, …) and override only
+// resolvePublishScope (fixed org scope) and publishEntry (assert it is / isn't hit).
+const registryClient = vi.hoisted(() => ({
+  resolvePublishScope: vi.fn(),
+  publishEntry: vi.fn(),
+}))
+vi.mock('../src/services/registryClient.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryClient.js')>()),
+  resolvePublishScope: registryClient.resolvePublishScope,
+  publishEntry: registryClient.publishEntry,
+}))
+
+vi.mock('../src/middleware/rateLimitMiddleware.js', () => ({
+  rateLimitMiddleware:
+    () => (_req: express.Request, _res: express.Response, next: express.NextFunction) =>
+      next(),
+}))
+
+const baseBody = (imageRef: string) => ({
+  name: 'helloo',
+  version: '1.0.0',
+  entryType: 'mcp-server',
+  description: 'x',
+  author: 'x',
+  mcpServer: { serverMode: 'local', imageRef },
+})
+
+describe('POST /admin/registry/entries: evenfire imageRef ↔ name identity (publish-time)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
+    registryClient.resolvePublishScope.mockReset()
+    registryClient.publishEntry.mockReset()
+    registryClient.resolvePublishScope.mockResolvedValue({
+      curator: false,
+      orgName: 'acme',
+      scope: '@acme',
+    })
+    registryClient.publishEntry.mockResolvedValue({ name: '@acme/helloo', version: '1.0.0' })
+  })
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    vi.resetModules()
+  })
+
+  it('rejects a mismatched imageRef at publish (422) without creating the entry', async () => {
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    // name → @acme/helloo, but the image repo is @acme/hello — mismatch.
+    const res = await request(app)
+      .post('/api/v1/admin/registry/entries')
+      .send(baseBody('registry.evenfire.ai/acme/hello:v1'))
+    expect(res.status).toBe(422)
+    expect(res.body.error).toMatch(/must equal the entry name/)
+    expect(res.body.error).toContain('acme/hello')
+    expect(res.body.error).toContain('acme/helloo')
+    expect(registryClient.publishEntry).not.toHaveBeenCalled()
+  })
+
+  it('allows a matching imageRef (201) and forwards the scoped name', async () => {
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app)
+      .post('/api/v1/admin/registry/entries')
+      .send(baseBody('registry.evenfire.ai/acme/helloo:v1'))
+    expect(res.status).toBe(201)
+    expect(registryClient.publishEntry).toHaveBeenCalledTimes(1)
+    expect(registryClient.publishEntry.mock.calls[0][0]).toMatchObject({ name: '@acme/helloo' })
+  })
+
+  it('does not check a non-evenfire image (201) — the constraint is host-scoped', async () => {
+    const { createApp } = await import('../src/app.js')
+    const app = createApp(new MockGateway('mcp-server') as never)
+    const res = await request(app)
+      .post('/api/v1/admin/registry/entries')
+      .send(baseBody('ghcr.io/acme/hello:v1'))
+    expect(res.status).toBe(201)
+    expect(registryClient.publishEntry).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What & why

An **evenfire-hosted local connector**'s `imageRef` repo must equal its scoped entry name (`@org/name`) — the cross-org pull grant is resolved from the OCI path (`callerHasGrant("@org/name")`), so a mismatch means a granted pull is silently denied (`ImagePullBackOff`). control-api enforces this at **install/upgrade** (`registryImageRefIdentity.ts`).

But **publish never checked it**: `POST /admin/registry/entries` applied the scope and forwarded to the registry. So you could publish a valid-looking connector (e.g. name `@test-oss-jose/helloo`, image `…/hello`) and only discover it was un-installable at the **review/install** step, with a raw `422`.

## Change

`POST /admin/registry/entries` now runs the **same** `checkEvenfireImageRefMatchesEntry` before publishing — so a mismatch fails fast at publish with the identical message, which surfaces directly in the publish form's error banner. Non-local entries, non-evenfire images, and curator/unscoped publishes are unaffected (the check no-ops there, same as install).

## Tests

`test/app.publishImageRefIdentity.test.ts` (supertest): mismatch → `422` and `publishEntry` is **not** called; match → `201` with the scoped name forwarded; a non-evenfire image (`ghcr.io/…`) → `201` (host-scoped constraint). Neighboring registry-route suites still green (168 tests).

## Not included
Client-side inline validation on the Image Ref field (as-you-type) — the server guard already surfaces the exact message at publish-submit; the inline version is an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)