### PR TITLE
fix(ci): build mcp-host images with repo-root context (rooted: true)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -184,18 +184,22 @@ jobs:
             changed: ${{ needs.detect.outputs.host-context-controller }}
           - image: mcp-host
             path: mcp-host
+            rooted: true
             platforms: linux/amd64,linux/arm64
             changed: ${{ needs.detect.outputs.mcp-host }}
           - image: mcp-host-slim
             path: mcp-host
+            rooted: true
             dockerfile: Dockerfile.slim
             changed: ${{ needs.detect.outputs.mcp-host }}
           - image: mcp-host-full
             path: mcp-host
+            rooted: true
             dockerfile: Dockerfile.full
             changed: ${{ needs.detect.outputs.mcp-host }}
           - image: mcp-host-desktop
             path: mcp-host
+            rooted: true
             dockerfile: Dockerfile.desktop
             changed: ${{ needs.detect.outputs.mcp-host }}
           - image: mcp-proxy


### PR DESCRIPTION
## Problem

All four `mcp-host` image builds fail in `build-publish`:

```
Dockerfile.full:23
 >>> COPY mcp-host/src ./src
ERROR: "/mcp-host/src": not found     (also "/packages/llm-providers": not found)
```

The mcp-host Dockerfiles `COPY packages/llm-providers` and `COPY mcp-host/src` — **repo-root-relative** paths (`Dockerfile.full` even documents *"BUILD CONTEXT = repo root"*). But the build-publish matrix built mcp-host from the `mcp-host/` service dir, so `packages/` was invisible. This surfaced once `llm-providers` was extracted into `packages/` and mcp-host started `COPY`ing it — the four mcp-host matrix entries were never marked `rooted`.

Because `build-push` failed, `notify-infra` (`needs: build-push`) was **skipped**, so it also silently blocks the public→infra `images-published` dispatch.

## Fix

Add `rooted: true` to the four mcp-host variants (`mcp-host`, `-slim`, `-full`, `-desktop`). The `buildargs` step then sets `context: .` for them — exactly how `control-api` / `host-context-controller` / `workflow-recipes` (which also `COPY packages/`) already build green.

Verified: an audit of all matrix entries shows these four were the **only** `packages/`-COPYing images missing `rooted: true`.

## Validation

- `actionlint` + YAML parse clean.
- CI on this PR rebuilds mcp-host — should now go green.