### PR TITLE
ci: pin @claude to Opus 4.8 and drop the second model job

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,15 +1,16 @@
 name: Claude Code
 
 # On-demand Claude, triggered by a mention in an issue, a PR comment, or a PR
-# review. Two models are available:
-#   @claude       -> Claude Sonnet 5  (fast, cheaper; the default)
-#   @claude-opus  -> Claude Opus 4.8  (deeper, pricier)
+# review. One model, one job:
+#   @claude -> Claude Opus 4.8
 # There is no automatic review on every PR.
 #
-# Mirrors keyper-labs/evenfire (the private repo), plus a second Opus job. Each
-# job pins its own model and its own trigger_phrase; the job-level `if` routes a
-# mention to exactly one job. The default job excludes `@claude-opus` so a single
-# comment never runs both. Actions are SHA-pinned per this repo's policy.
+# Mirrors keyper-labs/evenfire (the private repo). Actions are SHA-pinned per
+# this repo's policy. Note the trigger is a substring match, so `@claude-opus`,
+# `@claude-sonnet`, and any other `@claude-*` suffix also land here and run
+# Opus 4.8 — harmless while this is the only job, but if a second model job is
+# ever added back, this job's `if` must exclude that job's phrase or a single
+# comment will fire both.
 
 on:
   issue_comment:
@@ -22,13 +23,12 @@ on:
     types: [submitted]
 
 jobs:
-  # @claude -> Sonnet 5 (default). Excludes @claude-opus so only one job fires.
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-opus')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude-opus')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude-opus')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && !(contains(github.event.issue.body, '@claude-opus') || contains(github.event.issue.title, '@claude-opus')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,41 +42,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code (Sonnet)
+      - name: Run Claude Code
         uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "@claude"
-          claude_args: |
-            --model claude-sonnet-5
-          additional_permissions: |
-            actions: read
-
-  # @claude-opus -> Opus 4.8 (deeper, opt-in).
-  claude-opus:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude-opus')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude-opus')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude-opus')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude-opus') || contains(github.event.issue.title, '@claude-opus')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code (Opus)
-        uses: anthropics/claude-code-action@44423bdec74b97d67543eb16c110546762c110b2 # v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "@claude-opus"
           claude_args: |
             --model claude-opus-4-8
           additional_permissions: |


### PR DESCRIPTION
## What

One on-demand reviewer, one model. Replaces the two-job Sonnet/Opus split in `claude.yml` with a single job on **Opus 4.8**.

| Mention | Before | After |
|---|---|---|
| `@claude` | `claude-sonnet-5` | **`claude-opus-4-8`** |
| `@claude-opus` | separate job, `claude-opus-4-8` | removed (still routes to `@claude` → Opus 4.8) |
| Sonnet 5 | default model | gone from the workflow |

With only one job left, the `!contains(..., '@claude-opus')` exclusion clauses in the job `if` were dead weight, so they're removed too — the condition is back to a plain `@claude` check.

## Behavior notes

- `trigger_phrase` is a **substring** match, so a leftover `@claude-opus` in an old comment or doc still lands on this job and runs Opus 4.8. Nothing breaks.
- If a second model job is ever added back, this job's `if` must exclude that job's phrase, or one comment fires both. Called out in a comment at the top of the file.
- Unchanged: no auto-review on PRs (by design), action SHA pins, least-privilege `permissions`, `additional_permissions: actions: read`, and `CLAUDE_CODE_OAUTH_TOKEN` auth.

## When this takes effect

`issue_comment`, `issues`, `pull_request_review`, and `pull_request_review_comment` all run the workflow definition from the **default branch**. This has no effect until it reaches `main` — and it can't be tested by commenting on this PR, which would still use `main`'s copy.

## Verification

- `yaml.safe_load` parses the file; one job, `trigger_phrase: "@claude"`, `--model claude-opus-4-8`, zero leftover `@claude-*` suffix references in the `if`.
- No other file in the repo references the removed trigger phrases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)