### PR TITLE
ci: auto-delete merged head branches, except dev

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,55 @@
+name: Delete merged branch
+
+# Deletes a PR's head branch once the PR is merged, EXCEPT for long-lived
+# branches. The exception that matters is `dev`: the dev -> main promotion PR
+# uses `dev` itself as the head branch, so GitHub's repo-level "Automatically
+# delete head branches" setting deleted `dev` on the v0.5.0 promotion. That
+# setting is all-or-nothing, so it stays OFF and this workflow does the cleanup
+# with an exception list instead.
+#
+# `pull_request_target` rather than `pull_request` so the workflow file is read
+# from the base branch — cleanup then applies to PRs opened before this landed,
+# instead of only to branches cut afterwards. Nothing from the PR is checked
+# out or run here, so the write-scoped token never touches contributor code.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete:
+    name: Delete head branch
+    runs-on: ubuntu-latest
+    # Fork branches are not ours to delete.
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Delete head branch unless it is long-lived
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Branches that outlive any single PR.
+          KEEP=(dev main cla-signatures gh-pages)
+          for keep in "${KEEP[@]}"; do
+            if [[ "$HEAD_REF" == "$keep" ]]; then
+              echo "::notice::'$HEAD_REF' is long-lived — keeping it."
+              exit 0
+            fi
+          done
+
+          # Already gone (someone clicked "Delete branch", or this is a re-run).
+          if ! gh api "repos/$REPO/git/ref/heads/$HEAD_REF" --silent 2>/dev/null; then
+            echo "::notice::'$HEAD_REF' no longer exists — nothing to do."
+            exit 0
+          fi
+
+          gh api -X DELETE "repos/$REPO/git/ref/heads/$HEAD_REF"
+          echo "::notice::Deleted merged branch '$HEAD_REF'."


### PR DESCRIPTION
## Summary

Deletes a PR's head branch when the PR is merged — except for long-lived branches, `dev` above all.

## Why not the repo setting

GitHub's `delete_branch_on_merge` ("Automatically delete head branches") has no exception list. The dev → main promotion PR uses **`dev` itself as the head branch**, so that setting deleted `dev` during the v0.5.0 promotion; it has been off ever since, which is why nothing gets cleaned up today.

Branch protection does not save `dev` either: the `dev protection` ruleset has had a `deletion` rule since 2026-07-23, and `dev` was still auto-deleted on 2026-07-24 — repo admins sit in `bypass_actors` with `bypass_mode: always`. Removing that bypass would also start enforcing the 1-approval and required-status-check rules against admins on `dev`, so it is not a free fix.

So the repo setting stays **off** and the cleanup happens here, where the exception list is explicit.

## Behaviour

| Merge | Head branch | Result |
| --- | --- | --- |
| feature → `dev` | `feat/x` | deleted |
| feature → `main` | `chore/y-main` | deleted (once this reaches `main`) |
| `dev` → `main` (promotion) | `dev` | **kept** |
| fork PR | contributor's branch | untouched |

Keep-list: `dev`, `main`, `cla-signatures`, `gh-pages`. Already-deleted branches are a no-op, so clicking "Delete branch" at merge time still works.

## Notes

- `pull_request_target` (not `pull_request`) so the workflow file is read from the **base** branch — this applies to the ~50 PRs already open, rather than only to branches cut after it lands. Nothing from the PR is checked out or executed, so the write-scoped token is never exposed to contributor code.
- Default workflow token is read-only repo-wide, hence the explicit `permissions: contents: write`.
- Takes effect for `main`-based PRs only after it flows to `main` via the next promotion.

## Test plan

- `actionlint` clean (includes shellcheck on the `run` block).
- `gh api repos/.../git/ref/heads/<ref>` existence probe verified against real refs, including a slashed branch name (`docs/readme-redesign` → found) and a missing one (→ not found).
- End-to-end verification is the merge of this PR itself: `ci/auto-delete-merged-branches` should disappear on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)