### PR TITLE
fix(control-api): restore member-registration revoke migration

### DIFF
--- a/control-api/src/db.ts
+++ b/control-api/src/db.ts
@@ -4747,6 +4747,18 @@ export const CONTROL_API_MIGRATIONS: DbMigration[] = [
       `)
     },
   },
+  {
+    version: '0070_member_registration_runtime_delete_revoke',
+    apply: async db => {
+      // 0069 granted DELETE to the runtime role. Credential revocation is an
+      // UPDATE, so remove the unnecessary destructive privilege without
+      // rewriting a migration that may already be recorded in deployed DBs.
+      await db.query(`
+        REVOKE DELETE ON TABLE member_registration_credentials
+          FROM control_api_runtime;
+      `)
+    },
+  },
 ]
 
 async function consolidateWorkflowAllowedUsersToTriggers(db: DbClient): Promise<void> {

--- a/control-api/test/db.ready.test.ts
+++ b/control-api/test/db.ready.test.ts
@@ -7,7 +7,7 @@ describe('assertDbReady', () => {
 
     await expect(assertDbReady({ query })).resolves.toBeUndefined()
     expect(query).toHaveBeenCalledWith(expect.stringContaining('schema_migrations'), [
-      '0069_member_registration_runtime_access',
+      '0070_member_registration_runtime_delete_revoke',
     ])
   })
 
@@ -15,7 +15,7 @@ describe('assertDbReady', () => {
     const query = vi.fn().mockResolvedValue({ rows: [{ ready: false }], rowCount: 1 })
 
     await expect(assertDbReady({ query })).rejects.toThrow(
-      'migration 0069_member_registration_runtime_access is required'
+      'migration 0070_member_registration_runtime_delete_revoke is required'
     )
   })
 })

--- a/control-api/test/db.runtimeAccessMigrations.test.ts
+++ b/control-api/test/db.runtimeAccessMigrations.test.ts
@@ -38,4 +38,20 @@ describe('runtime access migrations', () => {
       'GRANT USAGE, SELECT ON SEQUENCE member_registration_credentials_id_seq'
     )
   })
+
+  it('0070 revokes DELETE while retaining the control-api runtime table boundary', async () => {
+    const { initDb } = await import('../src/db.js')
+    await initDb()
+
+    const sqls = clientQuery.mock.calls.map(([sql]) => String(sql))
+    const deleteRevocation = sqls.find(sql =>
+      sql.includes('REVOKE DELETE ON TABLE member_registration_credentials')
+    )
+    const recordedVersions = clientQuery.mock.calls
+      .filter(([sql]) => String(sql).includes('INSERT INTO schema_migrations'))
+      .map(([, params]) => (Array.isArray(params) ? params[0] : undefined))
+
+    expect(deleteRevocation).toContain('FROM control_api_runtime')
+    expect(recordedVersions).toContain('0070_member_registration_runtime_delete_revoke')
+  })
 })


### PR DESCRIPTION
## Summary
- restore migration 0070 required by the public database bootstrap verifier
- revoke obsolete DELETE access for the control-api runtime role while preserving its credential-revocation UPDATE capability
- align database readiness and runtime-access migration coverage with the required schema version

## Validation
- focused migration/readiness tests: 5 passed
- full control-api test suite and production build: passed
- clean dedicated minikube profile: migration job succeeded; all services report OK; no unhealthy pods

Fixes #150