### PR TITLE
chore: add column sorting to LLM models table

### DIFF
--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -1524,10 +1524,18 @@ textarea.cu-input {
   font-size: 0.8125rem;
 }
 
-/* Sortable table header label: reads as header text, behaves as a button. */
+/* Sortable table header label: reads as header text, behaves as a button.
+   Inherits the <th> typography (0.7rem, uppercase) through `.cu-link`'s
+   `font: inherit` — deliberately NOT combined with `.cu-link--sm`, which would
+   bump it to 0.8125rem and break size parity with plain headers and with the
+   loading skeleton. */
 .cu-link--sort {
   color: var(--cu-text-muted);
   white-space: nowrap;
+}
+
+.cu-link--sort:hover {
+  color: var(--cu-text);
 }
 
 .cu-link--danger {

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -1524,6 +1524,12 @@ textarea.cu-input {
   font-size: 0.8125rem;
 }
 
+/* Sortable table header label: reads as header text, behaves as a button. */
+.cu-link--sort {
+  color: var(--cu-text-muted);
+  white-space: nowrap;
+}
+
 .cu-link--danger {
   color: var(--cu-danger);
 }

--- a/control-ui/components/LlmModelTable.tsx
+++ b/control-ui/components/LlmModelTable.tsx
@@ -16,7 +16,23 @@ import { TablePanelHeader } from './TablePanelHeader'
 import { IconPencil, IconRefresh, IconX } from './icons'
 import { SelectInput } from './ui'
 
-const MODEL_COLUMNS: TableHeaderColumn[] = [
+type ModelSortKey =
+  | 'provider'
+  | 'model'
+  | 'vendor'
+  | 'displayName'
+  | 'contextWindow'
+  | 'enabled'
+  | 'source'
+  | 'stale'
+
+// A column may only opt into sorting if its key is one `compareByKey` knows how
+// to order — marking `sortable: true` on any other column is a compile error,
+// so MODEL_COLUMNS and the comparator cannot drift apart.
+type ModelColumn = TableHeaderColumn &
+  ({ sortable: true; key: ModelSortKey } | { sortable?: false })
+
+const MODEL_COLUMNS: ModelColumn[] = [
   { key: 'provider', label: 'Provider', width: '10%', sortable: true },
   { key: 'model', label: 'Model', minWidth: '12rem', sortable: true },
   { key: 'vendor', label: 'Vendor', width: '10rem', sortable: true },
@@ -39,36 +55,33 @@ const ALL_PROVIDERS = '__all__'
 type EnabledFilter = 'all' | 'enabled' | 'disabled'
 type SourceFilter = 'all' | 'manual' | 'discovery'
 
-type ModelSortKey =
-  | 'provider'
-  | 'model'
-  | 'vendor'
-  | 'displayName'
-  | 'contextWindow'
-  | 'enabled'
-  | 'source'
-  | 'stale'
-
-const SORTABLE_KEYS = new Set<string>(
-  MODEL_COLUMNS.filter(column => column.sortable).map(column => column.key)
+const SORTABLE_KEYS: ReadonlySet<ModelSortKey> = new Set(
+  MODEL_COLUMNS.flatMap(column => (column.sortable ? [column.key] : []))
 )
+
+function isModelSortKey(key: string): key is ModelSortKey {
+  return (SORTABLE_KEYS as ReadonlySet<string>).has(key)
+}
 
 // Rows with no value for the sorted column always sink to the bottom, in both
 // directions — flipping the direction must not promote "—" cells to the top.
-function isBlank(value: string | number | null | undefined): boolean {
-  return value === null || value === undefined || value === ''
-}
-
-function compareBlankLast(
-  a: string | number | null | undefined,
-  b: string | number | null | undefined
-): number | null {
-  const aBlank = isBlank(a)
-  const bBlank = isBlank(b)
+// Returns null when both sides have a value and the caller must compare them.
+function compareBlankLast(aBlank: boolean, bBlank: boolean): number | null {
   if (aBlank && bBlank) return 0
   if (aBlank) return 1
   if (bBlank) return -1
   return null
+}
+
+function isBlankText(value: string | null | undefined): boolean {
+  return value === null || value === undefined || value === ''
+}
+
+// Mirrors `formatContextWindow`, which renders '—' for null/undefined AND for
+// any non-finite number — a NaN off the wire must sink with the empty cells,
+// not land mid-table.
+function isBlankNumber(value: number | null | undefined): boolean {
+  return !Number.isFinite(value)
 }
 
 function compareByKey(
@@ -88,17 +101,20 @@ function compareByKey(
     case 'model':
       return sign * a.model.localeCompare(b.model)
     case 'vendor': {
-      const blank = compareBlankLast(a.vendor, b.vendor)
+      const blank = compareBlankLast(isBlankText(a.vendor), isBlankText(b.vendor))
       if (blank !== null) return blank
       return sign * String(a.vendor).localeCompare(String(b.vendor))
     }
     case 'displayName': {
-      const blank = compareBlankLast(a.display_name, b.display_name)
+      const blank = compareBlankLast(isBlankText(a.display_name), isBlankText(b.display_name))
       if (blank !== null) return blank
       return sign * String(a.display_name).localeCompare(String(b.display_name))
     }
     case 'contextWindow': {
-      const blank = compareBlankLast(a.context_window_tokens, b.context_window_tokens)
+      const blank = compareBlankLast(
+        isBlankNumber(a.context_window_tokens),
+        isBlankNumber(b.context_window_tokens)
+      )
       if (blank !== null) return blank
       return sign * (Number(a.context_window_tokens) - Number(b.context_window_tokens))
     }
@@ -110,6 +126,12 @@ function compareByKey(
       return sign * (a.source ?? 'manual').localeCompare(b.source ?? 'manual')
     case 'stale':
       return sign * (Number(a.stale === true) - Number(b.stale === true))
+    default: {
+      // `strict` is off in this project, so a missing case would otherwise
+      // return undefined silently. This makes it a compile error.
+      const exhaustive: never = key
+      return exhaustive
+    }
   }
 }
 
@@ -176,20 +198,24 @@ export function LlmModelTable({
     return [...filteredItems].sort((a, b) => {
       const primary = compareByKey(a, b, sortKey, sortDir)
       if (primary !== 0) return primary
-      // Stable tie-breaker so equal cells never shuffle between renders.
-      const byProvider = a.provider.localeCompare(b.provider)
+      // Deliberate secondary order for rows that tie on the sorted column:
+      // provider then model, always ascending, so a tied group still reads
+      // top-to-bottom the way the Provider column is labelled. Reuses the
+      // provider comparator so the tie-break sorts on the display label
+      // ("Anthropic"), not the raw slug ("claude").
+      const byProvider = compareByKey(a, b, 'provider', 'asc')
       if (byProvider !== 0) return byProvider
       return a.model.localeCompare(b.model)
     })
   }, [filteredItems, sortKey, sortDir])
 
   function toggleSort(nextKey: string) {
-    if (!SORTABLE_KEYS.has(nextKey)) return
+    if (!isModelSortKey(nextKey)) return
     if (sortKey === nextKey) {
       setSortDir(prev => (prev === 'asc' ? 'desc' : 'asc'))
       return
     }
-    setSortKey(nextKey as ModelSortKey)
+    setSortKey(nextKey)
     setSortDir('asc')
   }
 

--- a/control-ui/components/LlmModelTable.tsx
+++ b/control-ui/components/LlmModelTable.tsx
@@ -11,20 +11,26 @@ import { SectionSearchInput } from './SectionSearchInput'
 import { IconModels } from './Sidebar/icons'
 import { SkeletonTableRows } from './SkeletonTableRows'
 import { TableHeaderRow } from './TableHeaderRow'
-import type { TableHeaderColumn } from './TableHeaderRow/types'
+import type { TableHeaderColumn, TableSortDirection } from './TableHeaderRow/types'
 import { TablePanelHeader } from './TablePanelHeader'
 import { IconPencil, IconRefresh, IconX } from './icons'
 import { SelectInput } from './ui'
 
 const MODEL_COLUMNS: TableHeaderColumn[] = [
-  { key: 'provider', label: 'Provider', width: '10%' },
-  { key: 'model', label: 'Model', minWidth: '12rem' },
-  { key: 'vendor', label: 'Vendor', width: '10rem' },
-  { key: 'displayName', label: 'Display name', minWidth: '10rem' },
-  { key: 'contextWindow', label: 'Context window', align: 'right', width: '9rem' },
-  { key: 'enabled', label: 'Enabled', width: '6rem' },
-  { key: 'source', label: 'Source', width: '7rem' },
-  { key: 'stale', label: 'Stale', width: '6rem' },
+  { key: 'provider', label: 'Provider', width: '10%', sortable: true },
+  { key: 'model', label: 'Model', minWidth: '12rem', sortable: true },
+  { key: 'vendor', label: 'Vendor', width: '10rem', sortable: true },
+  { key: 'displayName', label: 'Display name', minWidth: '10rem', sortable: true },
+  {
+    key: 'contextWindow',
+    label: 'Context window',
+    align: 'right',
+    width: '9rem',
+    sortable: true,
+  },
+  { key: 'enabled', label: 'Enabled', width: '6rem', sortable: true },
+  { key: 'source', label: 'Source', width: '7rem', sortable: true },
+  { key: 'stale', label: 'Stale', width: '6rem', sortable: true },
   { key: 'actions', width: '5rem', align: 'right', ariaLabel: 'Actions' },
 ]
 
@@ -32,6 +38,80 @@ const ALL_PROVIDERS = '__all__'
 
 type EnabledFilter = 'all' | 'enabled' | 'disabled'
 type SourceFilter = 'all' | 'manual' | 'discovery'
+
+type ModelSortKey =
+  | 'provider'
+  | 'model'
+  | 'vendor'
+  | 'displayName'
+  | 'contextWindow'
+  | 'enabled'
+  | 'source'
+  | 'stale'
+
+const SORTABLE_KEYS = new Set<string>(
+  MODEL_COLUMNS.filter(column => column.sortable).map(column => column.key)
+)
+
+// Rows with no value for the sorted column always sink to the bottom, in both
+// directions — flipping the direction must not promote "—" cells to the top.
+function isBlank(value: string | number | null | undefined): boolean {
+  return value === null || value === undefined || value === ''
+}
+
+function compareBlankLast(
+  a: string | number | null | undefined,
+  b: string | number | null | undefined
+): number | null {
+  const aBlank = isBlank(a)
+  const bBlank = isBlank(b)
+  if (aBlank && bBlank) return 0
+  if (aBlank) return 1
+  if (bBlank) return -1
+  return null
+}
+
+function compareByKey(
+  a: LlmAllowedModel,
+  b: LlmAllowedModel,
+  key: ModelSortKey,
+  dir: TableSortDirection
+): number {
+  const sign = dir === 'asc' ? 1 : -1
+  switch (key) {
+    case 'provider':
+      // Sort on the label the operator actually reads, not the raw slug.
+      return (
+        sign *
+        getProviderDisplayLabel(a.provider).localeCompare(getProviderDisplayLabel(b.provider))
+      )
+    case 'model':
+      return sign * a.model.localeCompare(b.model)
+    case 'vendor': {
+      const blank = compareBlankLast(a.vendor, b.vendor)
+      if (blank !== null) return blank
+      return sign * String(a.vendor).localeCompare(String(b.vendor))
+    }
+    case 'displayName': {
+      const blank = compareBlankLast(a.display_name, b.display_name)
+      if (blank !== null) return blank
+      return sign * String(a.display_name).localeCompare(String(b.display_name))
+    }
+    case 'contextWindow': {
+      const blank = compareBlankLast(a.context_window_tokens, b.context_window_tokens)
+      if (blank !== null) return blank
+      return sign * (Number(a.context_window_tokens) - Number(b.context_window_tokens))
+    }
+    case 'enabled':
+      // false < true, so ascending lists Disabled before Enabled.
+      return sign * (Number(a.enabled) - Number(b.enabled))
+    case 'source':
+      // Legacy rows without `source` render as Manual — sort them the same way.
+      return sign * (a.source ?? 'manual').localeCompare(b.source ?? 'manual')
+    case 'stale':
+      return sign * (Number(a.stale === true) - Number(b.stale === true))
+  }
+}
 
 export function LlmModelTable({
   items,
@@ -48,6 +128,9 @@ export function LlmModelTable({
   const [providerFilter, setProviderFilter] = useState<string>(ALL_PROVIDERS)
   const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>('all')
   const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all')
+  // null = untouched, keep the order the API returned.
+  const [sortKey, setSortKey] = useState<ModelSortKey | null>(null)
+  const [sortDir, setSortDir] = useState<TableSortDirection>('asc')
   const normalizedSearch = searchQuery.trim().toLowerCase()
 
   const providerOptions = useMemo(() => {
@@ -85,6 +168,30 @@ export function LlmModelTable({
         .includes(normalizedSearch)
     })
   }, [items, normalizedSearch, providerFilter, enabledFilter, sourceFilter])
+
+  // Sorting runs on the already-filtered subset, so filters stay applied by
+  // construction and the header count keeps tracking `filteredItems`.
+  const sortedItems = useMemo(() => {
+    if (!sortKey) return filteredItems
+    return [...filteredItems].sort((a, b) => {
+      const primary = compareByKey(a, b, sortKey, sortDir)
+      if (primary !== 0) return primary
+      // Stable tie-breaker so equal cells never shuffle between renders.
+      const byProvider = a.provider.localeCompare(b.provider)
+      if (byProvider !== 0) return byProvider
+      return a.model.localeCompare(b.model)
+    })
+  }, [filteredItems, sortKey, sortDir])
+
+  function toggleSort(nextKey: string) {
+    if (!SORTABLE_KEYS.has(nextKey)) return
+    if (sortKey === nextKey) {
+      setSortDir(prev => (prev === 'asc' ? 'desc' : 'asc'))
+      return
+    }
+    setSortKey(nextKey as ModelSortKey)
+    setSortDir('asc')
+  }
 
   const hasActiveFilter =
     Boolean(normalizedSearch) ||
@@ -212,10 +319,15 @@ export function LlmModelTable({
         <div className="cu-table-wrap">
           <table className="cu-table cu-table--header-band">
             <thead>
-              <TableHeaderRow columns={MODEL_COLUMNS} />
+              <TableHeaderRow
+                columns={MODEL_COLUMNS}
+                sortKey={sortKey}
+                sortDir={sortDir}
+                onSortToggle={toggleSort}
+              />
             </thead>
             <tbody>
-              {filteredItems.map((model: LlmAllowedModel) => (
+              {sortedItems.map((model: LlmAllowedModel) => (
                 <tr key={model.id} className="cu-table__row">
                   <td>{getProviderDisplayLabel(model.provider)}</td>
                   <td className="cu-px-model">

--- a/control-ui/components/TableHeaderRow/index.tsx
+++ b/control-ui/components/TableHeaderRow/index.tsx
@@ -3,7 +3,12 @@
 import React from 'react'
 import type { TableHeaderColumn, TableHeaderRowProps } from './types'
 
-function sortAriaLabel(column: TableHeaderColumn, isActive: boolean, nextDir: string) {
+// Hint for the pointer tooltip only. It must NOT be an aria-label: that would
+// override the button's text as the accessible name and, since the button is
+// the sole content of the <th>, screen readers would announce "Sort by model
+// ascending" as the header of every cell in the column. The sort state is
+// already conveyed by `aria-sort` on the <th>.
+function sortTitle(column: TableHeaderColumn, nextDir: 'ascending' | 'descending') {
   const name =
     column.sortLabel ??
     (typeof column.label === 'string' ? column.label : (column.ariaLabel ?? column.key))
@@ -21,8 +26,9 @@ export function TableHeaderRow({
       {columns.map(column => {
         const isSortable = Boolean(column.sortable) && Boolean(onSortToggle)
         const isActive = isSortable && sortKey === column.key
-        // The label announces the direction the *next* click will apply.
-        const nextDir = isActive && sortDir === 'asc' ? 'descending' : 'ascending'
+        // The tooltip announces the direction the *next* click will apply.
+        const nextDir: 'ascending' | 'descending' =
+          isActive && sortDir === 'asc' ? 'descending' : 'ascending'
         return (
           <th
             key={column.key}
@@ -38,12 +44,14 @@ export function TableHeaderRow({
             {isSortable ? (
               <button
                 type="button"
-                className="cu-link cu-link--sm cu-link--sort"
+                className="cu-link cu-link--sort"
                 onClick={() => onSortToggle?.(column.key)}
-                aria-label={sortAriaLabel(column, isActive, nextDir)}
+                title={sortTitle(column, nextDir)}
               >
                 {column.label}
-                {isActive ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+                {isActive ? (
+                  <span aria-hidden="true">{sortDir === 'asc' ? ' ↑' : ' ↓'}</span>
+                ) : null}
               </button>
             ) : (
               column.label

--- a/control-ui/components/TableHeaderRow/index.tsx
+++ b/control-ui/components/TableHeaderRow/index.tsx
@@ -1,25 +1,56 @@
 'use client'
 
 import React from 'react'
-import type { TableHeaderColumn } from './types'
+import type { TableHeaderColumn, TableHeaderRowProps } from './types'
 
-export function TableHeaderRow({ columns }: { columns: TableHeaderColumn[] }) {
+function sortAriaLabel(column: TableHeaderColumn, isActive: boolean, nextDir: string) {
+  const name =
+    column.sortLabel ??
+    (typeof column.label === 'string' ? column.label : (column.ariaLabel ?? column.key))
+  return `Sort by ${name.toLowerCase()} ${nextDir}`
+}
+
+export function TableHeaderRow({
+  columns,
+  sortKey = null,
+  sortDir = 'asc',
+  onSortToggle,
+}: TableHeaderRowProps) {
   return (
     <tr>
-      {columns.map(column => (
-        <th
-          key={column.key}
-          aria-label={column.ariaLabel}
-          title={column.title}
-          style={{
-            ...(column.width ? { width: column.width } : {}),
-            ...(column.minWidth ? { minWidth: column.minWidth } : {}),
-            ...(column.align ? { textAlign: column.align } : {}),
-          }}
-        >
-          {column.label}
-        </th>
-      ))}
+      {columns.map(column => {
+        const isSortable = Boolean(column.sortable) && Boolean(onSortToggle)
+        const isActive = isSortable && sortKey === column.key
+        // The label announces the direction the *next* click will apply.
+        const nextDir = isActive && sortDir === 'asc' ? 'descending' : 'ascending'
+        return (
+          <th
+            key={column.key}
+            aria-label={column.ariaLabel}
+            aria-sort={isActive ? (sortDir === 'asc' ? 'ascending' : 'descending') : undefined}
+            title={column.title}
+            style={{
+              ...(column.width ? { width: column.width } : {}),
+              ...(column.minWidth ? { minWidth: column.minWidth } : {}),
+              ...(column.align ? { textAlign: column.align } : {}),
+            }}
+          >
+            {isSortable ? (
+              <button
+                type="button"
+                className="cu-link cu-link--sm cu-link--sort"
+                onClick={() => onSortToggle?.(column.key)}
+                aria-label={sortAriaLabel(column, isActive, nextDir)}
+              >
+                {column.label}
+                {isActive ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+              </button>
+            ) : (
+              column.label
+            )}
+          </th>
+        )
+      })}
     </tr>
   )
 }

--- a/control-ui/components/TableHeaderRow/types.ts
+++ b/control-ui/components/TableHeaderRow/types.ts
@@ -23,5 +23,11 @@ export type TableHeaderRowProps = {
   // Key of the currently sorted column, or null for "unsorted" (server order).
   sortKey?: string | null
   sortDir?: TableSortDirection
+  // Receives the key of the clicked column. Implementations are expected to
+  // invert `sortDir` when that key is already active and to reset to 'asc' when
+  // switching to a different column. The header tooltip depends on it: for any
+  // inactive column it announces the next click as ascending, so a caller that
+  // preserved the current direction across columns would render a hint that
+  // contradicts what the click actually does.
   onSortToggle?: (key: string) => void
 }

--- a/control-ui/components/TableHeaderRow/types.ts
+++ b/control-ui/components/TableHeaderRow/types.ts
@@ -1,11 +1,27 @@
 import type { ReactNode } from 'react'
 
+export type TableSortDirection = 'asc' | 'desc'
+
 export type TableHeaderColumn = {
   align?: 'left' | 'right' | 'center'
   ariaLabel?: string
   key: string
   label?: ReactNode
   minWidth?: string
+  // Opt-in: renders the label as a sort button and exposes `aria-sort`. Only
+  // takes effect when the row also receives `onSortToggle`.
+  sortable?: boolean
+  // Plain-text name used in the sort button's aria-label when `label` is not a
+  // string (e.g. an icon + text node).
+  sortLabel?: string
   title?: string
   width?: string
+}
+
+export type TableHeaderRowProps = {
+  columns: TableHeaderColumn[]
+  // Key of the currently sorted column, or null for "unsorted" (server order).
+  sortKey?: string | null
+  sortDir?: TableSortDirection
+  onSortToggle?: (key: string) => void
 }

--- a/control-ui/components/TableHeaderRow/types.ts
+++ b/control-ui/components/TableHeaderRow/types.ts
@@ -11,8 +11,8 @@ export type TableHeaderColumn = {
   // Opt-in: renders the label as a sort button and exposes `aria-sort`. Only
   // takes effect when the row also receives `onSortToggle`.
   sortable?: boolean
-  // Plain-text name used in the sort button's aria-label when `label` is not a
-  // string (e.g. an icon + text node).
+  // Plain-text name used in the sort button's title tooltip when `label` is
+  // not a string (e.g. an icon + text node).
   sortLabel?: string
   title?: string
   width?: string

--- a/control-ui/components/__tests__/LlmModelTable.test.tsx
+++ b/control-ui/components/__tests__/LlmModelTable.test.tsx
@@ -132,8 +132,11 @@ describe('LlmModelTable sorting', () => {
     )
   }
 
-  function sortButton(column: string) {
-    return screen.getByRole('button', { name: new RegExp(`^Sort by ${column} `) })
+  // The header button's accessible name is its visible label (plus the ↑/↓
+  // indicator once active) — deliberately not an aria-label, which would leak
+  // into the <th>'s accessible name and be announced for every cell.
+  function sortButton(label: string) {
+    return screen.getByRole('button', { name: new RegExp(`^${label}( [↑↓])?$`) })
   }
 
   const modelC: LlmAllowedModel = { ...baseModel, id: 'm-c', model: 'ccc' }
@@ -150,11 +153,11 @@ describe('LlmModelTable sorting', () => {
   it('sorts ascending on the first click and inverts on the second', () => {
     const { container } = renderTable([modelC, modelA, modelB])
 
-    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('Model'))
     expect(rowModels(container)).toEqual(['aaa', 'bbb', 'ccc'])
     expect(container.querySelector('th[aria-sort]')?.getAttribute('aria-sort')).toBe('ascending')
 
-    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('Model'))
     expect(rowModels(container)).toEqual(['ccc', 'bbb', 'aaa'])
     expect(container.querySelector('th[aria-sort]')?.getAttribute('aria-sort')).toBe('descending')
   })
@@ -166,11 +169,11 @@ describe('LlmModelTable sorting', () => {
       { ...baseModel, id: 'm-3', model: 'ccc', context_window_tokens: 200 },
     ])
 
-    fireEvent.click(sortButton('model'))
-    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('Model'))
+    fireEvent.click(sortButton('Model'))
     expect(rowModels(container)).toEqual(['ccc', 'bbb', 'aaa'])
 
-    fireEvent.click(sortButton('context window'))
+    fireEvent.click(sortButton('Context window'))
     expect(rowModels(container)).toEqual(['bbb', 'ccc', 'aaa'])
   })
 
@@ -184,7 +187,7 @@ describe('LlmModelTable sorting', () => {
     fireEvent.change(screen.getByLabelText('Filter by enabled state'), {
       target: { value: 'enabled' },
     })
-    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('Model'))
 
     expect(rowModels(container)).toEqual(['aaa-on', 'zzz-on'])
     expect(screen.queryByText('mmm-off')).not.toBeInTheDocument()
@@ -197,8 +200,8 @@ describe('LlmModelTable sorting', () => {
       { ...baseModel, id: 'm-3', model: 'mmm', enabled: false },
     ])
 
-    fireEvent.click(sortButton('model'))
-    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('Model'))
+    fireEvent.click(sortButton('Model'))
     expect(rowModels(container)).toEqual(['zzz', 'mmm', 'aaa'])
 
     fireEvent.change(screen.getByLabelText('Filter by enabled state'), {
@@ -210,9 +213,9 @@ describe('LlmModelTable sorting', () => {
   })
 
   it.each([
-    ['vendor', 'vendor'] as const,
-    ['display name', 'display_name'] as const,
-    ['context window', 'context_window_tokens'] as const,
+    ['Vendor', 'vendor'] as const,
+    ['Display name', 'display_name'] as const,
+    ['Context window', 'context_window_tokens'] as const,
   ])('keeps rows with no %s last in both directions', (columnLabel, field) => {
     const withValue = field === 'context_window_tokens' ? 1000 : 'aaa'
     const withHigherValue = field === 'context_window_tokens' ? 2000 : 'zzz'
@@ -229,8 +232,99 @@ describe('LlmModelTable sorting', () => {
     expect(rowModels(container)).toEqual(['high', 'low', 'none'])
   })
 
+  it('keeps a NaN context window with the empty ones at the bottom', () => {
+    // formatContextWindow renders '—' for any non-finite value, so the sort
+    // must treat it as empty rather than leaving it mid-table.
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'nan', context_window_tokens: Number.NaN },
+      { ...baseModel, id: 'm-2', model: 'low', context_window_tokens: 1000 },
+      { ...baseModel, id: 'm-3', model: 'high', context_window_tokens: 2000 },
+    ])
+
+    fireEvent.click(sortButton('Context window'))
+    expect(rowModels(container)).toEqual(['low', 'high', 'nan'])
+
+    fireEvent.click(sortButton('Context window'))
+    expect(rowModels(container)).toEqual(['high', 'low', 'nan'])
+  })
+
+  it('sorts providers by display label, not by the raw slug', () => {
+    // 'claude' renders as "Anthropic" and 'bailian' as "Bailian", so label
+    // order (Anthropic, Bailian) is the inverse of slug order (bailian,
+    // claude). Sorting on the slug would flip this expectation.
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', provider: 'bailian', model: 'aaa-bailian' },
+      { ...baseModel, id: 'm-2', provider: 'claude', model: 'zzz-anthropic' },
+    ])
+
+    fireEvent.click(sortButton('Provider'))
+    expect(rowModels(container)).toEqual(['zzz-anthropic', 'aaa-bailian'])
+
+    fireEvent.click(sortButton('Provider'))
+    expect(rowModels(container)).toEqual(['aaa-bailian', 'zzz-anthropic'])
+  })
+
+  it('sorts Disabled before Enabled when ascending', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'on', enabled: true },
+      { ...baseModel, id: 'm-2', model: 'off', enabled: false },
+    ])
+
+    fireEvent.click(sortButton('Enabled'))
+    expect(rowModels(container)).toEqual(['off', 'on'])
+
+    fireEvent.click(sortButton('Enabled'))
+    expect(rowModels(container)).toEqual(['on', 'off'])
+  })
+
+  it('sorts non-stale before stale when ascending', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'stale-row', source: 'discovery', stale: true },
+      { ...baseModel, id: 'm-2', model: 'fresh-row', source: 'discovery', stale: false },
+    ])
+
+    fireEvent.click(sortButton('Stale'))
+    expect(rowModels(container)).toEqual(['fresh-row', 'stale-row'])
+
+    fireEvent.click(sortButton('Stale'))
+    expect(rowModels(container)).toEqual(['stale-row', 'fresh-row'])
+  })
+
+  it('sorts Discovered before Manual when ascending', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'manual-row', source: 'manual' },
+      { ...baseModel, id: 'm-2', model: 'discovered-row', source: 'discovery' },
+    ])
+
+    fireEvent.click(sortButton('Source'))
+    expect(rowModels(container)).toEqual(['discovered-row', 'manual-row'])
+
+    fireEvent.click(sortButton('Source'))
+    expect(rowModels(container)).toEqual(['manual-row', 'discovered-row'])
+  })
+
+  it('breaks ties by provider label then model, in input-independent order', () => {
+    // All three enabled rows tie on the sorted column, and their input order is
+    // the reverse of the expected one — so a missing (or slug-based) tie-break
+    // produces a different result.
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', provider: 'bailian', model: 'mmm', enabled: true },
+      { ...baseModel, id: 'm-2', provider: 'claude', model: 'zzz', enabled: true },
+      { ...baseModel, id: 'm-3', provider: 'claude', model: 'aaa', enabled: true },
+      { ...baseModel, id: 'm-4', provider: 'claude', model: 'ddd', enabled: false },
+    ])
+
+    fireEvent.click(sortButton('Enabled'))
+    // Disabled first, then the tied Enabled group: Anthropic (aaa, zzz) before
+    // Bailian (mmm).
+    expect(rowModels(container)).toEqual(['ddd', 'aaa', 'zzz', 'mmm'])
+  })
+
   it('does not turn the Actions column into a sort control', () => {
-    renderTable([baseModel])
-    expect(screen.queryByRole('button', { name: /^Sort by actions/ })).toBeNull()
+    const { container } = renderTable([baseModel])
+    const headers = Array.from(container.querySelectorAll('thead th'))
+    const actionsHeader = headers[headers.length - 1]
+    expect(actionsHeader?.getAttribute('aria-label')).toBe('Actions')
+    expect(actionsHeader?.querySelector('button')).toBeNull()
   })
 })

--- a/control-ui/components/__tests__/LlmModelTable.test.tsx
+++ b/control-ui/components/__tests__/LlmModelTable.test.tsx
@@ -123,3 +123,114 @@ describe('LlmModelTable filters', () => {
     expect(screen.getByText('No models match this filter.')).toBeInTheDocument()
   })
 })
+
+describe('LlmModelTable sorting', () => {
+  // Reads the rendered order of the Model column (tbody only).
+  function rowModels(container: HTMLElement): string[] {
+    return Array.from(container.querySelectorAll('.cu-px-model')).map(cell =>
+      (cell.textContent ?? '').trim()
+    )
+  }
+
+  function sortButton(column: string) {
+    return screen.getByRole('button', { name: new RegExp(`^Sort by ${column} `) })
+  }
+
+  const modelC: LlmAllowedModel = { ...baseModel, id: 'm-c', model: 'ccc' }
+  const modelA: LlmAllowedModel = { ...baseModel, id: 'm-a', model: 'aaa' }
+  const modelB: LlmAllowedModel = { ...baseModel, id: 'm-b', model: 'bbb' }
+
+  it('keeps the server order until a header is clicked', () => {
+    const { container } = renderTable([modelC, modelA, modelB])
+    expect(rowModels(container)).toEqual(['ccc', 'aaa', 'bbb'])
+    // Nothing is announced as sorted before the first click.
+    expect(container.querySelector('th[aria-sort]')).toBeNull()
+  })
+
+  it('sorts ascending on the first click and inverts on the second', () => {
+    const { container } = renderTable([modelC, modelA, modelB])
+
+    fireEvent.click(sortButton('model'))
+    expect(rowModels(container)).toEqual(['aaa', 'bbb', 'ccc'])
+    expect(container.querySelector('th[aria-sort]')?.getAttribute('aria-sort')).toBe('ascending')
+
+    fireEvent.click(sortButton('model'))
+    expect(rowModels(container)).toEqual(['ccc', 'bbb', 'aaa'])
+    expect(container.querySelector('th[aria-sort]')?.getAttribute('aria-sort')).toBe('descending')
+  })
+
+  it('switches to ascending when a different column becomes the sort key', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'aaa', context_window_tokens: 300 },
+      { ...baseModel, id: 'm-2', model: 'bbb', context_window_tokens: 100 },
+      { ...baseModel, id: 'm-3', model: 'ccc', context_window_tokens: 200 },
+    ])
+
+    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('model'))
+    expect(rowModels(container)).toEqual(['ccc', 'bbb', 'aaa'])
+
+    fireEvent.click(sortButton('context window'))
+    expect(rowModels(container)).toEqual(['bbb', 'ccc', 'aaa'])
+  })
+
+  it('sorts only the filtered subset and keeps the filter applied', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'zzz-on', enabled: true },
+      { ...baseModel, id: 'm-2', model: 'mmm-off', enabled: false },
+      { ...baseModel, id: 'm-3', model: 'aaa-on', enabled: true },
+    ])
+
+    fireEvent.change(screen.getByLabelText('Filter by enabled state'), {
+      target: { value: 'enabled' },
+    })
+    fireEvent.click(sortButton('model'))
+
+    expect(rowModels(container)).toEqual(['aaa-on', 'zzz-on'])
+    expect(screen.queryByText('mmm-off')).not.toBeInTheDocument()
+  })
+
+  it('keeps the active sort when a filter changes', () => {
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'zzz', enabled: true },
+      { ...baseModel, id: 'm-2', model: 'aaa', enabled: true },
+      { ...baseModel, id: 'm-3', model: 'mmm', enabled: false },
+    ])
+
+    fireEvent.click(sortButton('model'))
+    fireEvent.click(sortButton('model'))
+    expect(rowModels(container)).toEqual(['zzz', 'mmm', 'aaa'])
+
+    fireEvent.change(screen.getByLabelText('Filter by enabled state'), {
+      target: { value: 'enabled' },
+    })
+    // Still descending — narrowing the set must not reset the sort.
+    expect(rowModels(container)).toEqual(['zzz', 'aaa'])
+    expect(container.querySelector('th[aria-sort]')?.getAttribute('aria-sort')).toBe('descending')
+  })
+
+  it.each([
+    ['vendor', 'vendor'] as const,
+    ['display name', 'display_name'] as const,
+    ['context window', 'context_window_tokens'] as const,
+  ])('keeps rows with no %s last in both directions', (columnLabel, field) => {
+    const withValue = field === 'context_window_tokens' ? 1000 : 'aaa'
+    const withHigherValue = field === 'context_window_tokens' ? 2000 : 'zzz'
+    const { container } = renderTable([
+      { ...baseModel, id: 'm-1', model: 'low', [field]: withValue },
+      { ...baseModel, id: 'm-2', model: 'none', [field]: null },
+      { ...baseModel, id: 'm-3', model: 'high', [field]: withHigherValue },
+    ])
+
+    fireEvent.click(sortButton(columnLabel))
+    expect(rowModels(container)).toEqual(['low', 'high', 'none'])
+
+    fireEvent.click(sortButton(columnLabel))
+    expect(rowModels(container)).toEqual(['high', 'low', 'none'])
+  })
+
+  it('does not turn the Actions column into a sort control', () => {
+    renderTable([baseModel])
+    expect(screen.queryByRole('button', { name: /^Sort by actions/ })).toBeNull()
+  })
+})

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.352",
+  "version": "0.1.353",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.352",
+      "version": "0.1.353",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.356",
+  "version": "0.1.357",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.356",
+      "version": "0.1.357",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.353",
+  "version": "0.1.354",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.353",
+      "version": "0.1.354",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.356",
+  "version": "0.1.357",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.352",
+  "version": "0.1.353",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.353",
+  "version": "0.1.354",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
**What**
Adds ascending/descending sorting to every column of the LLM models table in control-ui, except the actions column. Sorting runs client-side on the filtered rows, so active filters are preserved and only the visible subset is reordered.

**Why**
The models list could only be read in server order, which makes it slow to find or compare models once the catalog grows. Operators can now reorder by provider, model, context window, enabled state, staleness or source.

**How**
- `TableHeaderRow` gains opt-in sortable columns (`sortable` on the column plus `sortKey`/`sortDir`/`onSortToggle` row props) and exposes `aria-sort`. Without the new props the rendered markup is unchanged, so existing consumers are unaffected.
- `LlmModelTable` holds the sort state with a two-state toggle (asc first) and typed comparators: provider sorts by display label, blank values go last in both directions, context window compares numerically with non-finite values treated as blank, and ties fall back to a stable provider/model comparison.
- Accessibility: the header's accessible name stays the visible label, direction is conveyed by `aria-sort`, the next-click hint lives in the button `title`, and the sort arrow is hidden from assistive tech.
- A new `.cu-link--sort` style keeps sortable headers at the table's 0.7rem uppercase typography, matching plain headers and the loading skeleton.

**Testing**
- Full control-ui suite: `npm test`, 112 files / 1102 tests passed.
- 14 new `LlmModelTable` cases: toggle behavior, filter preservation, blank-last ordering, provider-by-label ordering, numeric and NaN context window, tie-breaking, and server-order default.