### PR TITLE
fix(mcp-host): install ca-certificates in the slim runtime image

### DIFF
--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -355,6 +355,18 @@ jobs:
       - name: No unannotated Cf-Access-* header reads
         run: bash scripts/check-no-cf-access-header-read.sh
 
+  # ─── Dockerfile CA-bundle guard ───────────────────────────────────────────
+  # An image that ships git/curl/wget but no CA bundle fails every TLS
+  # verification while Node's own fetch keeps working, so it looks healthy until
+  # an agent shells out. Assert the dependency is declared, not inherited.
+  dockerfile-ca-guard:
+    name: Validate Dockerfile CA bundles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Every image shipping a TLS tool installs ca-certificates
+        run: bash scripts/check-dockerfile-ca-certificates.sh
+
   # ─── Deploy manifest check (public overlays) ──────────────────────────────
   # The public repo carries base + minikube overlays only; the gcp-dev/gcp-prod
   # overlays live in keyper-labs/evenfire-infra and are rendered by infra CI.

--- a/mcp-host/Dockerfile.full
+++ b/mcp-host/Dockerfile.full
@@ -30,9 +30,14 @@ FROM node:24.16.0@sha256:40ad9f3064e67d6860b4bc3fe1880b2953934fd6320ada990e45fe0
 
 WORKDIR /app
 
-# Fill gaps in full Debian base
+# Fill gaps in full Debian base.
+#
+# This base already ships ca-certificates, unlike node:*-slim. Listing it is a
+# no-op layer that makes the CA bundle a stated dependency of the tools we ship
+# instead of a property of whichever base digest is pinned.
+# Guarded by scripts/check-dockerfile-ca-certificates.sh.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    jq wget \
+    ca-certificates jq wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the shared package + package files, install production dependencies only

--- a/mcp-host/Dockerfile.slim
+++ b/mcp-host/Dockerfile.slim
@@ -30,9 +30,17 @@ FROM node:24.16.0-slim@sha256:2c87ef9bd3c6a3bd4b472b4bec2ce9d16354b0c574f736c476
 
 WORKDIR /app
 
-# System tools
+# System tools.
+#
+# ca-certificates is required, not optional: node:*-slim installs it to fetch
+# Node and then purges it, leaving /etc/ssl/certs empty, and
+# --no-install-recommends stops apt pulling it back in via git/curl/wget. Drop
+# it and every TLS call from a shipped tool fails verification (git "CAfile:
+# none", curl exit 000) while mcp-host's own fetch keeps working — Node carries
+# its own CA store — so the image looks healthy until an agent uses shell_exec.
+# Guarded by scripts/check-dockerfile-ca-certificates.sh.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    bash git curl wget jq \
+    bash ca-certificates git curl wget jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the shared package + package files, install production dependencies only

--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.210",
+  "version": "0.1.211",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-mcp-host",
-      "version": "0.1.210",
+      "version": "0.1.211",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.210",
+  "version": "0.1.211",
   "description": "MCP Host - reads Host CRD and provides LLM access via OpenAI/Claude",
   "main": "dist/main.js",
   "engines": {

--- a/mcp-servers/airtable/Dockerfile
+++ b/mcp-servers/airtable/Dockerfile
@@ -3,7 +3,10 @@ FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-RUN apk add --no-cache git
+# ca-certificates is what makes the HTTPS clone below verifiable. The alpine
+# base happens to ship a bundle today; declare the dependency so a base bump
+# cannot silently remove it. Guarded by scripts/check-dockerfile-ca-certificates.sh.
+RUN apk add --no-cache ca-certificates git
 
 # Clone the latest source which includes HTTP transport support
 RUN git clone --depth 1 https://github.com/domdomegg/airtable-mcp-server.git .

--- a/mcp-servers/package-lock.json
+++ b/mcp-servers/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clerum/mcp-servers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clerum/mcp-servers",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "js-yaml": "^4.1.1"
       },

--- a/mcp-servers/package.json
+++ b/mcp-servers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clerum/mcp-servers",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "MCP servers for Clerum testing",
   "type": "module",
   "main": "index.ts",

--- a/scripts/check-dockerfile-ca-certificates.sh
+++ b/scripts/check-dockerfile-ca-certificates.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Lint: any image that installs a TLS-using system tool must also install a CA
+# bundle, in the same package list.
+#
+# Why: `node:*-slim` installs ca-certificates to fetch Node, then purges it with
+# `apt-get purge --auto-remove`, leaving /etc/ssl/certs empty. `--no-install-
+# recommends` then stops apt from pulling it back in as a recommendation of
+# git/curl/wget. The result is an image whose shipped tools cannot verify any
+# certificate, while Node's own fetch keeps working (Node bundles its own CA
+# store and never consults /etc/ssl/certs). That asymmetry makes the image look
+# healthy on every normal code path and only break for tools the agent invokes,
+# and the failure surfaces as `curl` exit 000 / git "CAfile: none", which reads
+# like an egress problem rather than a missing bundle.
+#
+# The rule is deliberately about the declaration, not the base image: bases
+# differ and get re-pinned, so an image that ships git/curl/wget states its CA
+# dependency explicitly instead of inheriting it by luck. Re-declaring it on a
+# base that already has it is a no-op layer.
+#
+# Exempt a deliberate, reviewed case with a `# CA-CERTS-OK: <reason>` comment
+# anywhere in the same RUN instruction.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+violations=0
+
+while IFS= read -r dockerfile; do
+  output="$(awk -v file="$dockerfile" '
+    # Packages whose whole job is to talk TLS to the outside world.
+    BEGIN {
+      split("git curl wget", tls_tools, " ")
+    }
+
+    # Report every TLS tool installed without ca-certificates alongside it.
+    function check(cmd, lineno,   mgr, rest, list, cut, n, tok, i, j, has_ca, found, seen) {
+      has_ca = 0
+      found = ""
+      # A single RUN can chain several installs; walk them all.
+      rest = cmd
+      while (1) {
+        if (match(rest, /apt(-get)?[ \t]+(-[^ \t]+[ \t]+)*install/)) {
+          mgr = "apt"
+        } else if (match(rest, /apk[ \t]+add/)) {
+          mgr = "apk"
+        } else {
+          break
+        }
+        list = substr(rest, RSTART + RLENGTH)
+        rest = list
+        # A package list ends at the next shell operator.
+        cut = match(list, /(&&|\|\||[;|])/)
+        if (cut > 0) list = substr(list, 1, cut - 1)
+
+        n = split(list, tok, /[ \t]+/)
+        for (i = 1; i <= n; i++) {
+          if (tok[i] == "" || substr(tok[i], 1, 1) == "-") continue
+          sub(/=.*$/, "", tok[i])   # strip pinned versions: nodejs=24.16.0-1
+          if (tok[i] == "ca-certificates" || tok[i] == "ca-certificates-bundle") {
+            has_ca = 1
+            continue
+          }
+          for (j in tls_tools) {
+            if (tok[i] == tls_tools[j] && !(tok[i] in seen)) {
+              seen[tok[i]] = 1
+              found = (found == "" ? tok[i] : found " " tok[i])
+            }
+          }
+        }
+      }
+      if (found != "" && !has_ca) {
+        printf "%s:%d: installs %s without ca-certificates\n", file, lineno, found
+      }
+    }
+
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      stripped = line
+      gsub(/^[ \t]+|[ \t]+$/, "", stripped)
+
+      # Comments may sit between continuation lines; keep the exemption marker.
+      if (substr(stripped, 1, 1) == "#") {
+        if (stripped ~ /CA-CERTS-OK:/) exempt = 1
+        next
+      }
+
+      if (buf == "") start = NR
+      buf = buf " " line
+
+      if (line ~ /\\[ \t]*$/) {
+        sub(/\\[ \t]*$/, " ", buf)
+        next
+      }
+
+      if (buf ~ /CA-CERTS-OK:/) exempt = 1
+      if (!exempt) check(buf, start)
+      buf = ""
+      exempt = 0
+      delete seen
+    }
+  ' "$dockerfile")"
+
+  if [ -n "$output" ]; then
+    while IFS= read -r v; do
+      echo "VIOLATION: $v" >&2
+      violations=$((violations + 1))
+    done <<<"$output"
+  fi
+done < <(find . -type f -name 'Dockerfile*' \
+           -not -path '*/node_modules/*' -not -path './.git/*' | sort)
+
+if [ "$violations" -ne 0 ]; then
+  echo "FAIL: $violations image(s) ship a TLS-using tool with no CA bundle." >&2
+  echo "      Add ca-certificates to the same package list, or annotate the RUN with '# CA-CERTS-OK: <reason>'." >&2
+  exit 1
+fi
+echo "PASS: every image shipping git/curl/wget also installs a CA bundle."


### PR DESCRIPTION
`mcp-host-slim` ships `git`, `curl` and `wget` with no CA bundle, so every TLS connection those tools make fails certificate verification. The agent's `shell_exec` cannot `git clone`, `curl`, or `npm install` from anything HTTPS. Egress is fine; only verification fails.

## The fix

```diff
--- a/mcp-host/Dockerfile.slim
+++ b/mcp-host/Dockerfile.slim
  RUN apt-get update && apt-get install -y --no-install-recommends \
-     bash git curl wget jq \
+     bash ca-certificates git curl wget jq \
      && rm -rf /var/lib/apt/lists/*
```

That one package is the whole behavioural change. The rest of the diff is a regression guard plus two no-op declarations.

## Why it broke

`node:*-slim` installs `ca-certificates` to fetch Node and then purges it with `apt-get purge --auto-remove`, leaving `/etc/ssl/certs` empty. `--no-install-recommends` then stops apt pulling it back in as a recommendation of git/curl/wget. So the base looks like a normal Debian image but has no trust store at all.

Two things made this hard to see:

- **The failure is opaque.** `curl` returns `000` and git reports `server certificate verification failed. CAfile: none`, both of which read like a network/egress problem. It takes disabling verification (`curl -k` succeeding) to establish the connection was fine all along.
- **Node hides it.** mcp-host's own outbound calls work, because Node bundles its own CA store and never consults `/etc/ssl/certs`. The image looks healthy on every normal code path and only breaks for tools the agent invokes.

Observed on `clerum-dev`, namespace `mcp-host`, image `mcp-host-slim:sha-c553b1a`: Debian 12 bookworm, `ca-certificates` not installed, `/etc/ssl/certs` absent, git 2.39.5, curl 7.88.1, no `SSL_CERT_FILE` / `GIT_SSL_CAINFO` overrides.

## Which image

`Dockerfile.slim` is the one, from the `mcp-host-slim` matrix entry in `build-publish.yml` (`dockerfile: Dockerfile.slim`). The deployed tag `sha-c553b1a` is a commit in this repo, so this repo builds it. Probing each runtime base directly:

| Dockerfile | Runtime base | `ca-certificates.crt` | certs in `/etc/ssl/certs` |
|---|---|---|---|
| `Dockerfile` | node:24.16.0-alpine | present | 1 |
| **`Dockerfile.slim`** | **node:24.16.0-slim (bookworm)** | **missing** | **0** |
| `Dockerfile.full` | node:24.16.0 (bookworm) | present | 285 |
| `Dockerfile.desktop` | webtop ubuntu (installs it) | present | — |

`Dockerfile.slim` is the only Debian-slim runtime in the repo, so the runtime break is limited to it.

## Full change set

- **`mcp-host/Dockerfile.slim`** — add `ca-certificates`. This is the fix.
- **`mcp-host/Dockerfile.full`, `mcp-servers/airtable/Dockerfile`** — already worked, since their bases keep a bundle. They now list it too, so the CA bundle is a *declared* dependency of the tools each image ships rather than a property of whichever base digest happens to be pinned. No behaviour change; a no-op apt/apk layer.
- **`scripts/check-dockerfile-ca-certificates.sh`** — fails any Dockerfile that installs git/curl/wget without a CA bundle in the same package list. Escape hatch: `# CA-CERTS-OK: <reason>` on the RUN. Wired into `ci-public` as `dockerfile-ca-guard`.
- Package version bumps are from the repo's staged-package pre-commit hook.

## Verification

The guard was written first and fails on the unfixed tree:

```
VIOLATION: ./mcp-host/Dockerfile.full:34: installs wget without ca-certificates
VIOLATION: ./mcp-host/Dockerfile.slim:34: installs git curl wget without ca-certificates
VIOLATION: ./mcp-servers/airtable/Dockerfile:6: installs git without ca-certificates
FAIL: 3 image(s) ship a TLS-using tool with no CA bundle.
```

and passes after. It was also exercised against fixtures covering chained installs in one `RUN`, the exemption marker, version-pinned package names, the `apk` form and the short `apt install` form.

**Rebuilt `mcp-host-slim` and ran the reproduction**, as the image's own `nodejs` user:

```
whoami: nodejs
os: Debian GNU/Linux 12 (bookworm)
ca-certificates.crt: -rw-r--r-- 1 root root 216591 /etc/ssl/certs/ca-certificates.crt
certs in /etc/ssl/certs: 285
git version 2.39.5 / curl 7.88.1
SSL_CERT_FILE=  GIT_SSL_CAINFO=          # no overrides, verification on

curl https://api.github.com       -> 200
curl https://registry.npmjs.org   -> 200
wget https://api.github.com       -> OK
git clone --depth 1 https://github.com/octocat/Hello-World.git -> OK
```

The clone is the one that matters, since it exercises git's own TLS path rather than curl's.

**A/B on the base image**, changing only whether `ca-certificates` is in the apt list and holding everything else fixed. This reproduces the reported failure exactly and shows the one-word change is what flips it:

```
before:  certs 0    curl -> 000   git clone -> FAILED
           fatal: ... server certificate verification failed. CAfile: none CRLfile: none
         node fetch -> 200        # the asymmetry that hid this

after:   certs 285  curl -> 200   git clone -> OK
         node fetch -> 200
```

## On whether git/curl belong in the runtime at all

Worth asking, since their presence combined with `shell_exec` is what makes this reachable. Keeping them and supporting them properly is the right call: the slim variant's stated use case is *"agent shell execution with common Unix tools"*, and `shell_exec` is a shipped capability. The previous state was the worst of the options — present but unusable, failing confusingly. The alternative, removing them, would make the limitation explicit but drop a capability that works fine once the bundle is there.

## Rollout

Merging rebuilds and republishes `mcp-host-slim` (the `mcp-host: 'mcp-host/**'` change filter matches). Host pods keep failing until they roll onto the new tag.

---

Reported internally as private issue #840; that tracker is not public, so this PR carries the full context rather than pointing at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)