### PR TITLE
fix(minikube): guard --skip-build staleness find|head against SIGPIPE (Error 141)

### DIFF
--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -568,7 +568,7 @@ if [ "$SKIP_BUILD" = true ]; then
       control-api/src \
       control-ui/components \
       control-ui/lib \
-      -type f -newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1)
+      -type f -newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1 || true)
     if [ -n "$NEWEST_SRC" ]; then
       warn "Source files changed since last image build (e.g., $NEWEST_SRC)."
       warn "Images may be STALE. Run without --skip-build to rebuild."

--- a/scripts/tests/test-minikube-full-setup.sh
+++ b/scripts/tests/test-minikube-full-setup.sh
@@ -295,6 +295,33 @@ assert_reset_db_flag_backcompat() {
   fi
 }
 
+assert_skip_build_staleness_find_is_sigpipe_guarded() {
+  # full-setup.sh runs `set -euo pipefail`. The --skip-build staleness check
+  # pipes `find <source dirs> -newer "$LAST_BUILD_MARKER" | head -1`; when find
+  # has matches, head closes the pipe after line 1 and find dies with SIGPIPE
+  # (141), which pipefail turns into a fatal `make Error 141`. The pipeline must
+  # tolerate that exit status.
+  if grep -Fq 'newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1 || true' scripts/minikube/full-setup.sh; then
+    pass "skip-build staleness find|head pipeline is SIGPIPE-guarded"
+  else
+    fail "skip-build staleness find|head is unguarded — SIGPIPE (141) aborts --skip-build"
+  fi
+}
+
+assert_pipefail_head_guard_prevents_abort() {
+  # Deterministic proof the guard is not vacuous: `yes | head -1` always leaves
+  # the producer writing when head exits, so under `set -euo pipefail` the bare
+  # form aborts (SIGPIPE 141) while the `|| true` form (as applied above) exits 0.
+  local bare_rc=0 guarded_rc=0
+  bash -c 'set -euo pipefail; v=$(yes | head -1); : "$v"' >/dev/null 2>&1 || bare_rc=$?
+  bash -c 'set -euo pipefail; v=$(yes | head -1 || true); : "$v"' >/dev/null 2>&1 || guarded_rc=$?
+  if [ "$bare_rc" -ne 0 ] && [ "$guarded_rc" -eq 0 ]; then
+    pass "pipefail SIGPIPE guard (|| true) prevents the abort the bare pipeline hits"
+  else
+    fail "SIGPIPE guard behaved unexpectedly (bare_rc=$bare_rc guarded_rc=$guarded_rc)"
+  fi
+}
+
 assert_broken_profile_is_recreated
 assert_healthy_profile_skips_recreate
 assert_branch_profile_deploy_dir_is_used
@@ -305,5 +332,7 @@ assert_full_setup_defaults_to_db_rebuild
 assert_makefile_passes_reuse_db
 assert_reuse_db_normalizer_precedes_flag_loop
 assert_reset_db_flag_backcompat
+assert_skip_build_staleness_find_is_sigpipe_guarded
+assert_pipefail_head_guard_prevents_abort
 
 exit $FAIL


### PR DESCRIPTION
## Problem

`make minikube-setup ARGS="--skip-build"` aborts at **Step 5/12: Build Images** with:

```
make: *** [minikube-setup] Error 141
```

`--skip-build` is therefore unusable whenever any tracked source file is newer than the last image-build marker — i.e. after almost any edit, and on many fresh clones.

## Root cause

`scripts/minikube/full-setup.sh` runs `set -euo pipefail`. The `--skip-build` path does an image-staleness check (full-setup.sh:563):

```bash
NEWEST_SRC=$(find <source dirs> -type f -newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1)
```

When `find` has matches, `head -1` reads the first line and closes the pipe; `find` is still writing, gets **SIGPIPE**, and exits **141**. Under `pipefail` that becomes the pipeline's exit status, and `set -e` turns it into a fatal error — aborting the whole setup before it reaches deploy.

(This is timing/size dependent — it needs `find` to still be writing when `head` closes, which the real source tree triggers but a tiny dir does not. That's why it surfaces on real runs, not trivially.)

## Fix

Tolerate the pipeline's exit status — we only want one example path for a warning message:

```diff
-      -type f -newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1)
+      -type f -newer "$LAST_BUILD_MARKER" 2>/dev/null | head -1 || true)
```

`2>/dev/null` already suppresses real `find` errors, and an empty result just takes the "no changes detected" branch — so ignoring the exit status is safe. Chosen over `find -print -quit` to keep a minimal, zero-portability-risk diff.

## Tests (`scripts/tests/test-minikube-full-setup.sh`)

- **Static regression guard** — asserts the `find … -newer "$LAST_BUILD_MARKER" … | head -1` line carries the `|| true` guard.
- **Deterministic behavioral proof** (non-vacuous) — `yes | head -1` always leaves the producer writing when `head` exits, so under `set -euo pipefail` the bare form aborts (141) while the `|| true` form exits 0.

RED→GREEN confirmed; `bash -n` clean. Full suite: 12/12 assertions pass.

## Notes / scope
- One sibling pipeline exists — `kubectl get pods -l app=control-postgres … | head -1` (full-setup.sh:926) — same SIGPIPE class in theory, but its output is bounded to a singleton deployment and always fits the pipe buffer, so it cannot trigger this in practice. Left as-is to keep the change focused on the reproduced bug.
- **Context:** found while live-verifying PR #115 (minikube-setup DB rebuild-by-default) — `--skip-build` was going to speed up that validation and instead tripped this pre-existing landmine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
