### PR TITLE
fix(seed): send agent-grant CAS precondition to admin API

### DIFF
--- a/scripts/e2e/seed-e2e-data.sh
+++ b/scripts/e2e/seed-e2e-data.sh
@@ -454,6 +454,25 @@ put_json() {
   fi
 }
 
+# CAS-aware agent-grant replace. The admin agents endpoints
+# (control-api routes/admin/agentGrants.ts) guard writes with a compare-and-swap:
+# the body must carry expectedCurrentAgentNames, or the server rejects it with
+# 428 agent_grant_precondition_required. We GET the current grant first and send
+# its full stored set (active + deleted history) as the precondition, which keeps
+# the seed idempotent across re-runs. (The parallel contexts endpoints have no
+# such guard, so those still use put_json directly.)
+put_agents() {
+  local url="$1" agent="$2" label="$3"
+  ADMIN_GET_BODY=""
+  admin_get "$url" "GET $label"
+  local expected
+  expected="$(echo "$ADMIN_GET_BODY" | jq -c '([.agentNames[]?] + [.deletedAgentNames[]?])')"
+  put_json "$url" \
+    "$(jq -cn --arg a "$agent" --argjson e "$expected" \
+        '{agentNames: [$a], expectedCurrentAgentNames: $e}')" \
+    "$label"
+}
+
 ensure_seed_user_and_team() {
   local email="$1"
   local name="$2"
@@ -498,8 +517,7 @@ TEAM_ID="$ENSURE_TEAM_ID"
 # ─── Step 3: Idempotent user↔agent and user↔context bindings ───────────
 
 log "Binding user $DEV_EMAIL ↔ agent=$AGENT_NAME, context=$CONTEXT_ID"
-put_json "$CAPI_BASE/admin/users/$USER_ID/agents" \
-  "$(jq -cn --arg a "$AGENT_NAME" '{agentNames: [$a]}')" \
+put_agents "$CAPI_BASE/admin/users/$USER_ID/agents" "$AGENT_NAME" \
   "PUT /admin/users/:userId/agents"
 
 put_json "$CAPI_BASE/admin/users/$USER_ID/contexts" \
@@ -509,8 +527,7 @@ put_json "$CAPI_BASE/admin/users/$USER_ID/contexts" \
 # ─── Step 4: Team-level bindings (if the user has a team) ──────────────
 if [ -n "$TEAM_ID" ]; then
   log "Binding team ${TEAM_ID:0:8}… ↔ agent=$AGENT_NAME, context=$CONTEXT_ID"
-  put_json "$CAPI_BASE/admin/teams/$TEAM_ID/agents" \
-    "$(jq -cn --arg a "$AGENT_NAME" '{agentNames: [$a]}')" \
+  put_agents "$CAPI_BASE/admin/teams/$TEAM_ID/agents" "$AGENT_NAME" \
     "PUT /admin/teams/:teamId/agents"
   put_json "$CAPI_BASE/admin/teams/$TEAM_ID/contexts" \
     "$(jq -cn --arg c "$CONTEXT_ID" '{contextIds: [$c]}')" \
@@ -527,8 +544,7 @@ if [ "$SEED_SECOND_E2E_USER" = "true" ]; then
 
   # ─── Step 6: Idempotent user2↔agent and user2↔context bindings ───────
   log "Binding user $DEV_EMAIL_2 ↔ agent=$AGENT_NAME, context=$CONTEXT_ID"
-  put_json "$CAPI_BASE/admin/users/$USER_ID_2/agents" \
-    "$(jq -cn --arg a "$AGENT_NAME" '{agentNames: [$a]}')" \
+  put_agents "$CAPI_BASE/admin/users/$USER_ID_2/agents" "$AGENT_NAME" \
     "PUT /admin/users/:userId2/agents"
 
   put_json "$CAPI_BASE/admin/users/$USER_ID_2/contexts" \
@@ -538,8 +554,7 @@ if [ "$SEED_SECOND_E2E_USER" = "true" ]; then
   # ─── Step 7: Team-level bindings for second user (if the user has a team)
   if [ -n "$TEAM_ID_2" ]; then
     log "Binding team ${TEAM_ID_2:0:8}… ↔ agent=$AGENT_NAME, context=$CONTEXT_ID"
-    put_json "$CAPI_BASE/admin/teams/$TEAM_ID_2/agents" \
-      "$(jq -cn --arg a "$AGENT_NAME" '{agentNames: [$a]}')" \
+    put_agents "$CAPI_BASE/admin/teams/$TEAM_ID_2/agents" "$AGENT_NAME" \
       "PUT /admin/teams/:teamId2/agents"
     put_json "$CAPI_BASE/admin/teams/$TEAM_ID_2/contexts" \
       "$(jq -cn --arg c "$CONTEXT_ID" '{contextIds: [$c]}')" \

--- a/scripts/e2e/seed-stateless-host.sh
+++ b/scripts/e2e/seed-stateless-host.sh
@@ -209,12 +209,17 @@ associate_agents_union() {
   # PUT /admin/.../agents filters names against the ACTIVE agent set, so a
   # just-applied Host CR can lag. Retry until the response echoes the new
   # agent back; die loudly if it never does (silent filtering is a failure).
-  local url="$1" label="$2" attempt=1 union
+  local url="$1" label="$2" attempt=1 union expected
   while :; do
     admin_call GET "$url"
     union="$(echo "$ADMIN_BODY" | jq -c --arg a "$STATELESS_HOST" \
       '((.agentNames // []) + [$a]) | unique')"
-    admin_call PUT "$url" "$(jq -cn --argjson names "$union" '{agentNames: $names}')"
+    # CAS precondition: the server's stored set is active + deleted history.
+    # Omitting expectedCurrentAgentNames now yields 428 (agentGrants.ts).
+    expected="$(echo "$ADMIN_BODY" | jq -c '((.agentNames // []) + (.deletedAgentNames // []))')"
+    admin_call PUT "$url" \
+      "$(jq -cn --argjson names "$union" --argjson e "$expected" \
+        '{agentNames: $names, expectedCurrentAgentNames: $e}')"
     if echo "$ADMIN_BODY" | jq -e --arg a "$STATELESS_HOST" \
         '(.agentNames // []) | index($a) != null' >/dev/null; then
       ok "$label now includes '${STATELESS_HOST}'"


### PR DESCRIPTION
The admin agent-grant endpoints (control-api routes/admin/agentGrants.ts) guard writes with a compare-and-swap: PUT /admin/{users,teams}/:id/agents now requires expectedCurrentAgentNames in the body, else it returns 428 agent_grant_precondition_required. The TypeScript clients and tests were updated for this, but the bash seed scripts were missed — so a from-zero `make minikube-setup` aborts at Step 10 (Seed Test User), leaving the bootstrap admin on the publicly-known default password.

Route all agent-grant PUTs through a CAS-aware helper that GETs the current grant first and sends its full stored set (active + deleted history) as the precondition, keeping the seed idempotent across re-runs. The parallel contexts endpoints have no such guard and are left unchanged.

- scripts/e2e/seed-e2e-data.sh: add put_agents helper; route the 4 agent PUTs
- scripts/e2e/seed-stateless-host.sh: add precondition to the union PUT

Verified against a live minikube from-zero run: all four agent-grant PUTs return 200 and the seed completes.

## Summary

## Testing

- [ ] `npm test` passes for changed services
- [ ] `npx tsc --noEmit` clean

## Checklist

- [ ] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)
