### PR TITLE
fix(deploy): extend HCC post-overlay rollout timeout

### DIFF
--- a/deploy/scripts/provision-gfs-runtime.sh
+++ b/deploy/scripts/provision-gfs-runtime.sh
@@ -173,7 +173,7 @@ finalize_credentials_after_overlay() {
   fi
 
   log "Waiting for the post-overlay HCC rollout"
-  kctl -n control-plane rollout status deployment/host-context-controller --timeout=240s
+  kctl -n control-plane rollout status deployment/host-context-controller --timeout=480s
   wait_for_gfsc_secret_references
 
   log "Finalizing staged GFS credentials after the overlay"

--- a/scripts/tests/test-provision-gfs-runtime.sh
+++ b/scripts/tests/test-provision-gfs-runtime.sh
@@ -48,8 +48,8 @@ reconcile="$ROOT/deploy/scripts/reconcile-gfs-deploy-credentials.sh"
   echo 'FAIL: post-overlay credential reconciliation did not run once per deploy' >&2
   exit 1
 }
-[ "$(grep -Fc 'rollout status deployment/host-context-controller --timeout=240s' "$CALL_LOG")" -eq 3 ] || {
-  echo 'FAIL: HCC was not awaited before every post-overlay reconciliation' >&2
+[ "$(grep -Fc 'rollout status deployment/host-context-controller --timeout=480s' "$CALL_LOG")" -eq 3 ] || {
+  echo 'FAIL: HCC post-overlay rollout did not use its dedicated 480s timeout' >&2
   exit 1
 }
 for deployment in gfsc-writer gfsc-reader; do


### PR DESCRIPTION
## Summary
- Extend the post-overlay `host-context-controller` rollout timeout from 240s to 480s.
- Preserve the 240s rollout timeouts for `gfsc-writer` and `gfsc-reader`.
- Lock the distinct timeout contract in the focused runtime provisioning test.

## Validation
- `bash -n deploy/scripts/provision-gfs-runtime.sh`
- `bash scripts/tests/test-provision-gfs-runtime.sh`
- `git diff --check`

## Scope
This is the controlled step 1 mitigation only. It does not change HCC readiness, `provider.start()`, MCP-server reconciliation, NetworkPolicies, CRDs, or GlobalFileSystem behavior.