### PR TITLE
chore(ci): trigger build-publish on `dev` (dev-cluster deploy branch)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -16,7 +16,12 @@ name: Build & Publish
 
 on:
   push:
-    branches: [main]
+    # `dev` is the integration branch → drives the clerum-dev deploy (build →
+    # dispatch → infra mirror + apply). `main` is the release branch (→ clerum
+    # prod via a dev→main promotion) and does NOT build/dispatch here — prod
+    # promotes dev-proven digests, it never rebuilds. The main→prod trigger is
+    # added with the prod pipeline (see the cutover spec, Phase 2).
+    branches: [dev]
   workflow_dispatch:
     inputs:
       build_all:


### PR DESCRIPTION
First concrete step of the dev/main → dev/prod cutover (mirrors the monorepo).

- `dev` = integration branch → drives **clerum-dev** (build → dispatch → infra mirror + apply)
- `main` = release branch → **clerum prod** via a `dev → main` promotion (Phase 2)

So `build-publish` now triggers on **`dev`** instead of `main`. During the dev-first phase, `main` is **inert on deploy**; its prod trigger lands with the prod pipeline.

**Safe:** infra stays `mode=diff` until the full-parity apply is built, so an OSS `dev` merge just mirrors + diffs (no live apply yet). This PR only repoints which branch builds.

Base = `dev` (the new integration branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)