### PR TITLE
feat(control-api): auto-claim the registry's one-time token instead of discarding it

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.367",
+  "version": "0.1.368",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.367",
+      "version": "0.1.368",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.373",
+  "version": "0.1.374",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.373",
+      "version": "0.1.374",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.368",
+  "version": "0.1.369",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.368",
+      "version": "0.1.369",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.374",
+  "version": "0.1.375",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.374",
+      "version": "0.1.375",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.375",
+  "version": "0.1.376",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.375",
+      "version": "0.1.376",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.370",
+  "version": "0.1.371",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.370",
+      "version": "0.1.371",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.372",
+      "version": "0.1.373",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.371",
+  "version": "0.1.372",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.371",
+      "version": "0.1.372",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.369",
+  "version": "0.1.370",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.369",
+      "version": "0.1.370",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.375",
+  "version": "0.1.376",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.371",
+  "version": "0.1.372",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.369",
+  "version": "0.1.370",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.368",
+  "version": "0.1.369",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.373",
+  "version": "0.1.374",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.370",
+  "version": "0.1.371",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.374",
+  "version": "0.1.375",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.367",
+  "version": "0.1.368",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from 'express'
 import { generateKeyPairSync } from 'node:crypto'
 import { config } from '../../config.js'
 import { type UiAuthedRequest, requireAuthForControlUI } from '../../middleware/controlUIAuth.js'
+import { rateLimitMiddleware } from '../../middleware/rateLimitMiddleware.js'
 import { rootLogger } from '../../observability/logger.js'
 import { findAdminById } from '../../services/adminAuthService.js'
 import {
@@ -506,6 +507,20 @@ export function createRegistryConnectRouter(): Router {
   router.post(
     '/admin/registry/connect/recover',
     requireAuthForControlUI,
+    // Per-admin token bucket — every call here rotates the deployment's
+    // one-time claim token at the shared registry (/:id/claim-token), which
+    // has no rate limiter of its own and emits a
+    // deployment.claim_token_reissued audit event on each rotate. 10/min is
+    // generous for a human-pressed recovery button while bounding registry
+    // rotate/audit spam from a looped admin.
+    rateLimitMiddleware({
+      bucketType: 'registry_connect_recover',
+      maxPerMinute: 10,
+      getBucketKey: req => {
+        const sub = (req as UiAuthedRequest).adminAuth?.sub
+        return sub ? `registry_connect_recover:${sub}` : null
+      },
+    }),
     async (req, res, next) => {
       try {
         const ctx = await requireSelfHostedAdmin(req, res)

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -257,6 +257,7 @@ export function createRegistryConnectRouter(): Router {
         org: string
       }
       await markConnected({
+        deploymentId: row.deploymentId,
         clientId: claimed.client_id,
         clientSecret: claimed.client_secret,
         orgName: claimed.org,

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -26,9 +26,99 @@ import { signPop } from '../../services/registryPopSigner.js'
  * status endpoint so operator approval is visible before the user claims —
  * matching the register → poll status → claim flow.
  */
+/** Bound every registry hop (registryClient.ts convention). */
+const REGISTRY_FETCH_TIMEOUT_MS = 10_000
+
 export function createRegistryConnectRouter(): Router {
   const router = Router()
   const base = (): string => `${config.registryUrl}/api/v1/deployments`
+
+  type ClaimOutcome =
+    | { kind: 'connected'; org: string }
+    | { kind: 'expired' }
+    | { kind: 'rejected' }
+    | { kind: 'already_claimed' }
+    | { kind: 'client_unavailable' }
+    | { kind: 'superseded' }
+    | { kind: 'unreachable'; err: unknown }
+    | { kind: 'error'; status: number }
+
+  // Single claim implementation shared by the manual paste route and the
+  // auto-claim path. EXCEPTION-TOTAL: markConnected encrypts and writes to
+  // Postgres AFTER the registry has already burned the one-time secret, so a
+  // throw here must be a value the caller can act on, never an unhandled 500.
+  async function redeemClaim(input: {
+    deploymentId: string
+    keyId: string
+    privateKeyPem: string
+    adminId: string
+    claimToken: string
+  }): Promise<ClaimOutcome> {
+    try {
+      const pop = signPop({
+        privateKeyPem: input.privateKeyPem,
+        sub: input.adminId,
+        kid: input.keyId,
+      })
+      const claimRes = await fetch(`${base()}/claim`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', DPoP: pop },
+        body: JSON.stringify({ claim_token: input.claimToken }),
+        signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+      })
+      if (claimRes.status === 410) return { kind: 'expired' }
+      // The registry returns 401 for both invalid_pop and invalid_claim_token;
+      // both mean the same to the operator — the claim was rejected.
+      if (claimRes.status === 401) return { kind: 'rejected' }
+      if (claimRes.status === 409) {
+        const err = await readErrorCode(claimRes)
+        return err === 'client_unavailable'
+          ? { kind: 'client_unavailable' }
+          : { kind: 'already_claimed' }
+      }
+      if (!claimRes.ok) {
+        rootLogger.error(
+          { event: 'registry_connect_claim_failed', status: claimRes.status },
+          'claim failed'
+        )
+        return { kind: 'error', status: claimRes.status }
+      }
+      const claimed = (await claimRes.json()) as {
+        client_id?: unknown
+        client_secret?: unknown
+        org?: unknown
+      }
+      // A hostile or mis-proxied registry must produce a clean outcome, not a
+      // Buffer.from(null) crash inside the encryption path.
+      if (
+        typeof claimed.client_id !== 'string' ||
+        typeof claimed.client_secret !== 'string' ||
+        typeof claimed.org !== 'string'
+      ) {
+        rootLogger.error(
+          { event: 'registry_connect_claim_malformed', status: claimRes.status },
+          'claim response missing required fields'
+        )
+        return { kind: 'error', status: claimRes.status }
+      }
+      const wrote = await markConnected({
+        deploymentId: input.deploymentId,
+        clientId: claimed.client_id,
+        clientSecret: claimed.client_secret,
+        orgName: claimed.org,
+      })
+      if (!wrote) {
+        rootLogger.error(
+          { event: 'registry_connect_claim_superseded', status: claimRes.status },
+          'claim succeeded but the connection row moved; credentials are lost'
+        )
+        return { kind: 'superseded' }
+      }
+      return { kind: 'connected', org: claimed.org }
+    } catch (err) {
+      return { kind: 'unreachable', err }
+    }
+  }
 
   async function requireSelfHostedAdmin(
     req: Request,
@@ -218,51 +308,41 @@ export function createRegistryConnectRouter(): Router {
         res.status(400).json({ error: 'invalid_request' })
         return
       }
-      const pop = signPop({ privateKeyPem: row.privateKeyPem, sub: ctx.adminId, kid: row.keyId })
-      const claimRes = await fetch(`${base()}/claim`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', DPoP: pop },
-        body: JSON.stringify({ claim_token: claimToken }),
-      })
-      if (claimRes.status === 410) {
-        res.status(410).json({ error: 'claim_expired' })
-        return
-      }
-      if (claimRes.status === 401) {
-        // The registry returns 401 for both invalid_pop and invalid_claim_token;
-        // both mean the same to the operator — the claim was rejected.
-        res.status(401).json({ error: 'claim_rejected' })
-        return
-      }
-      // C-M6: a claim 409 (already_claimed / client_unavailable) is a distinct,
-      // actionable state — surface it rather than the opaque 502.
-      if (claimRes.status === 409) {
-        const err = await readErrorCode(claimRes)
-        res
-          .status(409)
-          .json({ error: err === 'client_unavailable' ? 'client_unavailable' : 'already_claimed' })
-        return
-      }
-      if (!claimRes.ok) {
-        rootLogger.error(
-          { event: 'registry_connect_claim_failed', status: claimRes.status },
-          'claim failed'
-        )
-        res.status(502).json({ error: 'registry_integration_error' })
-        return
-      }
-      const claimed = (await claimRes.json()) as {
-        client_id: string
-        client_secret: string
-        org: string
-      }
-      await markConnected({
+      const outcome = await redeemClaim({
         deploymentId: row.deploymentId,
-        clientId: claimed.client_id,
-        clientSecret: claimed.client_secret,
-        orgName: claimed.org,
+        keyId: row.keyId,
+        privateKeyPem: row.privateKeyPem,
+        adminId: ctx.adminId,
+        claimToken,
       })
-      res.status(200).json({ state: 'connected', org: claimed.org })
+      switch (outcome.kind) {
+        case 'connected':
+          res.status(200).json({ state: 'connected', org: outcome.org })
+          return
+        case 'expired':
+          res.status(410).json({ error: 'claim_expired' })
+          return
+        case 'rejected':
+          res.status(401).json({ error: 'claim_rejected' })
+          return
+        case 'already_claimed':
+          res.status(409).json({ error: 'already_claimed' })
+          return
+        case 'client_unavailable':
+          res.status(409).json({ error: 'client_unavailable' })
+          return
+        case 'superseded':
+          res.status(409).json({ error: 'connection_superseded' })
+          return
+        // Preserves today's behaviour exactly: a registry-unreachable failure
+        // threw out of this handler and became a 500. Collapsing it to 502 here
+        // would be a silent contract change for the manual route.
+        case 'unreachable':
+          throw outcome.err
+        case 'error':
+          res.status(502).json({ error: 'registry_integration_error' })
+          return
+      }
     } catch (err) {
       next(err)
     }

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -20,6 +20,14 @@ import { signPop } from '../../services/registryPopSigner.js'
  * token — the deployment has none yet). Persists into registry_connection.
  * Managed mode has no connect flow (409 not_self_hosted).
  *
+ * GET reports state ∈ disconnected|pending|connecting|approved|rejected|connected.
+ * `connecting` means the registry auto-approved the registration and the
+ * inline claim did not land yet; it is finished by POST
+ * /admin/registry/connect/recover, never by pasting a token — under
+ * auto-approval no operator ever issues one. `approved` keeps the original
+ * operator-approved meaning: a human pastes the one-time claim token via POST
+ * /admin/registry/connect/claim.
+ *
  * Error mapping (C-M6): register 400 org_blocklisted and claim 409
  * already_claimed/client_unavailable are surfaced with distinct codes rather
  * than the opaque 502 registry_integration_error, and GET polls the registry
@@ -181,7 +189,9 @@ export function createRegistryConnectRouter(): Router {
   }
 
   // GET status — current state; polls the registry so operator approval is
-  // visible pre-claim (state ∈ disconnected|pending|approved|rejected|connected).
+  // visible pre-claim (state ∈ disconnected|pending|connecting|approved|rejected|connected).
+  // `connecting` is finished via POST /admin/registry/connect/recover, not by
+  // pasting a token.
   router.get('/admin/registry/connect', requireAuthForControlUI, async (req, res, next) => {
     try {
       const ctx = await requireSelfHostedAdmin(req, res)
@@ -521,6 +531,10 @@ export function createRegistryConnectRouter(): Router {
           res.status(409).json({ error: 'deployment_suspended' })
           return
         }
+        // Unreachable by construction: the registry's rejectDeployment is
+        // gated `WHERE status = 'pending'`, so a locally-'approved' row can
+        // never observe 'rejected' here — kept for defense in depth, which is
+        // also why the panel has no dedicated UI branch for this code.
         if (poll?.status === 'rejected') {
           res.status(409).json({ error: 'rejected' })
           return

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -228,6 +228,14 @@ export function createRegistryConnectRouter(): Router {
           res.status(409).json({ error: 'already_connected' })
           return
         }
+        // An 'approved' row is a registry-side auto-approval whose claim has not
+        // landed. Re-registering would DELETE it (dropping the keypair), leaving
+        // the approved deployment unrecoverable — rotate is PoP-gated — while it
+        // permanently holds its org name. Recovery is the only way forward.
+        if (existing && existing.status === 'approved') {
+          res.status(409).json({ error: 'recovery_in_progress' })
+          return
+        }
         const body = (req.body ?? {}) as {
           requested_org_name?: unknown
           contact_email?: unknown
@@ -253,17 +261,48 @@ export function createRegistryConnectRouter(): Router {
             requested_org_name: requestedOrgName,
             public_key_pem: publicKey,
             contact_email: contactEmail,
-            deployment_info: {},
+            // Capability declaration: the registry auto-approves ONLY for clients
+            // that can consume a 201 + claim_token. Without it, flipping the
+            // registry's open-registration flag would strand every control-api
+            // running code older than this change.
+            deployment_info: { auto_claim: true, client: 'control-api' },
             pop,
           }),
+          signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
         })
-        // C-M6: surface the registry's 400 rejection code (org_blocklisted /
-        // invalid_request) instead of collapsing it into an opaque 502.
+        // Every mapping is an ALLOWLIST with a stated default. readErrorCode
+        // returns null on a non-JSON body (routine for an ingress-generated 429),
+        // and an unbounded pass-through would reflect a registry-controlled
+        // string into our response and the panel's code comparisons.
         if (regRes.status === 400) {
           const err = await readErrorCode(regRes)
+          const known = [
+            'org_blocklisted',
+            'invalid_contact_email',
+            'invalid_deployment_info',
+            'deployment_info_too_large',
+          ]
+          res.status(400).json({ error: known.includes(err ?? '') ? err : 'invalid_request' })
+          return
+        }
+        if (regRes.status === 409) {
+          const err = await readErrorCode(regRes)
+          if (err === 'org_name_taken' || err === 'jti_replayed') {
+            res.status(409).json({ error: err })
+            return
+          }
+          res.status(502).json({ error: 'registry_integration_error' })
+          return
+        }
+        if (regRes.status === 429) {
+          const err = await readErrorCode(regRes)
+          const retryAfter = regRes.headers.get('retry-after')
+          if (retryAfter) res.set('Retry-After', retryAfter)
           res
-            .status(400)
-            .json({ error: err === 'org_blocklisted' ? 'org_blocklisted' : 'invalid_request' })
+            .status(429)
+            .json({
+              error: err === 'registration_capacity' ? 'registration_capacity' : 'rate_limited',
+            })
           return
         }
         if (!regRes.ok) {
@@ -274,7 +313,23 @@ export function createRegistryConnectRouter(): Router {
           res.status(502).json({ error: 'registry_integration_error' })
           return
         }
-        const reg = (await regRes.json()) as { deployment_id: string; key_id: string }
+        const reg = (await regRes.json()) as {
+          deployment_id: string
+          key_id: string
+          claim_token?: unknown
+        }
+        const autoApproved = regRes.status === 201 && typeof reg.claim_token === 'string'
+        if (regRes.status !== 201 && regRes.status !== 202) {
+          rootLogger.error(
+            { event: 'registry_connect_register_unexpected', status: regRes.status },
+            'unexpected 2xx from register'
+          )
+          res.status(502).json({ error: 'registry_integration_error' })
+          return
+        }
+        // Persist BEFORE claiming. The keypair is the only artifact that can
+        // recover this deployment (rotate is PoP-gated); claiming first and dying
+        // before the write would burn the one-time token AND lose the key.
         await upsertPendingConnection({
           deploymentId: reg.deployment_id,
           keyId: reg.key_id,
@@ -283,10 +338,37 @@ export function createRegistryConnectRouter(): Router {
           requestedOrgName,
           contactEmail,
           registryUrl: config.registryUrl,
+          status: autoApproved ? 'approved' : 'pending',
         })
+        if (!autoApproved) {
+          res
+            .status(202)
+            .json({ state: 'pending', deploymentId: reg.deployment_id, requestedOrgName })
+          return
+        }
+        const outcome = await redeemClaim({
+          deploymentId: reg.deployment_id,
+          keyId: reg.key_id,
+          privateKeyPem: privateKey,
+          adminId: ctx.adminId,
+          claimToken: reg.claim_token as string,
+        })
+        if (outcome.kind === 'connected') {
+          res.status(200).json({
+            state: 'connected',
+            org: outcome.org,
+            deploymentId: reg.deployment_id,
+            authEnabled: config.registryAuthEnabled,
+          })
+          return
+        }
+        rootLogger.error(
+          { event: 'registry_connect_auto_claim_failed', status: 0, outcome: outcome.kind },
+          'auto-claim failed; recovery is available'
+        )
         res
           .status(202)
-          .json({ state: 'pending', deploymentId: reg.deployment_id, requestedOrgName })
+          .json({ state: 'connecting', deploymentId: reg.deployment_id, requestedOrgName })
       } catch (err) {
         next(err)
       }

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -139,18 +139,20 @@ export function createRegistryConnectRouter(): Router {
 
   // Poll the registry for the deployment's current lifecycle status. Best-effort:
   // a poll failure degrades to the locally-known pending state so GET never 500s
-  // on a transient registry hiccup. Returns the registry status string or null.
+  // on a transient registry hiccup. Returns the parsed status/suspended/claimed
+  // triple, or null on any failure.
   async function pollRegistryStatus(row: {
     deploymentId: string
     keyId: string
     privateKeyPem: string
     adminId: string
-  }): Promise<string | null> {
+  }): Promise<{ status: string | null; suspended: boolean; claimed: boolean } | null> {
     try {
       const pop = signPop({ privateKeyPem: row.privateKeyPem, sub: row.adminId, kid: row.keyId })
       const statusRes = await fetch(`${base()}/${row.deploymentId}/status`, {
         method: 'GET',
         headers: { DPoP: pop },
+        signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
       })
       if (!statusRes.ok) {
         rootLogger.warn(
@@ -159,8 +161,16 @@ export function createRegistryConnectRouter(): Router {
         )
         return null
       }
-      const parsed = (await statusRes.json()) as { status?: unknown }
-      return typeof parsed.status === 'string' ? parsed.status : null
+      const parsed = (await statusRes.json()) as {
+        status?: unknown
+        suspended?: unknown
+        claimed?: unknown
+      }
+      return {
+        status: typeof parsed.status === 'string' ? parsed.status : null,
+        suspended: parsed.suspended === true,
+        claimed: parsed.claimed === true,
+      }
     } catch (err) {
       rootLogger.warn(
         { event: 'registry_connect_status_poll_error', err: (err as Error).message },
@@ -190,14 +200,42 @@ export function createRegistryConnectRouter(): Router {
         })
         return
       }
+      // A locally-'approved' row is a registry auto-approval whose claim has
+      // not landed. GET stays READ-ONLY: it reports state so the panel can
+      // offer the recover button. It must never rotate — GET is also called by
+      // RegistryCatalog on every Marketplace mount and is reachable by
+      // cross-site navigation (SameSite=Lax), so a mutation here would rotate
+      // claim tokens on catalog browsing and on CSRF.
+      if (row.status === 'approved') {
+        const poll = await pollRegistryStatus({
+          deploymentId: row.deploymentId,
+          keyId: row.keyId,
+          privateKeyPem: row.privateKeyPem,
+          adminId: ctx.adminId,
+        })
+        const recoveryError = poll?.claimed
+          ? 'already_claimed'
+          : poll?.suspended
+            ? 'deployment_suspended'
+            : undefined
+        res.status(200).json({
+          state: 'connecting',
+          deploymentId: row.deploymentId,
+          requestedOrgName: row.requestedOrgName,
+          authEnabled: config.registryAuthEnabled,
+          ...(recoveryError ? { recoveryError } : {}),
+        })
+        return
+      }
       // Not yet connected — poll the registry so an operator approval (or
       // rejection) is reflected before the user attempts to claim.
-      const registryStatus = await pollRegistryStatus({
+      const poll = await pollRegistryStatus({
         deploymentId: row.deploymentId,
         keyId: row.keyId,
         privateKeyPem: row.privateKeyPem,
         adminId: ctx.adminId,
       })
+      const registryStatus = poll?.status ?? null
       const state =
         registryStatus === 'approved'
           ? 'approved'
@@ -450,6 +488,124 @@ export function createRegistryConnectRouter(): Router {
       next(err)
     }
   })
+
+  // POST recover — finish an auto-approved connection whose inline claim failed.
+  // Explicit POST rather than a side effect of GET: GET has a second caller
+  // (RegistryCatalog) and is CSRF-reachable, and /:id/claim-token is unthrottled
+  // at the registry.
+  router.post(
+    '/admin/registry/connect/recover',
+    requireAuthForControlUI,
+    async (req, res, next) => {
+      try {
+        const ctx = await requireSelfHostedAdmin(req, res)
+        if (!ctx) return
+        const row = await getRegistryConnection()
+        if (!row || row.status !== 'approved') {
+          res.status(409).json({ error: 'not_recoverable' })
+          return
+        }
+        // Cheapest check first: a read tells us whether a rotate can possibly
+        // help, so a terminal state costs no mutation and no audit event.
+        const poll = await pollRegistryStatus({
+          deploymentId: row.deploymentId,
+          keyId: row.keyId,
+          privateKeyPem: row.privateKeyPem,
+          adminId: ctx.adminId,
+        })
+        if (poll?.claimed) {
+          res.status(409).json({ error: 'already_claimed' })
+          return
+        }
+        if (poll?.suspended) {
+          res.status(409).json({ error: 'deployment_suspended' })
+          return
+        }
+        if (poll?.status === 'rejected') {
+          res.status(409).json({ error: 'rejected' })
+          return
+        }
+        rootLogger.info(
+          { event: 'registry_connect_recover_attempted', status: 0 },
+          'attempting auto-claim recovery'
+        )
+        let claimToken: string
+        try {
+          const pop = signPop({
+            privateKeyPem: row.privateKeyPem,
+            sub: ctx.adminId,
+            kid: row.keyId,
+          })
+          const rotRes = await fetch(`${base()}/${row.deploymentId}/claim-token`, {
+            method: 'POST',
+            headers: { DPoP: pop },
+            signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
+          })
+          if (rotRes.status === 409) {
+            res.status(409).json({ error: 'already_claimed' })
+            return
+          }
+          if (!rotRes.ok) {
+            rootLogger.error(
+              { event: 'registry_connect_recover_rotate_failed', status: rotRes.status },
+              'claim-token rotate failed'
+            )
+            res.status(202).json({ state: 'connecting', deploymentId: row.deploymentId })
+            return
+          }
+          const rotated = (await rotRes.json()) as { claim_token?: unknown }
+          if (typeof rotated.claim_token !== 'string') {
+            res.status(202).json({ state: 'connecting', deploymentId: row.deploymentId })
+            return
+          }
+          claimToken = rotated.claim_token
+        } catch {
+          // Never 500 on a registry hiccup — same guarantee the status poll makes.
+          res.status(202).json({ state: 'connecting', deploymentId: row.deploymentId })
+          return
+        }
+        const outcome = await redeemClaim({
+          deploymentId: row.deploymentId,
+          keyId: row.keyId,
+          privateKeyPem: row.privateKeyPem,
+          adminId: ctx.adminId,
+          claimToken,
+        })
+        switch (outcome.kind) {
+          case 'connected':
+            res.status(200).json({
+              state: 'connected',
+              org: outcome.org,
+              authEnabled: config.registryAuthEnabled,
+            })
+            return
+          // Terminal: the client is disabled (operator suspension). Retrying
+          // rotates forever against a deployment that was deliberately killed.
+          case 'client_unavailable':
+            rootLogger.error(
+              { event: 'registry_connect_recover_terminal', status: 0 },
+              'recovery terminal: client unavailable'
+            )
+            res.status(409).json({ error: 'client_unavailable' })
+            return
+          case 'already_claimed':
+            res.status(409).json({ error: 'already_claimed' })
+            return
+          case 'superseded':
+            res.status(409).json({ error: 'connection_superseded' })
+            return
+          case 'expired':
+            res.status(409).json({ error: 'claim_expired' })
+            return
+          default:
+            res.status(202).json({ state: 'connecting', deploymentId: row.deploymentId })
+            return
+        }
+      } catch (err) {
+        next(err)
+      }
+    }
+  )
 
   // DELETE — disconnect (drop the row).
   router.delete('/admin/registry/connect', requireAuthForControlUI, async (req, res, next) => {

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -298,11 +298,9 @@ export function createRegistryConnectRouter(): Router {
           const err = await readErrorCode(regRes)
           const retryAfter = regRes.headers.get('retry-after')
           if (retryAfter) res.set('Retry-After', retryAfter)
-          res
-            .status(429)
-            .json({
-              error: err === 'registration_capacity' ? 'registration_capacity' : 'rate_limited',
-            })
+          res.status(429).json({
+            error: err === 'registration_capacity' ? 'registration_capacity' : 'rate_limited',
+          })
           return
         }
         if (!regRes.ok) {
@@ -313,12 +311,10 @@ export function createRegistryConnectRouter(): Router {
           res.status(502).json({ error: 'registry_integration_error' })
           return
         }
-        const reg = (await regRes.json()) as {
-          deployment_id: string
-          key_id: string
-          claim_token?: unknown
-        }
-        const autoApproved = regRes.status === 201 && typeof reg.claim_token === 'string'
+        // Checked BEFORE parsing the body: a 2xx status this route doesn't
+        // expect (a proxy splash page, an empty 204) may carry a non-JSON
+        // body, and parsing first would throw out of this handler and surface
+        // as a bare 500 instead of the intended 502.
         if (regRes.status !== 201 && regRes.status !== 202) {
           rootLogger.error(
             { event: 'registry_connect_register_unexpected', status: regRes.status },
@@ -327,6 +323,21 @@ export function createRegistryConnectRouter(): Router {
           res.status(502).json({ error: 'registry_integration_error' })
           return
         }
+        const reg = (await regRes.json()) as {
+          deployment_id: string
+          key_id: string
+          claim_token?: unknown
+        }
+        // 201 IS the registry's approval, independent of whether this
+        // particular response body carries a usable token. Deriving the
+        // persisted status from the claim_token's presence/type instead of
+        // the HTTP status would write 'pending' for an already-approved
+        // deployment whenever the token is missing or malformed (partial
+        // rollout, response-rewriting proxy). Task 5's recovery endpoint
+        // refuses a 'pending' row, so that deployment could never recover and
+        // would squat its org name forever.
+        const isApproved = regRes.status === 201
+        const hasClaimToken = typeof reg.claim_token === 'string'
         // Persist BEFORE claiming. The keypair is the only artifact that can
         // recover this deployment (rotate is PoP-gated); claiming first and dying
         // before the write would burn the one-time token AND lose the key.
@@ -338,12 +349,22 @@ export function createRegistryConnectRouter(): Router {
           requestedOrgName,
           contactEmail,
           registryUrl: config.registryUrl,
-          status: autoApproved ? 'approved' : 'pending',
+          status: isApproved ? 'approved' : 'pending',
         })
-        if (!autoApproved) {
+        if (!isApproved) {
           res
             .status(202)
             .json({ state: 'pending', deploymentId: reg.deployment_id, requestedOrgName })
+          return
+        }
+        if (!hasClaimToken) {
+          rootLogger.error(
+            { event: 'registry_connect_auto_claim_missing_token', status: 0 },
+            '201 response carried no usable claim_token; recovery is available'
+          )
+          res
+            .status(202)
+            .json({ state: 'connecting', deploymentId: reg.deployment_id, requestedOrgName })
           return
         }
         const outcome = await redeemClaim({

--- a/control-api/src/services/registryConnectionDb.ts
+++ b/control-api/src/services/registryConnectionDb.ts
@@ -1,5 +1,5 @@
 import { config } from '../config.js'
-import { pool } from '../db.js'
+import { pool, withTransaction } from '../db.js'
 import type { DbClient } from '../db.js'
 import {
   decryptOAuthSecret,
@@ -108,43 +108,60 @@ export async function upsertPendingConnection(
     requestedOrgName: string
     contactEmail: string
     registryUrl: string
+    /** 'approved' marks a registry auto-approval whose claim has not landed yet. */
+    status?: 'pending' | 'approved'
   },
-  db: DbClient = pool
+  db?: DbClient
 ): Promise<void> {
   const encPriv = encryptOAuthSecret(encKey(), input.privateKeyPem)
-  // Singleton table: delete any prior row then insert. (A connect restart replaces
-  // a stale pending row — the deployment keypair is regenerated fresh each request.)
-  await db.query(`DELETE FROM registry_connection`)
-  await db.query(
-    `INSERT INTO registry_connection
-       (deployment_id, key_id, public_key_pem, private_key_encrypted,
-        requested_org_name, contact_email, status, registry_url)
-     VALUES ($1,$2,$3,$4,$5,$6,'pending',$7)`,
-    [
-      input.deploymentId,
-      input.keyId,
-      input.publicKeyPem,
-      encPriv,
-      input.requestedOrgName,
-      input.contactEmail,
-      input.registryUrl,
-    ]
-  )
+  const status = input.status ?? 'pending'
+  // Singleton table: replace any prior row. DELETE + INSERT must be ATOMIC —
+  // a crash between them destroys the deployment keypair, which is the only
+  // artifact that can recover an already-approved deployment (rotate is
+  // PoP-gated). An explicit db means the caller already owns a transaction.
+  const run = async (tx: DbClient): Promise<void> => {
+    await tx.query(`DELETE FROM registry_connection`)
+    await tx.query(
+      `INSERT INTO registry_connection
+         (deployment_id, key_id, public_key_pem, private_key_encrypted,
+          requested_org_name, contact_email, status, registry_url)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+      [
+        input.deploymentId,
+        input.keyId,
+        input.publicKeyPem,
+        encPriv,
+        input.requestedOrgName,
+        input.contactEmail,
+        status,
+        input.registryUrl,
+      ]
+    )
+  }
+  if (db) await run(db)
+  else await withTransaction(run)
   cached = undefined
 }
 
 export async function markConnected(
-  input: { clientId: string; clientSecret: string; orgName: string },
+  input: { deploymentId: string; clientId: string; clientSecret: string; orgName: string },
   db: DbClient = pool
-): Promise<void> {
+): Promise<boolean> {
   const encSecret = encryptOAuthSecret(encKey(), input.clientSecret)
-  await db.query(
+  // Scoped to the deployment that actually claimed. Without the predicate a
+  // DELETE or a second registration landing mid-claim would either silently
+  // swallow the credentials or stamp THIS deployment's client secret onto a
+  // DIFFERENT deployment's keypair — machine creds and voucher signing key
+  // would then belong to two different deployments.
+  const res = await db.query(
     `UPDATE registry_connection
         SET client_id = $1, client_secret_encrypted = $2, org_name = $3,
-            status = 'connected', updated_at = now()`,
-    [input.clientId, encSecret, input.orgName]
+            status = 'connected', updated_at = now()
+      WHERE deployment_id = $4 AND status <> 'connected'`,
+    [input.clientId, encSecret, input.orgName, input.deploymentId]
   )
   cached = undefined
+  return (res.rowCount ?? 0) > 0
 }
 
 export async function deleteConnection(db: DbClient = pool): Promise<void> {

--- a/control-api/src/utils/log/redact.ts
+++ b/control-api/src/utils/log/redact.ts
@@ -13,6 +13,10 @@ export const TOKEN_LEAK_REDACT_PATHS: readonly string[] = [
   'password',
   'password_hash',
   'passwordHash',
+  'claim_token',
+  'claimToken',
+  'client_secret',
+  'clientSecret',
 ]
 
 /** Asserted by unit tests so redactions can grow but never shrink. */
@@ -22,4 +26,8 @@ export const REQUIRED_REDACT_PATHS: readonly string[] = [
   'headers.authorization',
   'accessToken',
   'refreshToken',
+  'claim_token',
+  'claimToken',
+  'client_secret',
+  'clientSecret',
 ]

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -678,6 +678,25 @@ describe('GET — local approved row', () => {
     const res = await request(app()).get('/admin/registry/connect').expect(200)
     expect(res.body).toMatchObject({ state: 'connecting', recoveryError: 'already_claimed' })
   })
+
+  // Deleting the `poll?.suspended ? 'deployment_suspended'` arm of the
+  // recoveryError ternary fails no other test. Without it, an operator who
+  // suspends an auto-approved-but-unclaimed deployment leaves the panel
+  // offering "Finish connecting" with no terminal message.
+  it('surfaces a terminal recoveryError when suspended', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: true, claimed: false }, 200),
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body).toMatchObject({ state: 'connecting', recoveryError: 'deployment_suspended' })
+  })
 })
 
 // THE operator-flow regression proof. A flag-off registration stays locally
@@ -716,13 +735,24 @@ describe('POST recover', () => {
       requestedOrgName: 'acme',
     })
     connDb.markConnected.mockResolvedValue(true)
-    routeFetch({
+    const spy = routeFetch({
       '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
       'claim-token': () => json({ claim_token: 'tok-new' }, 200),
       '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
     })
     const res = await request(app()).post('/admin/registry/connect/recover').expect(200)
     expect(res.body).toMatchObject({ state: 'connected', org: 'acme', authEnabled: true })
+    // The rotate call itself must be a real, authenticated, bounded POST — not
+    // just a URL the mock happens to match. Each of these mutates production
+    // 100% of the time while leaving a body-only assertion green.
+    const rot = spy.mock.calls.find(c => String(c[0]).includes('claim-token'))!
+    expect((rot[1] as RequestInit).method).toBe('POST')
+    expect((rot[1] as RequestInit).headers).toMatchObject({ DPoP: expect.any(String) })
+    expect((rot[1] as RequestInit).signal).toBeInstanceOf(AbortSignal)
+    // And the token redeemed against /claim must be the ROTATED one, not the
+    // stale row/deploymentId — otherwise a bad rotate silently redeems garbage.
+    const claim = spy.mock.calls.find(c => String(c[0]).endsWith('/claim'))!
+    expect(JSON.parse(String((claim[1] as RequestInit).body)).claim_token).toBe('tok-new')
   })
 
   it('refuses when the local row is pending', async () => {
@@ -733,11 +763,17 @@ describe('POST recover', () => {
       privateKeyPem: pkForTest(),
       requestedOrgName: 'acme',
     })
+    // afterEach's restoreAllMocks() leaves globalThis.fetch REAL; if the
+    // row.status !== 'approved' gate is ever widened, this proves it loudly
+    // (a thrown "unexpected fetch") instead of emitting a real outbound
+    // request to example.com.
+    const spy = routeFetch({})
     const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
     expect(res.body.error).toBe('not_recoverable')
+    expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
   })
 
-  it('reports already_claimed WITHOUT spending a rotate', async () => {
+  it('reports already_claimed WITHOUT spending a rotate', { retry: 0 }, async () => {
     connDb.getRegistryConnection.mockResolvedValue({
       status: 'approved',
       deploymentId: 'dep-1',
@@ -753,7 +789,7 @@ describe('POST recover', () => {
     expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
   })
 
-  it('reports deployment_suspended without rotating', async () => {
+  it('reports deployment_suspended without rotating', { retry: 0 }, async () => {
     connDb.getRegistryConnection.mockResolvedValue({
       status: 'approved',
       deploymentId: 'dep-1',
@@ -761,17 +797,38 @@ describe('POST recover', () => {
       privateKeyPem: pkForTest(),
       requestedOrgName: 'acme',
     })
-    routeFetch({
+    const spy = routeFetch({
       '/status': () => json({ status: 'approved', suspended: true, claimed: false }, 200),
     })
     const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
     expect(res.body.error).toBe('deployment_suspended')
+    expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
+  })
+
+  // Deleting the `poll?.status === 'rejected'` guard fails no other test: it
+  // would fall through to a rotate against a rejected deployment, the claim
+  // 401s, and the user sees a "still connecting" spinner instead of a
+  // terminal error.
+  it('reports rejected without rotating', { retry: 0 }, async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    const spy = routeFetch({
+      '/status': () => json({ status: 'rejected', suspended: false, claimed: false }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('rejected')
+    expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
   })
 
   // client_unavailable means the registry client is disabled (operator
   // suspension). Retrying rotates forever against a deployment an operator
   // deliberately killed, so it must be terminal.
-  it('treats client_unavailable as terminal', async () => {
+  it('treats client_unavailable as terminal', { retry: 0 }, async () => {
     connDb.getRegistryConnection.mockResolvedValue({
       status: 'approved',
       deploymentId: 'dep-1',
@@ -788,9 +845,74 @@ describe('POST recover', () => {
     expect(res.body.error).toBe('client_unavailable')
   })
 
+  // The rotate call ITSELF can 409 (a second recover after the deployment was
+  // claimed elsewhere in between the status poll and the rotate). Falling
+  // through to !rotRes.ok -> 202 would tell the user to keep retrying a
+  // permanently-claimed deployment instead of a terminal 409.
+  it('rotate 409 reports already_claimed', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ error: 'already_claimed' }, 409),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('already_claimed')
+  })
+
+  // A non-OK, non-409 rotate (e.g. registry 503) must degrade to 202
+  // connecting, never a 500 — the never-500 guarantee applies to the rotate
+  // response, not just to a thrown fetch.
+  it('rotate 503 degrades to 202 connecting', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ error: 'boom' }, 503),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(202)
+    expect(res.body.state).toBe('connecting')
+  })
+
+  // A rotate response with a 200 status but a non-JSON body (an ingress or
+  // proxy splash page) must not let `await rotRes.json()` throw OUTSIDE the
+  // try/catch that guards the rest of this block — the register route
+  // already guards the equivalent hazard (registryConnect.ts:352-363).
+  it('rotate 200 with a non-JSON body degrades to 202 connecting', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      const url = String(input)
+      if (url.includes('/status')) {
+        return json({ status: 'approved', suspended: false, claimed: false }, 200)
+      }
+      if (url.includes('claim-token')) {
+        return new Response('<html>', { status: 200 })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(202)
+    expect(res.body.state).toBe('connecting')
+  })
+
   // GET never 500s on a registry hiccup (registryConnect.ts:50-52); recovery
   // must honour the same guarantee.
-  it('degrades to 202 connecting when the rotate fetch throws', async () => {
+  it('degrades to 202 connecting when the rotate fetch throws', { retry: 0 }, async () => {
     connDb.getRegistryConnection.mockResolvedValue({
       status: 'approved',
       deploymentId: 'dep-1',

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
     username: 'alice',
     status: 'active',
   })
+  connDb.markConnected.mockResolvedValue(true)
   cfg.registryConnectionMode = 'self-hosted'
   cfg.registryAuthEnabled = true
 })
@@ -233,6 +234,7 @@ describe('registry connect flow', () => {
     expect(String(url)).toContain('/api/v1/deployments/claim')
     expect((init as RequestInit).headers).toHaveProperty('DPoP')
     expect(connDb.markConnected).toHaveBeenCalledWith({
+      deploymentId: 'dep-9',
       clientId: 'cid',
       clientSecret: 'csecret',
       orgName: 'acme',
@@ -315,6 +317,44 @@ describe('registry connect flow', () => {
       .send({ claim_token: 't' })
       .expect(409)
     expect(res.body.error).toBe('not_pending')
+  })
+
+  it('claim → registry 500 → 502 registry_integration_error', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'pending',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 500 }))
+    const res = await request(app())
+      .post('/admin/registry/connect/claim')
+      .send({ claim_token: 'tok-abc' })
+      .expect(502)
+    expect(res.body.error).toBe('registry_integration_error')
+    expect(connDb.markConnected).not.toHaveBeenCalled()
+  })
+
+  it('claim → markConnected matches no row → 409 connection_superseded', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'pending',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    connDb.markConnected.mockResolvedValue(false)
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }), {
+        status: 200,
+      })
+    )
+    const res = await request(app())
+      .post('/admin/registry/connect/claim')
+      .send({ claim_token: 'tok-abc' })
+      .expect(409)
+    expect(res.body.error).toBe('connection_superseded')
   })
 
   it('DELETE → 204 drops the row', async () => {

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import { generateKeyPairSync } from 'node:crypto'
 import request from 'supertest'
 import { createRegistryConnectRouter } from '../src/routes/admin/registryConnect.js'
+import { checkAndIncrement } from '../src/services/rateLimiterService.js'
 
 const { cfg } = vi.hoisted(() => ({
   cfg: {
@@ -38,6 +39,13 @@ const connDb = vi.hoisted(() => ({
   deleteConnection: vi.fn(),
 }))
 vi.mock('../src/services/registryConnectionDb.js', () => connDb)
+
+// The recover route is now behind rateLimitMiddleware, which calls
+// checkAndIncrement (a real Postgres round-trip in production). Mock it so
+// this suite stays hermetic; individual tests override the resolved value to
+// exercise the allowed/denied branches.
+const rateLimiter = vi.hoisted(() => ({ checkAndIncrement: vi.fn() }))
+vi.mock('../src/services/rateLimiterService.js', () => rateLimiter)
 
 function app(): express.Express {
   const a = express()
@@ -82,6 +90,11 @@ beforeEach(() => {
   connDb.markConnected.mockResolvedValue(true)
   cfg.registryConnectionMode = 'self-hosted'
   cfg.registryAuthEnabled = true
+  rateLimiter.checkAndIncrement.mockResolvedValue({
+    allowed: true,
+    remaining: 9,
+    resetMs: Date.now() + 60000,
+  })
 })
 afterEach(() => vi.restoreAllMocks())
 
@@ -761,6 +774,54 @@ describe('POST recover', () => {
     // stale row/deploymentId — otherwise a bad rotate silently redeems garbage.
     const claim = spy.mock.calls.find(c => String(c[0]).endsWith('/claim'))!
     expect(JSON.parse(String((claim[1] as RequestInit).body)).claim_token).toBe('tok-new')
+  })
+
+  // The route is rate-limited (each call rotates a one-time claim token at
+  // the shared registry, which has no limiter of its own). This proves the
+  // middleware sits AFTER requireAuthForControlUI (bucket keyed on
+  // adminAuth.sub) and BEFORE the handler without breaking the normal
+  // success path.
+  it('is rate-limited per admin, keyed on adminAuth.sub, and still succeeds when allowed', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    connDb.markConnected.mockResolvedValue(true)
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ claim_token: 'tok-new' }, 200),
+      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
+    expect(checkAndIncrement).toHaveBeenCalledWith('registry_connect_recover:admin-uuid-123', 10)
+    expect(res.headers['x-ratelimit-limit']).toBe('10')
+  })
+
+  // Proves the limiter actually blocks, and blocks BEFORE any registry work:
+  // a denied admin must not burn a rotate or reach getRegistryConnection.
+  it('429s when the per-admin bucket is exceeded, without touching the registry', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    rateLimiter.checkAndIncrement.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetMs: Date.now() + 30000,
+    })
+    const spy = routeFetch({})
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(429)
+    expect(res.body.error).toBe('Too Many Requests')
+    expect(res.headers['retry-after']).toBeDefined()
+    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
+    expect(spy.mock.calls.length).toBe(0)
   })
 
   it('refuses when the local row is pending', async () => {

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -1,5 +1,5 @@
 // test/routes.registryConnect.test.ts
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import express from 'express'
 import { generateKeyPairSync } from 'node:crypto'
 import request from 'supertest'
@@ -405,7 +405,7 @@ describe('register — auto-claim (201)', () => {
   it('claims immediately and reports connected', async () => {
     connDb.getRegistryConnection.mockResolvedValue(null)
     connDb.markConnected.mockResolvedValue(true)
-    routeFetch({
+    const spy = routeFetch({
       '/register': () =>
         json(
           {
@@ -425,6 +425,14 @@ describe('register — auto-claim (201)', () => {
       .expect(200)
     expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
     expect(res.body.authEnabled).toBe(true)
+    // The claim call must actually carry the token the registry minted, and
+    // be PoP-authenticated — otherwise every auto-approved self-hoster gets a
+    // registry-side 401 and silently falls back to 202 connecting.
+    const [claimUrl, claimInit] = spy.mock.calls[1]!
+    expect(String(claimUrl)).toContain('/claim')
+    expect((claimInit as RequestInit).headers).toHaveProperty('DPoP')
+    const claimBody = JSON.parse(String((claimInit as RequestInit).body))
+    expect(claimBody.claim_token).toBe('tok-abc')
   })
 
   // The mocks return undefined, so `await x` and `void x` produce IDENTICAL
@@ -439,6 +447,13 @@ describe('register — auto-claim (201)', () => {
       await new Promise(r => setImmediate(r))
       events.push('persisted')
     })
+    // vitest's restoreAllMocks() only restores vi.spyOn registrations and
+    // clearAllMocks() only calls mockClear — neither undoes mockImplementation.
+    // If the assertion below FAILS (the exact mutation this test exists to
+    // catch), a bare mockReset() on the next line never runs and this
+    // implementation leaks into every later test in the file. onTestFinished
+    // runs regardless of pass/fail.
+    onTestFinished(() => connDb.upsertPendingConnection.mockReset())
     vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
       const url = String(input)
       if (url.includes('/register')) {
@@ -456,7 +471,6 @@ describe('register — auto-claim (201)', () => {
       .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
       .expect(200)
     expect(events).toEqual(['register', 'persisted', 'claim'])
-    connDb.upsertPendingConnection.mockReset()
   })
 
   it("persists status 'approved' and reports connecting when the claim fails", async () => {
@@ -506,8 +520,31 @@ describe('register — auto-claim (201)', () => {
       .post('/admin/registry/connect/request')
       .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
       .expect(202)
-    const body = JSON.parse(String((spy.mock.calls[0]![1] as RequestInit).body))
+    const init = spy.mock.calls[0]![1] as RequestInit
+    const body = JSON.parse(String(init.body))
     expect(body.deployment_info).toMatchObject({ auto_claim: true })
+    // A hung registry must not pin this request indefinitely.
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  // Registry truth (201 = approved, one-time token burned) must win over the
+  // response body's shape. A partial rollout or a response-rewriting proxy
+  // could return 201 without a usable claim_token; if that persisted
+  // 'pending', Task 5's recovery endpoint would refuse the row forever and
+  // the org name would be squatted permanently.
+  it('201 without a usable claim_token still persists approved and reports connecting', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    routeFetch({
+      '/register': () => json({ deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved' }, 201),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    expect(res.body).toMatchObject({ state: 'connecting', deploymentId: 'dep-1' })
+    expect(connDb.upsertPendingConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved' })
+    )
   })
 })
 
@@ -540,9 +577,23 @@ describe('register — new registry rejections map to distinct codes', () => {
     ['per-IP', 429, { error: 'RATE_LIMITED' }, 429, 'rate_limited'],
     ['bad email', 400, { error: 'invalid_contact_email' }, 400, 'invalid_contact_email'],
     ['blocklist', 400, { error: 'org_blocklisted' }, 400, 'org_blocklisted'],
+    ['unknown 400', 400, { error: 'who_knows' }, 400, 'invalid_request'],
+    // deployment_info is non-empty as of this task (auto_claim capability
+    // declaration), so this registry rejection is newly reachable.
+    [
+      'info too large',
+      400,
+      { error: 'deployment_info_too_large' },
+      400,
+      'deployment_info_too_large',
+    ],
     ['bad pop', 401, { error: 'invalid_pop' }, 502, 'registry_integration_error'],
     ['unknown 409', 409, { error: 'who_knows' }, 502, 'registry_integration_error'],
     ['unparseable 429', 429, 'not json', 429, 'rate_limited'],
+    // Pins the ordering fix: the status check must run BEFORE the body is
+    // parsed, or a non-JSON body on an unexpected 2xx throws out of the
+    // handler and surfaces as a bare 500 instead of the intended 502.
+    ['unexpected 200', 200, 'not json', 502, 'registry_integration_error'],
   ]
   for (const [name, regStatus, regBody, want, code] of cases) {
     it(`${name} → ${want} ${code}`, async () => {

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -646,3 +646,165 @@ describe('register — guarded while a recovery is outstanding', () => {
     expect(connDb.upsertPendingConnection).not.toHaveBeenCalled()
   })
 })
+
+describe('GET — local approved row', () => {
+  it('reports connecting and never rotates', { retry: 0 }, async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    const spy = routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body.state).toBe('connecting')
+    expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
+  })
+
+  it('surfaces a terminal recoveryError when already claimed', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: true }, 200),
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body).toMatchObject({ state: 'connecting', recoveryError: 'already_claimed' })
+  })
+})
+
+// THE operator-flow regression proof. A flag-off registration stays locally
+// 'pending' until a human pastes a token; rotating would silently invalidate
+// the token an operator delivered out of band.
+describe('GET — local pending row is never rotated', () => {
+  it(
+    'reports approved from the registry poll without touching claim-token',
+    { retry: 0 },
+    async () => {
+      connDb.getRegistryConnection.mockResolvedValue({
+        status: 'pending',
+        deploymentId: 'dep-1',
+        keyId: 'kid-1',
+        privateKeyPem: pkForTest(),
+        requestedOrgName: 'acme',
+      })
+      const spy = routeFetch({
+        '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      })
+      const res = await request(app()).get('/admin/registry/connect').expect(200)
+      expect(res.body.state).toBe('approved')
+      expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
+      expect(connDb.markConnected).not.toHaveBeenCalled()
+    }
+  )
+})
+
+describe('POST recover', () => {
+  it('rotates then claims and reports connected', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    connDb.markConnected.mockResolvedValue(true)
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ claim_token: 'tok-new' }, 200),
+      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', org: 'acme', authEnabled: true })
+  })
+
+  it('refuses when the local row is pending', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'pending',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('not_recoverable')
+  })
+
+  it('reports already_claimed WITHOUT spending a rotate', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    const spy = routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: true }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('already_claimed')
+    expect(spy.mock.calls.map(c => String(c[0])).some(u => u.includes('claim-token'))).toBe(false)
+  })
+
+  it('reports deployment_suspended without rotating', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: true, claimed: false }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('deployment_suspended')
+  })
+
+  // client_unavailable means the registry client is disabled (operator
+  // suspension). Retrying rotates forever against a deployment an operator
+  // deliberately killed, so it must be terminal.
+  it('treats client_unavailable as terminal', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ claim_token: 'tok-new' }, 200),
+      '/claim': () => json({ error: 'client_unavailable' }, 409),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(409)
+    expect(res.body.error).toBe('client_unavailable')
+  })
+
+  // GET never 500s on a registry hiccup (registryConnect.ts:50-52); recovery
+  // must honour the same guarantee.
+  it('degrades to 202 connecting when the rotate fetch throws', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      if (String(input).includes('/status')) {
+        return json({ status: 'approved', suspended: false, claimed: false }, 200)
+      }
+      throw new Error('ECONNREFUSED')
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(202)
+    expect(res.body.state).toBe('connecting')
+  })
+})

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -402,38 +402,46 @@ describe('registry connect flow', () => {
 })
 
 describe('register — auto-claim (201)', () => {
-  it('claims immediately and reports connected', async () => {
-    connDb.getRegistryConnection.mockResolvedValue(null)
-    connDb.markConnected.mockResolvedValue(true)
-    const spy = routeFetch({
-      '/register': () =>
-        json(
-          {
-            deployment_id: 'dep-1',
-            key_id: 'kid-1',
-            status: 'approved',
-            claim_token: 'tok-abc',
-            claim_expires_at: '2026-07-30T00:00:00Z',
-          },
-          201
-        ),
-      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
-    })
-    const res = await request(app())
-      .post('/admin/registry/connect/request')
-      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
-      .expect(200)
-    expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
-    expect(res.body.authEnabled).toBe(true)
-    // The claim call must actually carry the token the registry minted, and
-    // be PoP-authenticated — otherwise every auto-approved self-hoster gets a
-    // registry-side 401 and silently falls back to 202 connecting.
-    const [claimUrl, claimInit] = spy.mock.calls[1]!
-    expect(String(claimUrl)).toContain('/claim')
-    expect((claimInit as RequestInit).headers).toHaveProperty('DPoP')
-    const claimBody = JSON.parse(String((claimInit as RequestInit).body))
-    expect(claimBody.claim_token).toBe('tok-abc')
-  })
+  // Parameterized over registryAuthEnabled: the beforeEach default is `true`,
+  // so a mutation replacing `authEnabled: config.registryAuthEnabled` with the
+  // literal `true` on the 201-connected response passes an authEnabled-only-true
+  // suite. The `false` case is the one that would catch it.
+  it.each([true, false])(
+    'claims immediately and reports connected (registryAuthEnabled=%s)',
+    async registryAuthEnabled => {
+      cfg.registryAuthEnabled = registryAuthEnabled
+      connDb.getRegistryConnection.mockResolvedValue(null)
+      connDb.markConnected.mockResolvedValue(true)
+      const spy = routeFetch({
+        '/register': () =>
+          json(
+            {
+              deployment_id: 'dep-1',
+              key_id: 'kid-1',
+              status: 'approved',
+              claim_token: 'tok-abc',
+              claim_expires_at: '2026-07-30T00:00:00Z',
+            },
+            201
+          ),
+        '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+      })
+      const res = await request(app())
+        .post('/admin/registry/connect/request')
+        .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+        .expect(200)
+      expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
+      expect(res.body.authEnabled).toBe(registryAuthEnabled)
+      // The claim call must actually carry the token the registry minted, and
+      // be PoP-authenticated — otherwise every auto-approved self-hoster gets a
+      // registry-side 401 and silently falls back to 202 connecting.
+      const [claimUrl, claimInit] = spy.mock.calls[1]!
+      expect(String(claimUrl)).toContain('/claim')
+      expect((claimInit as RequestInit).headers).toHaveProperty('DPoP')
+      const claimBody = JSON.parse(String((claimInit as RequestInit).body))
+      expect(claimBody.claim_token).toBe('tok-abc')
+    }
+  )
 
   // The mocks return undefined, so `await x` and `void x` produce IDENTICAL
   // invocationCallOrder — an ordering assertion built on call order is green

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -54,6 +54,24 @@ function pkForTest(): string {
   }).privateKey
 }
 
+/**
+ * Route fetches by URL, constructing a FRESH Response per call. The existing
+ * mockResolvedValue idiom cannot be reused here: it returns one Response
+ * instance, and reading its body twice throws 'Body is unusable'.
+ */
+function routeFetch(handlers: Record<string, () => Response>): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+    const url = String(input)
+    for (const [fragment, make] of Object.entries(handlers)) {
+      if (url.includes(fragment)) return make()
+    }
+    throw new Error(`unexpected fetch: ${url}`)
+  }) as ReturnType<typeof vi.spyOn>
+}
+
+const json = (body: unknown, status: number, headers?: Record<string, string>) =>
+  new Response(JSON.stringify(body), { status, headers })
+
 beforeEach(() => {
   vi.clearAllMocks()
   adminSvc.findAdminById.mockResolvedValue({
@@ -361,5 +379,219 @@ describe('registry connect flow', () => {
     connDb.getRegistryConnection.mockResolvedValue({ status: 'pending', deploymentId: 'dep-9' })
     await request(app()).delete('/admin/registry/connect').expect(204)
     expect(connDb.deleteConnection).toHaveBeenCalled()
+  })
+
+  // The redeemClaim extraction must NOT convert a registry-unreachable failure
+  // into a 502. It escapes the handler and the Express error handler makes it a
+  // 500, exactly as before the refactor. Collapsing it to 502 would be a silent
+  // contract change for the manual paste route.
+  it('manual claim → registry unreachable → 500, not 502', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'pending',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+    await request(app())
+      .post('/admin/registry/connect/claim')
+      .send({ claim_token: 'tok-abc' })
+      .expect(500)
+  })
+})
+
+describe('register — auto-claim (201)', () => {
+  it('claims immediately and reports connected', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    connDb.markConnected.mockResolvedValue(true)
+    routeFetch({
+      '/register': () =>
+        json(
+          {
+            deployment_id: 'dep-1',
+            key_id: 'kid-1',
+            status: 'approved',
+            claim_token: 'tok-abc',
+            claim_expires_at: '2026-07-30T00:00:00Z',
+          },
+          201
+        ),
+      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
+    expect(res.body.authEnabled).toBe(true)
+  })
+
+  // The mocks return undefined, so `await x` and `void x` produce IDENTICAL
+  // invocationCallOrder — an ordering assertion built on call order is green
+  // against the exact mutation it exists to catch. Assert on an event log
+  // driven by a real async implementation instead.
+  it('persists the row BEFORE burning the one-time token', { retry: 0 }, async () => {
+    const events: string[] = []
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    connDb.markConnected.mockResolvedValue(true)
+    connDb.upsertPendingConnection.mockImplementation(async () => {
+      await new Promise(r => setImmediate(r))
+      events.push('persisted')
+    })
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      const url = String(input)
+      if (url.includes('/register')) {
+        events.push('register')
+        return json(
+          { deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved', claim_token: 'tok-abc' },
+          201
+        )
+      }
+      events.push('claim')
+      return json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200)
+    })
+    await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(200)
+    expect(events).toEqual(['register', 'persisted', 'claim'])
+    connDb.upsertPendingConnection.mockReset()
+  })
+
+  it("persists status 'approved' and reports connecting when the claim fails", async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    routeFetch({
+      '/register': () =>
+        json(
+          { deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved', claim_token: 'tok-abc' },
+          201
+        ),
+      '/claim': () => json({ error: 'boom' }, 500),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    expect(res.body).toMatchObject({ state: 'connecting', deploymentId: 'dep-1' })
+    expect(connDb.upsertPendingConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'approved' })
+    )
+  })
+
+  it('reports connecting when the claim fetch throws', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      if (String(input).includes('/register')) {
+        return json(
+          { deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved', claim_token: 'tok-abc' },
+          201
+        )
+      }
+      throw new Error('ECONNREFUSED')
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    expect(res.body.state).toBe('connecting')
+  })
+
+  it('declares the auto_claim capability in deployment_info', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    const spy = routeFetch({
+      '/register': () => json({ deployment_id: 'dep-1', key_id: 'kid-1', status: 'pending' }, 202),
+    })
+    await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    const body = JSON.parse(String((spy.mock.calls[0]![1] as RequestInit).body))
+    expect(body.deployment_info).toMatchObject({ auto_claim: true })
+  })
+})
+
+describe('register — 202 pending path is unchanged', () => {
+  // Asserting only the response body lets a mutation that pastes
+  // status:'approved' into the 202 branch survive: the body is identical, and
+  // the never-rotate test below uses a synthetic row so it never observes the
+  // real write. Assert the persisted status too.
+  it("replies pending AND persists status 'pending'", { retry: 0 }, async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    routeFetch({
+      '/register': () => json({ deployment_id: 'dep-1', key_id: 'kid-1', status: 'pending' }, 202),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    expect(res.body).toMatchObject({ state: 'pending', deploymentId: 'dep-1' })
+    expect(connDb.upsertPendingConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'pending' })
+    )
+  })
+})
+
+describe('register — new registry rejections map to distinct codes', () => {
+  const cases: Array<[string, number, unknown, number, string]> = [
+    ['org_name_taken', 409, { error: 'org_name_taken' }, 409, 'org_name_taken'],
+    ['jti_replayed', 409, { error: 'jti_replayed' }, 409, 'jti_replayed'],
+    ['capacity', 429, { error: 'registration_capacity' }, 429, 'registration_capacity'],
+    ['per-IP', 429, { error: 'RATE_LIMITED' }, 429, 'rate_limited'],
+    ['bad email', 400, { error: 'invalid_contact_email' }, 400, 'invalid_contact_email'],
+    ['blocklist', 400, { error: 'org_blocklisted' }, 400, 'org_blocklisted'],
+    ['bad pop', 401, { error: 'invalid_pop' }, 502, 'registry_integration_error'],
+    ['unknown 409', 409, { error: 'who_knows' }, 502, 'registry_integration_error'],
+    ['unparseable 429', 429, 'not json', 429, 'rate_limited'],
+  ]
+  for (const [name, regStatus, regBody, want, code] of cases) {
+    it(`${name} → ${want} ${code}`, async () => {
+      connDb.getRegistryConnection.mockResolvedValue(null)
+      routeFetch({
+        '/register': () =>
+          typeof regBody === 'string'
+            ? new Response(regBody, { status: regStatus })
+            : json(regBody, regStatus),
+      })
+      const res = await request(app())
+        .post('/admin/registry/connect/request')
+        .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+        .expect(want)
+      expect(res.body.error).toBe(code)
+      expect(connDb.upsertPendingConnection).not.toHaveBeenCalled()
+    })
+  }
+
+  it('forwards Retry-After on a per-IP rate limit', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    routeFetch({
+      '/register': () => json({ error: 'RATE_LIMITED' }, 429, { 'Retry-After': '86400' }),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(429)
+    expect(res.headers['retry-after']).toBe('86400')
+  })
+})
+
+describe('register — guarded while a recovery is outstanding', () => {
+  it('rejects a re-request when the local row is approved', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(409)
+    expect(res.body.error).toBe('recovery_in_progress')
+    // upsertPendingConnection DELETEs the row and regenerates the keypair.
+    // Doing that here would destroy the only artifact that can recover an
+    // already-approved deployment and permanently squat its org name.
+    expect(connDb.upsertPendingConnection).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -386,8 +386,13 @@ describe('markConnected — scoped write', () => {
     const upd = dbQuery.mock.calls.find(([sql]) =>
       String(sql).includes('UPDATE registry_connection')
     )
-    expect(String(upd![0])).toMatch(/WHERE\s+deployment_id\s*=\s*\$4/)
-    expect(String(upd![0])).toMatch(/status\s*<>\s*'connected'/)
+    // ONE contiguous assertion: mutating the AND to OR (a row belonging to a
+    // DIFFERENT deployment with status 'pending' would then also match) must
+    // fail this test. Two independent regexes each match an OR-joined clause
+    // just as well as an AND-joined one, so they cannot catch that mutation.
+    expect(String(upd![0])).toMatch(
+      /WHERE\s+deployment_id\s*=\s*\$4\s+AND\s+status\s*<>\s*'connected'/
+    )
     expect((upd![1] as string[])[3]).toBe('dep-9')
   })
 

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -36,6 +36,8 @@ vi.mock('../src/config.js', () => ({ config: cfg }))
 const dbQuery = vi.fn()
 vi.mock('../src/db.js', () => ({
   pool: { query: (t: string, v?: unknown[]) => dbQuery(t, v) },
+  withTransaction: async (fn: (db: unknown) => Promise<unknown>) =>
+    fn({ query: (t: string, v?: unknown[]) => dbQuery(t, v) }),
 }))
 
 const keypair = () =>
@@ -222,7 +224,12 @@ describe('markConnected — writes ciphertext for the client secret (C-I3a)', ()
     cfg.oauthEncryptionKey = encKeyHex
     dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
 
-    await markConnected({ clientId: 'cid-9', clientSecret: 'super-secret-xyz', orgName: 'acme' })
+    await markConnected({
+      deploymentId: 'dep-9',
+      clientId: 'cid-9',
+      clientSecret: 'super-secret-xyz',
+      orgName: 'acme',
+    })
 
     const upd = dbQuery.mock.calls.find(([sql]) =>
       String(sql).includes('UPDATE registry_connection')
@@ -321,5 +328,78 @@ describe('resolveMachineCreds (C-I3b)', () => {
       rowCount: 1,
     })
     expect(await resolveMachineCreds()).toBeNull()
+  })
+})
+
+describe('upsertPendingConnection — status parameter reaches the SQL', () => {
+  it('defaults to pending', async () => {
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+    await upsertPendingConnection({
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      publicKeyPem: 'PUB',
+      privateKeyPem: keypair().privateKey,
+      requestedOrgName: 'acme',
+      contactEmail: 'a@x.io',
+      registryUrl: 'https://r.example',
+    })
+    const insert = dbQuery.mock.calls.find(([sql]) =>
+      String(sql).includes('INSERT INTO registry_connection')
+    )
+    // status is a BOUND PARAMETER ($7), not a SQL literal
+    expect(String(insert![0])).not.toMatch(/'pending'/)
+    expect((insert![1] as string[])[6]).toBe('pending')
+  })
+
+  it("writes 'approved' when asked", async () => {
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+    await upsertPendingConnection({
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      publicKeyPem: 'PUB',
+      privateKeyPem: keypair().privateKey,
+      requestedOrgName: 'acme',
+      contactEmail: 'a@x.io',
+      registryUrl: 'https://r.example',
+      status: 'approved',
+    })
+    const insert = dbQuery.mock.calls.find(([sql]) =>
+      String(sql).includes('INSERT INTO registry_connection')
+    )
+    expect((insert![1] as string[])[6]).toBe('approved')
+  })
+})
+
+describe('markConnected — scoped write', () => {
+  it('scopes the UPDATE to the deployment and returns true on a match', async () => {
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 1 })
+    const ok = await markConnected({
+      deploymentId: 'dep-9',
+      clientId: 'cid-9',
+      clientSecret: 'super-secret-xyz',
+      orgName: 'acme',
+    })
+    expect(ok).toBe(true)
+    const upd = dbQuery.mock.calls.find(([sql]) =>
+      String(sql).includes('UPDATE registry_connection')
+    )
+    expect(String(upd![0])).toMatch(/WHERE\s+deployment_id\s*=\s*\$4/)
+    expect(String(upd![0])).toMatch(/status\s*<>\s*'connected'/)
+    expect((upd![1] as string[])[3]).toBe('dep-9')
+  })
+
+  it('returns false when no row matched (row deleted or superseded mid-claim)', async () => {
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+    const ok = await markConnected({
+      deploymentId: 'dep-9',
+      clientId: 'cid-9',
+      clientSecret: 'super-secret-xyz',
+      orgName: 'acme',
+    })
+    expect(ok).toBe(false)
   })
 })

--- a/control-api/test/utils.log.redact.test.ts
+++ b/control-api/test/utils.log.redact.test.ts
@@ -25,4 +25,11 @@ describe('token-leak redaction', () => {
   it('redacts the registry voucher field (defense-in-depth)', () => {
     expect(TOKEN_LEAK_REDACT_PATHS).toContain('voucher')
   })
+
+  it('redacts registry connect claim tokens and client secrets', () => {
+    for (const p of ['claim_token', 'claimToken', 'client_secret', 'clientSecret']) {
+      expect(TOKEN_LEAK_REDACT_PATHS).toContain(p)
+      expect(REQUIRED_REDACT_PATHS).toContain(p)
+    }
+  })
 })

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import {
+  type RegistryRecoveryError,
   disconnectRegistryConnection,
   getRegistryConnection,
+  recoverRegistryConnection,
   requestRegistryConnection,
   submitRegistryClaim,
 } from '../lib/api'
@@ -16,6 +18,13 @@ type View =
   | { kind: 'loading' }
   | { kind: 'request' }
   | { kind: 'pending'; deploymentId?: string; requestedOrgName?: string }
+  | {
+      kind: 'connecting'
+      deploymentId?: string
+      requestedOrgName?: string
+      authEnabled?: boolean
+      recoveryError?: RegistryRecoveryError
+    }
   | { kind: 'approved'; deploymentId?: string; requestedOrgName?: string }
   | { kind: 'rejected'; requestedOrgName?: string }
   | { kind: 'connected'; org?: string; authEnabled?: boolean }
@@ -34,15 +43,28 @@ export default function RegistryConnectPanel() {
   const [busy, setBusy] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
 
-  // GET returns one of five states (registryConnect.ts): disconnected | pending |
-  // approved | rejected | connected. The reducer maps each to exactly one View —
-  // `approved` (not `pending`) carries the claim-entry form, because A1's claim
-  // token only becomes redeemable once the registry poll flips pending → approved.
+  // GET returns one of six states (registryConnect.ts): disconnected | pending |
+  // connecting | approved | rejected | connected. The reducer maps each to
+  // exactly one View. `connecting` means the registry auto-approved the request
+  // and the inline claim did not land yet — it is finished by pressing "Finish
+  // connecting" (handleRecover), never by pasting a token; under auto-approval no
+  // operator ever issues one. `approved` keeps its original meaning: an operator
+  // approved and a human must paste the token they were given out of band —
+  // A1's claim token only becomes redeemable once the registry poll flips
+  // pending → approved.
   const load = useCallback(async () => {
     try {
       const s = await getRegistryConnection()
       if (s.state === 'connected')
         setView({ kind: 'connected', org: s.org, authEnabled: s.authEnabled })
+      else if (s.state === 'connecting')
+        setView({
+          kind: 'connecting',
+          deploymentId: s.deploymentId,
+          requestedOrgName: s.requestedOrgName,
+          authEnabled: s.authEnabled,
+          recoveryError: s.recoveryError,
+        })
       else if (s.state === 'approved')
         setView({
           kind: 'approved',
@@ -57,7 +79,16 @@ export default function RegistryConnectPanel() {
           deploymentId: s.deploymentId,
           requestedOrgName: s.requestedOrgName,
         })
-      else setView({ kind: 'request' }) // disconnected
+      else if (s.state === 'disconnected') setView({ kind: 'request' })
+      else {
+        // Exhaustiveness guard. The old default was `{kind:'request'}`, which
+        // renders the registration FORM for any unrecognised state — and
+        // re-registering deletes the deployment keypair. A new state must be a
+        // compile error here, never a data-loss path.
+        const never: never = s.state
+        void never
+        setView({ kind: 'error' })
+      }
     } catch (e) {
       const code = (e as { code?: string }).code
       if (code === 'not_self_hosted') setView({ kind: 'not-self-hosted' })
@@ -75,27 +106,64 @@ export default function RegistryConnectPanel() {
       setFormError('Organization name and contact email are required.')
       return
     }
+    // The registry requires a dot-TLD (isValidContactEmail). Failing that check
+    // server-side costs one of ~5 daily registration attempts per IP, so spend
+    // it only on an address that can succeed.
+    if (!/^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@.]{2,}$/.test(email.trim())) {
+      setFormError('Enter a full contact email such as ops@example.com.')
+      return
+    }
     setBusy(true)
     try {
       const s = await requestRegistryConnection({
         requestedOrgName: orgName.trim(),
         contactEmail: email.trim(),
       })
-      // A fresh request always lands pending — the operator must approve it before
-      // the claim token is usable, so we go to the waiting view (not claim-entry).
-      setView({
-        kind: 'pending',
-        deploymentId: s.deploymentId,
-        requestedOrgName: s.requestedOrgName,
-      })
-      showToast('Registration requested — an Evenfire operator must approve it.', {
-        tone: 'success',
-      })
+      // The request endpoint can now settle three ways: the registry auto-claims
+      // the deployment inline (connected), auto-approves but the inline claim did
+      // not land (connecting — finished via handleRecover), or an operator must
+      // approve it by hand (pending, the original claim-token flow).
+      if (s.state === 'connected') {
+        setView({ kind: 'connected', org: s.org, authEnabled: s.authEnabled })
+        showToast(`Connected to @${s.org}.`, { tone: 'success' })
+      } else if (s.state === 'connecting') {
+        setView({
+          kind: 'connecting',
+          deploymentId: s.deploymentId,
+          requestedOrgName: s.requestedOrgName,
+          authEnabled: s.authEnabled,
+        })
+        showToast('Registered — finishing the connection.', { tone: 'success' })
+      } else {
+        setView({
+          kind: 'pending',
+          deploymentId: s.deploymentId,
+          requestedOrgName: s.requestedOrgName,
+        })
+        showToast('Registration requested — an Evenfire operator must approve it.', {
+          tone: 'success',
+        })
+      }
     } catch (e) {
       const code = (e as { code?: string }).code
       if (code === 'already_connected') await load()
+      else if (code === 'recovery_in_progress') await load()
       else if (code === 'org_blocklisted')
         setFormError('That organization name is not available. Try a different one.')
+      else if (code === 'org_name_taken')
+        setFormError(
+          'That organization name is already taken. Try a different one. Registration attempts are limited to about 5 per day, so choose carefully.'
+        )
+      else if (code === 'registration_capacity')
+        setFormError('The registry is not accepting new registrations right now. Try again later.')
+      else if (code === 'rate_limited')
+        setFormError('Too many registration attempts from this network. Try again tomorrow.')
+      else if (code === 'invalid_contact_email')
+        setFormError(
+          'That contact email is not a valid address. Use a full address such as ops@example.com.'
+        )
+      else if (code === 'jti_replayed')
+        setFormError('That registration attempt could not be completed. Try again.')
       else setFormError('Could not request registration. Try again shortly.')
     } finally {
       setBusy(false)
@@ -129,9 +197,68 @@ export default function RegistryConnectPanel() {
     }
   }
 
+  // Finish an auto-approved connection whose inline claim failed. Explicit
+  // user action: recovery rotates a claim token at the registry, so it must
+  // never fire from a passive render.
+  async function handleRecover() {
+    setFormError(null)
+    setBusy(true)
+    try {
+      const s = await recoverRegistryConnection()
+      if (s.state === 'connected') {
+        setView({ kind: 'connected', org: s.org, authEnabled: s.authEnabled })
+        showToast(`Connected to @${s.org}.`, { tone: 'success' })
+      } else {
+        await load()
+        setFormError('Still finishing the connection. Try again in a moment.')
+      }
+    } catch (e) {
+      const code = (e as { code?: string }).code
+      if (code === 'already_claimed' || code === 'connection_superseded')
+        setFormError(
+          'This deployment can no longer authenticate: its one-time credentials were issued but never stored. Disconnect, then register again with a different organization name.'
+        )
+      else if (code === 'deployment_suspended')
+        setFormError('This deployment has been suspended by Evenfire. Contact support.')
+      else if (code === 'client_unavailable')
+        setFormError('This deployment can no longer authenticate. Contact support.')
+      else if (code === 'not_recoverable') await load()
+      else setFormError('Could not finish connecting. Try again shortly.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   // From the terminal `rejected` view: drop the dead request row (DELETE) so the
   // operator can submit a fresh one. Best-effort — land on the request form either way.
   async function handleStartOver() {
+    setBusy(true)
+    try {
+      await disconnectRegistryConnection()
+    } catch {
+      /* best-effort — the next GET reports disconnected once the row is gone */
+    } finally {
+      setBusy(false)
+    }
+    setClaimToken('')
+    setFormError(null)
+    setView({ kind: 'request' })
+  }
+
+  // From the `connecting` view: with re-registration blocked server-side by
+  // recovery_in_progress, this DELETE is now the ONLY remaining path that can
+  // destroy a recoverable deployment — it deletes the keypair and permanently
+  // squats the org name at the registry. Route it through the same confirm
+  // dialog as handleDisconnect instead of a bare button.
+  async function handleStartOverFromConnecting() {
+    const ok = await confirm({
+      title: 'Start over',
+      message:
+        'Starting over deletes this deployment’s stored registry credentials. The organization name will be lost permanently and this deployment cannot be recovered afterwards — you would need to register again under a different name. This cannot be undone.',
+      confirmLabel: 'Start over',
+      tone: 'danger',
+    })
+    if (!ok) return
     setBusy(true)
     try {
       await disconnectRegistryConnection()
@@ -250,6 +377,54 @@ export default function RegistryConnectPanel() {
               <div className="cu-form-inline">
                 <Button type="button" variant="ghost" size="sm" onClick={() => void load()}>
                   Refresh status
+                </Button>
+              </div>
+            </div>
+          ) : null}
+
+          {view.kind === 'connecting' ? (
+            <div className="cu-form-stack">
+              <p className="cu-banner">
+                Registration approved
+                {view.requestedOrgName ? ` for @${view.requestedOrgName}` : ''}. Finishing the
+                connection — no operator approval is needed.
+              </p>
+              {view.recoveryError === 'already_claimed' ||
+              view.recoveryError === 'connection_superseded' ? (
+                <p className="cu-banner cu-banner--warn">
+                  This deployment can no longer authenticate: its one-time credentials were issued
+                  but never stored. Disconnect, then register again with a different organization
+                  name.
+                </p>
+              ) : null}
+              {view.recoveryError === 'deployment_suspended' ? (
+                <p className="cu-banner cu-banner--warn">
+                  This deployment has been suspended by Evenfire. Contact support.
+                </p>
+              ) : null}
+              {formError ? <p className="cu-banner cu-banner--warn">{formError}</p> : null}
+              <div className="cu-form-inline">
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => void handleRecover()}
+                >
+                  {busy ? 'Finishing…' : 'Finish connecting'}
+                </Button>
+                {/* Gated by confirm(), not a bare Disconnect: with re-registration
+                    blocked by recovery_in_progress, this is the only remaining path
+                    that can delete a recoverable deployment's keypair and squat its
+                    org name. */}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  disabled={busy}
+                  onClick={() => void handleStartOverFromConnecting()}
+                >
+                  Start over
                 </Button>
               </div>
             </div>

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -157,7 +157,7 @@ export default function RegistryConnectPanel() {
       else if (code === 'registration_capacity')
         setFormError('The registry is not accepting new registrations right now. Try again later.')
       else if (code === 'rate_limited')
-        setFormError('Too many registration attempts from this network. Try again tomorrow.')
+        setFormError('Too many registration attempts from this network. Try again later.')
       else if (code === 'invalid_contact_email')
         setFormError(
           'That contact email is not a valid address. Use a full address such as ops@example.com.'
@@ -189,6 +189,12 @@ export default function RegistryConnectPanel() {
         setFormError('That claim token has expired. Ask your operator to re-issue it.')
       else if (code === 'claim_rejected')
         setFormError('That claim token was rejected. Check it and try again.')
+      else if (code === 'connection_superseded')
+        // Terminal, not retryable: the registry already burned this one-time
+        // token and the credentials it returned could not be saved here.
+        setFormError(
+          'This deployment can no longer authenticate: its one-time credentials were issued but never stored. Disconnect, then register again with a different organization name.'
+        )
       else if (code === 'not_pending')
         await load() // server state moved on — re-sync
       else setFormError('Could not complete the claim. Try again shortly.')

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -139,6 +139,34 @@ describe('RegistryConnectPanel', () => {
     await waitFor(() => expect(screen.getByText(/has expired/)).toBeInTheDocument())
   })
 
+  // The server can 409 connection_superseded when markConnected matches no
+  // row (the claim token was already redeemed and burned, but the credentials
+  // could not be saved to this connection). Falling through to the generic
+  // "Could not complete the claim. Try again shortly." would tell the user to
+  // retry a claim that can never succeed again.
+  it('shows terminal copy on a connection_superseded code, not a retry prompt', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'approved',
+      deploymentId: 'd',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.submitRegistryClaim).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'connection_superseded' })
+    )
+    render(<RegistryConnectPanel />)
+    await waitFor(() => screen.getByPlaceholderText('paste claim token'))
+    fireEvent.change(screen.getByPlaceholderText('paste claim token'), {
+      target: { value: 'tok-1' },
+    })
+    fireEvent.click(screen.getByText('Complete connection'))
+    await waitFor(() =>
+      expect(
+        screen.getByText(/one-time credentials were issued but never stored/i)
+      ).toBeInTheDocument()
+    )
+    expect(screen.queryByText(/Try again shortly/i)).toBeNull()
+  })
+
   it('shows connected + Disconnect when already connected', async () => {
     vi.mocked(api.getRegistryConnection).mockResolvedValue({
       state: 'connected',
@@ -333,6 +361,28 @@ describe('RegistryConnectPanel', () => {
     await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
     expect(
       await screen.findByText(/can no longer authenticate. Contact support/i)
+    ).toBeInTheDocument()
+  })
+
+  // handleRecover's terminal arm (already_claimed / connection_superseded)
+  // drives the "Disconnect, then register again" copy. This is distinct from
+  // the "shows the terminal message when recovery is already claimed" test
+  // above, which exercises GET's recoveryError JSX, not this REJECTION path.
+  // Deleting this catch branch would keep the suite green while the user
+  // retries forever, spending an unthrottled registry rotate each time.
+  it('shows terminal disconnect-and-restart copy when recovery reports already_claimed', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'already_claimed' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(
+      await screen.findByText(/one-time credentials were issued but never stored/i)
     ).toBeInTheDocument()
   })
 

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -316,7 +316,11 @@ describe('RegistryConnectPanel', () => {
     expect(await screen.findByText(/Connected to the Evenfire Registry.*@acme/)).toBeInTheDocument()
   })
 
-  it('shows a retry message when recovery is not yet finished', async () => {
+  // Renamed from the original "shows a retry message when recovery is not yet
+  // finished" — that name was misleading. This drives a REJECTION (the
+  // client_unavailable catch arm), not a resolved-but-not-connected response.
+  // The resolved-but-not-connected case is covered separately below.
+  it('shows contact-support copy when recovery reports client_unavailable', async () => {
     vi.mocked(api.getRegistryConnection).mockResolvedValue({
       state: 'connecting',
       deploymentId: 'dep-1',
@@ -329,6 +333,106 @@ describe('RegistryConnectPanel', () => {
     await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
     expect(
       await screen.findByText(/can no longer authenticate. Contact support/i)
+    ).toBeInTheDocument()
+  })
+
+  // IMPORTANT-1 fix: handleRequest's direct `connecting` branch (:129-136) had
+  // zero coverage — every other connecting-view test reached that state via
+  // GET/load(), never via requestRegistryConnection() itself resolving
+  // 'connecting'. Without this test, collapsing that branch into the final
+  // `else` (rendering `pending` + the "must approve it" toast) would leave the
+  // suite green while telling an auto-approved-but-unclaimed user to wait for
+  // an operator who will never act.
+  it('lands on the connecting view directly when the request resolves connecting', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    vi.mocked(api.requestRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@x.io')
+    await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+    expect(await screen.findByRole('button', { name: /finish connecting/i })).toBeInTheDocument()
+    expect(screen.getByText(/Registered — finishing the connection\./i)).toBeInTheDocument()
+    // Toast is a separate mutation from the view — same hazard as the
+    // connected-view test above, now for the connecting case.
+    expect(screen.queryByText(/must approve it/i)).toBeNull()
+  })
+
+  // IMPORTANT-2 fix: the remaining four of handleRecover's six outcome
+  // branches (:211-213 resolved-non-connected, :221 deployment_suspended,
+  // :225 not_recoverable, :226 the generic catch-all) had no coverage.
+
+  it('re-syncs and shows a still-finishing message when recover resolves without connecting', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(
+      await screen.findByText(/Still finishing the connection\. Try again in a moment\./i)
+    ).toBeInTheDocument()
+    // Proves the `await load()` re-sync actually ran, not just that some
+    // message appeared — the GET mock is hit once on mount and once here.
+    expect(api.getRegistryConnection).toHaveBeenCalledTimes(2)
+  })
+
+  it('shows suspended copy when recovery reports deployment_suspended', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'deployment_suspended' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(
+      await screen.findByText(/This deployment has been suspended by Evenfire\. Contact support\./i)
+    ).toBeInTheDocument()
+  })
+
+  it('re-syncs without an error message when recovery reports not_recoverable', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'not_recoverable' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    await waitFor(() => expect(api.getRegistryConnection).toHaveBeenCalledTimes(2))
+    // Distinguishes the silent re-sync from the generic catch-all, which DOES
+    // set a formError.
+    expect(screen.queryByText(/Could not finish connecting/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /finish connecting/i })).toBeInTheDocument()
+  })
+
+  it('falls back to the generic finish-connecting error for an unmapped recover code', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'something_unmapped' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(
+      await screen.findByText(/Could not finish connecting\. Try again shortly\./i)
     ).toBeInTheDocument()
   })
 

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -1,6 +1,7 @@
 // control-ui/components/__tests__/RegistryConnectPanel.test.tsx
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as api from '../../lib/api'
 import * as ConfirmDialogModule from '../ConfirmDialog'
 import RegistryConnectPanel from '../RegistryConnectPanel'
@@ -11,6 +12,7 @@ vi.mock('../../lib/api', () => ({
   requestRegistryConnection: vi.fn(),
   submitRegistryClaim: vi.fn(),
   disconnectRegistryConnection: vi.fn(),
+  recoverRegistryConnection: vi.fn(),
 }))
 vi.mock('../ConfirmDialog', () => ({ useConfirmDialog: vi.fn() }))
 
@@ -173,5 +175,210 @@ describe('RegistryConnectPanel', () => {
       expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
     )
     expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
+  })
+
+  it('lands on the connected view when registration auto-claims', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    vi.mocked(api.requestRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      org: 'acme',
+      authEnabled: true,
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@x.io')
+    await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+    // Scoped to the banner text (not just "@acme") because the success toast also
+    // renders "Connected to @acme." — a bare /@acme/ match would be ambiguous.
+    expect(await screen.findByText(/Connected to the Evenfire Registry.*@acme/)).toBeInTheDocument()
+    // The toast is a SEPARATE mutation from the view: branching the view but
+    // leaving the toast unconditional tells a connected user to wait for an
+    // operator who does not exist.
+    expect(screen.queryByText(/must approve it/i)).toBeNull()
+  })
+
+  it('renders the connecting view with a finish button and no paste box', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    expect(await screen.findByRole('button', { name: /finish connecting/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/claim token/i)).toBeNull()
+  })
+
+  // load()'s default arm renders the registration form. Shipping a new state
+  // without a branch would show "Register this deployment" to an already-approved
+  // deployment, and re-registering destroys its keypair.
+  it('never renders the registration form for the connecting state', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    await screen.findByRole('button', { name: /finish connecting/i })
+    expect(screen.queryByRole('button', { name: /request registration/i })).toBeNull()
+  })
+
+  it('shows the terminal message when recovery is already claimed', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+      recoveryError: 'already_claimed',
+    })
+    render(<RegistryConnectPanel />)
+    expect(await screen.findByText(/can no longer authenticate/i)).toBeInTheDocument()
+  })
+
+  it('rejects a malformed contact email before calling the server', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    render(<RegistryConnectPanel />)
+    await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+    await userEvent.type(screen.getByLabelText(/email/i), 'not-an-email')
+    await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+    expect(await screen.findByText(/full contact email/i)).toBeInTheDocument()
+    expect(api.requestRegistryConnection).not.toHaveBeenCalled()
+  })
+
+  // `recovery_in_progress` is deliberately NOT in this table: it re-syncs via
+  // load() rather than setting form copy, so it needs its own mock and gets its
+  // own test below.
+  it.each([
+    ['org_name_taken', /already taken/i],
+    ['registration_capacity', /not accepting new registrations/i],
+    ['rate_limited', /too many registration attempts/i],
+    ['invalid_contact_email', /not a valid/i],
+    // The registry maps some register conflicts to jti_replayed. Copy must read
+    // as "could not complete", never surface "replay attack" to an operator.
+    ['jti_replayed', /could not be completed/i],
+  ])('renders distinct copy for %s', async (code, matcher) => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+    vi.mocked(api.requestRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@x.io')
+    await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+    expect(await screen.findByText(matcher)).toBeInTheDocument()
+  })
+
+  // control-api now sends a non-empty deployment_info, so these become reachable.
+  // They share the generic fallback copy — the bar here is just "doesn't crash or
+  // render blank".
+  it.each(['invalid_deployment_info', 'deployment_info_too_large'])(
+    'falls back to the generic registration error for %s without crashing',
+    async code => {
+      vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
+      vi.mocked(api.requestRegistryConnection).mockRejectedValue(
+        Object.assign(new Error('x'), { code })
+      )
+      render(<RegistryConnectPanel />)
+      await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+      await userEvent.type(screen.getByLabelText(/email/i), 'a@x.io')
+      await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+      expect(
+        await screen.findByText(/Could not request registration\. Try again shortly\./i)
+      ).toBeInTheDocument()
+    }
+  )
+
+  it('re-syncs to the connecting view when a re-request is refused', async () => {
+    vi.mocked(api.getRegistryConnection)
+      .mockResolvedValueOnce({ state: 'disconnected' })
+      .mockResolvedValue({ state: 'connecting', deploymentId: 'dep-1', requestedOrgName: 'acme' })
+    vi.mocked(api.requestRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'recovery_in_progress' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.type(await screen.findByLabelText(/organization/i), 'acme')
+    await userEvent.type(screen.getByLabelText(/email/i), 'a@x.io')
+    await userEvent.click(screen.getByRole('button', { name: /request registration/i }))
+    expect(await screen.findByRole('button', { name: /finish connecting/i })).toBeInTheDocument()
+  })
+
+  it('completes the connection via the recover button', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      org: 'acme',
+      authEnabled: true,
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(await screen.findByText(/Connected to the Evenfire Registry.*@acme/)).toBeInTheDocument()
+  })
+
+  it('shows a retry message when recovery is not yet finished', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(api.recoverRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'client_unavailable' })
+    )
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /finish connecting/i }))
+    expect(
+      await screen.findByText(/can no longer authenticate. Contact support/i)
+    ).toBeInTheDocument()
+  })
+
+  // --- Addition: Disconnect/Start over on the `connecting` view must be gated by
+  // confirm(), because it is now the only remaining path that can delete a
+  // recoverable deployment's keypair and permanently squat its org name.
+  it('start over on the connecting view requires confirmation before disconnecting', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    const confirmMock = vi.fn().mockResolvedValue(true)
+    vi.mocked(ConfirmDialogModule.useConfirmDialog).mockReturnValue({
+      confirm: confirmMock,
+      confirmDialog: null,
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /start over/i }))
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    const message = confirmMock.mock.calls[0]?.[0]?.message as string
+    expect(message).toMatch(/lost permanently/i)
+    expect(message).toMatch(/cannot be recovered/i)
+    await waitFor(() => expect(api.disconnectRegistryConnection).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not disconnect the connecting view when Start over is cancelled', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    vi.mocked(ConfirmDialogModule.useConfirmDialog).mockReturnValue({
+      confirm: vi.fn().mockResolvedValue(false),
+      confirmDialog: null,
+    })
+    render(<RegistryConnectPanel />)
+    await userEvent.click(await screen.findByRole('button', { name: /start over/i }))
+    expect(api.disconnectRegistryConnection).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /finish connecting/i })).toBeInTheDocument()
+  })
+
+  it('does not render a bare Disconnect button on the connecting view', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connecting',
+      deploymentId: 'dep-1',
+      requestedOrgName: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    await screen.findByRole('button', { name: /finish connecting/i })
+    expect(screen.queryByRole('button', { name: /^disconnect$/i })).toBeNull()
   })
 })

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -3376,28 +3376,50 @@ export async function revokeRegistryApiKey(id: string): Promise<void> {
 }
 
 // ─── Self-hosted registry connect flow (spec §6.1/§6.3) ───────────────────────
-// Drives control-api's /api/v1/admin/registry/connect endpoints (Plan A1 Task 7,
-// control-api/src/routes/admin/registryConnect.ts). GET polls the registry status
-// endpoint, so state ∈ disconnected|pending|approved|rejected|connected — the panel
-// renders one view per state. Uses registryCodedRequest so it can branch on err.code
-// (not_self_hosted, already_connected, not_pending, claim_expired, claim_rejected).
+// Drives control-api's /api/v1/admin/registry/connect endpoints
+// (control-api/src/routes/admin/registryConnect.ts). GET is READ-ONLY and polls
+// the registry status endpoint, so state ∈ disconnected | pending | connecting |
+// approved | rejected | connected — the panel renders one view per state.
 //
-// GET fields by state: connected → { deploymentId, org }; pending/approved/rejected
-// → { deploymentId, requestedOrgName }; disconnected → {}. All fields optional below.
-// There is NO rejection_reason in the contract.
+// `connecting` means the registry AUTO-APPROVED (open registration) and the
+// inline claim has not completed. It is finished by recoverRegistryConnection(),
+// never by pasting a token — under auto-approval no operator ever sees one.
+// `approved` keeps its original meaning: an operator approved and a human must
+// paste the token they were given out of band.
+//
+// GET fields by state: connected → { deploymentId, org, authEnabled };
+// connecting → { deploymentId, requestedOrgName, authEnabled, recoveryError? };
+// pending/approved/rejected → { deploymentId, requestedOrgName };
+// disconnected → {}. There is NO rejection_reason in the contract.
+//
+// Uses registryCodedRequest so callers can branch on err.code: not_self_hosted,
+// already_connected, recovery_in_progress, not_pending, not_recoverable,
+// org_name_taken, registration_capacity, rate_limited, invalid_contact_email,
+// org_blocklisted, claim_expired, claim_rejected, already_claimed,
+// deployment_suspended, client_unavailable, connection_superseded.
 
 export type RegistryConnectionState =
   | 'disconnected'
   | 'pending'
+  | 'connecting'
   | 'approved'
   | 'rejected'
   | 'connected'
+
+export type RegistryRecoveryError =
+  | 'already_claimed'
+  | 'deployment_suspended'
+  | 'client_unavailable'
+  | 'connection_superseded'
+  | 'claim_expired'
+
 export type RegistryConnectionStatus = {
   state: RegistryConnectionState
   deploymentId?: string
   requestedOrgName?: string
   org?: string
   authEnabled?: boolean
+  recoveryError?: RegistryRecoveryError
 }
 
 export async function getRegistryConnection(): Promise<RegistryConnectionStatus> {
@@ -3427,4 +3449,11 @@ export async function submitRegistryClaim(input: {
 
 export async function disconnectRegistryConnection(): Promise<void> {
   await registryCodedRequest('DELETE', '/api/v1/admin/registry/connect')
+}
+
+export async function recoverRegistryConnection(): Promise<RegistryConnectionStatus> {
+  return registryCodedRequest(
+    'POST',
+    '/api/v1/admin/registry/connect/recover'
+  ) as Promise<RegistryConnectionStatus>
 }

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.352",
+  "version": "0.1.353",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.352",
+      "version": "0.1.353",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.354",
+  "version": "0.1.355",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.354",
+      "version": "0.1.355",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.355",
+  "version": "0.1.356",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.355",
+      "version": "0.1.356",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.353",
+  "version": "0.1.354",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.353",
+      "version": "0.1.354",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.354",
+  "version": "0.1.355",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.355",
+  "version": "0.1.356",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.352",
+  "version": "0.1.353",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.353",
+  "version": "0.1.354",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -151,21 +151,22 @@ Details: [Connect Telegram](../how-to/connect-telegram.md).
 
 ## Troubleshooting
 
-| Symptom                                    | Fix                                                                                               |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| Agent never replies                        | No real LLM key in `.env`; with several keys, set `CLERUM_MODEL_PROVIDER` explicitly (see step 1) |
+| Symptom                                    | Fix                                                                                                                                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Agent never replies                        | No real LLM key in `.env`; with several keys, set `CLERUM_MODEL_PROVIDER` explicitly (see step 1)                                                                                    |
 | `minikube start` fails on memory           | Raise Docker Desktop to ≥10 GB RAM / 6 CPUs — or, if you can't spare it, `MINIKUBE_MEMORY=9216 make minikube-setup` (stock Docker Desktop's ~9.9 GB is just under the 10 GB default) |
-| Pods `Pending` early on                    | Calico is still coming up — wait, then `make minikube-status`                                     |
-| postgres CrashLoopBackOff after cold start | `make minikube-setup ARGS="--reset-db --skip-build"`                                              |
-| Port-forwards die                          | re-run `make minikube-pf-all` (it holds them open; Ctrl-C stops)                                  |
+| Pods `Pending` early on                    | Calico is still coming up — wait, then `make minikube-status`                                                                                                                        |
+| postgres CrashLoopBackOff after cold start | `make minikube-setup ARGS="--reset-db --skip-build"`                                                                                                                                 |
+| Port-forwards die                          | re-run `make minikube-pf-all` (it holds them open; Ctrl-C stops)                                                                                                                     |
 
 ## Next steps
 
-| Goal                      | Doc                                                                                            |
-| ------------------------- | ---------------------------------------------------------------------------------------------- |
-| Wire an MCP connector     | [Add an MCP server](../how-to/add-mcp-server.md)                                               |
-| Tune the approval gates   | [Configure approvals](../how-to/configure-approvals.md)                                        |
-| Understand the design     | [Why evenfire](../concepts/why-evenfire.md) · [Security model](../../README.md#security-model) |
-| Deep deployment reference | [Minikube guide](../deploy/minikube.md) · [Production notes](../deploy/production.md)          |
-| Tour the other UIs        | [Surfaces index](../surfaces/README.md)                                                        |
-| Learning paths            | [Learning path](learning-path.md)                                                              |
+| Goal                           | Doc                                                                                            |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Wire an MCP connector          | [Add an MCP server](../how-to/add-mcp-server.md)                                               |
+| Connect to the shared registry | [Connect to the registry](../how-to/connect-to-registry.md)                                    |
+| Tune the approval gates        | [Configure approvals](../how-to/configure-approvals.md)                                        |
+| Understand the design          | [Why evenfire](../concepts/why-evenfire.md) · [Security model](../../README.md#security-model) |
+| Deep deployment reference      | [Minikube guide](../deploy/minikube.md) · [Production notes](../deploy/production.md)          |
+| Tour the other UIs             | [Surfaces index](../surfaces/README.md)                                                        |
+| Learning paths                 | [Learning path](learning-path.md)                                                              |

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -18,21 +18,30 @@ and use registry SSO from your Control UI.
 ## Connect
 
 Open **Control UI → Registry → Connect** (`/registry/connect`). The panel walks a
-small state machine — `disconnected → pending → approved → connected`:
+small state machine — `disconnected → pending | connecting → approved → connected`:
 
-1. **Request.** Enter a **requested org name** and a **contact email**, and
-   submit. Your control-api generates a signing keypair, registers the request
-   with the registry, and saves it as **pending**. (The keypair is how the
-   registry later confirms the claim really comes from your deployment — you
-   never handle it.) A reserved or blocked org name is refused up front.
-2. **Wait for approval.** An Evenfire operator reviews the request and either
-   approves or rejects it. The panel polls the registry, so the decision appears
-   without you re-submitting.
-3. **Claim.** On approval the operator sends you a **one-time claim token**
-   out-of-band. Paste it into the panel to finish connecting. The token is
-   single-use and short-lived.
-4. **Connected.** The panel shows your bound org. You can now install catalog
-   entries, mint publish keys, and use registry SSO.
+1. **Request access.** You enter an organization name and a contact email. The
+   panel generates a keypair, registers with the registry, and saves the row.
+   (The keypair is how the registry knows later requests really come from this
+   deployment. It never leaves your cluster.)
+
+2. **What happens next depends on the registry.**
+
+   - **Open registration enabled** — the registry approves immediately and the
+     panel finishes connecting on its own. No operator is involved and no claim
+     token is ever shown to a human. If that automatic step cannot complete (a
+     network blip, or the registry briefly unavailable), the panel shows
+     **Finishing the connection** with a **Finish connecting** button; press it
+     to retry. Nothing is stranded, and you never need a token.
+
+   - **Open registration disabled** — the request lands as **pending**. An
+     Evenfire operator reviews it and either approves or rejects it. On
+     approval you receive a one-time claim token out of band; paste it into the
+     panel to finish connecting. Use **Refresh status** to check whether the
+     decision has landed.
+
+3. **Connected.** The deployment holds its machine credentials and can read the
+   catalog, publish entries, and push images to its own org.
 
 ## What connecting gives you
 

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -2,9 +2,10 @@
 
 The Evenfire registry (`registry.evenfire.ai`) is a shared catalog of connectors
 and recipes. A **managed** deployment is connected for you; a **self-hosted**
-deployment connects itself, once — after an Evenfire operator approves the
-request. This guide covers the self-hoster's side of that flow. Once connected
-you can install from the catalog, [publish under your own org](publish-plugin-to-registry.md),
+deployment connects itself, once. Depending on how the registry is configured,
+that either completes on its own or waits for an Evenfire operator to approve
+the request. This guide covers the self-hoster's side of that flow. Once
+connected you can install from the catalog, [publish under your own org](publish-plugin-to-registry.md),
 and use registry SSO from your Control UI.
 
 ## Prerequisites
@@ -17,13 +18,16 @@ and use registry SSO from your Control UI.
 
 ## Connect
 
-Open **Control UI → Registry → Connect** (`/registry/connect`). The panel walks a
-small state machine — `disconnected → pending | connecting → approved → connected`:
+Open **Control UI → Registry → Connect** (`/registry/connect`). The panel walks
+one of two state machines, depending on how the registry is configured:
 
-1. **Request access.** You enter an organization name and a contact email. The
-   panel generates a keypair, registers with the registry, and saves the row.
-   (The keypair is how the registry knows later requests really come from this
-   deployment. It never leaves your cluster.)
+- Auto-approved: `disconnected → connecting → connected`
+- Operator-approved: `disconnected → pending → approved → connected`
+
+1. **Request access.** You enter an organization name and a contact email. Your
+   control-api generates a signing keypair, registers with the registry, and
+   saves the row. (The keypair is how the registry knows later requests really
+   come from this deployment. It never leaves your cluster.)
 
 2. **What happens next depends on the registry.**
 
@@ -32,7 +36,12 @@ small state machine — `disconnected → pending | connecting → approved → 
      token is ever shown to a human. If that automatic step cannot complete (a
      network blip, or the registry briefly unavailable), the panel shows
      **Finishing the connection** with a **Finish connecting** button; press it
-     to retry. Nothing is stranded, and you never need a token.
+     to retry. In most cases, retrying with **Finish connecting** will succeed and
+     you never need a token. If the panel reports that the deployment can no
+     longer authenticate, **Finish connecting** will not help — the only path
+     forward is **Start over**, which permanently deletes the deployment's stored
+     registry credentials and gives up the organization name. If you use
+     **Start over**, you must register again under a different organization name.
 
    - **Open registration disabled** — the request lands as **pending**. An
      Evenfire operator reviews it and either approves or rejects it. On

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -36,11 +36,14 @@ one of two state machines, depending on how the registry is configured:
      network blip, or the registry briefly unavailable), the panel shows
      **Finishing the connection** with a **Finish connecting** button; press it
      to retry. In most cases, retrying with **Finish connecting** will succeed and
-     you never need a token. If the panel reports that the deployment can no
-     longer authenticate, **Finish connecting** will not help — the only path
-     forward is **Start over**, which permanently deletes the deployment's stored
-     registry credentials and gives up the organization name. If you use
-     **Start over**, you must register again under a different organization name.
+     you never need a token. If the panel says to contact support, do that: a
+     suspended deployment can be reversed by Evenfire, and **Start over** would
+     destroy a keypair you may still need. Only use **Start over** when the
+     panel says the deployment's one-time credentials were issued but never
+     stored. That connection cannot be recovered: **Start over** permanently
+     deletes the deployment's stored registry credentials and gives up the
+     organization name. If you use **Start over**, you must register again
+     under a different organization name.
 
    - **Open registration disabled** — the request lands as **pending**. An
      Evenfire operator reviews it and either approves or rejects it. On

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -30,7 +30,6 @@ one of two state machines, depending on how the registry is configured:
    come from this deployment. It never leaves your cluster.)
 
 2. **What happens next depends on the registry.**
-
    - **Open registration enabled** — the registry approves immediately and the
      panel finishes connecting on its own. No operator is involved and no claim
      token is ever shown to a human. If that automatic step cannot complete (a

--- a/docs/surfaces/control-ui.md
+++ b/docs/surfaces/control-ui.md
@@ -92,7 +92,8 @@ five steps live together.
    applies to custom coordinator images in workflow recipes, not to
    connector images, and it is required by default there. A self-hosted
    deployment [connects to the registry](../how-to/connect-to-registry.md) once
-   (operator-approved) before it can install or
+   (automatically, or after an operator approves it, depending on the
+   registry) before it can install or
    [publish](../how-to/publish-plugin-to-registry.md) under its own org.
 
    ![Control UI registry catalog at /registry showing trust levels and the install flow](../assets/control-ui-registry-install.webp)


### PR DESCRIPTION
## What this fixes

Registry PR #59 adds open self-hosted registration: with `CLERUM_REGISTRY_OPEN_REGISTRATION` on, `POST /api/v1/deployments/register` auto-approves inside the transaction and returns `201` with a one-time `claim_token`.

The self-hosted control-api could not consume that response. In `control-api/src/routes/admin/registryConnect.ts` on `dev`:

- `:187` parsed the response as `{ deployment_id, key_id }` — the `claim_token` was dropped on the floor.
- `:179` used `if (!regRes.ok)`, so `201` passed as success and nothing distinguished auto-approved from pending.
- `:199` always replied `{ state: 'pending' }`.
- `:72` the status poller parsed `{ status?: unknown }` and never read `claimed`.

The token only ever exists in that response body. Discarding it meant every open registration stranded permanently: approved at the registry, holding a valid keypair, with no credentials and no way to obtain them.

A second defect rode along: PR #59's new rejections (`409 org_name_taken`, `429 registration_capacity`, `429 RATE_LIMITED`, `400 invalid_contact_email`) all collapsed into an opaque `502 registry_integration_error`. A self-hoster who picked a taken org name was told "registry integration error".

## What changed

**control-api**

- `redeemClaim()` is now the single claim implementation, shared by the manual paste route and the new automatic paths. It is exception-total: `markConnected` encrypts and writes to Postgres *after* the registry has already burned the one-time secret, so a throw there must be a value the caller can act on.
- The register handler branches on status. On `201` it persists the connection row **first**, then redeems the token. On `202` it is byte-identical to before.
- New `POST /admin/registry/connect/recover` finishes a connection whose inline claim failed: it reads `/status` first, returns terminal errors without spending a rotate, then rotates a fresh token and redeems it.
- `GET /admin/registry/connect` stays read-only.
- Registry rejections map to distinct, actionable codes via allowlists with stated defaults.
- Every registry `fetch` in the file is now bounded with `AbortSignal.timeout`.

**control-ui**

- New `connecting` wire state with a **Finish connecting** button. Under auto-approval no operator ever sees a claim token, so the old "paste the token your operator gave you" view is the wrong thing to show.
- `load()`'s catch-all default is replaced by an explicit `disconnected` branch plus a `never` exhaustiveness guard.
- `handleRequest` branches the view **and** the toast on the response.
- Distinct copy for each new registry rejection, plus client-side email validation so a typo does not spend one of the registry's ~5 daily per-IP registration attempts.

**docs** — `docs/how-to/connect-to-registry.md` documents both approval paths and drops the claim that the panel polls (it does not; it loads once on mount).

## Safety properties

Four properties are load-bearing. Each was verified against the final integrated state, not per-commit, and each has a test that fails under mutation:

1. **The operator flow cannot be broken.** A `202 pending` registration must never cause a `POST /:id/claim-token` rotate — rotating would silently invalidate the one-time token an operator delivered out of band to a human. There is exactly one rotate call site, behind a `status !== 'approved'` gate, and exactly one writer of local `'approved'`, derived from `regRes.status === 201` alone.
2. **`GET` is read-only.** It is called by `RegistryCatalog.tsx` on every Marketplace mount and is reachable by cross-site top-level navigation (`SameSite=Lax`, no CSRF check in this repo). Recovery is therefore an explicit `POST`, not a side effect of `GET`.
3. **Persist before claim.** The keypair is the only artifact that can recover an approved deployment, because rotate is proof-of-possession gated. Claiming first and dying before the write would burn the token *and* lose the key.
4. **Credentials cannot cross-wire.** `markConnected` had no `WHERE` clause; it now scopes to the deployment that actually claimed and reports a 0-row match instead of silently succeeding.

`claim_token` and `client_secret` are never logged, returned, or persisted outside the encrypted column. The four names are also added to `TOKEN_LEAK_REDACT_PATHS` and `REQUIRED_REDACT_PATHS`, the latter enforced by an existing test so redactions can grow but never shrink.

## Testing

- control-api: **3519 passed**, 51 skipped
- control-ui: **1112 passed**
- `node scripts/prettier/run-all.mjs --check` clean on all 14 files this branch touches (pre-existing `tests/e2e/` drift on `dev` is untouched)

## Release ordering — read before flipping the flag

**This branch is safe to merge on its own. It is behaviour-neutral while the registry flag is off.**

`CLERUM_REGISTRY_OPEN_REGISTRATION` must **not** be enabled on the shared registry until a capability gate lands there. Without it, the flag is all-or-nothing: every control-api older than this branch receives a `201`, discards the token, and strands permanently. That gate makes auto-approval conditional on the client declaring `deployment_info.auto_claim === true`, which this branch now sends.

The gate is written and its suite is green, but it is **not pushed** — PR #59's worktree is held by another active session, so it lives on a separate local branch pending coordination.

## Known follow-ups (deliberately not in this PR)

- **Register timeout strand window.** If the registry commits a registration and burns the claim token but answers after the 10s timeout, nothing is persisted locally and re-registering that org name returns `409 org_name_taken` permanently, while the operator sees a bare 500. This pre-dates the change for any register-fetch failure; the timeout widens it. Wants a distinct error code and panel copy.
- **`authEnabled` on the recovery response** has no negative-case test, so hardcoding `true` there would survive the suite. Blast radius is a missing "enable registry auth" banner for a self-hoster running `CLERUM_REGISTRY_AUTH_ENABLED=false`, and it self-heals on the next page load.
- **`connection_superseded` on the manual claim path** renders terminal copy telling the user to disconnect, but it renders in the `approved` view, which has no Disconnect control. Rare race; a dead end rather than a data-loss path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
