### PR TITLE
test: auto-deploy proof #1 (OSS dev → infra apply)

### DIFF
--- a/nginx-egress-proxy/README.md
+++ b/nginx-egress-proxy/README.md
@@ -86,3 +86,5 @@ CI builds and publishes the image via
 into the deploy-time GCP Artifact Registry. There are no static manifests for
 this service: Deployments, ConfigMaps, and Services are created dynamically by
 host-context-controller — see its [README](../host-context-controller/README.md).
+
+<!-- auto-deploy proof: OSS dev → build → mirror → infra apply (2026-07-22) -->


### PR DESCRIPTION
First of two proof merges for Task 10: a single-service change (nginx-egress-proxy README) to verify a real OSS `dev` merge auto-deploys clerum-dev end to end (build → mirror → infra apply → notify). Safe doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)