### PR TITLE
ci(claude): add @claude on-demand responder

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,55 @@
+name: Claude Code
+
+# On-demand Claude, triggered by an @claude mention in an issue, a PR comment,
+# or a PR review. Contributors comment "@claude ..." on a PR to request a review
+# or ask Claude to make a change. There is no automatic review on every PR.
+#
+# Mirrors keyper-labs/evenfire (the private repo); the only deltas are the
+# SHA-pinned actions required by this repo's action-pinning policy.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If not specified, Claude
+          # follows the instructions in the comment that tagged it.
+          # prompt: 'Review this PR for correctness, security, and tests.'
+
+          # Optional: customize behavior via claude_args
+          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
## What

Brings the `@claude` on-demand responder to `main` (already on `dev` via #162). Contributors comment `@claude ...` on a PR or issue to request a review or a change. **No automatic per-PR review** — matches the private repo (`keyper-labs/evenfire`, which has only `claude.yml`).

Single new file: `.github/workflows/claude.yml`, byte-identical to what merged to `dev`. Mirrors the private repo's known-good config (least-privilege read perms; Claude posts as the installed Claude GitHub App via OIDC `id-token: write`), with actions SHA-pinned per this repo's enforced action-pinning policy.

## Required before it works

No org-level secret exists; set a repo secret:

\`\`\`
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo evenfire-ai/evenfire
\`\`\`

Without it, `@claude` silently no-ops (green run, no reply).

## Note (public repo)

`@claude` is triggerable by anyone who can comment, so any GitHub user could invoke it and consume the token quota. Left ungated per the goal of contributor availability; gate on `github.event.comment.author_association` if abused.

## Relationship to dev→main promotion

This is a targeted single-file PR so `main` gets the responder now without waiting for a full dev→main promotion. Content is identical to `dev`, so a later promotion merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)