### PR TITLE
ci: sha-pin actions on main (match dev #139 under pin enforcement)

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -65,7 +65,7 @@ jobs:
       webhook-gateway: ${{ steps.filter.outputs.webhook-gateway }}
       webhook-proxy: ${{ steps.filter.outputs.webhook-proxy }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
       - name: Detect changed paths
         id: filter
         if: steps.base.outputs.force_all != 'true'
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         with:
           base: ${{ github.event.before }}
           filters: |
@@ -263,20 +263,20 @@ jobs:
             path: webhook-proxy
             changed: ${{ needs.detect.outputs.webhook-proxy }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
 
       - name: Set up QEMU
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to ghcr.io
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -308,7 +308,7 @@ jobs:
 
       - name: Build and push
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ steps.buildargs.outputs.context }}
           file: ${{ steps.buildargs.outputs.file }}
@@ -329,7 +329,7 @@ jobs:
 
       - name: Upload built-image marker
         if: ${{ matrix.changed == 'true' || needs.detect.outputs.force_all == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: built-${{ matrix.image }}
           path: /tmp/built/${{ matrix.image }}
@@ -347,7 +347,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.build_all }}
     steps:
       - name: Collect built-image markers
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/built
           pattern: built-*

--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -10,7 +10,7 @@ jobs:
     name: Repo hygiene (no internal working artifacts)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: No superpowers docs may be tracked
         # docs/superpowers/ holds per-developer working artifacts (brainstorm
         # specs, implementation plans) that are gitignored by convention. The
@@ -66,9 +66,9 @@ jobs:
           - packages/workflow-sdk
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,16 +47,16 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: javascript-typescript
           build-mode: none
           queries: security-and-quality
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: '/language:javascript-typescript'


### PR DESCRIPTION
## Why now

`sha_pinning_required` was just enabled repo-wide. **#139 pinned `dev`; `main` was still unpinned.** CodeQL runs on `main` via **push, PR-to-main, and a weekly Monday schedule**, and `ci-public` runs on push to `main` — so under the live enforcement, the next scheduled CodeQL run (and any push/PR to main) would **fail** until main's workflows are pinned.

## What

Pins the same first-party actions (`actions/*`, `docker/*`, `github/codeql-action`) + `dorny/paths-filter` on `main` to the **same SHAs as dev #139**. No behavior change; same versions.

## Note

This PR's own checks pass enforcement because `pull_request` runs on the merge-result (base + this branch), which is fully pinned. Once merged, main is compliant and the next `dev→main` promotion stays a no-op on these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)