### PR TITLE
ci(codeql): scan dev PRs and pushes; add manual re-run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,17 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    # dev is the integration branch where feature PRs land first; without it,
+    # code merged to dev goes unscanned until it reaches main, and PRs targeting
+    # dev never get a CodeQL run at all (their alerts freeze the moment a PR is
+    # retargeted away from main).
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
+  # Manual re-run: lets a maintainer re-scan a branch after a fix without
+  # waiting for the weekly schedule (e.g. to clear an alert whose PR was
+  # retargeted from main to dev mid-review).
+  workflow_dispatch:
   schedule:
     # Weekly, so newly-published CodeQL queries reach the default branch even in
     # a quiet week. Monday 07:00 UTC.


### PR DESCRIPTION
## Why

CodeQL only triggered on `main` (`push` + `pull_request: branches:[main]`), but `dev` is the integration branch where feature PRs land first. Two consequences:

- **PRs targeting `dev` never got a CodeQL run at all** — no SAST gate on the integration branch.
- An alert raised while a PR briefly pointed at `main` (e.g. after a `dev`→`main` promotion auto-retargeted it) **freezes as `open`** once the PR is pointed back at `dev`, because no new CodeQL run re-evaluates the fix. This currently blocks PR #158: its rate-limiting fix is committed (`f2dfeb080`), but CodeQL cannot re-scan it while the PR targets `dev`.

## What

- Add `dev` to the `push` and `pull_request` branch filters so the integration branch is scanned.
- Add `workflow_dispatch` so a maintainer can re-run the scan on demand instead of waiting for the Monday schedule.

## After merge

A new commit / re-sync on a `dev`-targeting PR (e.g. #158) triggers CodeQL against the current head, closing alerts whose fixes are already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
