### PR TITLE
fix(ci): skip notify-infra cleanly on a no-op push

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -361,6 +361,11 @@ jobs:
         if: ${{ env.DISPATCH_REPO != '' && env.DISPATCH_TOKEN != '' }}
         run: |
           set -euo pipefail
+          # download-artifact creates nothing when zero markers match, so
+          # /tmp/built may not exist. Ensure it does — otherwise `find` errors
+          # and, under `set -e`, fails the job before the empty-check runs
+          # (a no-op push must skip cleanly, not go red).
+          mkdir -p /tmp/built
           # Space-separated list of images actually (re)built this run. Empty on a
           # no-op / config-only push — in which case DO NOT dispatch (nothing to
           # mirror; a bare dispatch would make the mirror fail on absent tags).


### PR DESCRIPTION
## Problem

Live-verified on the #121 merge (itself a workflow-only push): `notify-infra` **failed** on a no-op push. The dispatch was correctly *not* fired (no mirror ran on infra), but the job went red.

Root cause: with zero `built-<image>` markers, `download-artifact` creates no `/tmp/built` dir; under `set -euo pipefail` the `find /tmp/built` errors and trips `set -e` **before** the empty-check that would have `exit 0`'d cleanly.

## Fix

`mkdir -p /tmp/built` before the `find`. An empty run now resolves to an empty image list → "no images built — skipping dispatch" → green.

- No behavior change on a real build (partial or full): markers exist, `/tmp/built` exists, dispatch fires as before.
- Only the no-op path changes: red X → clean skip.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)