### PR TITLE
ci(build-publish): least-privilege token + pin third-party action (H4 hardening)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -29,9 +29,11 @@ on:
         type: boolean
         default: false
 
+# Least-privilege default: only build-push needs to write packages. detect (runs
+# the third-party paths-filter action) and notify-infra get read-only, so a
+# compromised action in those jobs cannot push images to ghcr.
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -93,7 +95,9 @@ jobs:
       - name: Detect changed paths
         id: filter
         if: steps.base.outputs.force_all != 'true'
-        uses: dorny/paths-filter@v4
+        # SHA-pinned (v4): third-party, individual-maintainer action — pin so a
+        # hijacked tag can't run arbitrary code in a job that has repo write.
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         with:
           base: ${{ github.event.before }}
           filters: |
@@ -158,6 +162,9 @@ jobs:
     name: Build & push (${{ matrix.image }})
     runs-on: ubuntu-latest
     needs: detect
+    permissions:
+      contents: read
+      packages: write
     # Gate at step level: the `matrix` context is not available in a job-level
     # `if`, so each step checks whether this image changed (or a full build was
     # requested). Unchanged images spin an empty job and exit fast.


### PR DESCRIPTION
## What

Two supply-chain hardening changes to `build-publish.yml` (finding **H4** from the OSS-triggered-deploy spec review):

1. **Least-privilege token.** `packages: write` moves from workflow level to the **`build-push` job only**; the workflow default is now `contents: read`. Verified safe: only `build-push` uses `docker/login` + `build-push-action`; `detect` (which runs the third-party `dorny/paths-filter`) and `notify-infra` (`download-artifact` + a PAT-based dispatch) need read-only. Today the paths-filter action runs in a job holding a ghcr-push token it never uses — this removes that blast radius.
2. **Pin the third-party action.** `dorny/paths-filter@v4` → SHA-pinned (`7b450ff`, = v4). Individual-maintainer action → pin so a hijacked tag can't run arbitrary code in a job with repo access.

## Why

`build-publish` is becoming the prod image source under the deploy cutover; a poisoned build pushes images the mirror then copies digest-identically into Artifact Registry. Repo Actions policy is `allowed_actions: all` / `sha_pinning_required: false`, so nothing enforces pinning yet — this is the highest-risk action pinned by hand.

## Not behavior-changing

Same action versions, same push behavior. `build-push` retains `packages: write`.

## Follow-ups (not this PR)

- Flip repo/org `sha_pinning_required: true` once all workflows are pinned (enforces pinning everywhere at once).
- The other H-items (dispatch payload validation H1, infra protection H2, ruleset H3) are settings/design changes tracked in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)