### PR TITLE
feat(control-api): enable the Publisher UI by default on all deploys

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.360",
+  "version": "0.1.361",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.360",
+      "version": "0.1.361",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.360",
+  "version": "0.1.361",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -549,15 +549,13 @@ export const config: Config = {
   registryClientSecret: process.env.CLERUM_REGISTRY_CLIENT_SECRET ?? '',
   registryAuthEnabled: process.env.CLERUM_REGISTRY_AUTH_ENABLED === 'true',
   registryConnectionMode,
-  // 'true'/'false' wins explicitly; otherwise default OFF for self-hosted,
-  // ON for managed — reuses the registryConnectionMode value above rather
-  // than re-parsing REGISTRY_CONNECTION_MODE.
-  publisherUiEnabled:
-    process.env.CONTROL_API_PUBLISHER_UI_ENABLED === 'true'
-      ? true
-      : process.env.CONTROL_API_PUBLISHER_UI_ENABLED === 'false'
-        ? false
-        : registryConnectionMode !== 'self-hosted',
+  // Default ON for every deploy now that the Publisher UI is production-ready
+  // (publish → install verified end-to-end); only an explicit
+  // CONTROL_API_PUBLISHER_UI_ENABLED='false' disables it. This flag only exposes
+  // the surface — the control-ui still fails CLOSED for curator / non-org-bound
+  // deploys (isPublisherEnabled requires scope.scope !== null && !curator), so an
+  // unconnected self-hosted deploy won't show the Publisher regardless.
+  publisherUiEnabled: process.env.CONTROL_API_PUBLISHER_UI_ENABLED !== 'false',
   adminAuthMaxFailures: Number(process.env.CONTROL_API_ADMIN_AUTH_MAX_FAILURES || 5),
   adminAuthLockMinutes: Number(process.env.CONTROL_API_ADMIN_AUTH_LOCK_MINUTES || 15),
   adminBootstrapUsername: requiredOrDevDefault('CONTROL_API_ADMIN_BOOTSTRAP_USERNAME', 'admin'),

--- a/control-api/test/app.publisherUiEnabled.test.ts
+++ b/control-api/test/app.publisherUiEnabled.test.ts
@@ -60,13 +60,13 @@ describe('GET /admin/registry/publish-scope: publisherUiEnabled (effective, thro
     vi.resetModules()
   })
 
-  it('is false by default in self-hosted mode', async () => {
+  it('is true by default in self-hosted mode (now production-ready)', async () => {
     process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
     const { createApp } = await import('../src/app.js')
     const app = createApp(new MockGateway('mcp-server') as never)
     const res = await request(app).get('/api/v1/admin/registry/publish-scope')
     expect(res.status).toBe(200)
-    expect(res.body.publisherUiEnabled).toBe(false)
+    expect(res.body.publisherUiEnabled).toBe(true)
     // The registry-derived fields still pass through untouched.
     expect(res.body.scope).toBe('@acme')
   })

--- a/control-api/test/config.publisherUiEnabled.test.ts
+++ b/control-api/test/config.publisherUiEnabled.test.ts
@@ -13,42 +13,49 @@ afterEach(() => {
   vi.resetModules()
 })
 
-describe('config: publisherUiEnabled (mode-based default + env override)', () => {
-  it('defaults to false when REGISTRY_CONNECTION_MODE=self-hosted', async () => {
+describe('config: publisherUiEnabled (default ON; only CONTROL_API_PUBLISHER_UI_ENABLED=false disables)', () => {
+  it('defaults to true on self-hosted (Publisher UI is production-ready)', async () => {
     process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
     const { config } = await import('../src/config.js')
-    expect(config.publisherUiEnabled).toBe(false)
+    expect(config.publisherUiEnabled).toBe(true)
   })
 
-  it('defaults to true when REGISTRY_CONNECTION_MODE=managed', async () => {
+  it('defaults to true on managed', async () => {
     process.env.REGISTRY_CONNECTION_MODE = 'managed'
     const { config } = await import('../src/config.js')
     expect(config.publisherUiEnabled).toBe(true)
   })
 
-  it('defaults to true when REGISTRY_CONNECTION_MODE is unset (implicit managed)', async () => {
+  it('defaults to true when REGISTRY_CONNECTION_MODE is unset', async () => {
     const { config } = await import('../src/config.js')
     expect(config.publisherUiEnabled).toBe(true)
   })
 
-  it('CONTROL_API_PUBLISHER_UI_ENABLED=true overrides the self-hosted default to true', async () => {
-    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
-    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'true'
-    const { config } = await import('../src/config.js')
-    expect(config.publisherUiEnabled).toBe(true)
-  })
-
-  it('CONTROL_API_PUBLISHER_UI_ENABLED=false overrides the managed default to false', async () => {
+  it('CONTROL_API_PUBLISHER_UI_ENABLED=false disables it (even on managed)', async () => {
     process.env.REGISTRY_CONNECTION_MODE = 'managed'
     process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'false'
     const { config } = await import('../src/config.js')
     expect(config.publisherUiEnabled).toBe(false)
   })
 
-  it('an unrecognized CONTROL_API_PUBLISHER_UI_ENABLED value falls back to the mode-based default', async () => {
+  it('CONTROL_API_PUBLISHER_UI_ENABLED=false disables it on self-hosted too', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'false'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(false)
+  })
+
+  it('CONTROL_API_PUBLISHER_UI_ENABLED=true keeps it enabled', async () => {
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'true'
+    const { config } = await import('../src/config.js')
+    expect(config.publisherUiEnabled).toBe(true)
+  })
+
+  it('an unrecognized value stays enabled — only "false" disables', async () => {
     process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
     process.env.CONTROL_API_PUBLISHER_UI_ENABLED = 'yes'
     const { config } = await import('../src/config.js')
-    expect(config.publisherUiEnabled).toBe(false)
+    expect(config.publisherUiEnabled).toBe(true)
   })
 })

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -65,10 +65,9 @@ data:
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
   CLERUM_REGISTRY_AUTH_ENABLED: 'false'
-  # The Publisher UI (Sidebar entry + /publisher route) defaults OFF for
-  # self-hosted deployments (mode-based default, derived from
-  # REGISTRY_CONNECTION_MODE above; ON for managed) — publishing into the
-  # curated registry isn't part of the self-hosted flow. Force it on by
-  # uncommenting the line below.
-  # CONTROL_API_PUBLISHER_UI_ENABLED: 'true'
+  # The Publisher UI (Sidebar entry + /publisher route) defaults ON for every
+  # deploy. It only surfaces for an org-bound, non-curator deploy (the control-ui
+  # fails closed otherwise), so an unconnected self-hosted deploy still won't show
+  # it. Set the line below to 'false' to hide it explicitly.
+  # CONTROL_API_PUBLISHER_UI_ENABLED: 'false'
   CLERUM_ATTACHMENT_MAX_BYTES: '52428800'


### PR DESCRIPTION
## What & why

Now that the Publisher **publish → install** flow is production-ready (verified end-to-end this cycle — `@@` scope display, docker push-path, install K8s name, publish-time imageRef guard all shipped in #114/#116/#117), flip the Publisher UI to **default ON for every deploy**.

Previously `publisherUiEnabled` defaulted **off for self-hosted** (PR #108's guard, when the surface wasn't ready). Now:

- `config.publisherUiEnabled` = `CONTROL_API_PUBLISHER_UI_ENABLED !== 'false'` — **default ON**; only an explicit `=false` disables it.
- **Still fails closed** where it should: the control-ui's `isPublisherEnabled` requires `scope.scope !== null && !curator`, so a **curator** or **unconnected** self-hosted deploy won't surface the Publisher regardless of this flag.

## Changes
- `control-api/src/config.ts` — the default flip (+ comment).
- `control-api/test/config.publisherUiEnabled.test.ts` + `app.publisherUiEnabled.test.ts` — updated the two self-hosted cases to expect ON; added an "unrecognized value stays enabled" case. `routes.registryInstall` (reads `config.publisherUiEnabled` dynamically) unchanged.
- `deploy/overlays/minikube/configmaps/control-api-config.yaml` — the commented hint now documents "set to 'false' to hide".

No control-ui change (its `isPublisherEnabled` already treats an absent/true flag as enabled). Existing dogfood cluster already shows the Publisher via the runtime env override; this makes it the default for fresh/OSS deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)