### PR TITLE
feat: preserve chat context when opening desktop apps

### DIFF
--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evenfire",
-  "version": "0.1.312",
+  "version": "0.1.313",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evenfire",
-      "version": "0.1.312",
+      "version": "0.1.313",
       "license": "MPL-2.0",
       "dependencies": {
         "@tanstack/react-query": "5.100.10",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evenfire",
   "productName": "Evenfire",
-  "version": "0.1.312",
+  "version": "0.1.313",
   "private": true,
   "license": "MPL-2.0",
   "description": "Evenfire desktop client for secure agent and workflow access",

--- a/desktop-app/ui/src/App.tsx
+++ b/desktop-app/ui/src/App.tsx
@@ -26,6 +26,7 @@ import { ContextsPage } from '@pages/ContextsPage'
 import { FilesPage } from '@pages/FilesPage'
 import { McpServersPage } from '@pages/McpServersPage'
 import { SandboxUiPage } from '@pages/SandboxUiPage'
+import type { SandboxUiConversationOrigin } from '@pages/SandboxUiPage.types'
 import { SettingsPage } from '@pages/SettingsPage'
 import { TeamDetailsPage } from '@pages/TeamDetailsPage'
 import { TeamsPage } from '@pages/TeamsPage'
@@ -141,6 +142,8 @@ export function App() {
   const [activeSandboxUiApp, setActiveSandboxUiApp] = React.useState<ActiveSandboxUiApp | null>(
     null
   )
+  const [sandboxUiConversationOrigin, setSandboxUiConversationOrigin] =
+    React.useState<SandboxUiConversationOrigin | null>(null)
   const [sidebarSettingsMenuOpen, setSidebarSettingsMenuOpen] = React.useState(false)
   const [headerShellOverlayOpen, setHeaderShellOverlayOpen] = React.useState(false)
   const [headerNotificationTrayOpen, setHeaderNotificationTrayOpen] = React.useState(false)
@@ -155,6 +158,21 @@ export function App() {
     (vm.navItem === DESKTOP_ROUTES.chat && Boolean(vm.selectedAgent))
   const notificationTrayUsesDrawer = Boolean(activeSandboxUiApp)
   const appNotificationDrawerOpen = notificationTrayUsesDrawer && headerNotificationTrayOpen
+  const activeConversationOrigin = React.useMemo<SandboxUiConversationOrigin | null>(() => {
+    if (vm.navItem !== DESKTOP_ROUTES.chat || !vm.selectedAgent || !vm.activeChatId) {
+      return null
+    }
+    const conversation =
+      vm.chatList.find(chat => chat.id === vm.activeChatId) ??
+      vm.latestChatSessions.find(
+        chat => chat.agentRef === vm.selectedAgent && chat.id === vm.activeChatId
+      )
+    return {
+      agentName: vm.selectedAgent,
+      chatId: vm.activeChatId,
+      title: conversation?.title.trim() || 'Conversation',
+    }
+  }, [vm.activeChatId, vm.chatList, vm.latestChatSessions, vm.navItem, vm.selectedAgent])
 
   React.useEffect(() => {
     document.documentElement.setAttribute('data-theme', themeMode)
@@ -204,22 +222,35 @@ export function App() {
 
   const handleSandboxUiOpening = React.useCallback((app: ActiveSandboxUiApp) => {
     setActiveSandboxUiApp(app)
-    setSidebarCollapsed(true)
   }, [])
 
   const handleSandboxUiClosed = React.useCallback(() => {
     setActiveSandboxUiApp(null)
-    setSidebarCollapsed(false)
+    setSandboxUiConversationOrigin(null)
     setHeaderShellOverlayOpen(false)
     setSidebarSettingsMenuOpen(false)
   }, [])
 
   const handleSandboxUiRemoved = React.useCallback(() => {
     setActiveSandboxUiApp(null)
-    setSidebarCollapsed(false)
+    setSandboxUiConversationOrigin(null)
     setHeaderShellOverlayOpen(false)
     setSidebarSettingsMenuOpen(false)
   }, [])
+
+  const handleSandboxUiBackToConversation = React.useCallback(() => {
+    if (!sandboxUiConversationOrigin) return
+    const origin = sandboxUiConversationOrigin
+    setActiveSandboxUiApp(null)
+    setSandboxUiConversationOrigin(null)
+    setHeaderShellOverlayOpen(false)
+    setSidebarSettingsMenuOpen(false)
+    vm.handleSelectChatAgent(origin.agentName, {
+      selectLatest: false,
+      chatId: origin.chatId,
+      title: origin.title,
+    })
+  }, [sandboxUiConversationOrigin, vm.handleSelectChatAgent])
 
   React.useEffect(() => {
     setNotificationDrawerReady(false)
@@ -231,12 +262,12 @@ export function App() {
 
   const handleOpenSandboxUiApp = React.useCallback(
     (app: ActiveSandboxUiApp) => {
+      setSandboxUiConversationOrigin(activeConversationOrigin)
       setActiveSandboxUiApp(app)
       vm.handleNavSelect(DESKTOP_ROUTES.apps)
-      setSidebarCollapsed(true)
       setSandboxUiShortcutOpenRequestId(value => value + 1)
     },
-    [vm.handleNavSelect]
+    [activeConversationOrigin, vm.handleNavSelect]
   )
 
   React.useEffect(() => {
@@ -252,7 +283,7 @@ export function App() {
       event.preventDefault()
       if (activeSandboxUiApp) {
         setActiveSandboxUiApp(null)
-        setSidebarCollapsed(false)
+        setSandboxUiConversationOrigin(null)
       }
       setHeaderShellOverlayOpen(false)
       setSidebarSettingsMenuOpen(false)
@@ -687,11 +718,13 @@ export function App() {
                               {vm.navItem === DESKTOP_ROUTES.apps && (
                                 <SandboxUiPage
                                   boundsRefreshKey={sandboxUiBoundsRefreshKey}
+                                  conversationOrigin={sandboxUiConversationOrigin}
                                   headerShellOverlayOpen={headerShellOverlayOpen}
                                   sidebarShellOverlayOpen={sidebarSettingsMenuOpen}
                                   toastShellOverlayOpen={vm.toasts.length > 0}
                                   shortcutApp={activeSandboxUiApp}
                                   shortcutOpenRequestId={sandboxUiShortcutOpenRequestId}
+                                  onBackToConversation={handleSandboxUiBackToConversation}
                                   onEmbeddedAppOpening={handleSandboxUiOpening}
                                   onEmbeddedAppBack={handleSandboxUiClosed}
                                   onEmbeddedAppRemoved={handleSandboxUiRemoved}

--- a/desktop-app/ui/src/components/SidebarNav/icons.tsx
+++ b/desktop-app/ui/src/components/SidebarNav/icons.tsx
@@ -92,6 +92,16 @@ export function IconDownload(props: IconProps) {
   )
 }
 
+export function IconUpload(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...BASE_STROKE_PROPS} {...props}>
+      <path d="M12 21V9" />
+      <path d="m7 14 5-5 5 5" />
+      <path d="M5 3h14" />
+    </svg>
+  )
+}
+
 export function IconEdit(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true" {...BASE_STROKE_PROPS} {...props}>

--- a/desktop-app/ui/src/components/agents/ComposerPanel.tsx
+++ b/desktop-app/ui/src/components/agents/ComposerPanel.tsx
@@ -10,6 +10,7 @@ import {
   IconConnectors,
   IconContexts,
   IconPlus,
+  IconUpload,
   IconWorkflows,
 } from '@components/SidebarNav/icons'
 import {
@@ -649,7 +650,7 @@ export function ComposerPanel({ inline = false, agentSelector }: ComposerPanelPr
                       Global File System
                     </MenuItem>
                     <MenuItem
-                      leadingIcon={<IconAttachFile />}
+                      leadingIcon={<IconUpload />}
                       onClick={openUploadPicker}
                       role="menuitem"
                     >

--- a/desktop-app/ui/src/pages/SandboxUiPage.tsx
+++ b/desktop-app/ui/src/pages/SandboxUiPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Button, StatusBanner } from '@components/Common'
-import { IconClose, IconRefresh, IconSandboxUi } from '../components/SidebarNav/icons'
+import { IconChat, IconClose, IconRefresh, IconSandboxUi } from '../components/SidebarNav/icons'
 import { clickableRowProps } from '../lib/clickableRowProps'
 import type { SandboxUiPageProps } from './SandboxUiPage.types'
 
@@ -146,11 +146,13 @@ const APP_PAGE_SIZE = 6
 
 export function SandboxUiPage({
   boundsRefreshKey = 0,
+  conversationOrigin = null,
   headerShellOverlayOpen = false,
   sidebarShellOverlayOpen = false,
   toastShellOverlayOpen = false,
   shortcutApp = null,
   shortcutOpenRequestId = 0,
+  onBackToConversation,
   onEmbeddedAppOpening,
   onEmbeddedAppBack,
   onEmbeddedAppRemoved,
@@ -297,6 +299,12 @@ export function SandboxUiPage({
     onEmbeddedAppBack?.()
   }, [closeEmbed, onEmbeddedAppBack])
 
+  const handleBackToConversation = useCallback(async () => {
+    if (!conversationOrigin || !onBackToConversation) return
+    await closeEmbed()
+    onBackToConversation()
+  }, [closeEmbed, conversationOrigin, onBackToConversation])
+
   // In-place hard-reload of the embedded app — fetches freshly-arrived
   // server data (e.g. new inbox items) without tearing the view down, so the
   // user no longer has to navigate away and back to see updates.
@@ -384,6 +392,20 @@ export function SandboxUiPage({
     return (
       <section className="page">
         <div className="sandbox-ui-mounted-header">
+          {conversationOrigin && onBackToConversation ? (
+            <Button
+              color="neutral"
+              variant="soft"
+              size="sm"
+              className="sandbox-ui-conversation-btn"
+              aria-label={`Back to ${conversationOrigin.title}`}
+              title={`Back to ${conversationOrigin.title}`}
+              onClick={() => void handleBackToConversation()}
+            >
+              <IconChat />
+              <span>Back to {conversationOrigin.title}</span>
+            </Button>
+          ) : null}
           <Button
             color="neutral"
             variant="soft"

--- a/desktop-app/ui/src/pages/SandboxUiPage.types.ts
+++ b/desktop-app/ui/src/pages/SandboxUiPage.types.ts
@@ -1,12 +1,20 @@
 import type { ActiveSandboxUiApp } from '@/uiTypes'
 
+export type SandboxUiConversationOrigin = {
+  agentName: string
+  chatId: string
+  title: string
+}
+
 export type SandboxUiPageProps = {
   boundsRefreshKey?: string | number
+  conversationOrigin?: SandboxUiConversationOrigin | null
   headerShellOverlayOpen?: boolean
   sidebarShellOverlayOpen?: boolean
   toastShellOverlayOpen?: boolean
   shortcutApp?: ActiveSandboxUiApp | null
   shortcutOpenRequestId?: number
+  onBackToConversation?: () => void
   onEmbeddedAppOpening?: (app: ActiveSandboxUiApp) => void
   onEmbeddedAppBack?: () => void
   onEmbeddedAppRemoved?: () => void

--- a/desktop-app/ui/src/pages/__tests__/SandboxUiPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/SandboxUiPage.test.tsx
@@ -147,6 +147,44 @@ describe('SandboxUiPage', () => {
       })
     })
     expect(await screen.findByRole('button', { name: 'Back to apps' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /^Back to .+ planning$/ })).toBeNull()
+  })
+
+  it('returns to the originating conversation from an app', async () => {
+    sandboxUi.listApps.mockResolvedValueOnce({
+      apps: [
+        {
+          appRef: 'sandbox-recipes/sales-crm',
+          title: "Andy's Sales CRM",
+          defaultPath: '/',
+          ready: true,
+          phase: 'active',
+          updatedAt: null,
+        },
+      ],
+    })
+    sandboxUi.open.mockResolvedValueOnce(undefined)
+    sandboxUi.close.mockResolvedValueOnce(undefined)
+    const onBackToConversation = vi.fn()
+
+    render(
+      <SandboxUiPage
+        conversationOrigin={{
+          agentName: 'sales-agent',
+          chatId: 'chat-123',
+          title: 'Quarterly planning',
+        }}
+        onBackToConversation={onBackToConversation}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: "Open Andy's Sales CRM" }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Back to Quarterly planning' }))
+
+    await waitFor(() => {
+      expect(sandboxUi.close).toHaveBeenCalledTimes(1)
+      expect(onBackToConversation).toHaveBeenCalledTimes(1)
+    })
   })
 
   it('reports when resized embedded app bounds are applied', async () => {

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -12257,6 +12257,7 @@ pre {
   padding-right: 360px;
 }
 
+.sandbox-ui-conversation-btn,
 .sandbox-ui-close-btn,
 .sandbox-ui-refresh-btn {
   display: inline-flex;
@@ -12268,6 +12269,18 @@ pre {
   background: rgba(var(--panel-rgb), 0.95);
 }
 
+.sandbox-ui-conversation-btn {
+  min-width: 0;
+  max-width: min(360px, 45vw);
+}
+
+.sandbox-ui-conversation-btn span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sandbox-ui-conversation-btn svg,
 .sandbox-ui-close-btn svg,
 .sandbox-ui-refresh-btn svg {
   width: 16px;


### PR DESCRIPTION
## What changed
- Replaces the composer Upload Files paperclip with an upward upload arrow.
- Keeps sidebar compaction entirely user-controlled when opening and closing apps.
- Shows a return-to-conversation button only when an app was launched from an active chat.
- Restores the exact agent and conversation when that button is selected.
- Truncates long conversation names visually while preserving the accessible label.
- Adds coverage for app launches with and without conversation context.

## Why

Opening an embedded app from a conversation should preserve enough navigation context to return
to that exact chat, without changing the user's sidebar preference.

## Impact

The change is limited to the Desktop App UI. The repository hook also advances the Desktop App
version from 0.1.312 to 0.1.313.

## Validation

- Targeted Sandbox UI and Sidebar tests: 16 tests passed.
- Desktop App TypeScript and production builds passed.
- Strict repository style rules passed.
- Prettier and diff checks passed.
