### PR TITLE
docs(security): replace placeholder reporting address with security@evenfire.ai

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,20 +7,21 @@ system. Please help us keep operators and end users safe.
 
 **Do not open a public GitHub issue for security reports.**
 
-Prefer, in order:
+Use either channel. Both reach the core maintainers.
 
-1. **GitHub Private Vulnerability Reporting** on this repository (Security →
-   Advisories / “Report a vulnerability”), if enabled for the repo.
-2. **Email:** `security@example.com`  
-   Include a clear description, impact, affected components/versions, and
-   reproduction steps when possible. Encrypt sensitive attachments if you can.
+1. **GitHub Private Vulnerability Reporting** (preferred):
+   [open a private report](https://github.com/evenfire-ai/evenfire/security/advisories/new).
+   It is enabled on this repository, keeps the report private until we publish
+   an advisory, and gives you a thread to track the fix.
+2. **Email:** `security@evenfire.ai`
+
+Include a clear description, impact, affected components/versions, and
+reproduction steps when possible. Encrypt sensitive attachments if you can.
 
 We aim to **acknowledge within 3 business days** and to keep you informed of
 the fix timeline. Please give us a reasonable window before any public
-disclosure.
-
-If `security@example.com` is unreachable, reach the core maintainers / GitHub
-org owners via a private channel (see [GOVERNANCE.md](GOVERNANCE.md)).
+disclosure. If you have had no acknowledgement after 3 business days, follow up
+on the other channel before considering public disclosure.
 
 ## Supported versions
 


### PR DESCRIPTION
Fixes #174

## Problem

`SECURITY.md` told reporters to email `security@example.com`. `example.com` is IANA-reserved for documentation and cannot receive mail, so the repository had no working vulnerability reporting channel. The other two paths were no better:

- Private Vulnerability Reporting was hedged as "if enabled for the repo", so a reporter could not tell whether it would work.
- The fallback pointed at `GOVERNANCE.md` for "a private channel", but `GOVERNANCE.md` lists no contact details at all.

A good-faith reporter following the policy either sent the report into a void or fell back to opening a public issue, which is the exact outcome the policy exists to prevent.

## Change

`SECURITY.md` only. Every other doc (`README.md`, `ARCHITECTURE.md`, `docs/faq.md`, `docs/README.md`, `docs/deploy/production.md`, `docs/get-started/learning-path.md`, `docs/how-to/member-invitations-self-hosted.md`) just links here, so the fix is contained.

- Email channel now points at `security@evenfire.ai`.
- Private Vulnerability Reporting promoted to the unconditional primary channel, with a direct link to the report form.
- Dead `GOVERNANCE.md` fallback replaced with a concrete escalation: no acknowledgement after 3 business days, follow up on the other channel.

## Verification

- PVR is actually enabled: `GET /repos/evenfire-ai/evenfire/private-vulnerability-reporting` returns `{"enabled":true}`.
- `evenfire.ai` has live Google Workspace MX records (`aspmx.l.google.com` and alts), so the domain accepts mail.

## Still open for a human

The 3-business-day acknowledgement SLA is unchanged, per point 3 of the issue. That is a commitment about who is watching the inbox, not something a doc edit can establish. Two things to confirm before this merges:

1. `security@evenfire.ai` exists as a mailbox or group and is routed to someone (the MX records prove the domain accepts mail, not that this address resolves).
2. Someone is on the hook for the 3-day acknowledgement on both channels. `GOVERNANCE.md` says maintainers triage weekly, which is slower than what this policy promises.

Also adjacent and deliberately out of scope: `CODE_OF_CONDUCT.md:40` still points at `conduct@example.com`, the same class of bug. Worth a follow-up issue once the right address is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)