### PR TITLE
fix(rpc-proxy): point HCC base-URL dev default at the real endpoint (split from #205)

### DIFF
--- a/rpc-proxy/package-lock.json
+++ b/rpc-proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-rpc-proxy",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-rpc-proxy",
-      "version": "0.1.50",
+      "version": "0.1.51",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/rpc-proxy/package.json
+++ b/rpc-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-rpc-proxy",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "External-facing RPC proxy for tenant-scoped MCP access",
   "main": "dist/main.js",
   "engines": {

--- a/rpc-proxy/src/config.hccBaseUrl.test.ts
+++ b/rpc-proxy/src/config.hccBaseUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+/**
+ * The dev default for RPC_PROXY_HCC_BASE_URL must name the same HCC endpoint the
+ * deployed configmap injects. They drifted once: the default pointed at
+ * host-context-controller.mcp-server (a Service that exists in no overlay, and
+ * one the rpc-proxy egress NetworkPolicy would block anyway — it only permits
+ * the api-gateway peer), while the real target is
+ * host-context-controller-api-gateway.control-plane. NODE_ENV=production is
+ * baked into the image so the default is unreachable in-cluster today, but a
+ * developer running rpc-proxy locally would inherit the wrong endpoint. Pin the
+ * two together so they cannot silently diverge again.
+ */
+describe('rpc-proxy HCC base URL default', () => {
+  const repoRoot = path.join(__dirname, '../..')
+
+  const configSource = readFileSync(path.join(__dirname, 'config.ts'), 'utf8')
+  const defaultMatch = configSource.match(
+    /requiredOrDevDefault\(\s*'RPC_PROXY_HCC_BASE_URL',\s*(?:\/\/[^\n]*\n\s*)*'([^']+)'/
+  )
+
+  const configmap = readFileSync(
+    path.join(repoRoot, 'deploy/overlays/minikube/configmaps/rpc-proxy-config.yaml'),
+    'utf8'
+  )
+  const configmapMatch = configmap.match(/RPC_PROXY_HCC_BASE_URL:\s*"?([^"\n]+)"?/)
+
+  it('parses both sources', () => {
+    expect(defaultMatch?.[1]).toBeTruthy()
+    expect(configmapMatch?.[1]).toBeTruthy()
+  })
+
+  it('dev default matches the deployed configmap endpoint', () => {
+    expect(defaultMatch?.[1]).toBe(configmapMatch?.[1]?.trim())
+  })
+
+  it('targets the api-gateway in control-plane, not a nonexistent Service', () => {
+    expect(defaultMatch?.[1]).toContain('host-context-controller-api-gateway.control-plane')
+  })
+})

--- a/rpc-proxy/src/config.ts
+++ b/rpc-proxy/src/config.ts
@@ -216,7 +216,12 @@ export const config: Config = {
   ),
   hccBaseUrl: requiredOrDevDefault(
     'RPC_PROXY_HCC_BASE_URL',
-    'http://host-context-controller.mcp-server.svc.cluster.local:8081'
+    // Must mirror the real topology: rpc-proxy reaches HCC only through the
+    // nginx api-gateway in control-plane. The egress NetworkPolicy in
+    // deploy/base/rpc-proxy/networkpolicies.yaml only allows that peer, and no
+    // host-context-controller Service exists in mcp-server. Kept in sync with
+    // the deployed configmap by config.hccBaseUrl.test.ts.
+    'http://host-context-controller-api-gateway.control-plane.svc.cluster.local:8081'
   ),
   hostNamespace: requiredOrDevDefault('RPC_PROXY_HOST_NAMESPACE', 'mcp-host'),
   desktopCookieName: process.env.RPC_PROXY_DESKTOP_COOKIE_NAME || 'clerum_desktop_session',


### PR DESCRIPTION
## What this is

The **rpc-proxy** slice of PR #205, extracted to merge on its own (zach88's round-3 recommendation). 4 files, one dev-default correction plus its regression fence.

## Extraction is diff-neutral

- Based on **current `origin/dev` (`1c8d2da`)**, which touches no `rpc-proxy/` file → clean fast-forward.
- `rpc-proxy/` is **byte-identical to `87c374b`** — `git diff 87c374b -- rpc-proxy/` is empty.
- Touches only `rpc-proxy/` (4 files).

## What it fixes

The `RPC_PROXY_HCC_BASE_URL` dev default pointed at `host-context-controller.mcp-server` — a Service that exists in no overlay, and one the rpc-proxy egress NetworkPolicy would block anyway (it only permits the api-gateway peer). Dead since the initial import. Points it at `host-context-controller-api-gateway.control-plane`, and adds a test pinning the dev default to the deployed configmap so the two cannot silently diverge again.

Latent, not live (NODE_ENV=production is baked into the image, so in-cluster the configmap always supplies the value), but an objectively wrong endpoint that would mislead anyone running rpc-proxy locally.

## Verification (this branch)

- `tsc --noEmit`: clean.
- Full suite: **32 files / 426 tests pass**.

## Follow-up (not blocking; lands on this branch)

- **M7**: assert the value against the Service YAML (`api-gateway.yaml` Service host+port), not only the configmap, so a Service rename is caught.

Merge-order-free vs `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
