### PR TITLE
fix(control-api): add 0070 migration revoking runtime DELETE on membe…

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.365",
+  "version": "0.1.366",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.365",
+      "version": "0.1.366",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.365",
+  "version": "0.1.366",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/db.ts
+++ b/control-api/src/db.ts
@@ -4747,6 +4747,19 @@ export const CONTROL_API_MIGRATIONS: DbMigration[] = [
       `)
     },
   },
+  {
+    version: '0070_member_registration_runtime_delete_revoke',
+    apply: async db => {
+      // 0069 granted control_api_runtime full DML (incl. DELETE) on
+      // member_registration_credentials. The runtime access contract classifies
+      // this table as `upsert` (SELECT/INSERT/UPDATE only), so revoke DELETE to
+      // match. Idempotent: REVOKE of an already-absent privilege is a no-op.
+      await db.query(`
+        REVOKE DELETE ON TABLE member_registration_credentials
+          FROM control_api_runtime;
+      `)
+    },
+  },
 ]
 
 async function consolidateWorkflowAllowedUsersToTriggers(db: DbClient): Promise<void> {


### PR DESCRIPTION
…r_registration_credentials

Migration 0069 grants control_api_runtime full DML (incl. DELETE) on member_registration_credentials, but the runtime access contract classifies the table as `upsert` (SELECT/INSERT/UPDATE only). Without this follow-up, the minikube migration gate fails verifying that the 0070 delete-revoke migration was recorded, blocking `make minikube-setup`.

Idempotent: REVOKE of an already-absent privilege is a no-op.

## Summary

## Testing

- [ ] `npm test` passes for changed services
- [ ] `npx tsc --noEmit` clean

## Checklist

- [ ] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)
