### PR TITLE
fix(hcc): raise proxy_ssl_verify_depth so cross-signed root chains verify

### DIFF
--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.154",
+      "version": "0.1.155",
       "license": "MIT",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/__tests__/reconciler.remote.test.ts
+++ b/host-context-controller/src/__tests__/reconciler.remote.test.ts
@@ -298,6 +298,23 @@ describe('McpServerReconciler remote egress proxy', () => {
       expect(conf).toContain('proxy_ssl_verify on')
     })
 
+    // nginx defaults proxy_ssl_verify_depth to 1, which only admits chains with a
+    // single untrusted intermediate. Upstreams mid-root-rollover (Let's Encrypt
+    // "Root YE"/"Root YR", "Microsoft TLS ECC Root G2") serve a chain that reaches
+    // a trusted anchor via a cross-signed root — two untrusted intermediates — and
+    // nginx rejects them with "(20:unable to get local issuer certificate)" even
+    // though the CA bundle is complete. Verified against real upstreams: without
+    // this directive mcp.postman.com / api.firecrawl.dev / learn.microsoft.com all
+    // fail the handshake; with it they connect while verification stays on.
+    it('should raise proxy_ssl_verify_depth to admit cross-signed root chains', () => {
+      const cm = (reconciler as any).buildNginxConfigMap(REMOTE_SERVER)
+      const conf = cm.data['default.conf.template']
+
+      const match = conf.match(/proxy_ssl_verify_depth\s+(\d+);/)
+      expect(match).not.toBeNull()
+      expect(Number(match![1])).toBeGreaterThanOrEqual(3)
+    })
+
     it('should include a /health endpoint returning 200', () => {
       const cm = (reconciler as any).buildNginxConfigMap(REMOTE_SERVER)
       const conf = cm.data['default.conf.template']

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -389,6 +389,16 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
         proxy_ssl_verify on;
         proxy_ssl_server_name on;
         proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+        # nginx defaults proxy_ssl_verify_depth to 1, which only admits a chain
+        # with a single untrusted intermediate. CAs mid-root-rollover serve a
+        # chain that reaches a trusted anchor through a cross-signed root, so the
+        # leaf sits two intermediates below the trust store: Let's Encrypt via
+        # "Root YE"/"Root YR" (cross-signed by ISRG Root X2/X1) and Microsoft via
+        # "Microsoft TLS ECC Root G2" (cross-signed by MS ECC Root 2017). At depth
+        # 1 nginx rejects those with "(20:unable to get local issuer certificate)"
+        # even though the CA bundle is complete — it looks like a missing root but
+        # is purely the depth cap. Raising the depth keeps verification fully on.
+        proxy_ssl_verify_depth 3;
     }
 
     # Health check endpoint


### PR DESCRIPTION
## Summary

Remote MCP servers backed by the nginx egress proxy failed the upstream TLS handshake for several popular recipes (Postman, Firecrawl, Microsoft Learn, and others), returning `502` with:

```
upstream SSL certificate verify error: (20:unable to get local issuer certificate)
while SSL handshaking to upstream
```

The fix is one directive. Certificate verification stays **fully on**.

```nginx
proxy_ssl_verify on;
proxy_ssl_server_name on;
proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
proxy_ssl_verify_depth 3;   # <-- added
```

## Root cause

nginx defaults [`proxy_ssl_verify_depth`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_verify_depth) to **1**, which admits only a chain containing a *single* untrusted intermediate. We never set it, so we inherited that default.

Several major CAs are currently mid-root-rollover. They issue from a brand-new root that is not yet in any shipped CA bundle, and make it chain to a trusted anchor by cross-signing it with their previous root. That puts the leaf **two** untrusted intermediates below the trust anchor instead of one.

The decisive clue was that some upstreams worked and others didn't, under identical config and an identical CA bundle:

| upstream | chain terminates in | in the image's 145-root bundle? | untrusted intermediates | result |
|---|---|---|---|---|
| `api.exa.ai` | `GTS Root R4` | present | 1 | works |
| `mcp.postman.com` | `ISRG Root YE` | missing, cross-signed by `ISRG Root X2` (present) | 2 | fails |
| `api.firecrawl.dev` | `ISRG Root YR` | missing, cross-signed by `ISRG Root X1` (present) | 2 | fails |
| `learn.microsoft.com` | `Microsoft TLS ECC Root G2` | missing, cross-signed by `MS ECC Root 2017` (present) | 2 | fails |

At depth 1 nginx stops walking the chain before it reaches the anchor and reports error 20. That error string means "I ran out of places to look", so it reads exactly like a missing root or a missing intermediate, which is what makes this one deceptive: **the CA bundle is complete and the upstreams send complete chains.** The cap is the only thing wrong.

`openssl s_client` verifies all four of these hosts against the very same bundle, because its verification depth is effectively uncapped. That divergence between `openssl` succeeding and nginx failing is the fingerprint of this bug.

## Two theories that were ruled out

Recording these so nobody burns time re-testing them:

- **"nginx doesn't fetch the intermediate the upstream omits (no AIA fetching)."** Refuted: all four upstreams send complete chains (3–4 certs). Nothing is missing, so there is nothing to fetch.
- **"The CA bundle in the image is incomplete/stale."** Refuted: 145 roots, present and readable at `/etc/ssl/certs/ca-certificates.crt`, and `openssl` verifies all four hosts against that exact file extracted from the image.

SNI was also cleared — these hosts verify with and without it, and `proxy_ssl_server_name on` was already set.

## Why not an "insecure skip verify" CRD flag

An earlier pass at this proposed adding `spec.remote.insecureSkipUpstreamTlsVerify` to the CRD and templating `proxy_ssl_verify` off per server. That was designed against the missing-intermediate theory. It should not be built:

- It ships a permanent TLS-disabling escape hatch, and pushes the decision to disable TLS verification onto recipe authors.
- It isn't reachable anyway — these upstreams verify correctly once the depth is right.
- It would have masked the real bug for every recipe, not just these.

## Verification

Reproduced and verified against the real image (`nginx:1.30.1-alpine` via `nginx-egress-proxy/Dockerfile`) using the config emitted by the actual `buildNginxConfigMap()`, against live upstreams.

| upstream | before | after |
|---|---|---|
| `mcp.postman.com` | 502 TLS failure | `401` (upstream auth, no credentials supplied) |
| `api.firecrawl.dev` | 502 TLS failure | `404` (upstream path) |
| `learn.microsoft.com` | 502 TLS failure | **`200` — full MCP `initialize` handshake** |
| `api.exa.ai` | `404` | `404` (unchanged, was never affected) |

Certificate verify errors in the nginx log: **0**.

The Microsoft Learn response is a genuine MCP session through the proxy, not just a completed handshake:

```
event: message
data: {"result":{"protocolVersion":"2024-11-05","capabilities":{...},
       "serverInfo":{"name":"Microsoft Learn MCP Server","version":"1.0.0"}, ...
```

Test suite: **924/924 passing**, including a new regression test asserting the generated config sets a depth of at least 3.

## Why 3

Observed worst case today is 2. Depth 3 leaves one hop of headroom for the next CA transition without meaningfully weakening anything — every certificate must still chain to a root in the trust store and pass full validation. The depth cap is a chain-length bound, not the security control; `proxy_ssl_verify on` plus the trust store is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
