### PR TITLE
fix(deploy): sync member_registration_credentials access profile to upsert

### DIFF
--- a/deploy/scripts/control-api-runtime-access-profiles.tsv
+++ b/deploy/scripts/control-api-runtime-access-profiles.tsv
@@ -28,7 +28,7 @@ llm_allowed_models	legacy_dml
 llm_allowed_models_audit	append
 llm_catalog_sync_runs	append
 llm_model_prices	legacy_dml
-member_registration_credentials	legacy_dml
+member_registration_credentials	upsert
 notification_deliveries	legacy_dml
 oauth_grants	legacy_dml
 plugin_workload_sdk_grants	legacy_dml


### PR DESCRIPTION
Migration 0070 revoked runtime DELETE on `member_registration_credentials`, but the contract TSV still listed it as `legacy_dml` (expects DELETE) — so the migration-gate verification fails (`expected 0, got 1`). Reclassify to `upsert`, matching the monorepo. One-line data-file sync that #127 (script logic) missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)