### PR TITLE
feat(control-api): derive registry auth from the connection row in self-hosted mode

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.387",
+  "version": "0.1.388",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.387",
+      "version": "0.1.388",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.386",
+  "version": "0.1.387",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.386",
+      "version": "0.1.387",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.376",
+  "version": "0.1.377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.376",
+      "version": "0.1.377",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.383",
+  "version": "0.1.384",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.383",
+      "version": "0.1.384",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.385",
+  "version": "0.1.386",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.385",
+      "version": "0.1.386",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.389",
+  "version": "0.1.390",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.389",
+      "version": "0.1.390",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.382",
+  "version": "0.1.383",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.382",
+      "version": "0.1.383",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.379",
+  "version": "0.1.380",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.379",
+      "version": "0.1.380",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.384",
+  "version": "0.1.385",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.384",
+      "version": "0.1.385",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.381",
+  "version": "0.1.382",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.381",
+      "version": "0.1.382",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.390",
+  "version": "0.1.391",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.390",
+      "version": "0.1.391",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.378",
+  "version": "0.1.379",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.378",
+      "version": "0.1.379",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.380",
+  "version": "0.1.381",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.380",
+      "version": "0.1.381",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.388",
+  "version": "0.1.389",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.388",
+      "version": "0.1.389",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.377",
+      "version": "0.1.378",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.391",
+  "version": "0.1.392",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.391",
+      "version": "0.1.392",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.385",
+  "version": "0.1.386",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.389",
+  "version": "0.1.390",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.382",
+  "version": "0.1.383",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.390",
+  "version": "0.1.391",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.391",
+  "version": "0.1.392",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.387",
+  "version": "0.1.388",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.386",
+  "version": "0.1.387",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.380",
+  "version": "0.1.381",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.376",
+  "version": "0.1.377",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.381",
+  "version": "0.1.382",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.384",
+  "version": "0.1.385",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.388",
+  "version": "0.1.389",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.378",
+  "version": "0.1.379",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.383",
+  "version": "0.1.384",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.379",
+  "version": "0.1.380",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -807,25 +807,39 @@ for (const key of NAMESPACE_KEYS) {
 }
 
 // Registry consumer auth guard: when auth is on, refuse to boot without OAuth2
-// credentials and refuse a registry URL outside the allowlist (defense against
+// credentials; separately, refuse a registry URL outside the allowlist for any
+// deployment that will really talk to a registry (defense against
 // cross-environment misconfiguration sending writes to the wrong registry).
-if (config.registryAuthEnabled) {
-  // Mode must be set EXPLICITLY when the registry is enabled — never inferred
-  // from which credentials happen to be present (S10: no silent split-brain).
-  if (!process.env.REGISTRY_CONNECTION_MODE) {
-    throw new Error(
-      'REGISTRY_CONNECTION_MODE is required (managed|self-hosted) when CLERUM_REGISTRY_AUTH_ENABLED=true'
-    )
-  }
-  console.log(`[ControlAPI] Registry connection mode: ${config.registryConnectionMode}`)
 
-  // URL allowlist applies in BOTH modes. The shared registry
-  // `registry.evenfire.ai` is the default a self-hoster connects to (see
-  // docs/how-to/connect-to-registry.md); the in-cluster URL covers a
-  // self-hosted registry-api. A deployment that runs its own registry adds its
-  // URL via CLERUM_REGISTRY_URL_ALLOWLIST (comma-separated) rather than editing
-  // this list. `example.com` is the reserved-domain fixture used across the
-  // test suite — inert (no real registry) and kept so tests need no churn.
+// A configured URL is MANDATORY whenever auth is on. Today this is enforced
+// implicitly — allowed.includes('') is never true, so an empty URL falls
+// through to the allowlist throw. The allowlist block below is preconditioned
+// on registryUrl !== '', which would SKIP that throw and let a managed
+// deployment with auth on and no URL boot, then fail later with a bare fetch
+// URL-parse TypeError. Kept as its own check so the OR cannot swallow it.
+if (config.registryAuthEnabled && config.registryUrl === '') {
+  throw new Error('CLERUM_REGISTRY_URL is required when CLERUM_REGISTRY_AUTH_ENABLED=true')
+}
+
+// URL allowlist — defense against cross-environment misconfiguration sending
+// writes to the wrong registry. Enforced whenever the deployment will really
+// talk to a registry: an EXPLICITLY self-hosted deployment (which POSTs its
+// registration before any credentials exist, so gating this on auth was always
+// backwards), or any auth-enabled deployment. The shared registry
+// `registry.evenfire.ai` is the default a self-hoster connects to (see
+// docs/how-to/connect-to-registry.md); the in-cluster URL covers a
+// self-hosted registry-api. A deployment that runs its own registry adds its
+// URL via CLERUM_REGISTRY_URL_ALLOWLIST (comma-separated) rather than editing
+// this list. `example.com` is the reserved-domain fixture used across the
+// test suite — inert (no real registry) and kept so tests need no churn.
+//
+// Reads process.env directly, NOT config.registryConnectionMode: the mode
+// PARSER defaults to 'managed' when unset, so gating on the parsed value would
+// newly break managed deployments that rely on that default.
+if (
+  config.registryUrl !== '' &&
+  (process.env.REGISTRY_CONNECTION_MODE === 'self-hosted' || config.registryAuthEnabled)
+) {
   const allowed = [
     'https://registry.evenfire.ai',
     'http://registry-api.registry.svc.cluster.local:8085',
@@ -845,6 +859,19 @@ if (config.registryAuthEnabled) {
       `CLERUM_REGISTRY_URL=${config.registryUrl} is not in the registry URL allowlist: ${allowed.join(', ')}`
     )
   }
+}
+
+// Mode requirement (S10: never infer mode from which credentials exist) and the
+// managed credential/voucher checks stay gated on auth, UNCHANGED.
+if (config.registryAuthEnabled) {
+  // Mode must be set EXPLICITLY when the registry is enabled — never inferred
+  // from which credentials happen to be present (S10: no silent split-brain).
+  if (!process.env.REGISTRY_CONNECTION_MODE) {
+    throw new Error(
+      'REGISTRY_CONNECTION_MODE is required (managed|self-hosted) when CLERUM_REGISTRY_AUTH_ENABLED=true'
+    )
+  }
+  console.log(`[ControlAPI] Registry connection mode: ${config.registryConnectionMode}`)
 
   if (config.registryConnectionMode === 'managed') {
     // Managed machine creds live in env (unchanged).

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -833,9 +833,12 @@ if (config.registryAuthEnabled && config.registryUrl === '') {
 // this list. `example.com` is the reserved-domain fixture used across the
 // test suite — inert (no real registry) and kept so tests need no churn.
 //
-// Reads process.env directly, NOT config.registryConnectionMode: the mode
-// PARSER defaults to 'managed' when unset, so gating on the parsed value would
-// newly break managed deployments that rely on that default.
+// The gate must never be `config.registryUrl !== ''` alone — dropping the
+// self-hosted disjunct is exactly the rejected design that broke managed mode
+// (see the regression test below). Reading process.env directly here is
+// defensive against a future change to the parser's default; for today's
+// parser it is equivalent to config.registryConnectionMode, not itself
+// load-bearing.
 if (
   config.registryUrl !== '' &&
   (process.env.REGISTRY_CONNECTION_MODE === 'self-hosted' || config.registryAuthEnabled)

--- a/control-api/src/main.ts
+++ b/control-api/src/main.ts
@@ -2,7 +2,7 @@ import { config } from './config.js'
 import { assertDbReady, pool } from './db.js'
 import { K8sGateway } from './k8s.js'
 import { reconcileAllowedModelsConfigMapOnBoot } from './llmAllowedModelsBootReconcile.js'
-import { assertRegistryConnectionReady } from './registryBootGuard.js'
+import { logRegistryConnectionState } from './registryBootGuard.js'
 import { ControlApiServer } from './server.js'
 import {
   startAdminRevokedTokenCleanup,
@@ -52,9 +52,10 @@ async function main(): Promise<void> {
   await assertDbReady()
   console.log('[ControlAPI] Database schema ready')
 
-  // Self-hosted fail-fast (spec §8 / §14.3): refuse to boot a registry-enabled
-  // self-hosted deployment that has no registry_connection identity row.
-  await assertRegistryConnectionReady()
+  // Observability only (never fatal): report whether this self-hosted deployment
+  // holds a registry identity. Auth is derived from credential presence, so a
+  // missing row simply means auth is inactive until the connect flow runs.
+  await logRegistryConnectionState()
 
   // Anti-drift (spec §3-R3.4 / V7): re-materialize the LLM allowlist ConfigMap
   // from Postgres. Non-fatal — logs + metric on failure, never aborts boot.

--- a/control-api/src/registryBootGuard.ts
+++ b/control-api/src/registryBootGuard.ts
@@ -1,6 +1,7 @@
 import { config } from './config.js'
 import { rootLogger } from './observability/logger.js'
 import { getRegistryConnection } from './services/registryConnectionDb.js'
+import type { RegistryConnectionRow } from './services/registryConnectionDb.js'
 
 /**
  * Boot-time observability for the self-hosted registry identity.
@@ -16,13 +17,31 @@ import { getRegistryConnection } from './services/registryConnectionDb.js'
  * disappeared (bad restore, accidental delete). INFO rather than WARN so it
  * does not cry wolf on every first boot.
  *
+ * The read itself is guarded separately: this now runs for every self-hosted
+ * deployment on every boot (not just when auth was enabled), so a rotated
+ * CLERUM_OAUTH_ENCRYPTION_KEY, a Postgres volume restored alongside a
+ * different key Secret, or a transient pool blip can make getRegistryConnection
+ * reject. That rejection must never escape — it would otherwise turn a
+ * deployment that used to boot fine into a crashloop. WARN (not INFO) here,
+ * because an unreadable row is a real operational problem, unlike a merely
+ * absent one.
+ *
  * Standalone module importing only config + logger + registryConnectionDb, so
  * its test does not pull in main.ts's server/cron graph.
  */
 export async function logRegistryConnectionState(): Promise<void> {
   if (config.registryConnectionMode !== 'self-hosted') return
   if (config.registryUrl === '') return
-  const row = await getRegistryConnection()
+  let row: RegistryConnectionRow | null = null
+  try {
+    row = await getRegistryConnection()
+  } catch (err) {
+    rootLogger.warn(
+      { event: 'registry_connection_state_unreadable', err: (err as Error).message },
+      'could not read the registry connection row at boot'
+    )
+    return
+  }
   const connected = row?.clientId != null
   rootLogger.info(
     { event: 'registry_connection_state', connected },

--- a/control-api/src/registryBootGuard.ts
+++ b/control-api/src/registryBootGuard.ts
@@ -1,22 +1,33 @@
 import { config } from './config.js'
+import { rootLogger } from './observability/logger.js'
 import { getRegistryConnection } from './services/registryConnectionDb.js'
 
 /**
- * Self-hosted fail-fast (spec §8 / §14.3): a registry-enabled self-hosted
- * control-api must have a claimed registry_connection row (its identity), else
- * it would silently boot unable to emit vouchers. Cannot live in config.ts
- * (synchronous, no DB access). Fail-closed at M3 — no break-glass bypass.
+ * Boot-time observability for the self-hosted registry identity.
  *
- * C-M5: this lives in a standalone module importing ONLY config +
- * registryConnectionDb so its test doesn't pull in main.ts's server/cron graph.
+ * This used to be a fail-fast guard that threw when registry auth was enabled
+ * without a connection row. With auth now DERIVED from credential presence,
+ * that state is unrepresentable — and throwing would have been a boot-order
+ * deadlock: control-api could not start without a connection, and a connection
+ * could not be made without a running control-api.
+ *
+ * It still logs, because "no row" has two very different causes: a fresh
+ * install that has not connected yet (normal), and a deployment whose row
+ * disappeared (bad restore, accidental delete). INFO rather than WARN so it
+ * does not cry wolf on every first boot.
+ *
+ * Standalone module importing only config + logger + registryConnectionDb, so
+ * its test does not pull in main.ts's server/cron graph.
  */
-export async function assertRegistryConnectionReady(): Promise<void> {
-  if (!config.registryAuthEnabled) return
+export async function logRegistryConnectionState(): Promise<void> {
   if (config.registryConnectionMode !== 'self-hosted') return
+  if (config.registryUrl === '') return
   const row = await getRegistryConnection()
-  if (!row) {
-    throw new Error(
-      '[ControlAPI] self-hosted registry mode requires a registry_connection row — run the connect flow before enabling registry auth'
-    )
-  }
+  const connected = row?.clientId != null
+  rootLogger.info(
+    { event: 'registry_connection_state', connected },
+    connected
+      ? 'self-hosted registry connection present'
+      : 'self-hosted registry not yet connected — auth inactive until the connect flow completes'
+  )
 }

--- a/control-api/src/registryBootGuard.ts
+++ b/control-api/src/registryBootGuard.ts
@@ -31,7 +31,6 @@ import type { RegistryConnectionRow } from './services/registryConnectionDb.js'
  */
 export async function logRegistryConnectionState(): Promise<void> {
   if (config.registryConnectionMode !== 'self-hosted') return
-  if (config.registryUrl === '') return
   let row: RegistryConnectionRow | null = null
   try {
     row = await getRegistryConnection()

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -2166,7 +2166,14 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     req: Request,
     res: Response
   ): Promise<{ admin: AdminUserRecord; orgName: string } | null> {
-    if (!(await isRegistryAuthActive())) {
+    let authActive: boolean
+    try {
+      authActive = await isRegistryAuthActive()
+    } catch {
+      res.status(502).json({ error: 'registry_integration_error' })
+      return null
+    }
+    if (!authActive) {
       res.status(409).json({ error: 'registry_auth_disabled' })
       return null
     }
@@ -2264,7 +2271,14 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     req: Request,
     res: Response
   ): Promise<{ orgName: string; actingUserId: string } | null> {
-    if (!(await isRegistryAuthActive())) {
+    let authActive: boolean
+    try {
+      authActive = await isRegistryAuthActive()
+    } catch {
+      res.status(502).json({ error: 'registry_integration_error' })
+      return null
+    }
+    if (!authActive) {
       res.status(409).json({ error: 'registry_auth_disabled' })
       return null
     }

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -33,6 +33,7 @@ import {
   updateVersionMetadata,
   uploadArtifacts,
 } from '../../services/registryClient.js'
+import { isRegistryAuthActive } from '../../services/registryConnectionDb.js'
 import {
   validateWorkflowRecipeEgressPreflight,
   validateWorkflowRecipeLimits,
@@ -2165,7 +2166,7 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     req: Request,
     res: Response
   ): Promise<{ admin: AdminUserRecord; orgName: string } | null> {
-    if (!config.registryAuthEnabled) {
+    if (!(await isRegistryAuthActive())) {
       res.status(409).json({ error: 'registry_auth_disabled' })
       return null
     }
@@ -2263,7 +2264,7 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     req: Request,
     res: Response
   ): Promise<{ orgName: string; actingUserId: string } | null> {
-    if (!config.registryAuthEnabled) {
+    if (!(await isRegistryAuthActive())) {
       res.status(409).json({ error: 'registry_auth_disabled' })
       return null
     }

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -2177,6 +2177,10 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
       res.status(409).json({ error: 'registry_auth_disabled' })
       return null
     }
+    if (config.registryConnectionMode === 'self-hosted' && config.registryUrl === '') {
+      res.status(409).json({ error: 'registry_url_not_configured' })
+      return null
+    }
     const sub = (req as UiAuthedRequest).adminAuth?.sub
     const admin = sub ? await findAdminById(sub) : null
     if (!admin || admin.status !== 'active') {
@@ -2280,6 +2284,10 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     }
     if (!authActive) {
       res.status(409).json({ error: 'registry_auth_disabled' })
+      return null
+    }
+    if (config.registryConnectionMode === 'self-hosted' && config.registryUrl === '') {
+      res.status(409).json({ error: 'registry_url_not_configured' })
       return null
     }
     const actingUserId = (req as UiAuthedRequest).adminAuth?.sub

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -201,100 +201,135 @@ export function createRegistryConnectRouter(): Router {
   // visible pre-claim (state ∈ disconnected|pending|connecting|approved|rejected|connected).
   // `connecting` is finished via POST /admin/registry/connect/recover, not by
   // pasting a token.
-  router.get('/admin/registry/connect', requireAuthForControlUI, async (req, res, next) => {
-    try {
-      const ctx = await requireSelfHostedAdmin(req, res)
-      if (!ctx) return
-      const row = await getRegistryConnection()
-      // Hoisted: every branch below reports authEnabled, and this call is
-      // cache-friendly here — getRegistryConnection() just populated (or hit)
-      // the process-local cache that isRegistryAuthActive()'s self-hosted
-      // path reads via resolveMachineCreds(), so this cannot trigger a fresh
-      // Postgres round-trip on its own. It CAN still reject (a bare
-      // pool.query with no try/catch of its own), so this is guarded the same
-      // way the sibling admin registry routes guard it
-      // (routes/admin/registry.ts's prepareKeysRequest/resolveSelfServiceOrg)
-      // rather than letting it fall through to the generic catch below and
-      // surface as a bare 500 — GET already documents a never-500-on-a-hiccup
-      // guarantee for the status poll, and this preserves that for the newly
-      // derived read too.
-      let authEnabled: boolean
+  router.get(
+    '/admin/registry/connect',
+    requireAuthForControlUI,
+    // Per-admin token bucket — this route is mounted by RegistryCatalog on
+    // every Marketplace visit (control-ui/components/RegistryCatalog.tsx),
+    // not just the connect panel, and is reachable by top-level cross-site
+    // navigation (the session cookie is SameSite=Lax and this router has no
+    // CSRF/origin check). Each call makes an outbound registry /status
+    // fetch, so this bounds that outbound traffic under a CSRF-driven loop
+    // while staying generous enough for normal navigation (Marketplace
+    // mount, connect panel mount, refresh button).
+    rateLimitMiddleware({
+      bucketType: 'registry_connect_status',
+      maxPerMinute: 30,
+      getBucketKey: req => {
+        const sub = (req as UiAuthedRequest).adminAuth?.sub
+        return sub ? `registry_connect_status:${sub}` : null
+      },
+    }),
+    async (req, res, next) => {
       try {
-        authEnabled = await isRegistryAuthActive()
-      } catch {
-        res.status(502).json({ error: 'registry_integration_error' })
-        return
-      }
-      if (!row) {
-        res.status(200).json({ state: 'disconnected', authEnabled })
-        return
-      }
-      if (row.status === 'connected') {
-        res.status(200).json({
-          state: 'connected',
-          deploymentId: row.deploymentId,
-          org: row.orgName,
-          authEnabled,
-        })
-        return
-      }
-      // A locally-'approved' row is a registry auto-approval whose claim has
-      // not landed. GET stays READ-ONLY: it reports state so the panel can
-      // offer the recover button. It must never rotate — GET is also called by
-      // RegistryCatalog on every Marketplace mount and is reachable by
-      // cross-site navigation (SameSite=Lax), so a mutation here would rotate
-      // claim tokens on catalog browsing and on CSRF.
-      if (row.status === 'approved') {
+        const ctx = await requireSelfHostedAdmin(req, res)
+        if (!ctx) return
+        const row = await getRegistryConnection()
+        // Hoisted: every branch below reports authEnabled, and this call is
+        // cache-friendly here — getRegistryConnection() just populated (or hit)
+        // the process-local cache that isRegistryAuthActive()'s self-hosted
+        // path reads via resolveMachineCreds(), so this cannot trigger a fresh
+        // Postgres round-trip on its own. It CAN still reject (a bare
+        // pool.query with no try/catch of its own), so this is guarded the same
+        // way the sibling admin registry routes guard it
+        // (routes/admin/registry.ts's prepareKeysRequest/resolveSelfServiceOrg)
+        // rather than letting it fall through to the generic catch below and
+        // surface as a bare 500 — GET already documents a never-500-on-a-hiccup
+        // guarantee for the status poll, and this preserves that for the newly
+        // derived read too.
+        let authEnabled: boolean
+        try {
+          authEnabled = await isRegistryAuthActive()
+        } catch {
+          res.status(502).json({ error: 'registry_integration_error' })
+          return
+        }
+        if (!row) {
+          res.status(200).json({ state: 'disconnected', authEnabled })
+          return
+        }
+        if (row.status === 'connected') {
+          res.status(200).json({
+            state: 'connected',
+            deploymentId: row.deploymentId,
+            org: row.orgName,
+            authEnabled,
+          })
+          return
+        }
+        // A locally-'approved' row is a registry auto-approval whose claim has
+        // not landed. GET stays READ-ONLY: it reports state so the panel can
+        // offer the recover button. It must never rotate — GET is also called by
+        // RegistryCatalog on every Marketplace mount and is reachable by
+        // cross-site navigation (SameSite=Lax), so a mutation here would rotate
+        // claim tokens on catalog browsing and on CSRF.
+        if (row.status === 'approved') {
+          const poll = await pollRegistryStatus({
+            deploymentId: row.deploymentId,
+            keyId: row.keyId,
+            privateKeyPem: row.privateKeyPem,
+            adminId: ctx.adminId,
+          })
+          const recoveryError = poll?.claimed
+            ? 'already_claimed'
+            : poll?.suspended
+              ? 'deployment_suspended'
+              : undefined
+          res.status(200).json({
+            state: 'connecting',
+            deploymentId: row.deploymentId,
+            requestedOrgName: row.requestedOrgName,
+            authEnabled,
+            ...(recoveryError ? { recoveryError } : {}),
+          })
+          return
+        }
+        // Not yet connected — poll the registry so an operator approval (or
+        // rejection) is reflected before the user attempts to claim.
         const poll = await pollRegistryStatus({
           deploymentId: row.deploymentId,
           keyId: row.keyId,
           privateKeyPem: row.privateKeyPem,
           adminId: ctx.adminId,
         })
-        const recoveryError = poll?.claimed
-          ? 'already_claimed'
-          : poll?.suspended
-            ? 'deployment_suspended'
-            : undefined
+        const registryStatus = poll?.status ?? null
+        const state =
+          registryStatus === 'approved'
+            ? 'approved'
+            : registryStatus === 'rejected'
+              ? 'rejected'
+              : 'pending'
         res.status(200).json({
-          state: 'connecting',
+          state,
           deploymentId: row.deploymentId,
           requestedOrgName: row.requestedOrgName,
           authEnabled,
-          ...(recoveryError ? { recoveryError } : {}),
         })
-        return
+      } catch (err) {
+        next(err)
       }
-      // Not yet connected — poll the registry so an operator approval (or
-      // rejection) is reflected before the user attempts to claim.
-      const poll = await pollRegistryStatus({
-        deploymentId: row.deploymentId,
-        keyId: row.keyId,
-        privateKeyPem: row.privateKeyPem,
-        adminId: ctx.adminId,
-      })
-      const registryStatus = poll?.status ?? null
-      const state =
-        registryStatus === 'approved'
-          ? 'approved'
-          : registryStatus === 'rejected'
-            ? 'rejected'
-            : 'pending'
-      res.status(200).json({
-        state,
-        deploymentId: row.deploymentId,
-        requestedOrgName: row.requestedOrgName,
-        authEnabled,
-      })
-    } catch (err) {
-      next(err)
     }
-  })
+  )
 
   // POST request — generate keypair, register with the registry, persist pending.
   router.post(
     '/admin/registry/connect/request',
     requireAuthForControlUI,
+    // Per-admin token bucket — registration is a rare, deliberate,
+    // once-in-a-deployment-lifetime action, and each call consumes one of
+    // the shared registry's ~5/day per-IP registration attempts (and can
+    // create a deployment row there). 3/min still allows a legitimate retry
+    // after a transient failure (e.g. a typo'd org name) while capping how
+    // much of that daily budget a looped admin can burn through in a single
+    // minute.
+    rateLimitMiddleware({
+      bucketType: 'registry_connect_request',
+      maxPerMinute: 3,
+      getBucketKey: req => {
+        const sub = (req as UiAuthedRequest).adminAuth?.sub
+        return sub ? `registry_connect_request:${sub}` : null
+      },
+    }),
     async (req, res, next) => {
       try {
         const ctx = await requireSelfHostedAdmin(req, res)

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -102,8 +102,11 @@ export function createRegistryConnectRouter(): Router {
       // Buffer.from(null) crash inside the encryption path.
       if (
         typeof claimed.client_id !== 'string' ||
+        claimed.client_id.length === 0 ||
         typeof claimed.client_secret !== 'string' ||
-        typeof claimed.org !== 'string'
+        claimed.client_secret.length === 0 ||
+        typeof claimed.org !== 'string' ||
+        claimed.org.length === 0
       ) {
         rootLogger.error(
           { event: 'registry_connect_claim_malformed', status: claimRes.status },
@@ -132,16 +135,17 @@ export function createRegistryConnectRouter(): Router {
 
   async function requireSelfHostedAdmin(
     req: Request,
-    res: Response
+    res: Response,
+    options: { requireRegistryUrl?: boolean } = {}
   ): Promise<{ adminId: string } | null> {
     if (config.registryConnectionMode !== 'self-hosted') {
       res.status(409).json({ error: 'not_self_hosted' })
       return null
     }
-    // Task 4 permits booting without a registry URL. Fail cleanly here rather
-    // than letting base() build '/api/v1/deployments' and fetch() throw
-    // TypeError: Failed to parse URL, which surfaces as a bare 500.
-    if (config.registryUrl === '') {
+    // Network-dependent connect routes need a configured registry URL. DELETE
+    // is deliberately exempt: it only removes local credentials, and must
+    // remain the recovery path after an operator removes a broken/stale URL.
+    if (options.requireRegistryUrl !== false && config.registryUrl === '') {
       res.status(409).json({ error: 'registry_url_not_configured' })
       return null
     }
@@ -486,23 +490,16 @@ export function createRegistryConnectRouter(): Router {
           claimToken: reg.claim_token as string,
         })
         if (outcome.kind === 'connected') {
-          // The connect itself already succeeded (markConnected committed
-          // inside redeemClaim) by the time we get here — a rejecting
-          // isRegistryAuthActive() must not surface as an uncaught rejection
-          // or a bare 500 for a request whose underlying mutation landed.
-          // Same 502 the sibling admin registry routes use for this accessor.
-          let authEnabled: boolean
-          try {
-            authEnabled = await isRegistryAuthActive()
-          } catch {
-            res.status(502).json({ error: 'registry_integration_error' })
-            return
-          }
+          // redeemClaim validated a non-empty credential pair and
+          // markConnected committed it. Do not perform a second fallible DB
+          // read after this irreversible one-time claim has succeeded: a
+          // transient read failure must not turn a completed connection into a
+          // misleading 502 response.
           res.status(200).json({
             state: 'connected',
             org: outcome.org,
             deploymentId: reg.deployment_id,
-            authEnabled,
+            authEnabled: true,
           })
           return
         }
@@ -676,21 +673,13 @@ export function createRegistryConnectRouter(): Router {
         })
         switch (outcome.kind) {
           case 'connected': {
-            // Same reasoning as the auto-claim branch in POST /request: the
-            // recover has already succeeded (markConnected committed) by the
-            // time we're here, so a rejecting isRegistryAuthActive() must
-            // degrade to 502 rather than an uncaught rejection or a bare 500.
-            let authEnabled: boolean
-            try {
-              authEnabled = await isRegistryAuthActive()
-            } catch {
-              res.status(502).json({ error: 'registry_integration_error' })
-              return
-            }
+            // Same committed-outcome rule as POST /request: recovery already
+            // consumed the one-time token and stored a validated credential
+            // pair, so its response must not depend on a redundant DB read.
             res.status(200).json({
               state: 'connected',
               org: outcome.org,
-              authEnabled,
+              authEnabled: true,
             })
             return
           }
@@ -725,7 +714,7 @@ export function createRegistryConnectRouter(): Router {
   // DELETE — disconnect (drop the row).
   router.delete('/admin/registry/connect', requireAuthForControlUI, async (req, res, next) => {
     try {
-      const ctx = await requireSelfHostedAdmin(req, res)
+      const ctx = await requireSelfHostedAdmin(req, res, { requireRegistryUrl: false })
       if (!ctx) return
       await deleteConnection()
       res.status(204).end()

--- a/control-api/src/routes/admin/registryConnect.ts
+++ b/control-api/src/routes/admin/registryConnect.ts
@@ -9,6 +9,7 @@ import { findAdminById } from '../../services/adminAuthService.js'
 import {
   deleteConnection,
   getRegistryConnection,
+  isRegistryAuthActive,
   markConnected,
   upsertPendingConnection,
 } from '../../services/registryConnectionDb.js'
@@ -137,6 +138,13 @@ export function createRegistryConnectRouter(): Router {
       res.status(409).json({ error: 'not_self_hosted' })
       return null
     }
+    // Task 4 permits booting without a registry URL. Fail cleanly here rather
+    // than letting base() build '/api/v1/deployments' and fetch() throw
+    // TypeError: Failed to parse URL, which surfaces as a bare 500.
+    if (config.registryUrl === '') {
+      res.status(409).json({ error: 'registry_url_not_configured' })
+      return null
+    }
     const sub = (req as UiAuthedRequest).adminAuth?.sub
     const admin = sub ? await findAdminById(sub) : null
     if (!admin || admin.status !== 'active') {
@@ -198,8 +206,27 @@ export function createRegistryConnectRouter(): Router {
       const ctx = await requireSelfHostedAdmin(req, res)
       if (!ctx) return
       const row = await getRegistryConnection()
+      // Hoisted: every branch below reports authEnabled, and this call is
+      // cache-friendly here — getRegistryConnection() just populated (or hit)
+      // the process-local cache that isRegistryAuthActive()'s self-hosted
+      // path reads via resolveMachineCreds(), so this cannot trigger a fresh
+      // Postgres round-trip on its own. It CAN still reject (a bare
+      // pool.query with no try/catch of its own), so this is guarded the same
+      // way the sibling admin registry routes guard it
+      // (routes/admin/registry.ts's prepareKeysRequest/resolveSelfServiceOrg)
+      // rather than letting it fall through to the generic catch below and
+      // surface as a bare 500 — GET already documents a never-500-on-a-hiccup
+      // guarantee for the status poll, and this preserves that for the newly
+      // derived read too.
+      let authEnabled: boolean
+      try {
+        authEnabled = await isRegistryAuthActive()
+      } catch {
+        res.status(502).json({ error: 'registry_integration_error' })
+        return
+      }
       if (!row) {
-        res.status(200).json({ state: 'disconnected', authEnabled: config.registryAuthEnabled })
+        res.status(200).json({ state: 'disconnected', authEnabled })
         return
       }
       if (row.status === 'connected') {
@@ -207,7 +234,7 @@ export function createRegistryConnectRouter(): Router {
           state: 'connected',
           deploymentId: row.deploymentId,
           org: row.orgName,
-          authEnabled: config.registryAuthEnabled,
+          authEnabled,
         })
         return
       }
@@ -233,7 +260,7 @@ export function createRegistryConnectRouter(): Router {
           state: 'connecting',
           deploymentId: row.deploymentId,
           requestedOrgName: row.requestedOrgName,
-          authEnabled: config.registryAuthEnabled,
+          authEnabled,
           ...(recoveryError ? { recoveryError } : {}),
         })
         return
@@ -257,7 +284,7 @@ export function createRegistryConnectRouter(): Router {
         state,
         deploymentId: row.deploymentId,
         requestedOrgName: row.requestedOrgName,
-        authEnabled: config.registryAuthEnabled,
+        authEnabled,
       })
     } catch (err) {
       next(err)
@@ -424,11 +451,23 @@ export function createRegistryConnectRouter(): Router {
           claimToken: reg.claim_token as string,
         })
         if (outcome.kind === 'connected') {
+          // The connect itself already succeeded (markConnected committed
+          // inside redeemClaim) by the time we get here — a rejecting
+          // isRegistryAuthActive() must not surface as an uncaught rejection
+          // or a bare 500 for a request whose underlying mutation landed.
+          // Same 502 the sibling admin registry routes use for this accessor.
+          let authEnabled: boolean
+          try {
+            authEnabled = await isRegistryAuthActive()
+          } catch {
+            res.status(502).json({ error: 'registry_integration_error' })
+            return
+          }
           res.status(200).json({
             state: 'connected',
             org: outcome.org,
             deploymentId: reg.deployment_id,
-            authEnabled: config.registryAuthEnabled,
+            authEnabled,
           })
           return
         }
@@ -601,13 +640,25 @@ export function createRegistryConnectRouter(): Router {
           claimToken,
         })
         switch (outcome.kind) {
-          case 'connected':
+          case 'connected': {
+            // Same reasoning as the auto-claim branch in POST /request: the
+            // recover has already succeeded (markConnected committed) by the
+            // time we're here, so a rejecting isRegistryAuthActive() must
+            // degrade to 502 rather than an uncaught rejection or a bare 500.
+            let authEnabled: boolean
+            try {
+              authEnabled = await isRegistryAuthActive()
+            } catch {
+              res.status(502).json({ error: 'registry_integration_error' })
+              return
+            }
             res.status(200).json({
               state: 'connected',
               org: outcome.org,
-              authEnabled: config.registryAuthEnabled,
+              authEnabled,
             })
             return
+          }
           // Terminal: the client is disabled (operator suspension). Retrying
           // rotates forever against a deployment that was deliberately killed.
           case 'client_unavailable':

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -1,13 +1,12 @@
 /**
  * Registry Client — fetches entries from Clerum Registry service.
- * When CLERUM_REGISTRY_AUTH_ENABLED=true, calls are Bearer-authenticated
- * via OAuth2 client_credentials minted from CLERUM_REGISTRY_CLIENT_ID/SECRET.
- * Auth-off mode preserved for minikube: mintToken returns "" and the
- * Authorization header is omitted downstream.
+ * Managed deployments use CLERUM_REGISTRY_AUTH_ENABLED plus env-provided
+ * client credentials. Self-hosted deployments become Bearer-authenticated when
+ * their claimed registry_connection row holds machine credentials.
  */
 import { config } from '../config.js'
 import { rootLogger } from '../observability/logger.js'
-import { isRegistryAuthActive, resolveMachineCreds } from './registryConnectionDb.js'
+import { resolveMachineCreds } from './registryConnectionDb.js'
 
 const API_BASE = `${config.registryUrl}/api/v1`
 
@@ -76,36 +75,32 @@ export async function mintToken(envOverride?: NodeJS.ProcessEnv): Promise<string
   const now = Date.now()
   if (cached && now < cached.expiresAt - 30_000) return cached.token
 
-  // Env precedence: explicit override wins; otherwise process.env / config
-  // (which is what config also reads, but routes through env directly here so
-  // tests can mutate without rebuilding the config singleton). This resolves
-  // MANAGED creds — env/Secret, unchanged from before.
-  let id = env.CLERUM_REGISTRY_CLIENT_ID || (envOverride ? '' : config.registryClientId)
-  let secret = env.CLERUM_REGISTRY_CLIENT_SECRET || (envOverride ? '' : config.registryClientSecret)
+  // An explicit override is a test-only path and remains fully env-driven. In
+  // production, credentials MUST come from the mode-aware resolver: managed
+  // reads config/env, self-hosted reads only the claimed DB row. Reading env
+  // first here would create a split brain where isRegistryAuthActive authorizes
+  // the DB identity while the registry client authenticates as a stale managed
+  // identity left in the pod environment.
+  let id = envOverride ? env.CLERUM_REGISTRY_CLIENT_ID || '' : ''
+  let secret = envOverride ? env.CLERUM_REGISTRY_CLIENT_SECRET || '' : ''
   // Single source of truth for the registry base URL — env override wins for
   // tests/minikube, else config.registryUrl (mandatory + allowlisted when auth
   // is on). resolveMachineCreds no longer carries a `url`.
   const url = env.CLERUM_REGISTRY_URL || (envOverride ? '' : config.registryUrl)
 
-  // When creds are still absent AND no explicit env override is in play, fall
-  // through to the mode-aware resolver: managed → config env creds (a no-op
-  // here, already resolved above); self-hosted → the registry_connection DB row
-  // populated at claim. An explicit envOverride short-circuits this so the
-  // env-driven test/minikube paths never touch the DB.
-  if ((!id || !secret) && !envOverride) {
+  let authEnabled = false
+  if (!envOverride) {
     const resolved = await resolveMachineCreds()
     if (resolved) {
-      id = id || resolved.clientId
-      secret = secret || resolved.clientSecret
+      id = resolved.clientId
+      secret = resolved.clientSecret
     }
+    // Derive the decision from the SAME resolution used for the credentials.
+    // Managed deliberately keeps its env flag; self-hosted is active exactly
+    // when the DB row yielded a complete credential pair.
+    authEnabled =
+      config.registryConnectionMode === 'managed' ? config.registryAuthEnabled : resolved !== null
   }
-
-  // Auth is ACTIVE when credentials actually exist (self-hosted) or the env
-  // says so (managed). The old CLERUM_REGISTRY_AUTH_ENABLED override is gone:
-  // in self-hosted the var is inert, and in managed isRegistryAuthActive()
-  // returns it verbatim. envOverride still short-circuits for the env-driven
-  // test/minikube paths, which must never touch the DB.
-  const authEnabled = envOverride ? false : await isRegistryAuthActive()
 
   if (!id || !secret) {
     if (!authEnabled) return '' // minikube / auth-off

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -7,7 +7,7 @@
  */
 import { config } from '../config.js'
 import { rootLogger } from '../observability/logger.js'
-import { resolveMachineCreds } from './registryConnectionDb.js'
+import { isRegistryAuthActive, resolveMachineCreds } from './registryConnectionDb.js'
 
 const API_BASE = `${config.registryUrl}/api/v1`
 
@@ -100,13 +100,12 @@ export async function mintToken(envOverride?: NodeJS.ProcessEnv): Promise<string
     }
   }
 
-  const authEnabledRaw = env.CLERUM_REGISTRY_AUTH_ENABLED
-  const authEnabled =
-    authEnabledRaw === undefined
-      ? envOverride
-        ? false
-        : config.registryAuthEnabled
-      : authEnabledRaw === 'true'
+  // Auth is ACTIVE when credentials actually exist (self-hosted) or the env
+  // says so (managed). The old CLERUM_REGISTRY_AUTH_ENABLED override is gone:
+  // in self-hosted the var is inert, and in managed isRegistryAuthActive()
+  // returns it verbatim. envOverride still short-circuits for the env-driven
+  // test/minikube paths, which must never touch the DB.
+  const authEnabled = envOverride ? false : await isRegistryAuthActive()
 
   if (!id || !secret) {
     if (!authEnabled) return '' // minikube / auth-off

--- a/control-api/src/services/registryConnectionDb.ts
+++ b/control-api/src/services/registryConnectionDb.ts
@@ -214,3 +214,21 @@ export async function resolveMachineCreds(): Promise<{
     clientSecret: config.registryClientSecret,
   }
 }
+
+/**
+ * Registry auth is ACTIVE when this deployment actually holds usable machine
+ * credentials.
+ *
+ * Self-hosted derives it from the claimed connection row, so connecting is the
+ * only operator action — there is no env var to set and no restart. Managed
+ * keeps CLERUM_REGISTRY_AUTH_ENABLED, because managed has no row (its creds
+ * come from env).
+ *
+ * Note this checks CREDENTIALS, not row presence: a 'pending' row, and an
+ * 'approved' row whose claim has not landed, both correctly report inactive.
+ * That falls out of resolveMachineCreds, which null-checks clientId/clientSecret.
+ */
+export async function isRegistryAuthActive(): Promise<boolean> {
+  if (config.registryConnectionMode === 'managed') return config.registryAuthEnabled
+  return (await resolveMachineCreds()) !== null
+}

--- a/control-api/src/services/registryConnectionDb.ts
+++ b/control-api/src/services/registryConnectionDb.ts
@@ -49,15 +49,19 @@ interface RawRow {
   registry_url: string | null
 }
 
-// Process-local cache: a control-api serves one deployment for its lifetime, so
-// the decrypted row is stable. Evicted by any write here + the test reset.
-// Caveat: eviction is process-local only — a post-connection DELETE/reconnect
-// clears this cache on THIS replica alone, so a reconnect-in-place on a
-// multi-replica deployment requires a rollout restart to evict peer replicas.
+// Process-local cache with a bounded TTL: a control-api serves one deployment
+// for its lifetime, so the decrypted row is stable — but the DERIVED auth state
+// (isRegistryAuthActive) is an access-control input, and an unbounded cache
+// would let a peer replica keep reporting auth-active forever after another
+// replica disconnected. The TTL caps that window; writes here still evict
+// immediately on the local process.
+const CONNECTION_CACHE_TTL_MS = 15_000
 let cached: RegistryConnectionRow | null | undefined
+let cachedAt = 0
 
 export function __resetRegistryConnectionCacheForTests(): void {
   cached = undefined
+  cachedAt = 0
 }
 
 function encKey(): Buffer {
@@ -67,7 +71,7 @@ function encKey(): Buffer {
 export async function getRegistryConnection(
   db: DbClient = pool
 ): Promise<RegistryConnectionRow | null> {
-  if (cached !== undefined) return cached
+  if (cached !== undefined && Date.now() - cachedAt < CONNECTION_CACHE_TTL_MS) return cached
   const res = await db.query(
     `SELECT deployment_id, key_id, public_key_pem, private_key_encrypted, client_id,
             client_secret_encrypted, org_name, requested_org_name, contact_email, status, registry_url
@@ -78,6 +82,7 @@ export async function getRegistryConnection(
   const raw = res.rows[0] as RawRow | undefined
   if (!raw) {
     cached = null
+    cachedAt = Date.now()
     return null
   }
   const key = encKey()
@@ -96,6 +101,7 @@ export async function getRegistryConnection(
     status: raw.status,
     registryUrl: raw.registry_url,
   }
+  cachedAt = Date.now()
   return cached
 }
 

--- a/control-api/test/app.publisherUiEnabled.test.ts
+++ b/control-api/test/app.publisherUiEnabled.test.ts
@@ -48,6 +48,7 @@ describe('GET /admin/registry/publish-scope: publisherUiEnabled (effective, thro
     process.env = { ...ORIGINAL_ENV }
     delete process.env.CONTROL_API_PUBLISHER_UI_ENABLED
     delete process.env.REGISTRY_CONNECTION_MODE
+    delete process.env.CLERUM_REGISTRY_URL
     registryClient.resolvePublishScope.mockReset()
     registryClient.resolvePublishScope.mockResolvedValue({
       curator: false,

--- a/control-api/test/config.publisherUiEnabled.test.ts
+++ b/control-api/test/config.publisherUiEnabled.test.ts
@@ -7,6 +7,7 @@ beforeEach(() => {
   process.env = { ...ORIGINAL_ENV }
   delete process.env.CONTROL_API_PUBLISHER_UI_ENABLED
   delete process.env.REGISTRY_CONNECTION_MODE
+  delete process.env.CLERUM_REGISTRY_URL
 })
 afterEach(() => {
   process.env = ORIGINAL_ENV

--- a/control-api/test/config.registryConnectionMode.test.ts
+++ b/control-api/test/config.registryConnectionMode.test.ts
@@ -133,6 +133,20 @@ describe('boot validation — URL allowlist re-gating', () => {
     await expect(import('../src/config.js')).resolves.toBeDefined()
   })
 
+  // The mutation-killer: the previous test's URL happens to be on the
+  // hardcoded allowlist, so it cannot distinguish the correct gate from the
+  // rejected `config.registryUrl !== ''` alone (which would run the allowlist
+  // here too and still pass by coincidence). An UNLISTED URL is required to
+  // prove the self-hosted disjunct — not just the auth disjunct — is what
+  // keeps this case from running the allowlist at all.
+  it('managed-by-default + UNLISTED url + auth off still boots', { retry: 0 }, async () => {
+    vi.resetModules()
+    delete process.env.REGISTRY_CONNECTION_MODE
+    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'false'
+    process.env.CLERUM_REGISTRY_URL = 'https://not-on-the-list.example.net'
+    await expect(import('../src/config.js')).resolves.toBeDefined()
+  })
+
   // The new explicit check. Today an empty URL with auth on throws via the
   // allowlist (allowed.includes('') is never true). The new allowlist block is
   // preconditioned on registryUrl !== '', which would skip it — so this needs

--- a/control-api/test/config.registryConnectionMode.test.ts
+++ b/control-api/test/config.registryConnectionMode.test.ts
@@ -100,3 +100,52 @@ describe('config: registry URL allowlist', () => {
     expect(config.registryUrl).toBe('https://registry.MyCorp.example')
   })
 })
+
+describe('boot validation — URL allowlist re-gating', () => {
+  // The hole this task closes: today the allowlist only runs when auth is on,
+  // and auth ships false, so a self-hosted deployment registers and claims
+  // credentials against a totally unvalidated URL.
+  it('self-hosted + unlisted URL throws even with NO auth env var', { retry: 0 }, async () => {
+    vi.resetModules()
+    delete process.env.CLERUM_REGISTRY_AUTH_ENABLED
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CLERUM_REGISTRY_URL = 'https://evil.example.net'
+    await expect(import('../src/config.js')).rejects.toThrow(/allowlist/)
+  })
+
+  it('self-hosted + allowlisted URL boots with no auth env var', { retry: 0 }, async () => {
+    vi.resetModules()
+    delete process.env.CLERUM_REGISTRY_AUTH_ENABLED
+    process.env.REGISTRY_CONNECTION_MODE = 'self-hosted'
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
+    await expect(import('../src/config.js')).resolves.toBeDefined()
+  })
+
+  // Regression guard for the managed hard constraint: mode UNSET (defaults to
+  // managed) + a URL + auth off must still boot. This mirrors
+  // startupGuards.registryConsumer.test.ts:85-91, restated here because two
+  // spec revisions broke exactly this case.
+  it('managed-by-default + URL + auth off still boots', { retry: 0 }, async () => {
+    vi.resetModules()
+    delete process.env.REGISTRY_CONNECTION_MODE
+    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'false'
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
+    await expect(import('../src/config.js')).resolves.toBeDefined()
+  })
+
+  // The new explicit check. Today an empty URL with auth on throws via the
+  // allowlist (allowed.includes('') is never true). The new allowlist block is
+  // preconditioned on registryUrl !== '', which would skip it — so this needs
+  // its own guard, and nothing covered it before.
+  it('auth on with an EMPTY url throws', { retry: 0 }, async () => {
+    vi.resetModules()
+    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'true'
+    process.env.REGISTRY_CONNECTION_MODE = 'managed'
+    process.env.CLERUM_REGISTRY_CLIENT_ID = 'id'
+    process.env.CLERUM_REGISTRY_CLIENT_SECRET = 's'
+    process.env.CONTROL_API_REGISTRY_VOUCHER_PRIVATE_KEY = voucherPem()
+    process.env.CONTROL_API_REGISTRY_VOUCHER_KID = 'key-uuid'
+    delete process.env.CLERUM_REGISTRY_URL
+    await expect(import('../src/config.js')).rejects.toThrow(/CLERUM_REGISTRY_URL is required/)
+  })
+})

--- a/control-api/test/main.selfHostedBootGuard.test.ts
+++ b/control-api/test/main.selfHostedBootGuard.test.ts
@@ -56,6 +56,28 @@ describe('logRegistryConnectionState', () => {
     )
   })
 
+  // Discriminator pin: status and clientId deliberately disagree. If the
+  // discriminator ever regressed from `clientId != null` to a status check,
+  // this fails — the two fixtures above alone would not catch that mutation
+  // because in both of them status and clientId happen to point the same way.
+  it('reports connected for a pending-status row that already holds a clientId', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({ status: 'pending', clientId: 'cid' })
+    await logRegistryConnectionState()
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true }),
+      expect.any(String)
+    )
+  })
+
+  it('reports NOT connected for a connected-status row with no clientId', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({ status: 'connected', clientId: null })
+    await logRegistryConnectionState()
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: false }),
+      expect.any(String)
+    )
+  })
+
   it('no-op in managed mode — does not even read the row', async () => {
     cfg.registryConnectionMode = 'managed'
     await expect(logRegistryConnectionState()).resolves.toBeUndefined()

--- a/control-api/test/main.selfHostedBootGuard.test.ts
+++ b/control-api/test/main.selfHostedBootGuard.test.ts
@@ -37,6 +37,23 @@ describe('logRegistryConnectionState', () => {
     )
   })
 
+  // A second deadlock regression guard, this time for the DB read itself. This
+  // now runs on EVERY self-hosted boot (not gated behind
+  // CLERUM_REGISTRY_AUTH_ENABLED), so getRegistryConnection rejecting — a
+  // rotated CLERUM_OAUTH_ENCRYPTION_KEY, a restored Postgres volume paired with
+  // a different key Secret, or a transient pool blip — must not escape as an
+  // unhandled rejection. `.resolves` is the detector: a future change that
+  // drops the try/catch fails this test with an unhandled rejection rather
+  // than a clean assertion failure.
+  it('does NOT throw when getRegistryConnection rejects', { retry: 0 }, async () => {
+    connDb.getRegistryConnection.mockRejectedValue(new Error('decrypt failed'))
+    await expect(logRegistryConnectionState()).resolves.toBeUndefined()
+    expect(logger.rootLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'registry_connection_state_unreadable' }),
+      expect.any(String)
+    )
+  })
+
   it('reports connected for a row holding client credentials', async () => {
     connDb.getRegistryConnection.mockResolvedValue({ status: 'connected', clientId: 'cid' })
     await expect(logRegistryConnectionState()).resolves.toBeUndefined()

--- a/control-api/test/main.selfHostedBootGuard.test.ts
+++ b/control-api/test/main.selfHostedBootGuard.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { assertRegistryConnectionReady } from '../src/registryBootGuard.js'
+import { logRegistryConnectionState } from '../src/registryBootGuard.js'
 
-// C-M5: the guard lives in a standalone module (src/registryBootGuard.ts) that
-// imports ONLY config + registryConnectionDb, so this test never pulls in
-// main.ts's full server/cron graph.
+// The function lives in a standalone module importing ONLY config, the logger,
+// and registryConnectionDb, so this test never pulls in main.ts's full
+// server/cron graph.
 const { cfg } = vi.hoisted(() => ({
   cfg: {
     registryConnectionMode: 'self-hosted',
-    registryAuthEnabled: true,
+    registryUrl: 'https://registry.evenfire.ai',
   } as Record<string, unknown>,
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
@@ -15,32 +15,57 @@ vi.mock('../src/config.js', () => ({ config: cfg }))
 const connDb = vi.hoisted(() => ({ getRegistryConnection: vi.fn() }))
 vi.mock('../src/services/registryConnectionDb.js', () => connDb)
 
+const logger = vi.hoisted(() => ({ rootLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }))
+vi.mock('../src/observability/logger.js', () => logger)
+
 afterEach(() => {
   vi.clearAllMocks()
   cfg.registryConnectionMode = 'self-hosted'
-  cfg.registryAuthEnabled = true
+  cfg.registryUrl = 'https://registry.evenfire.ai'
 })
 
-describe('assertRegistryConnectionReady (self-hosted boot guard)', () => {
-  it('throws when self-hosted + enabled + no connection row', async () => {
+describe('logRegistryConnectionState', () => {
+  // The deadlock regression guard. `.resolves` (not `.rejects`) is the detector:
+  // if a future change reintroduces a throw here, control-api cannot boot
+  // before it has connected, and this test fails.
+  it('does NOT throw when self-hosted with no connection row', { retry: 0 }, async () => {
     connDb.getRegistryConnection.mockResolvedValue(null)
-    await expect(assertRegistryConnectionReady()).rejects.toThrow(/registry_connection/)
+    await expect(logRegistryConnectionState()).resolves.toBeUndefined()
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: false }),
+      expect.any(String)
+    )
   })
 
-  it('passes when a connected row exists', async () => {
-    connDb.getRegistryConnection.mockResolvedValue({ status: 'connected' })
-    await expect(assertRegistryConnectionReady()).resolves.toBeUndefined()
+  it('reports connected for a row holding client credentials', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({ status: 'connected', clientId: 'cid' })
+    await expect(logRegistryConnectionState()).resolves.toBeUndefined()
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true }),
+      expect.any(String)
+    )
   })
 
-  it('no-op when registry auth is disabled', async () => {
-    cfg.registryAuthEnabled = false
-    connDb.getRegistryConnection.mockResolvedValue(null)
-    await expect(assertRegistryConnectionReady()).resolves.toBeUndefined()
+  // An auto-approved row whose claim has not landed has no clientId.
+  it('reports NOT connected for an approved row with no clientId', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({ status: 'approved', clientId: null })
+    await logRegistryConnectionState()
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: false }),
+      expect.any(String)
+    )
   })
 
-  it('no-op in managed mode', async () => {
+  it('no-op in managed mode — does not even read the row', async () => {
     cfg.registryConnectionMode = 'managed'
-    connDb.getRegistryConnection.mockResolvedValue(null)
-    await expect(assertRegistryConnectionReady()).resolves.toBeUndefined()
+    await expect(logRegistryConnectionState()).resolves.toBeUndefined()
+    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
+    expect(logger.rootLogger.info).not.toHaveBeenCalled()
+  })
+
+  it('no-op when no registry URL is configured', async () => {
+    cfg.registryUrl = ''
+    await expect(logRegistryConnectionState()).resolves.toBeUndefined()
+    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/main.selfHostedBootGuard.test.ts
+++ b/control-api/test/main.selfHostedBootGuard.test.ts
@@ -102,9 +102,14 @@ describe('logRegistryConnectionState', () => {
     expect(logger.rootLogger.info).not.toHaveBeenCalled()
   })
 
-  it('no-op when no registry URL is configured', async () => {
+  it('still reports connection state when no registry URL is configured', async () => {
     cfg.registryUrl = ''
+    connDb.getRegistryConnection.mockResolvedValue({ status: 'connected', clientId: 'cid' })
     await expect(logRegistryConnectionState()).resolves.toBeUndefined()
-    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
+    expect(connDb.getRegistryConnection).toHaveBeenCalledTimes(1)
+    expect(logger.rootLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ connected: true }),
+      expect.any(String)
+    )
   })
 })

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -167,6 +167,13 @@ describe('registryClient — mintToken derived auth (no envOverride)', () => {
     connDb.resolveMachineCreds.mockResolvedValue(null)
     connDb.isRegistryAuthActive.mockResolvedValue(false)
     await expect(mintToken()).resolves.toBe('') // NO ENV_OVERRIDE — see above
+    // Without this, the assertion above is vacuous: the old env-var-based
+    // implementation also resolves authEnabled=false here (config.registryAuthEnabled
+    // is frozen false at module load in this test env) WITHOUT ever calling
+    // isRegistryAuthActive — so the return-value alone can't tell the derived
+    // path apart from the old, un-refactored one. This call-count assertion fails
+    // under both a full revert and a "hardcoded/ignored accessor" mutation.
+    expect(connDb.isRegistryAuthActive).toHaveBeenCalledTimes(1)
   })
 
   it('throws when auth is active but credentials are unavailable', async () => {

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -11,16 +11,17 @@ import {
   searchEntries,
 } from '../src/services/registryClient.js'
 
-// Controls the derived-auth path (Task 7): mintToken() with NO envOverride
-// consults isRegistryAuthActive() for the authEnabled decision and
-// resolveMachineCreds() for self-hosted credentials. Every OTHER test in this
-// file drives mintToken via ENV_OVERRIDE or process.env id/secret directly,
-// so it never reaches either mock — only the two derived-auth tests below do.
+// mintToken() with NO envOverride resolves both the active decision and the
+// credential pair through this mode-aware dependency. Most tests in this file
+// populate process.env; the default mock mirrors managed-mode resolution from
+// those values so they exercise the normal client path without rebuilding the
+// config singleton.
 const connDb = vi.hoisted(() => ({
-  isRegistryAuthActive: vi.fn(),
   resolveMachineCreds: vi.fn(),
 }))
 vi.mock('../src/services/registryConnectionDb.js', () => connDb)
+
+const ORIGINAL_ENV = { ...process.env }
 
 function fakeTokenResponse(token = 'tok-abc', expiresIn = 600) {
   return new Response(
@@ -37,18 +38,18 @@ const ENV_OVERRIDE: NodeJS.ProcessEnv = {
 }
 
 beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV }
   __resetTokenCacheForTests()
   __resetScopeCacheForTests()
-  // Deterministic defaults for the connDb mock (no creds, auth off) rather
-  // than relying on an unconfigured vi.fn() resolving `undefined` (falsy, but
-  // for the wrong reason). Only the derived-auth tests below reach these; every
-  // other test in the file resolves id/secret from ENV_OVERRIDE/process.env
-  // before this mock would ever be consulted.
-  connDb.resolveMachineCreds.mockReset().mockResolvedValue(null)
-  connDb.isRegistryAuthActive.mockReset().mockResolvedValue(false)
+  connDb.resolveMachineCreds.mockReset().mockImplementation(async () => {
+    const clientId = process.env.CLERUM_REGISTRY_CLIENT_ID
+    const clientSecret = process.env.CLERUM_REGISTRY_CLIENT_SECRET
+    return clientId && clientSecret ? { clientId, clientSecret } : null
+  })
 })
 
 afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
   vi.unstubAllGlobals()
   vi.useRealTimers()
 })
@@ -146,15 +147,8 @@ describe('registryClient — mintToken cache behavior', () => {
 })
 
 describe('registryClient — mintToken derived auth (no envOverride)', () => {
-  // Critical: no ENV_OVERRIDE here. An envOverride short-circuits authEnabled
-  // to false by design (see mintToken), so these two tests must call
-  // mintToken() bare to actually reach the isRegistryAuthActive()-derived path.
-  // They also explicitly blank CLIENT_ID/SECRET: earlier tests in this file
-  // mutate the REAL process.env via Object.assign(process.env, ENV_OVERRIDE)
-  // and never reset it (only afterEach's unstubAllGlobals/useRealTimers run),
-  // so without this, a leftover id/secret from a prior test would populate
-  // `id`/`secret` and the credential-missing branch under test would never
-  // trigger.
+  // Critical: no ENV_OVERRIDE here. That test-only path intentionally bypasses
+  // the mode-aware resolver.
   beforeEach(() => {
     process.env = {
       ...process.env,
@@ -165,21 +159,8 @@ describe('registryClient — mintToken derived auth (no envOverride)', () => {
 
   it('returns an empty token when auth is inactive and no creds exist', async () => {
     connDb.resolveMachineCreds.mockResolvedValue(null)
-    connDb.isRegistryAuthActive.mockResolvedValue(false)
     await expect(mintToken()).resolves.toBe('') // NO ENV_OVERRIDE — see above
-    // Without this, the assertion above is vacuous: the old env-var-based
-    // implementation also resolves authEnabled=false here (config.registryAuthEnabled
-    // is frozen false at module load in this test env) WITHOUT ever calling
-    // isRegistryAuthActive — so the return-value alone can't tell the derived
-    // path apart from the old, un-refactored one. This call-count assertion fails
-    // under both a full revert and a "hardcoded/ignored accessor" mutation.
-    expect(connDb.isRegistryAuthActive).toHaveBeenCalledTimes(1)
-  })
-
-  it('throws when auth is active but credentials are unavailable', async () => {
-    connDb.resolveMachineCreds.mockResolvedValue(null)
-    connDb.isRegistryAuthActive.mockResolvedValue(true)
-    await expect(mintToken()).rejects.toThrow(/machine credentials unavailable/)
+    expect(connDb.resolveMachineCreds).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/control-api/test/registryClient.test.ts
+++ b/control-api/test/registryClient.test.ts
@@ -11,6 +11,17 @@ import {
   searchEntries,
 } from '../src/services/registryClient.js'
 
+// Controls the derived-auth path (Task 7): mintToken() with NO envOverride
+// consults isRegistryAuthActive() for the authEnabled decision and
+// resolveMachineCreds() for self-hosted credentials. Every OTHER test in this
+// file drives mintToken via ENV_OVERRIDE or process.env id/secret directly,
+// so it never reaches either mock — only the two derived-auth tests below do.
+const connDb = vi.hoisted(() => ({
+  isRegistryAuthActive: vi.fn(),
+  resolveMachineCreds: vi.fn(),
+}))
+vi.mock('../src/services/registryConnectionDb.js', () => connDb)
+
 function fakeTokenResponse(token = 'tok-abc', expiresIn = 600) {
   return new Response(
     JSON.stringify({ access_token: token, token_type: 'Bearer', expires_in: expiresIn }),
@@ -28,6 +39,13 @@ const ENV_OVERRIDE: NodeJS.ProcessEnv = {
 beforeEach(() => {
   __resetTokenCacheForTests()
   __resetScopeCacheForTests()
+  // Deterministic defaults for the connDb mock (no creds, auth off) rather
+  // than relying on an unconfigured vi.fn() resolving `undefined` (falsy, but
+  // for the wrong reason). Only the derived-auth tests below reach these; every
+  // other test in the file resolves id/secret from ENV_OVERRIDE/process.env
+  // before this mock would ever be consulted.
+  connDb.resolveMachineCreds.mockReset().mockResolvedValue(null)
+  connDb.isRegistryAuthActive.mockReset().mockResolvedValue(false)
 })
 
 afterEach(() => {
@@ -124,6 +142,37 @@ describe('registryClient — mintToken cache behavior', () => {
       // It must NOT use the credential-rejected wording.
       await expect(mintToken(ENV_OVERRIDE)).rejects.not.toThrow(/credential rejected/)
     }
+  })
+})
+
+describe('registryClient — mintToken derived auth (no envOverride)', () => {
+  // Critical: no ENV_OVERRIDE here. An envOverride short-circuits authEnabled
+  // to false by design (see mintToken), so these two tests must call
+  // mintToken() bare to actually reach the isRegistryAuthActive()-derived path.
+  // They also explicitly blank CLIENT_ID/SECRET: earlier tests in this file
+  // mutate the REAL process.env via Object.assign(process.env, ENV_OVERRIDE)
+  // and never reset it (only afterEach's unstubAllGlobals/useRealTimers run),
+  // so without this, a leftover id/secret from a prior test would populate
+  // `id`/`secret` and the credential-missing branch under test would never
+  // trigger.
+  beforeEach(() => {
+    process.env = {
+      ...process.env,
+      CLERUM_REGISTRY_CLIENT_ID: '',
+      CLERUM_REGISTRY_CLIENT_SECRET: '',
+    }
+  })
+
+  it('returns an empty token when auth is inactive and no creds exist', async () => {
+    connDb.resolveMachineCreds.mockResolvedValue(null)
+    connDb.isRegistryAuthActive.mockResolvedValue(false)
+    await expect(mintToken()).resolves.toBe('') // NO ENV_OVERRIDE — see above
+  })
+
+  it('throws when auth is active but credentials are unavailable', async () => {
+    connDb.resolveMachineCreds.mockResolvedValue(null)
+    connDb.isRegistryAuthActive.mockResolvedValue(true)
+    await expect(mintToken()).rejects.toThrow(/machine credentials unavailable/)
   })
 })
 

--- a/control-api/test/routes.adminRegistryGrants.test.ts
+++ b/control-api/test/routes.adminRegistryGrants.test.ts
@@ -53,7 +53,12 @@ vi.mock('../src/services/orgApiKeyClient.js', () => ({
   },
 }))
 vi.mock('../src/services/adminAuthService.js', () => ({ findAdminById: vi.fn() }))
-const { cfg } = vi.hoisted(() => ({ cfg: { registryAuthEnabled: true } }))
+// registryConnectionMode is required: the routes now call isRegistryAuthActive(),
+// which branches on mode first. 'managed' makes it return registryAuthEnabled
+// verbatim, which is the behaviour these tests intend to exercise.
+const { cfg } = vi.hoisted(() => ({
+  cfg: { registryAuthEnabled: true, registryConnectionMode: 'managed' },
+}))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 vi.mock('../src/services/rateLimiterService.js', () => ({
   checkAndIncrement: vi.fn(async () => ({

--- a/control-api/test/routes.adminRegistryGrants.test.ts
+++ b/control-api/test/routes.adminRegistryGrants.test.ts
@@ -60,6 +60,19 @@ const { cfg } = vi.hoisted(() => ({
   cfg: { registryAuthEnabled: true, registryConnectionMode: 'managed' },
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
+// Partial mock (unlike the Keys file's full replacement): the "wire shape"
+// tests below exercise the REAL registryClient.ts wrapper via importActual,
+// and its mintToken() calls resolveMachineCreds() unconditionally whenever env
+// creds are absent — regardless of the auth-enabled flag. A full-replacement
+// mock leaves resolveMachineCreds undefined and 500s those tests. Keep every
+// real export (resolveMachineCreds, getRegistryConnection, ...) and override
+// only the one symbol the route guard now consumes, mirroring the
+// registryClient.js partial mock above.
+const connDb = vi.hoisted(() => ({ isRegistryAuthActive: vi.fn() }))
+vi.mock('../src/services/registryConnectionDb.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/services/registryConnectionDb.js')>()
+  return { ...actual, isRegistryAuthActive: connDb.isRegistryAuthActive }
+})
 vi.mock('../src/services/rateLimiterService.js', () => ({
   checkAndIncrement: vi.fn(async () => ({
     allowed: true,
@@ -84,6 +97,15 @@ function makeApp(adminId: string | null = 'admin-1') {
 beforeEach(() => {
   vi.clearAllMocks()
   cfg.registryAuthEnabled = true
+  cfg.registryConnectionMode = 'managed'
+  // Default mirrors the real accessor's managed-mode branch (registryAuthEnabled
+  // verbatim) so the pre-existing tests below — which only flip
+  // cfg.registryAuthEnabled, not this mock — still reach the same 200/400/409
+  // they did before this module was mocked. Reading cfg at call time (not a
+  // captured literal) also means vi.clearAllMocks() can never silently freeze
+  // this to a stale value. The self-hosted test overrides this per-call via
+  // mockResolvedValue, independent of cfg.registryAuthEnabled.
+  connDb.isRegistryAuthActive.mockImplementation(async () => cfg.registryAuthEnabled)
   vi.mocked(checkAndIncrement).mockResolvedValue({
     allowed: true,
     remaining: 29,
@@ -229,6 +251,18 @@ describe('GET /admin/registry/grants + granted-to-me', () => {
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ grants: [] })
     expect(listGrantedToMe).toHaveBeenCalledWith('acme')
+  })
+
+  // Discriminates resolveSelfServiceOrg's guard from a plain config read: reverting
+  // just that guard to `if (!config.registryAuthEnabled)` would make this fail,
+  // since registryAuthEnabled is deliberately false here and only the mocked
+  // accessor says auth is active.
+  it('self-hosted: grants work with NO auth env var once credentials exist', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.registryAuthEnabled = false // deliberately off — must be ignored
+    connDb.isRegistryAuthActive.mockResolvedValue(true) // credentials exist
+    const res = await request(makeApp()).get('/admin/registry/grants')
+    expect(res.status).not.toBe(409)
   })
 })
 

--- a/control-api/test/routes.adminRegistryGrants.test.ts
+++ b/control-api/test/routes.adminRegistryGrants.test.ts
@@ -360,15 +360,31 @@ describe('wire shape (real wrappers, stubbed registry fetch)', () => {
     vi.stubGlobal('fetch', fetchMock)
     return fetchMock
   }
-  // registry auth OFF so authedFetch's mintToken() returns '' (no token round trip);
-  // every stubbed fetch call is the /org/... endpoint. The route's own
-  // registry_auth_disabled guard is bypassed because we only unmock the WRAPPERS
-  // here — config stays mocked with registryAuthEnabled true for the route guard,
-  // while the wrapper's mintToken reads process.env (set below) = auth off.
+  // Auth-derived (Task 7): the route guard (resolveSelfServiceOrg) AND
+  // mintToken now BOTH derive their auth state from the same
+  // isRegistryAuthActive() accessor — mintToken no longer has its own
+  // independent process.env.CLERUM_REGISTRY_AUTH_ENABLED read to diverge from
+  // it. A single blanket mock value can no longer give the guard "on" (so the
+  // request isn't 409'd) and the wrapper's mintToken "off" (so it returns ''
+  // instead of throwing on missing creds) at the same time.
+  //
+  // Fixed by sequencing connDb.isRegistryAuthActive per call instead: the
+  // guard's call is the FIRST isRegistryAuthActive() call made while handling
+  // the request (resolveSelfServiceOrg calls it before anything else and
+  // returns/409s before the route ever reaches createOrgGrant/revokeOrgGrant —
+  // see routes/admin/registry.ts's resolveSelfServiceOrg), so
+  // mockResolvedValueOnce(true) satisfies exactly that call. Every call after
+  // it — i.e. mintToken's own internal call, reached via
+  // createOrgGrant/revokeOrgGrant → authedFetch → mintToken — falls through to
+  // the mockResolvedValue(false) default, so mintToken takes the auth-off
+  // branch and returns '' (no token round trip), with no real credentials
+  // configured anywhere in this file's mocked config.
+  function armGuardOnMintTokenOff(): void {
+    connDb.isRegistryAuthActive.mockReset().mockResolvedValueOnce(true).mockResolvedValue(false)
+  }
 
   it('POST self_grant → 400 with {error:"self_grant"} verbatim', async () => {
-    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
-    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'false'
+    armGuardOnMintTokenOff()
     // Use the REAL wrapper for exactly this one request; mockImplementationOnce
     // ensures it does not leak into any later test in this file.
     const real = await vi.importActual<typeof import('../src/services/registryClient.js')>(
@@ -383,13 +399,10 @@ describe('wire shape (real wrappers, stubbed registry fetch)', () => {
     expect(res.status).toBe(400)
     expect(res.body).toEqual({ error: 'self_grant' })
     vi.unstubAllGlobals()
-    delete process.env.CLERUM_REGISTRY_AUTH_ENABLED
-    delete process.env.CLERUM_REGISTRY_URL
   })
 
   it('DELETE 204 → 204 (no 500 from res.json on empty body)', async () => {
-    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
-    process.env.CLERUM_REGISTRY_AUTH_ENABLED = 'false'
+    armGuardOnMintTokenOff()
     const real = await vi.importActual<typeof import('../src/services/registryClient.js')>(
       '../src/services/registryClient.js'
     )
@@ -401,7 +414,5 @@ describe('wire shape (real wrappers, stubbed registry fetch)', () => {
     const res = await request(makeApp()).delete('/admin/registry/grants/g1')
     expect(res.status).toBe(204)
     vi.unstubAllGlobals()
-    delete process.env.CLERUM_REGISTRY_AUTH_ENABLED
-    delete process.env.CLERUM_REGISTRY_URL
   })
 })

--- a/control-api/test/routes.adminRegistryGrants.test.ts
+++ b/control-api/test/routes.adminRegistryGrants.test.ts
@@ -57,7 +57,11 @@ vi.mock('../src/services/adminAuthService.js', () => ({ findAdminById: vi.fn() }
 // which branches on mode first. 'managed' makes it return registryAuthEnabled
 // verbatim, which is the behaviour these tests intend to exercise.
 const { cfg } = vi.hoisted(() => ({
-  cfg: { registryAuthEnabled: true, registryConnectionMode: 'managed' },
+  cfg: {
+    registryAuthEnabled: true,
+    registryConnectionMode: 'managed',
+    registryUrl: 'https://registry.evenfire.ai',
+  },
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 // Partial mock (unlike the Keys file's full replacement): the "wire shape"
@@ -98,6 +102,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   cfg.registryAuthEnabled = true
   cfg.registryConnectionMode = 'managed'
+  cfg.registryUrl = 'https://registry.evenfire.ai'
   // Default mirrors the real accessor's managed-mode branch (registryAuthEnabled
   // verbatim) so the pre-existing tests below — which only flip
   // cfg.registryAuthEnabled, not this mock — still reach the same 200/400/409
@@ -264,6 +269,20 @@ describe('GET /admin/registry/grants + granted-to-me', () => {
     const res = await request(makeApp()).get('/admin/registry/grants')
     expect(res.status).not.toBe(409)
   })
+
+  it('self-hosted: 409 registry_url_not_configured when credentials remain but URL was removed', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.registryAuthEnabled = false
+    cfg.registryUrl = ''
+    connDb.isRegistryAuthActive.mockResolvedValue(true)
+
+    const res = await request(makeApp()).get('/admin/registry/grants')
+
+    expect(res.status).toBe(409)
+    expect(res.body).toEqual({ error: 'registry_url_not_configured' })
+    expect(resolvePublishScope).not.toHaveBeenCalled()
+    expect(listOrgGrants).not.toHaveBeenCalled()
+  })
 })
 
 describe('DELETE /admin/registry/grants/:id', () => {
@@ -360,27 +379,13 @@ describe('wire shape (real wrappers, stubbed registry fetch)', () => {
     vi.stubGlobal('fetch', fetchMock)
     return fetchMock
   }
-  // Auth-derived (Task 7): the route guard (resolveSelfServiceOrg) AND
-  // mintToken now BOTH derive their auth state from the same
-  // isRegistryAuthActive() accessor — mintToken no longer has its own
-  // independent process.env.CLERUM_REGISTRY_AUTH_ENABLED read to diverge from
-  // it. A single blanket mock value can no longer give the guard "on" (so the
-  // request isn't 409'd) and the wrapper's mintToken "off" (so it returns ''
-  // instead of throwing on missing creds) at the same time.
-  //
-  // Fixed by sequencing connDb.isRegistryAuthActive per call instead: the
-  // guard's call is the FIRST isRegistryAuthActive() call made while handling
-  // the request (resolveSelfServiceOrg calls it before anything else and
-  // returns/409s before the route ever reaches createOrgGrant/revokeOrgGrant —
-  // see routes/admin/registry.ts's resolveSelfServiceOrg), so
-  // mockResolvedValueOnce(true) satisfies exactly that call. Every call after
-  // it — i.e. mintToken's own internal call, reached via
-  // createOrgGrant/revokeOrgGrant → authedFetch → mintToken — falls through to
-  // the mockResolvedValue(false) default, so mintToken takes the auth-off
-  // branch and returns '' (no token round trip), with no real credentials
-  // configured anywhere in this file's mocked config.
+  // Keep the route guard active while the real wrapper's managed token path is
+  // auth-off. mintToken now resolves credentials through resolveMachineCreds
+  // and reads the managed flag from config; it no longer performs a second
+  // isRegistryAuthActive call that tests can sequence independently.
   function armGuardOnMintTokenOff(): void {
-    connDb.isRegistryAuthActive.mockReset().mockResolvedValueOnce(true).mockResolvedValue(false)
+    cfg.registryAuthEnabled = false
+    connDb.isRegistryAuthActive.mockReset().mockResolvedValue(true)
   }
 
   it('POST self_grant → 400 with {error:"self_grant"} verbatim', async () => {

--- a/control-api/test/routes.adminRegistryKeys.test.ts
+++ b/control-api/test/routes.adminRegistryKeys.test.ts
@@ -124,6 +124,20 @@ describe('GET /admin/registry/keys', () => {
     expect(res.status).not.toBe(409)
   })
 
+  // isRegistryAuthActive() can now reject (self-hosted reaches a raw pool.query
+  // in getRegistryConnection with no try/catch of its own). The guard must catch
+  // it and degrade to the same 502 used for a resolvePublishScope failure one
+  // line below, rather than let the rejection escape uncaught — Express 4 does
+  // not forward async rejections to error middleware, so an uncaught one here
+  // would crash the process instead of producing a response.
+  it('502 registry_integration_error when isRegistryAuthActive rejects (does not throw)', async () => {
+    connDb.isRegistryAuthActive.mockRejectedValue(new Error('pg blip'))
+    const res = await request(makeApp()).get('/admin/registry/keys')
+    expect(res.status).toBe(502)
+    expect(res.body).toEqual({ error: 'registry_integration_error' })
+    expect(resolvePublishScope).not.toHaveBeenCalled()
+  })
+
   it('401 when admin missing/inactive', async () => {
     vi.mocked(findAdminById).mockResolvedValue(null as never)
     const res = await request(makeApp()).get('/admin/registry/keys')

--- a/control-api/test/routes.adminRegistryKeys.test.ts
+++ b/control-api/test/routes.adminRegistryKeys.test.ts
@@ -120,8 +120,10 @@ describe('GET /admin/registry/keys', () => {
     cfg.registryConnectionMode = 'self-hosted'
     cfg.registryAuthEnabled = false // deliberately off — must be ignored
     connDb.isRegistryAuthActive.mockResolvedValue(true) // credentials exist
+    vi.mocked(listKeys).mockResolvedValue({ keys: [{ id: 'k1' }] } as never)
     const res = await request(makeApp()).get('/admin/registry/keys')
-    expect(res.status).not.toBe(409)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ org: 'acme', keys: [{ id: 'k1' }] })
   })
 
   // isRegistryAuthActive() can now reject (self-hosted reaches a raw pool.query

--- a/control-api/test/routes.adminRegistryKeys.test.ts
+++ b/control-api/test/routes.adminRegistryKeys.test.ts
@@ -43,7 +43,11 @@ vi.mock('../src/services/adminAuthService.js', () => ({ findAdminById: vi.fn() }
 // which branches on mode first. 'managed' makes it return registryAuthEnabled
 // verbatim, which is the behaviour these tests intend to exercise.
 const { cfg } = vi.hoisted(() => ({
-  cfg: { registryAuthEnabled: true, registryConnectionMode: 'managed' },
+  cfg: {
+    registryAuthEnabled: true,
+    registryConnectionMode: 'managed',
+    registryUrl: 'https://registry.evenfire.ai',
+  },
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 // Narrow mock: registry.ts imports nothing else from registryConnectionDb, so
@@ -75,6 +79,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   cfg.registryAuthEnabled = true
   cfg.registryConnectionMode = 'managed'
+  cfg.registryUrl = 'https://registry.evenfire.ai'
   // Default mirrors the real accessor's managed-mode branch (registryAuthEnabled
   // verbatim) so the pre-existing tests below — which only flip
   // cfg.registryAuthEnabled, not this mock — still reach the same 200/409 they did
@@ -124,6 +129,20 @@ describe('GET /admin/registry/keys', () => {
     const res = await request(makeApp()).get('/admin/registry/keys')
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ org: 'acme', keys: [{ id: 'k1' }] })
+  })
+
+  it('self-hosted: 409 registry_url_not_configured when credentials remain but URL was removed', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.registryAuthEnabled = false
+    cfg.registryUrl = ''
+    connDb.isRegistryAuthActive.mockResolvedValue(true)
+
+    const res = await request(makeApp()).get('/admin/registry/keys')
+
+    expect(res.status).toBe(409)
+    expect(res.body).toEqual({ error: 'registry_url_not_configured' })
+    expect(resolvePublishScope).not.toHaveBeenCalled()
+    expect(listKeys).not.toHaveBeenCalled()
   })
 
   // isRegistryAuthActive() can now reject (self-hosted reaches a raw pool.query

--- a/control-api/test/routes.adminRegistryKeys.test.ts
+++ b/control-api/test/routes.adminRegistryKeys.test.ts
@@ -39,8 +39,17 @@ vi.mock('../src/services/registryClient.js', () => ({
   resolvePublishScope: vi.fn(),
 }))
 vi.mock('../src/services/adminAuthService.js', () => ({ findAdminById: vi.fn() }))
-const { cfg } = vi.hoisted(() => ({ cfg: { registryAuthEnabled: true } }))
+// registryConnectionMode is required: the routes now call isRegistryAuthActive(),
+// which branches on mode first. 'managed' makes it return registryAuthEnabled
+// verbatim, which is the behaviour these tests intend to exercise.
+const { cfg } = vi.hoisted(() => ({
+  cfg: { registryAuthEnabled: true, registryConnectionMode: 'managed' },
+}))
 vi.mock('../src/config.js', () => ({ config: cfg }))
+// Narrow mock: registry.ts imports nothing else from registryConnectionDb, so
+// stubbing only the accessor it now consumes is safe.
+const connDb = vi.hoisted(() => ({ isRegistryAuthActive: vi.fn() }))
+vi.mock('../src/services/registryConnectionDb.js', () => connDb)
 vi.mock('../src/services/rateLimiterService.js', () => ({
   checkAndIncrement: vi.fn(async () => ({
     allowed: true,
@@ -65,6 +74,15 @@ function makeApp(adminId: string | null = 'admin-1') {
 beforeEach(() => {
   vi.clearAllMocks()
   cfg.registryAuthEnabled = true
+  cfg.registryConnectionMode = 'managed'
+  // Default mirrors the real accessor's managed-mode branch (registryAuthEnabled
+  // verbatim) so the pre-existing tests below — which only flip
+  // cfg.registryAuthEnabled, not this mock — still reach the same 200/409 they did
+  // before this module was mocked. Reading cfg at call time (not a captured
+  // literal) also means vi.clearAllMocks() can never silently freeze this to a
+  // stale value. The self-hosted test overrides this per-call via
+  // mockResolvedValue, independent of cfg.registryAuthEnabled.
+  connDb.isRegistryAuthActive.mockImplementation(async () => cfg.registryAuthEnabled)
   vi.mocked(checkAndIncrement).mockResolvedValue({
     allowed: true,
     remaining: 29,
@@ -96,6 +114,14 @@ describe('GET /admin/registry/keys', () => {
     expect(res.status).toBe(409)
     expect(res.body).toEqual({ error: 'registry_auth_disabled' })
     expect(resolvePublishScope).not.toHaveBeenCalled()
+  })
+
+  it('self-hosted: keys work with NO auth env var once credentials exist', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.registryAuthEnabled = false // deliberately off — must be ignored
+    connDb.isRegistryAuthActive.mockResolvedValue(true) // credentials exist
+    const res = await request(makeApp()).get('/admin/registry/keys')
+    expect(res.status).not.toBe(409)
   })
 
   it('401 when admin missing/inactive', async () => {

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -37,6 +37,14 @@ const connDb = vi.hoisted(() => ({
   upsertPendingConnection: vi.fn(),
   markConnected: vi.fn(),
   deleteConnection: vi.fn(),
+  // The routes now derive authEnabled from credentials rather than reading
+  // config.registryAuthEnabled directly. This whole-module mock replaces the
+  // entire registryConnectionDb surface, so without this key `connDb` has no
+  // `isRegistryAuthActive` property and the routes' `await
+  // isRegistryAuthActive()` throws a TypeError in every handler. beforeEach
+  // re-arms a cfg-mirroring default (see below); tests that need the derived
+  // value to diverge from cfg override it per-test.
+  isRegistryAuthActive: vi.fn(),
 }))
 vi.mock('../src/services/registryConnectionDb.js', () => connDb)
 
@@ -88,8 +96,25 @@ beforeEach(() => {
     status: 'active',
   })
   connDb.markConnected.mockResolvedValue(true)
+  // Mirrors the real accessor's derivation at call time rather than a
+  // captured literal default (e.g. a static mockResolvedValue(true)), so
+  // pre-existing tests that only flip cfg.registryAuthEnabled — without ever
+  // touching this mock — still see it reflected in authEnabled (see 'GET
+  // connected -> includes authEnabled reflecting config (false)' below,
+  // which would otherwise get a stale `true`). vi.clearAllMocks() only clears
+  // call history, not implementations, but afterEach's restoreAllMocks()
+  // strips a prior test's mockResolvedValue/mockRejectedValue override, so
+  // this re-arm still runs every time to guarantee the default is never
+  // stale. Tests that need the derived value to diverge from cfg override it
+  // per-test with their own mockResolvedValue/mockRejectedValue, which wins
+  // for that test since it runs after this beforeEach.
+  connDb.isRegistryAuthActive.mockImplementation(async () => cfg.registryAuthEnabled)
   cfg.registryConnectionMode = 'self-hosted'
   cfg.registryAuthEnabled = true
+  // Reset every time: the registry_url_not_configured test below sets this to
+  // '' to exercise the new guard; without resetting it here that empty
+  // string would leak into every test that runs after it in this file.
+  cfg.registryUrl = 'https://example.com'
   rateLimiter.checkAndIncrement.mockResolvedValue({
     allowed: true,
     remaining: 9,
@@ -105,6 +130,33 @@ describe('registry connect flow', () => {
     const res = await request(app()).get('/admin/registry/connect').expect(200)
     expect(res.body.state).toBe('disconnected')
     expect(res.body.authEnabled).toBe(true)
+  })
+
+  // The discriminator: cfg.registryAuthEnabled is left at the beforeEach
+  // default (true) and never touched here. Only the mocked accessor says
+  // false. A route still reading config.registryAuthEnabled directly would
+  // report authEnabled: true and fail this assertion.
+  it('GET reports authEnabled false when no credentials exist', async () => {
+    connDb.isRegistryAuthActive.mockResolvedValue(false)
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body).toMatchObject({ state: 'disconnected', authEnabled: false })
+  })
+
+  // isRegistryAuthActive() can reject: self-hosted mode reaches a raw
+  // pool.query (via getRegistryConnection, inside resolveMachineCreds) with
+  // no try/catch of its own — see routes.adminRegistryKeys.test.ts's sibling
+  // test for the admin registry routes' version of this same hazard. GET
+  // already documents a "never 500 on a registry hiccup" guarantee for the
+  // status poll (pollRegistryStatus); this extends the same clean-degrade
+  // treatment to the newly-derived authEnabled read instead of letting the
+  // rejection fall through to the router's generic catch -> next(err) -> a
+  // bare 500.
+  it('GET → 502 registry_integration_error when isRegistryAuthActive rejects (does not throw)', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    connDb.isRegistryAuthActive.mockRejectedValue(new Error('pg blip'))
+    const res = await request(app()).get('/admin/registry/connect').expect(502)
+    expect(res.body.error).toBe('registry_integration_error')
   })
 
   it('GET connected → includes authEnabled reflecting config (true)', async () => {
@@ -133,6 +185,15 @@ describe('registry connect flow', () => {
     cfg.registryConnectionMode = 'managed'
     const res = await request(app()).get('/admin/registry/connect').expect(409)
     expect(res.body.error).toBe('not_self_hosted')
+  })
+
+  // Task 4 lets an unconfigured URL boot, so the connect routes must fail
+  // cleanly rather than building a request against '' (fetch throws
+  // TypeError: Failed to parse URL -> a bare 500).
+  it('returns 409 registry_url_not_configured when no registry URL is set', async () => {
+    cfg.registryUrl = ''
+    const res = await request(app()).get('/admin/registry/connect').expect(409)
+    expect(res.body.error).toBe('registry_url_not_configured')
   })
 
   it('GET pending → polls the registry status endpoint and surfaces approval', async () => {
@@ -394,6 +455,29 @@ describe('registry connect flow', () => {
     expect(connDb.deleteConnection).toHaveBeenCalled()
   })
 
+  // The disconnect transition: nothing currently re-reads state after a
+  // DELETE. cfg.registryAuthEnabled is never touched in this test (stays
+  // true throughout, per beforeEach) -- only the mocked accessor moves, so
+  // this discriminates a route deriving authEnabled from
+  // isRegistryAuthActive() from one still reading config.registryAuthEnabled.
+  it('authEnabled flips back to false after disconnect', { retry: 0 }, async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'connected',
+      deploymentId: 'dep-1',
+      orgName: 'acme',
+    })
+    connDb.isRegistryAuthActive.mockResolvedValue(true)
+    const before = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(before.body.authEnabled).toBe(true)
+
+    await request(app()).delete('/admin/registry/connect').expect(204)
+
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    connDb.isRegistryAuthActive.mockResolvedValue(false)
+    const after = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(after.body).toMatchObject({ state: 'disconnected', authEnabled: false })
+  })
+
   // The redeemClaim extraction must NOT convert a registry-unreachable failure
   // into a 502. It escapes the handler and the Express error handler makes it a
   // 500, exactly as before the refactor. Collapsing it to 502 would be a silent
@@ -455,6 +539,31 @@ describe('register — auto-claim (201)', () => {
       expect(claimBody.claim_token).toBe('tok-abc')
     }
   )
+
+  // By the time this branch runs, redeemClaim has already persisted the
+  // credentials (markConnected succeeded) -- isRegistryAuthActive() rejecting
+  // here must not crash the process. It degrades to the same 502 the sibling
+  // admin registry routes use for this accessor (routes.adminRegistryKeys.test.ts),
+  // rather than falling through to the router's generic catch -> next(err) ->
+  // a bare 500 for a request whose underlying connect already succeeded.
+  it('502 registry_integration_error when isRegistryAuthActive rejects after a successful auto-claim', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    connDb.markConnected.mockResolvedValue(true)
+    connDb.isRegistryAuthActive.mockRejectedValue(new Error('pg blip'))
+    routeFetch({
+      '/register': () =>
+        json(
+          { deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved', claim_token: 'tok-abc' },
+          201
+        ),
+      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+    })
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(502)
+    expect(res.body.error).toBe('registry_integration_error')
+  })
 
   // The mocks return undefined, so `await x` and `void x` produce IDENTICAL
   // invocationCallOrder — an ordering assertion built on call order is green
@@ -774,6 +883,29 @@ describe('POST recover', () => {
     // stale row/deploymentId — otherwise a bad rotate silently redeems garbage.
     const claim = spy.mock.calls.find(c => String(c[0]).endsWith('/claim'))!
     expect(JSON.parse(String((claim[1] as RequestInit).body)).claim_token).toBe('tok-new')
+  })
+
+  // Same hazard as the auto-claim path: by the time 'connected' is reached
+  // here, the rotate + redeemClaim have already succeeded (markConnected
+  // committed). isRegistryAuthActive() rejecting must degrade to 502, not an
+  // uncaught rejection or a bare 500, for a recovery that already succeeded.
+  it('502 registry_integration_error when isRegistryAuthActive rejects after a successful recover', async () => {
+    connDb.getRegistryConnection.mockResolvedValue({
+      status: 'approved',
+      deploymentId: 'dep-1',
+      keyId: 'kid-1',
+      privateKeyPem: pkForTest(),
+      requestedOrgName: 'acme',
+    })
+    connDb.markConnected.mockResolvedValue(true)
+    connDb.isRegistryAuthActive.mockRejectedValue(new Error('pg blip'))
+    routeFetch({
+      '/status': () => json({ status: 'approved', suspended: false, claimed: false }, 200),
+      'claim-token': () => json({ claim_token: 'tok-new' }, 200),
+      '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
+    })
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(502)
+    expect(res.body.error).toBe('registry_integration_error')
   })
 
   // The route is rate-limited (each call rotates a one-time claim token at

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -496,6 +496,75 @@ describe('registry connect flow', () => {
       .send({ claim_token: 'tok-abc' })
       .expect(500)
   })
+
+  // GET is mounted by RegistryCatalog on every Marketplace visit and is
+  // CSRF-reachable (SameSite=Lax, no origin check), so it too is now behind a
+  // per-admin token bucket. This proves the middleware sits AFTER
+  // requireAuthForControlUI (bucket keyed on adminAuth.sub) and BEFORE the
+  // handler without breaking the normal success path.
+  it('GET is rate-limited per admin, keyed on adminAuth.sub, and still succeeds when allowed', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    const res = await request(app()).get('/admin/registry/connect').expect(200)
+    expect(res.body.state).toBe('disconnected')
+    expect(checkAndIncrement).toHaveBeenCalledWith('registry_connect_status:admin-uuid-123', 30)
+    expect(res.headers['x-ratelimit-limit']).toBe('30')
+  })
+
+  // Proves the limiter blocks BEFORE any DB/registry work: a denied admin
+  // must not reach getRegistryConnection.
+  it('GET 429s when the per-admin bucket is exceeded, without touching the registry', async () => {
+    rateLimiter.checkAndIncrement.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetMs: Date.now() + 30000,
+    })
+    const res = await request(app()).get('/admin/registry/connect').expect(429)
+    expect(res.body.error).toBe('Too Many Requests')
+    expect(res.headers['retry-after']).toBeDefined()
+    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
+  })
+
+  // POST request registers against the SHARED production registry — each call
+  // consumes one of its ~5/day per-IP registration attempts. This proves the
+  // middleware sits AFTER requireAuthForControlUI (bucket keyed on
+  // adminAuth.sub) and BEFORE the handler without breaking the normal success
+  // path.
+  it('POST request is rate-limited per admin, keyed on adminAuth.sub, and still succeeds when allowed', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ deployment_id: 'dep-9', key_id: 'kid-9', status: 'pending' }), {
+        status: 202,
+      })
+    )
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+    expect(res.body.state).toBe('pending')
+    expect(checkAndIncrement).toHaveBeenCalledWith('registry_connect_request:admin-uuid-123', 3)
+    expect(res.headers['x-ratelimit-limit']).toBe('3')
+  })
+
+  // Proves the limiter blocks BEFORE any registry work: a denied admin must
+  // not burn a registration attempt against the shared registry's small daily
+  // per-IP quota.
+  it('POST request 429s when the per-admin bucket is exceeded, without touching the registry', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    rateLimiter.checkAndIncrement.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetMs: Date.now() + 30000,
+    })
+    const spy = routeFetch({})
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(429)
+    expect(res.body.error).toBe('Too Many Requests')
+    expect(res.headers['retry-after']).toBeDefined()
+    expect(connDb.getRegistryConnection).not.toHaveBeenCalled()
+    expect(spy.mock.calls.length).toBe(0)
+  })
 })
 
 describe('register — auto-claim (201)', () => {

--- a/control-api/test/routes.registryConnect.test.ts
+++ b/control-api/test/routes.registryConnect.test.ts
@@ -455,6 +455,12 @@ describe('registry connect flow', () => {
     expect(connDb.deleteConnection).toHaveBeenCalled()
   })
 
+  it('DELETE still drops the local row when the registry URL was removed', async () => {
+    cfg.registryUrl = ''
+    await request(app()).delete('/admin/registry/connect').expect(204)
+    expect(connDb.deleteConnection).toHaveBeenCalled()
+  })
+
   // The disconnect transition: nothing currently re-reads state after a
   // DELETE. cfg.registryAuthEnabled is never touched in this test (stays
   // true throughout, per beforeEach) -- only the mocked accessor moves, so
@@ -568,10 +574,9 @@ describe('registry connect flow', () => {
 })
 
 describe('register — auto-claim (201)', () => {
-  // Parameterized over registryAuthEnabled: the beforeEach default is `true`,
-  // so a mutation replacing `authEnabled: config.registryAuthEnabled` with the
-  // literal `true` on the 201-connected response passes an authEnabled-only-true
-  // suite. The `false` case is the one that would catch it.
+  // A successful claim has persisted a validated credential pair, so the
+  // response is authEnabled:true regardless of the now-inert self-hosted env
+  // flag. Parameterize over both values to pin that invariant.
   it.each([true, false])(
     'claims immediately and reports connected (registryAuthEnabled=%s)',
     async registryAuthEnabled => {
@@ -597,7 +602,7 @@ describe('register — auto-claim (201)', () => {
         .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
         .expect(200)
       expect(res.body).toMatchObject({ state: 'connected', org: 'acme' })
-      expect(res.body.authEnabled).toBe(registryAuthEnabled)
+      expect(res.body.authEnabled).toBe(true)
       // The claim call must actually carry the token the registry minted, and
       // be PoP-authenticated — otherwise every auto-approved self-hoster gets a
       // registry-side 401 and silently falls back to 202 connecting.
@@ -609,13 +614,7 @@ describe('register — auto-claim (201)', () => {
     }
   )
 
-  // By the time this branch runs, redeemClaim has already persisted the
-  // credentials (markConnected succeeded) -- isRegistryAuthActive() rejecting
-  // here must not crash the process. It degrades to the same 502 the sibling
-  // admin registry routes use for this accessor (routes.adminRegistryKeys.test.ts),
-  // rather than falling through to the router's generic catch -> next(err) ->
-  // a bare 500 for a request whose underlying connect already succeeded.
-  it('502 registry_integration_error when isRegistryAuthActive rejects after a successful auto-claim', async () => {
+  it('does not re-read auth state after a successful auto-claim', async () => {
     connDb.getRegistryConnection.mockResolvedValue(null)
     connDb.markConnected.mockResolvedValue(true)
     connDb.isRegistryAuthActive.mockRejectedValue(new Error('pg blip'))
@@ -630,8 +629,29 @@ describe('register — auto-claim (201)', () => {
     const res = await request(app())
       .post('/admin/registry/connect/request')
       .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
-      .expect(502)
-    expect(res.body.error).toBe('registry_integration_error')
+      .expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', authEnabled: true })
+    expect(connDb.isRegistryAuthActive).not.toHaveBeenCalled()
+  })
+
+  it('does not persist empty machine credentials from a malformed claim response', async () => {
+    connDb.getRegistryConnection.mockResolvedValue(null)
+    routeFetch({
+      '/register': () =>
+        json(
+          { deployment_id: 'dep-1', key_id: 'kid-1', status: 'approved', claim_token: 'tok-abc' },
+          201
+        ),
+      '/claim': () => json({ client_id: '', client_secret: '', org: 'acme' }, 200),
+    })
+
+    const res = await request(app())
+      .post('/admin/registry/connect/request')
+      .send({ requested_org_name: 'acme', contact_email: 'a@x.io' })
+      .expect(202)
+
+    expect(res.body.state).toBe('connecting')
+    expect(connDb.markConnected).not.toHaveBeenCalled()
   })
 
   // The mocks return undefined, so `await x` and `void x` produce IDENTICAL
@@ -954,11 +974,7 @@ describe('POST recover', () => {
     expect(JSON.parse(String((claim[1] as RequestInit).body)).claim_token).toBe('tok-new')
   })
 
-  // Same hazard as the auto-claim path: by the time 'connected' is reached
-  // here, the rotate + redeemClaim have already succeeded (markConnected
-  // committed). isRegistryAuthActive() rejecting must degrade to 502, not an
-  // uncaught rejection or a bare 500, for a recovery that already succeeded.
-  it('502 registry_integration_error when isRegistryAuthActive rejects after a successful recover', async () => {
+  it('does not re-read auth state after a successful recover', async () => {
     connDb.getRegistryConnection.mockResolvedValue({
       status: 'approved',
       deploymentId: 'dep-1',
@@ -973,8 +989,9 @@ describe('POST recover', () => {
       'claim-token': () => json({ claim_token: 'tok-new' }, 200),
       '/claim': () => json({ client_id: 'cid', client_secret: 'csecret', org: 'acme' }, 200),
     })
-    const res = await request(app()).post('/admin/registry/connect/recover').expect(502)
-    expect(res.body.error).toBe('registry_integration_error')
+    const res = await request(app()).post('/admin/registry/connect/recover').expect(200)
+    expect(res.body).toMatchObject({ state: 'connected', authEnabled: true })
+    expect(connDb.isRegistryAuthActive).not.toHaveBeenCalled()
   })
 
   // The route is rate-limited (each call rotates a one-time claim token at

--- a/control-api/test/services.registryClientMachineCreds.test.ts
+++ b/control-api/test/services.registryClientMachineCreds.test.ts
@@ -13,14 +13,8 @@ const { cfg } = vi.hoisted(() => ({
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 
-// Task 7: mintToken() now also calls isRegistryAuthActive() to derive
-// authEnabled (replacing the CLERUM_REGISTRY_AUTH_ENABLED env read). This is
-// a whole-module mock, so isRegistryAuthActive must be included here too —
-// otherwise it is undefined on the mocked module and mintToken's `await
-// isRegistryAuthActive()` throws a TypeError in both tests below.
 const resolver = vi.hoisted(() => ({
   resolveMachineCreds: vi.fn(),
-  isRegistryAuthActive: vi.fn(),
 }))
 vi.mock('../src/services/registryConnectionDb.js', () => resolver)
 
@@ -29,6 +23,8 @@ afterEach(() => {
   vi.restoreAllMocks()
   cfg.registryConnectionMode = 'self-hosted'
   cfg.registryAuthEnabled = true
+  delete process.env.CLERUM_REGISTRY_CLIENT_ID
+  delete process.env.CLERUM_REGISTRY_CLIENT_SECRET
 })
 
 describe('mintToken — self-hosted sources creds from the DB row', () => {
@@ -37,8 +33,6 @@ describe('mintToken — self-hosted sources creds from the DB row', () => {
       clientId: 'db-id',
       clientSecret: 'db-secret',
     })
-    // Mirrors the real self-hosted isRegistryAuthActive(): creds resolved → active.
-    resolver.isRegistryAuthActive.mockResolvedValue(true)
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(
@@ -54,8 +48,39 @@ describe('mintToken — self-hosted sources creds from the DB row', () => {
   it('returns "" (auth-off) when no creds are resolvable and auth is disabled', async () => {
     cfg.registryAuthEnabled = false
     resolver.resolveMachineCreds.mockResolvedValue(null)
-    // Mirrors the real self-hosted isRegistryAuthActive(): no creds → inactive.
-    resolver.isRegistryAuthActive.mockResolvedValue(false)
     expect(await mintToken()).toBe('')
+  })
+
+  it('ignores stale env credentials and authenticates with the self-hosted DB identity', async () => {
+    process.env.CLERUM_REGISTRY_CLIENT_ID = 'stale-managed-id'
+    process.env.CLERUM_REGISTRY_CLIENT_SECRET = 'stale-managed-secret'
+    resolver.resolveMachineCreds.mockResolvedValue({
+      clientId: 'db-id',
+      clientSecret: 'db-secret',
+    })
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ access_token: 'tok', expires_in: 300 }), { status: 200 })
+      )
+
+    await mintToken()
+
+    const [, init] = fetchSpy.mock.calls[0]
+    const auth = (init as RequestInit).headers as Record<string, string>
+    expect(auth.Authorization).toBe(`Basic ${Buffer.from('db-id:db-secret').toString('base64')}`)
+    expect(auth.Authorization).not.toContain(
+      Buffer.from('stale-managed-id:stale-managed-secret').toString('base64')
+    )
+  })
+
+  it('does not authenticate from stale env credentials before the DB connection exists', async () => {
+    process.env.CLERUM_REGISTRY_CLIENT_ID = 'stale-managed-id'
+    process.env.CLERUM_REGISTRY_CLIENT_SECRET = 'stale-managed-secret'
+    resolver.resolveMachineCreds.mockResolvedValue(null)
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+
+    await expect(mintToken()).resolves.toBe('')
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/services.registryClientMachineCreds.test.ts
+++ b/control-api/test/services.registryClientMachineCreds.test.ts
@@ -13,7 +13,15 @@ const { cfg } = vi.hoisted(() => ({
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 
-const resolver = vi.hoisted(() => ({ resolveMachineCreds: vi.fn() }))
+// Task 7: mintToken() now also calls isRegistryAuthActive() to derive
+// authEnabled (replacing the CLERUM_REGISTRY_AUTH_ENABLED env read). This is
+// a whole-module mock, so isRegistryAuthActive must be included here too —
+// otherwise it is undefined on the mocked module and mintToken's `await
+// isRegistryAuthActive()` throws a TypeError in both tests below.
+const resolver = vi.hoisted(() => ({
+  resolveMachineCreds: vi.fn(),
+  isRegistryAuthActive: vi.fn(),
+}))
 vi.mock('../src/services/registryConnectionDb.js', () => resolver)
 
 afterEach(() => {
@@ -29,6 +37,8 @@ describe('mintToken — self-hosted sources creds from the DB row', () => {
       clientId: 'db-id',
       clientSecret: 'db-secret',
     })
+    // Mirrors the real self-hosted isRegistryAuthActive(): creds resolved → active.
+    resolver.isRegistryAuthActive.mockResolvedValue(true)
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(
@@ -44,6 +54,8 @@ describe('mintToken — self-hosted sources creds from the DB row', () => {
   it('returns "" (auth-off) when no creds are resolvable and auth is disabled', async () => {
     cfg.registryAuthEnabled = false
     resolver.resolveMachineCreds.mockResolvedValue(null)
+    // Mirrors the real self-hosted isRegistryAuthActive(): no creds → inactive.
+    resolver.isRegistryAuthActive.mockResolvedValue(false)
     expect(await mintToken()).toBe('')
   })
 })

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -10,6 +10,7 @@ import {
   __resetRegistryConnectionCacheForTests,
   deleteConnection,
   getRegistryConnection,
+  isRegistryAuthActive,
   markConnected,
   resolveMachineCreds,
   resolveVoucherSigningMaterial,
@@ -443,5 +444,64 @@ describe('getRegistryConnection — cache TTL', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('isRegistryAuthActive', () => {
+  it('managed: returns the env value verbatim (true)', async () => {
+    cfg.registryConnectionMode = 'managed'
+    cfg.registryAuthEnabled = true
+    expect(await isRegistryAuthActive()).toBe(true)
+  })
+
+  it('managed: returns the env value verbatim (false)', async () => {
+    cfg.registryConnectionMode = 'managed'
+    cfg.registryAuthEnabled = false
+    expect(await isRegistryAuthActive()).toBe(false)
+  })
+
+  it('self-hosted: false with no connection row', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+    expect(await isRegistryAuthActive()).toBe(false)
+  })
+
+  // Kills a `row !== null` implementation. The DB status CHECK is
+  // ('pending','approved','connected') — there is NO 'connecting' status. An
+  // auto-approved-but-unclaimed row is status='approved' with a null client_id.
+  it('self-hosted: false for an approved row with no client_id', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    dbQuery.mockResolvedValue({
+      rows: [
+        makeRawRow(cfg.oauthEncryptionKey, {
+          status: 'approved',
+          client_id: null,
+          client_secret_encrypted: null,
+        }),
+      ],
+      rowCount: 1,
+    })
+    expect(await isRegistryAuthActive()).toBe(false)
+  })
+
+  it('self-hosted: true for a claimed row', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    const encSecret = encryptOAuthSecret(
+      deriveOAuthEncryptionKey(cfg.oauthEncryptionKey),
+      'db-secret-abc'
+    )
+    dbQuery.mockResolvedValue({
+      rows: [
+        makeRawRow(cfg.oauthEncryptionKey, {
+          status: 'connected',
+          client_id: 'db-cid',
+          client_secret_encrypted: encSecret,
+        }),
+      ],
+      rowCount: 1,
+    })
+    expect(await isRegistryAuthActive()).toBe(true)
   })
 })

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -408,3 +408,40 @@ describe('markConnected — scoped write', () => {
     expect(ok).toBe(false)
   })
 })
+
+describe('getRegistryConnection — cache TTL', () => {
+  it('serves a cached ROW inside the window, re-queries after it', { retry: 0 }, async () => {
+    vi.useFakeTimers()
+    try {
+      cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+      dbQuery.mockResolvedValue({ rows: [makeRawRow(cfg.oauthEncryptionKey)], rowCount: 1 })
+      await getRegistryConnection()
+      const afterFirst = dbQuery.mock.calls.length
+      await getRegistryConnection()
+      expect(dbQuery.mock.calls.length).toBe(afterFirst) // cache hit
+      vi.advanceTimersByTime(15_001)
+      await getRegistryConnection()
+      expect(dbQuery.mock.calls.length).toBe(afterFirst + 1) // re-queried
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // The easiest way to implement the TTL wrong: stamp cachedAt only on the
+  // row-found branch. Then `cached` is null (so `!== undefined` passes) but
+  // cachedAt stays 0, and EVERY call re-queries — the most common self-hosted
+  // state, hit on every mintToken and every admin-route auth check.
+  it('serves a cached NULL inside the window without re-querying', { retry: 0 }, async () => {
+    vi.useFakeTimers()
+    try {
+      dbQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+      await getRegistryConnection()
+      const afterFirst = dbQuery.mock.calls.length
+      await getRegistryConnection()
+      await getRegistryConnection()
+      expect(dbQuery.mock.calls.length).toBe(afterFirst)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -421,7 +421,15 @@ describe('getRegistryConnection — cache TTL', () => {
       const afterFirst = dbQuery.mock.calls.length
       await getRegistryConnection()
       expect(dbQuery.mock.calls.length).toBe(afterFirst) // cache hit
-      vi.advanceTimersByTime(15_001)
+      // Pin the TTL CONSTANT itself, not just its existence: 14_999ms elapsed
+      // is still inside the 15_000ms window. Without this checkpoint, shrinking
+      // CONNECTION_CACHE_TTL_MS to any smaller positive value would still pass
+      // this test — the only two checks otherwise present (elapsed 0, elapsed
+      // 15_001) cannot distinguish "TTL is 15_000" from "TTL is 1".
+      vi.advanceTimersByTime(14_999)
+      await getRegistryConnection()
+      expect(dbQuery.mock.calls.length).toBe(afterFirst) // still cached
+      vi.advanceTimersByTime(2) // total elapsed now 15_001
       await getRegistryConnection()
       expect(dbQuery.mock.calls.length).toBe(afterFirst + 1) // re-queried
     } finally {
@@ -442,6 +450,15 @@ describe('getRegistryConnection — cache TTL', () => {
       await getRegistryConnection()
       await getRegistryConnection()
       expect(dbQuery.mock.calls.length).toBe(afterFirst)
+      // The TTL must apply to a cached NULL exactly as it does to a cached row.
+      // The three reads above all happen at elapsed 0, so a mutation that
+      // special-cases `if (cached === null) return cached` ahead of the
+      // `Date.now() - cachedAt < TTL` check would cache "never connected"
+      // forever and this test would not catch it. Advancing past the TTL and
+      // requiring a re-query does.
+      vi.advanceTimersByTime(15_001)
+      await getRegistryConnection()
+      expect(dbQuery.mock.calls.length).toBe(afterFirst + 1) // re-queried
     } finally {
       vi.useRealTimers()
     }
@@ -497,6 +514,35 @@ describe('isRegistryAuthActive', () => {
       rows: [
         makeRawRow(cfg.oauthEncryptionKey, {
           status: 'connected',
+          client_id: 'db-cid',
+          client_secret_encrypted: encSecret,
+        }),
+      ],
+      rowCount: 1,
+    })
+    expect(await isRegistryAuthActive()).toBe(true)
+  })
+
+  // Discriminator pin: status and credential-presence deliberately disagree.
+  // isRegistryAuthActive derives auth from resolveMachineCreds (credential
+  // presence via clientId/clientSecret), never from row.status. Every fixture
+  // above happens to have status and credential-presence pointing the same
+  // way, so mutating the self-hosted branch to
+  // `(await getRegistryConnection())?.status === 'connected'` would still pass
+  // all of them. A 'pending' row that already holds real machine credentials
+  // must still report auth ACTIVE — that combination is exactly what a
+  // status-based implementation gets wrong.
+  it('self-hosted: true for a pending-status row that already holds real credentials', async () => {
+    cfg.registryConnectionMode = 'self-hosted'
+    cfg.oauthEncryptionKey = randomBytes(32).toString('hex')
+    const encSecret = encryptOAuthSecret(
+      deriveOAuthEncryptionKey(cfg.oauthEncryptionKey),
+      'db-secret-abc'
+    )
+    dbQuery.mockResolvedValue({
+      rows: [
+        makeRawRow(cfg.oauthEncryptionKey, {
+          status: 'pending',
           client_id: 'db-cid',
           client_secret_encrypted: encSecret,
         }),

--- a/control-api/test/services.registryConnectionDb.test.ts
+++ b/control-api/test/services.registryConnectionDb.test.ts
@@ -30,7 +30,7 @@ const { cfg } = vi.hoisted(() => ({
     registryClientSecret: '',
     registryUrl: 'https://registry.evenfire.ai',
     oauthEncryptionKey: '',
-  } as Record<string, string>,
+  } as Record<string, string | boolean>,
 }))
 vi.mock('../src/config.js', () => ({ config: cfg }))
 
@@ -92,6 +92,7 @@ afterEach(() => {
   cfg.registryClientSecret = ''
   cfg.registryUrl = 'https://registry.evenfire.ai'
   cfg.oauthEncryptionKey = ''
+  cfg.registryAuthEnabled = false
 })
 
 describe('resolveVoucherSigningMaterial — managed', () => {

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { CONTROL_ROUTES } from '@constants/routes'
 import {
   type CreateRegistryApiKeyInput,
   type CreatedRegistryApiKey,
@@ -18,6 +19,8 @@ import type { TableHeaderColumn } from './TableHeaderRow/types'
 import { TablePanelHeader } from './TablePanelHeader'
 import { useToast } from './Toast'
 import { Button } from './ui'
+
+// control-ui/components/RegistryApiKeysPanel.tsx
 
 type View =
   | { kind: 'loading' }
@@ -138,9 +141,8 @@ export default function RegistryApiKeysPanel() {
           ) : null}
           {view.kind === 'auth-disabled' ? (
             <p className="cu-banner cu-banner--info">
-              Registry authentication is disabled, so API keys can&apos;t be created here. To enable
-              it, set <code>CLERUM_REGISTRY_AUTH_ENABLED=true</code> and restart control-api, then
-              reload this page.
+              API keys become available once this deployment is connected to the registry.{' '}
+              <a href={CONTROL_ROUTES.marketplace.connect}>Connect to Evenfire Registry</a>.
             </p>
           ) : null}
           {view.kind === 'error' ? (

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -7,6 +7,7 @@ import {
   type CreatedRegistryApiKey,
   type RegistryApiKey,
   createRegistryApiKey,
+  getRegistryConnection,
   listRegistryApiKeys,
   revokeRegistryApiKey,
 } from '../lib/api'
@@ -54,6 +55,16 @@ export default function RegistryApiKeysPanel() {
   const [view, setView] = useState<View>({ kind: 'loading' })
   const [creating, setCreating] = useState(false)
   const [revealed, setRevealed] = useState<string | null>(null)
+  // The auth-disabled view needs mode-specific copy: self-hosted fixes it by
+  // connecting, managed fixes it via CLERUM_REGISTRY_AUTH_ENABLED (no connect
+  // flow exists there). Same best-effort detection RegistryCatalog uses for its
+  // Connect button — getRegistryConnection() 409s not_self_hosted in managed
+  // mode. Fail-open to 'self-hosted' (treat 'unknown' like RegistryCatalog does
+  // via its `!== 'managed'` check) since a transient error here is far more
+  // likely than a real managed deployment misreporting its own mode.
+  const [connectionMode, setConnectionMode] = useState<'self-hosted' | 'managed' | 'unknown'>(
+    'unknown'
+  )
 
   const load = useCallback(async () => {
     try {
@@ -71,9 +82,19 @@ export default function RegistryApiKeysPanel() {
     }
   }, [])
 
+  const loadConnectionMode = useCallback(async () => {
+    try {
+      await getRegistryConnection()
+      setConnectionMode('self-hosted')
+    } catch (e) {
+      setConnectionMode((e as { code?: string }).code === 'not_self_hosted' ? 'managed' : 'unknown')
+    }
+  }, [])
+
   useEffect(() => {
     void load()
-  }, [load])
+    void loadConnectionMode()
+  }, [load, loadConnectionMode])
 
   async function handleCreate(input: CreateRegistryApiKeyInput) {
     const created: CreatedRegistryApiKey = await createRegistryApiKey(input)
@@ -138,8 +159,18 @@ export default function RegistryApiKeysPanel() {
           ) : null}
           {view.kind === 'auth-disabled' ? (
             <p className="cu-banner cu-banner--info">
-              API keys become available once this deployment is connected to the registry.{' '}
-              <a href={CONTROL_ROUTES.marketplace.connect}>Connect to Evenfire Registry</a>.
+              {connectionMode === 'managed' ? (
+                <>
+                  Registry authentication for this deployment is controlled by{' '}
+                  <code>CLERUM_REGISTRY_AUTH_ENABLED</code>. An operator must enable it and restart
+                  control-api before API keys can be created here.
+                </>
+              ) : (
+                <>
+                  API keys become available once this deployment is connected to the registry.{' '}
+                  <a href={CONTROL_ROUTES.marketplace.connect}>Connect to Evenfire Registry</a>.
+                </>
+              )}
             </p>
           ) : null}
           {view.kind === 'error' ? (

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -1,4 +1,3 @@
-// control-ui/components/RegistryApiKeysPanel.tsx
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
@@ -19,8 +18,6 @@ import type { TableHeaderColumn } from './TableHeaderRow/types'
 import { TablePanelHeader } from './TablePanelHeader'
 import { useToast } from './Toast'
 import { Button } from './ui'
-
-// control-ui/components/RegistryApiKeysPanel.tsx
 
 type View =
   | { kind: 'loading' }

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -26,6 +26,7 @@ type View =
   | { kind: 'not-owner'; org?: string }
   | { kind: 'no-org' }
   | { kind: 'auth-disabled' }
+  | { kind: 'url-not-configured' }
   | { kind: 'error' }
 
 const API_KEYS_COLUMNS: TableHeaderColumn[] = [
@@ -78,6 +79,8 @@ export default function RegistryApiKeysPanel() {
       else if (status === 409 && code === 'no_org') setView({ kind: 'no-org' })
       else if (status === 409 && code === 'registry_auth_disabled')
         setView({ kind: 'auth-disabled' })
+      else if (status === 409 && code === 'registry_url_not_configured')
+        setView({ kind: 'url-not-configured' })
       else setView({ kind: 'error' })
     }
   }, [])
@@ -171,6 +174,13 @@ export default function RegistryApiKeysPanel() {
                   <a href={CONTROL_ROUTES.marketplace.connect}>Connect to Evenfire Registry</a>.
                 </>
               )}
+            </p>
+          ) : null}
+          {view.kind === 'url-not-configured' ? (
+            <p className="cu-banner cu-banner--warn">
+              This deployment still holds registry credentials, but <code>CLERUM_REGISTRY_URL</code>{' '}
+              is not configured. Restore the registry URL or disconnect the stale connection before
+              managing API keys.
             </p>
           ) : null}
           {view.kind === 'error' ? (

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -490,14 +490,6 @@ export default function RegistryConnectPanel() {
               deployment can now publish entries and push/pull images.
             </p>
           ) : null}
-
-          {view.kind === 'connected' && view.authEnabled === false ? (
-            <p className="cu-banner cu-banner--info" role="status">
-              To create and manage API keys for programmatic publishing, enable registry
-              authentication: set <code>CLERUM_REGISTRY_AUTH_ENABLED=true</code> and restart
-              control-api. See the &quot;connect to registry&quot; guide for details.
-            </p>
-          ) : null}
         </div>
       </div>
       {confirmDialog}

--- a/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
@@ -10,6 +10,7 @@ vi.mock('../../lib/api', () => ({
   listRegistryApiKeys: vi.fn(),
   createRegistryApiKey: vi.fn(),
   revokeRegistryApiKey: vi.fn(),
+  getRegistryConnection: vi.fn(),
 }))
 
 vi.mock('../ConfirmDialog', () => ({
@@ -68,15 +69,38 @@ describe('RegistryApiKeysPanel', () => {
     expect(await screen.findByText(/not bound to a registry org/i)).toBeInTheDocument()
   })
 
-  it('shows guidance to connect the registry on 409 registry_auth_disabled', async () => {
+  // self-hosted: getRegistryConnection() resolves (it's only a 409 in managed).
+  // Regression guard: the old env-var copy must NOT reappear on this branch —
+  // scoped to self-hosted only, since the managed branch below legitimately
+  // shows CLERUM_REGISTRY_AUTH_ENABLED again.
+  it('self-hosted + 409 registry_auth_disabled → shows connect guidance, no env-var copy', async () => {
     vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
       Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
     )
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
     render(<RegistryApiKeysPanel />)
     expect(
       await screen.findByText(/API keys become available once this deployment is connected/i)
     ).toBeInTheDocument()
     expect(screen.getByRole('link', { name: /connect to evenfire registry/i })).toBeInTheDocument()
+    expect(screen.queryByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeNull()
+  })
+
+  // managed: getRegistryConnection() 409s not_self_hosted (RegistryCatalog's own
+  // mode-detection convention). Managed has no connect flow, so the banner must
+  // point at the env var instead, and never link to the connect panel — that
+  // panel tells a managed deployment there's nothing to configure (dead end).
+  it('managed + 409 registry_auth_disabled → shows env-var guidance, no connect link', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
+    )
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'not_self_hosted' })
+    )
+    render(<RegistryApiKeysPanel />)
+    expect(await screen.findByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeInTheDocument()
+    expect(screen.getByText(/an operator must enable it/i)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /connect to evenfire registry/i })).toBeNull()
   })
 
   it('on create success, shows the reveal modal then refetches', async () => {

--- a/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
@@ -103,6 +103,17 @@ describe('RegistryApiKeysPanel', () => {
     expect(screen.queryByRole('link', { name: /connect to evenfire registry/i })).toBeNull()
   })
 
+  it('shows actionable configuration guidance when connected credentials remain without a URL', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 409, code: 'registry_url_not_configured' })
+    )
+    render(<RegistryApiKeysPanel />)
+
+    expect(await screen.findByText(/still holds registry credentials/i)).toBeInTheDocument()
+    expect(screen.getByText('CLERUM_REGISTRY_URL')).toBeInTheDocument()
+    expect(screen.getByText(/disconnect the stale connection/i)).toBeInTheDocument()
+  })
+
   it('on create success, shows the reveal modal then refetches', async () => {
     vi.mocked(api.listRegistryApiKeys)
       .mockResolvedValueOnce({ org: 'acme', keys: [] })

--- a/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
@@ -68,14 +68,15 @@ describe('RegistryApiKeysPanel', () => {
     expect(await screen.findByText(/not bound to a registry org/i)).toBeInTheDocument()
   })
 
-  it('shows actionable guidance to enable registry auth on 409 registry_auth_disabled', async () => {
+  it('shows guidance to connect the registry on 409 registry_auth_disabled', async () => {
     vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
       Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
     )
     render(<RegistryApiKeysPanel />)
-    expect(await screen.findByText(/registry authentication is disabled/i)).toBeInTheDocument()
-    expect(screen.getByText('CLERUM_REGISTRY_AUTH_ENABLED=true')).toBeInTheDocument()
-    expect(screen.getByText(/restart/i)).toBeInTheDocument()
+    expect(
+      await screen.findByText(/API keys become available once this deployment is connected/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /connect to evenfire registry/i })).toBeInTheDocument()
   })
 
   it('on create success, shows the reveal modal then refetches', async () => {

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -177,39 +177,31 @@ describe('RegistryConnectPanel', () => {
     await waitFor(() => expect(screen.getByText('Disconnect')).toBeInTheDocument())
   })
 
-  // Regression guard: self-hosted derives auth from credential presence, so a
-  // real `connected` response always has authEnabled: true — this combination
-  // is unreachable in practice. The panel used to render an env-var banner for
-  // it; that banner is gone. Pin its absence so a future change cannot
-  // resurrect the old CLERUM_REGISTRY_AUTH_ENABLED guidance.
-  it('connected + authEnabled:false → shows no auth guidance (unreachable in practice)', async () => {
-    vi.mocked(api.getRegistryConnection).mockResolvedValue({
-      state: 'connected',
-      deploymentId: 'd',
-      org: 'acme',
-      authEnabled: false,
-    })
-    render(<RegistryConnectPanel />)
-    await waitFor(() =>
-      expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
-    )
-    expect(screen.queryByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeNull()
-    expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
-  })
-
-  it('connected + authEnabled:true → does not show the enable-auth guidance', async () => {
-    vi.mocked(api.getRegistryConnection).mockResolvedValue({
-      state: 'connected',
-      deploymentId: 'd',
-      org: 'acme',
-      authEnabled: true,
-    })
-    render(<RegistryConnectPanel />)
-    await waitFor(() =>
-      expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
-    )
-    expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
-  })
+  // Regression guard: the panel used to render an env-var banner
+  // (CLERUM_REGISTRY_AUTH_ENABLED guidance) when connected without registry
+  // auth active. That banner is gone entirely, so pin its absence for BOTH
+  // authEnabled values, not just false. (Self-hosted derives auth from
+  // credential presence, so a real `connected` response always has
+  // authEnabled: true — connected + authEnabled:false is unreachable in
+  // practice — but the assertion must hold under either value so a future
+  // change cannot resurrect the old guidance behind just one of them.)
+  it.each([false, true])(
+    'connected + authEnabled:%s → shows no auth guidance',
+    async authEnabled => {
+      vi.mocked(api.getRegistryConnection).mockResolvedValue({
+        state: 'connected',
+        deploymentId: 'd',
+        org: 'acme',
+        authEnabled,
+      })
+      render(<RegistryConnectPanel />)
+      await waitFor(() =>
+        expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
+      )
+      expect(screen.queryByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeNull()
+      expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
+    }
+  )
 
   it('lands on the connected view when registration auto-claims', async () => {
     vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -177,7 +177,12 @@ describe('RegistryConnectPanel', () => {
     await waitFor(() => expect(screen.getByText('Disconnect')).toBeInTheDocument())
   })
 
-  it('connected + authEnabled:false → shows guidance to enable registry auth for API keys', async () => {
+  // Regression guard: self-hosted derives auth from credential presence, so a
+  // real `connected` response always has authEnabled: true — this combination
+  // is unreachable in practice. The panel used to render an env-var banner for
+  // it; that banner is gone. Pin its absence so a future change cannot
+  // resurrect the old CLERUM_REGISTRY_AUTH_ENABLED guidance.
+  it('connected + authEnabled:false → shows no auth guidance (unreachable in practice)', async () => {
     vi.mocked(api.getRegistryConnection).mockResolvedValue({
       state: 'connected',
       deploymentId: 'd',
@@ -186,9 +191,10 @@ describe('RegistryConnectPanel', () => {
     })
     render(<RegistryConnectPanel />)
     await waitFor(() =>
-      expect(screen.getByText(/enable registry authentication/i)).toBeInTheDocument()
+      expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
     )
-    expect(screen.getByText('CLERUM_REGISTRY_AUTH_ENABLED=true')).toBeInTheDocument()
+    expect(screen.queryByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeNull()
+    expect(screen.queryByText(/enable registry authentication/i)).toBeNull()
   })
 
   it('connected + authEnabled:true → does not show the enable-auth guidance', async () => {

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.358",
+  "version": "0.1.359",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.358",
+      "version": "0.1.359",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.357",
+  "version": "0.1.358",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.357",
+      "version": "0.1.358",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.356",
+  "version": "0.1.357",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.356",
+      "version": "0.1.357",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.360",
+  "version": "0.1.361",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.360",
+      "version": "0.1.361",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.359",
+  "version": "0.1.360",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.359",
+      "version": "0.1.360",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.357",
+  "version": "0.1.358",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.356",
+  "version": "0.1.357",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.360",
+  "version": "0.1.361",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.359",
+  "version": "0.1.360",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.358",
+  "version": "0.1.359",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -60,10 +60,12 @@ data:
   # turns on by itself once the connect flow completes and this deployment
   # holds machine credentials: there is no flag to set and no restart needed.
   # To run your OWN in-cluster registry instead, set CLERUM_REGISTRY_URL to
-  # http://registry-api.registry.svc.cluster.local:8085 and add it via
-  # CLERUM_REGISTRY_URL_ALLOWLIST. The allowlist applies to any explicitly
-  # self-hosted deployment with a registry URL configured, regardless of
-  # whether auth is active.
+  # http://registry-api.registry.svc.cluster.local:8085. That URL is already
+  # built into the allowlist, so no CLERUM_REGISTRY_URL_ALLOWLIST entry is
+  # needed for it; the setting is only for any OTHER registry URL. The
+  # allowlist applies to any explicitly self-hosted deployment with a registry
+  # URL configured, regardless of whether auth is active, and control-api
+  # refuses to start if the configured URL is not allowlisted.
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
   # The Publisher UI (Sidebar entry + /publisher route) defaults ON for every

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -56,15 +56,16 @@ data:
   # OSS default: point at the shared registry so a self-hoster browses the
   # public catalog out of the box and can run the connect flow (register →
   # approve → claim) against it. self-hosted is the only mode that fits an OSS
-  # deployment (managed = MCC-provisioned, not in this repo). Auth stays OFF
-  # until a connection is claimed — the boot guard (assertRegistryConnectionReady)
-  # only requires a connection row when auth is enabled, so this is crashloop-safe.
+  # deployment (managed = MCC-provisioned, not in this repo). Registry auth
+  # turns on by itself once the connect flow completes and this deployment
+  # holds machine credentials: there is no flag to set and no restart needed.
   # To run your OWN in-cluster registry instead, set CLERUM_REGISTRY_URL to
   # http://registry-api.registry.svc.cluster.local:8085 and add it via
-  # CLERUM_REGISTRY_URL_ALLOWLIST if you later enable auth.
+  # CLERUM_REGISTRY_URL_ALLOWLIST. The allowlist applies to any explicitly
+  # self-hosted deployment with a registry URL configured, regardless of
+  # whether auth is active.
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
-  CLERUM_REGISTRY_AUTH_ENABLED: 'false'
   # The Publisher UI (Sidebar entry + /publisher route) defaults ON for every
   # deploy. It only surfaces for an org-bound, non-curator deploy (the control-ui
   # fails closed otherwise), so an unconnected self-hosted deploy still won't show

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -14,6 +14,10 @@ and use registry SSO from your Control UI.
   `managed`, and the connect flow only runs in self-hosted mode — a managed
   deployment is connected automatically, so the panel has nothing to configure.
 - `CLERUM_REGISTRY_URL` set, with outbound HTTPS to the registry.
+- `CLERUM_REGISTRY_URL` must be in the allowlist. `https://registry.evenfire.ai`
+  and `http://registry-api.registry.svc.cluster.local:8085` are built in; add
+  any other registry URL via `CLERUM_REGISTRY_URL_ALLOWLIST`. control-api
+  refuses to start if the configured URL is not allowlisted.
 - You are an **admin** in your Control UI.
 
 ## Connect

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -61,25 +61,22 @@ one of two state machines, depending on how the registry is configured:
   [Publish a plugin to the registry](publish-plugin-to-registry.md).
 - **SSO** to registry API keys from your own Control UI.
 
-## Enable registry authentication (to manage API keys)
+## API keys for programmatic publishing
 
 Once connected, browsing the public catalog, publishing, and image push/pull all
 work using the credential stored when you claimed the connection — no further
 setup is needed for those.
 
 **Creating and managing API keys** (`efrk_` org keys, used for CI and other
-programmatic publishing) is a separate surface that requires **registry
-authentication** to be enabled. If you see a banner saying registry
-authentication is disabled, or you want to issue org API keys, enable it:
+programmatic publishing) needs registry authentication active. In self-hosted,
+connecting is sufficient: authentication turns on automatically the moment
+this deployment holds machine credentials, which is as soon as the connect
+flow above completes. There is no flag to set and no restart.
 
-1. Set `CLERUM_REGISTRY_AUTH_ENABLED=true` in the control-api config (e.g. the
-   `control-api-config` ConfigMap, or your env file).
-2. Restart control-api. The flag is read at boot only — there is no hot-reload.
-
-Note the boot guard this enables: with auth on and `REGISTRY_CONNECTION_MODE=self-hosted`,
-control-api requires a completed connection (which you already have once
-claimed) and the registry URL must be in the allowlist — `registry.evenfire.ai`
-is allowed by default; add others via `CLERUM_REGISTRY_URL_ALLOWLIST`.
+The registry URL allowlist still applies regardless of authentication: any
+explicitly self-hosted deployment with a registry URL configured must have
+that URL in the allowlist. `registry.evenfire.ai` is allowed by default; add
+others via `CLERUM_REGISTRY_URL_ALLOWLIST`.
 
 ## If something goes wrong
 


### PR DESCRIPTION
## Why

`CLERUM_REGISTRY_AUTH_ENABLED` was a manual env var an operator had to set **after** connecting a self-hosted deployment to the registry. Setting it too early was a boot-order deadlock:

```
auth on + no connection row → assertRegistryConnectionReady throws (main.ts:57)
  → control-api never listens → no Control UI → cannot run the connect flow
  → cannot create the row → crashloop
```

So the flag could not safely default to `true`, and an operator who set it early bricked the install. Since [#206](https://github.com/evenfire-ai/evenfire/pull/206) made connecting a single click with no operator involved, this manual flag was the last remaining friction in self-hosted onboarding.

Verified on a real cluster before starting: a freshly auto-claimed minikube deployment returned `409 registry_auth_disabled` from the API-keys panel until the var was patched to `true` and control-api restarted.

## What changed

**In self-hosted mode the env var is now inert.** Registry auth activates the moment the deployment holds machine credentials, which is when the connect flow completes. No env var, no restart.

- New `isRegistryAuthActive()` in `registryConnectionDb.ts` — managed returns the env flag verbatim, self-hosted returns `resolveMachineCreds() !== null`. It checks *credentials*, not row presence, so a `pending` row and an `approved`-but-unclaimed row both correctly report inactive.
- `registryBootGuard.ts` no longer throws. It logs whether a registry identity is present, so the "row disappeared after connecting" signal survives without the deadlock.
- The connection-row cache gains a 15s TTL, bounding staleness in both directions across replicas. Previously an access-control input could stay stale until pod restart.
- Six response fields, two admin route guards, and `registryClient.mintToken` now derive from the accessor.
- **Managed mode is untouched** — same env vars, same boot validation, same failure modes.

## A real hole this closes

The URL allowlist previously ran only when `registryAuthEnabled`, which ships `false`. Every default self-hosted deployment therefore **POSTed its registration and claimed machine credentials against a completely unvalidated registry URL**. The allowlist now applies to any explicitly self-hosted deployment with a URL configured, regardless of auth.

## Rate limiters on two connect routes

CodeQL flagged three `js/missing-rate-limiting` alerts on `registryConnect.ts`. One is a false positive — `POST …/recover` has had a limiter since #206; CodeQL cannot see this repo's PG-backed middleware. The other two were real pre-existing gaps, surfaced only because this branch touched those handlers. Both are now closed:

- **`GET /admin/registry/connect` → 30/min per admin.** Mounted by `RegistryCatalog` on every Marketplace visit, not just the connect panel, and reachable by top-level cross-site navigation (session cookie is `SameSite=Lax`, no CSRF or origin check). Each call makes an outbound registry `/status` fetch, so this bounds that traffic under a CSRF-driven loop while staying generous for normal navigation.
- **`POST …/request` → 3/min per admin.** Each call consumes one of the shared registry's ~5/day per-IP registration attempts and can create a deployment row there. 3/min allows a legitimate retry after a typo'd org name without letting a looped admin burn the daily budget in one minute.

Both mirror the per-admin token-bucket shape already used by `registry.ts` and the recover route. Tests assert the bucket key and limit (proving the middleware sits *after* `requireAuthForControlUI`) and that a 429 blocks before any DB or registry work.

## Managed-mode safety

This is the branch's hard constraint, and two design revisions broke it in review before landing — `parseRegistryConnectionMode()` defaults to `'managed'` when `REGISTRY_CONNECTION_MODE` is unset, which makes the obvious gates wrong in one direction or the other.

The final review built a 27-cell truth table over `REGISTRY_CONNECTION_MODE` × `CLERUM_REGISTRY_AUTH_ENABLED` × `CLERUM_REGISTRY_URL` and found **zero regressions**. One cell changes outcome — explicitly self-hosted + auth off + unlisted URL now refuses to boot, which is the intended hole closure. Three cells change only the error message. Every managed cell is identical.

`control-api/test/startupGuards.registryConsumer.test.ts` is **byte-identical to `dev`** and green — it is the regression proof and was deliberately never edited. The actual mutation-killer for the gate is a new test: mode unset + *unlisted* URL + auth off still boots. Dropping the self-hosted disjunct fails exactly that one test and nothing else.

## Testing

- control-api: **3553 passed**, 51 skipped
- control-ui: **1113 passed**
- `tsc --noEmit` clean in both; prettier clean on every touched file

## Behavioural change operators need to know

An explicitly self-hosted deployment whose `CLERUM_REGISTRY_URL` is not allowlisted now **refuses to start**. `https://registry.evenfire.ai` and `http://registry-api.registry.svc.cluster.local:8085` are built in; anything else needs `CLERUM_REGISTRY_URL_ALLOWLIST`. This is documented in the connect guide's Prerequisites, where the person configuring it will actually see it.

No existing deployment is affected: there are currently no self-hosted deployments, the minikube overlay uses an allowlisted URL, and both `gcp-prod` and `gcp-dev` are `managed` with the allowlisted shared registry.

## Known follow-ups (deliberately not in this PR)

- **`DELETE /admin/registry/connect` is blocked when no registry URL is configured.** The guard lives in the shared `requireSelfHostedAdmin`, but `DELETE` never builds a registry URL. An operator who removes `CLERUM_REGISTRY_URL` from a connected deployment cannot clear the stale row via the API. Recoverable by restoring the var and restarting; the fix is moving the guard into the four routes that need it.
- **Diagnostic ordering.** An auth-on deployment with no `REGISTRY_CONNECTION_MODE` now reports a URL error before the missing-mode error. Fails closed either way, but it is a two-step diagnosis of a one-step misconfiguration.
- **Disconnect still does not revoke registry-side.** `deleteConnection()` drops the local row only, and `registryClient` holds its own Bearer-token cache that is never cleared, so a disconnected deployment keeps working against the registry until token expiry. Pre-existing, but this change makes disconnect a routine action.
- A few test-hardening nits that do not guard live behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
