### PR TITLE
docs(nginx-egress-proxy): note ghcr → AR mirror (exercises incremental CI path)

### DIFF
--- a/nginx-egress-proxy/README.md
+++ b/nginx-egress-proxy/README.md
@@ -82,6 +82,7 @@ The generated config, sanitization rules, and deployment shape are asserted in
 
 CI builds and publishes the image via
 [.github/workflows/build-publish.yml](../.github/workflows/build-publish.yml)
-(ghcr.io). There are no static manifests for this service: Deployments,
-ConfigMaps, and Services are created dynamically by host-context-controller —
-see its [README](../host-context-controller/README.md).
+(ghcr.io), tagged `sha-<short>`. The private infra repo then mirrors that tag
+into the deploy-time GCP Artifact Registry. There are no static manifests for
+this service: Deployments, ConfigMaps, and Services are created dynamically by
+host-context-controller — see its [README](../host-context-controller/README.md).


### PR DESCRIPTION
Single-service change (README under `nginx-egress-proxy/**`) to prove the **incremental** cross-CI/CD path live, now that no-op and full paths are green.

Expected on merge:
1. `detect` flags **only** `nginx-egress-proxy` changed
2. build-publish builds/pushes just that image + drops one `built-nginx-egress-proxy` marker
3. `notify-infra` dispatches `client_payload.images = "nginx-egress-proxy"`
4. infra `mirror-images` mirrors **only** `nginx-egress-proxy` (skips the other 27 as absent)
5. `deploy-diff` renders green (spurious drift on unchanged services expected until per-service pins, Phase 1.1)

The doc line itself is accurate (the ghcr→AR mirror is real now). Safe to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)