### PR TITLE
self-hosted Marketplace UX redesign + org area

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.392",
+      "version": "0.1.393",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.392",
+  "version": "0.1.393",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -10,7 +10,7 @@ import { K8sGateway } from '../../k8s.js'
 import type { UiAuthedRequest } from '../../middleware/controlUIAuth.js'
 import { rateLimitMiddleware } from '../../middleware/rateLimitMiddleware.js'
 import { type AdminUserRecord, findAdminById } from '../../services/adminAuthService.js'
-import { createKey, listKeys, revokeKey } from '../../services/orgApiKeyClient.js'
+import { createKey, listImages, listKeys, revokeKey } from '../../services/orgApiKeyClient.js'
 import {
   RegistryProxyError,
   applyPublishScope,
@@ -2224,6 +2224,19 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
     try {
       const { keys } = await listKeys(ctx.admin, ctx.orgName)
       res.json({ org: ctx.orgName, keys })
+    } catch (err) {
+      handleKeysError(err, res, next, ctx.orgName)
+    }
+  })
+
+  // Org container images (+ tags) for the Marketplace images area. Same
+  // owner-gated org resolution + error mapping as the keys read.
+  router.get('/admin/registry/images', keysRateLimit, async (req, res, next) => {
+    const ctx = await prepareKeysRequest(req, res)
+    if (!ctx) return
+    try {
+      const { images } = await listImages(ctx.admin, ctx.orgName)
+      res.json({ org: ctx.orgName, images })
     } catch (err) {
       handleKeysError(err, res, next, ctx.orgName)
     }

--- a/control-api/src/services/orgApiKeyClient.ts
+++ b/control-api/src/services/orgApiKeyClient.ts
@@ -52,6 +52,12 @@ export interface CreateOrgApiKeyInput {
   scopes?: string[]
   expiresInDays?: number
 }
+export interface OrgImage {
+  name: string
+  visibility: string
+  createdAt: string
+  tags: string[]
+}
 
 async function exchangeVoucher(admin: AdminUserRecord): Promise<string> {
   const voucher = await mintIdentityVoucher(admin)
@@ -147,6 +153,31 @@ export async function listKeys(
   const res = await userAuthedFetch(admin, `/org/${encodeURIComponent(org)}/keys`)
   if (!res.ok) throw await toStatusError(res)
   return (await res.json()) as { keys: OrgApiKey[] }
+}
+
+// List the org's container image repositories. Read surface for the Control UI
+// images area; owner-gated user token, same path as listKeys. The registry
+// returns { repos: [{ id, name, visibility, createdAt }] } (tags not included);
+// tolerate an `images` key + a future `tags` field too.
+export async function listImages(
+  admin: AdminUserRecord,
+  org: string
+): Promise<{ images: OrgImage[] }> {
+  const res = await userAuthedFetch(admin, `/org/${encodeURIComponent(org)}/images`)
+  if (!res.ok) throw await toStatusError(res)
+  const raw = (await res.json()) as {
+    repos?: { name: string; visibility: string; createdAt: string; tags?: string[] }[]
+    images?: { name: string; visibility: string; createdAt: string; tags?: string[] }[]
+  }
+  const rows = raw?.images ?? raw?.repos ?? []
+  return {
+    images: rows.map(r => ({
+      name: r.name,
+      visibility: r.visibility,
+      createdAt: r.createdAt,
+      tags: r.tags ?? [],
+    })),
+  }
 }
 
 export async function createKey(

--- a/control-ui/README.md
+++ b/control-ui/README.md
@@ -21,22 +21,21 @@ Control UI requires an admin login — it is not an open dashboard.
 
 Sidebar destinations map to canonical App Router routes (`components/Sidebar/constants.tsx`):
 
-| Sidebar label     | Route                                                    | Contents                                                                         |
-| ----------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| Agents            | `/hosts`                                                 | Host list, detail tabs, guided creation wizard, per-tool approval overrides      |
-| Connectors        | `/mcp-servers`                                           | MCP server resources: list, create, edit, egress policy                          |
-| Plugins           | `/workflow-recipes`                                      | Workflow recipes by namespace/name: editor, secrets, integrations, runs          |
-| Shared Files      | `/shared-filesystems`                                    | Shared filesystem resources                                                      |
-| Global Files      | `/gfs`                                                   | Global File System browser and grant delegation                                  |
-| Marketplace       | `/registry`                                              | Registry catalog plus `/registry/install`, `/registry/keys`, `/registry/publish` |
-| Publisher         | `/publisher`                                             | Publisher credentials, entries, shared-with-me                                   |
-| External Channels | `/communication-channels`                                | Communication channel resources                                                  |
-| Users & Teams     | `/profile-admin/users`                                   | Users, teams, and admins administration                                          |
-| Contexts          | `/contexts`                                              | Context resources with per-context tabs                                          |
-| Secrets           | `/secrets`                                               | Secrets by scope, plus recipe secrets (values are write-only from the UI)        |
-| Outputs           | `/outputs`                                               | Generated outputs                                                                |
-| Cost & Usage      | `/cost/usage`, `/cost/llm-prices`, `/cost/token-budgets` | Token usage dashboard, model prices, token budgets                               |
-| Settings          | `/settings`                                              | Control settings panel                                                           |
+| Sidebar label     | Route                                                    | Contents                                                                                                               |
+| ----------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Agents            | `/hosts`                                                 | Host list, detail tabs, guided creation wizard, per-tool approval overrides                                            |
+| Connectors        | `/mcp-servers`                                           | MCP server resources: list, create, edit, egress policy                                                                |
+| Installed plugins | `/plugins`                                               | Installed plugins by namespace/name: editor, secrets, integrations, runs                                               |
+| Shared Files      | `/shared-filesystems`                                    | Shared filesystem resources                                                                                            |
+| Global Files      | `/gfs`                                                   | Global File System browser and grant delegation                                                                        |
+| Marketplace       | `/marketplace`                                           | Connectors catalog plus the org-named tab `/marketplace/org` (entries, credentials, connection) — the folded Publisher |
+| External Channels | `/communication-channels`                                | Communication channel resources                                                                                        |
+| Users & Teams     | `/profile-admin/users`                                   | Users, teams, and admins administration                                                                                |
+| Contexts          | `/contexts`                                              | Context resources with per-context tabs                                                                                |
+| Secrets           | `/secrets`                                               | Secrets by scope, plus recipe secrets (values are write-only from the UI)                                              |
+| Outputs           | `/outputs`                                               | Generated outputs                                                                                                      |
+| Cost & Usage      | `/cost/usage`, `/cost/llm-prices`, `/cost/token-budgets` | Token usage dashboard, model prices, token budgets                                                                     |
+| Settings          | `/settings`                                              | Control settings panel                                                                                                 |
 
 Routes not in the sidebar: `/control-admins/new` (invite a control admin), `/plugin-workload-sdk` (SDK grants and invocation search), and the public token flows listed above. Old top-level `/usage`, `/llm-prices`, and `/token-budgets` paths permanently redirect under `/cost/*` (`next.config.js`).
 

--- a/control-ui/app/constants/routes.ts
+++ b/control-ui/app/constants/routes.ts
@@ -71,6 +71,12 @@ export const CONTROL_ROUTES = {
     root: '/marketplace',
     connectors: '/marketplace/connectors',
     plugins: '/marketplace/plugins',
+    // The org-named tab (design spec §4): everything this deployment owns.
+    org: '/marketplace/org',
+    orgEntries: '/marketplace/org/entries',
+    orgImages: '/marketplace/org/images',
+    orgCredentials: '/marketplace/org/credentials',
+    orgConnection: '/marketplace/org/connection',
     install: (query?: ControlRouteQuery) => withQuery('/marketplace/install', query),
     publish: (query?: ControlRouteQuery) => withQuery('/marketplace/publish', query),
     keys: '/marketplace/keys',

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -8168,6 +8168,29 @@ textarea.cu-input {
   box-shadow: var(--cu-shadow);
 }
 
+/* Wider variant for modals with long content (e.g. Docker commands + config). */
+.cu-modal--wide {
+  width: min(46rem, 96vw);
+}
+
+/* Preformatted command / config snippet inside a modal or panel. Wraps long
+   lines (docker login … -p <secret>, push coordinates, dockerconfigjson) so
+   nothing is clipped, rather than overflowing a fixed-width dialog. */
+.cu-code-block {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  background: var(--cu-surface-alt, var(--cu-surface));
+  border: 1px solid var(--cu-border);
+  border-radius: var(--cu-radius-sm, var(--cu-radius));
+  font-family: var(--cu-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.85em;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
 /* Quick-pick chips row for multi-choice shortcuts */
 .cu-quick-picks {
   display: flex;

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -1989,6 +1989,22 @@ textarea.cu-input {
   text-transform: uppercase;
 }
 
+/* Previous-versions list inside an expanded owned-entry row: keep the label and
+   each version/Install line spaced so adjacent Install buttons don't touch. */
+.cu-marketplace-versions {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--cu-space-3);
+  min-width: 0;
+  max-width: 28rem;
+}
+
+.cu-marketplace-versions .cu-table-actions {
+  align-items: center;
+  gap: var(--cu-space-4);
+}
+
 .cu-expandable-field__code,
 .cu-code-text {
   color: var(--cu-text-soft);
@@ -2554,6 +2570,22 @@ textarea.cu-input {
   padding: 1.25rem 1rem;
   color: var(--cu-text-soft);
   font-size: 0.875rem;
+}
+
+.cu-empty__explainer {
+  max-width: 52ch;
+  margin: 0 auto;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cu-space-4);
+  line-height: 1.6;
+}
+
+/* No global paragraph reset, so zero the default margins and let the flex gap
+   alone space the paragraphs — otherwise the 1em margins compound with gap. */
+.cu-empty__explainer p {
+  margin: 0;
 }
 
 .cu-empty--compact {

--- a/control-ui/app/registry/entries/[name]/[version]/page.tsx
+++ b/control-ui/app/registry/entries/[name]/[version]/page.tsx
@@ -21,6 +21,7 @@ import {
   getRegistryCatalog,
   installRecipeFromRegistry,
 } from '@lib/api'
+import { useRegistryCapability } from '@lib/hooks/useRegistryCapability'
 import { trustBgColor, trustColor } from '@lib/trustLevel'
 
 export const dynamic = 'force-dynamic'
@@ -30,11 +31,13 @@ function RegistryEntryActionsMenu({
   onRemove,
   removing,
   sourceRepoUrl,
+  canManage,
 }: {
   onEdit: () => void
   onRemove: () => void
   removing: boolean
   sourceRepoUrl: string | null
+  canManage: boolean
 }) {
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
@@ -54,6 +57,10 @@ function RegistryEntryActionsMenu({
       document.removeEventListener('keydown', handleEsc)
     }
   }, [open])
+
+  // Non-owners see management removed entirely (design spec §5.4); the source
+  // repo link is discovery, so it stays. With neither, there is no menu.
+  if (!canManage && !sourceRepoUrl) return null
 
   return (
     <div ref={ref} className="cu-kebab">
@@ -81,29 +88,33 @@ function RegistryEntryActionsMenu({
               Source repo
             </a>
           ) : null}
-          <button
-            type="button"
-            className="cu-kebab__item"
-            role="menuitem"
-            onClick={() => {
-              setOpen(false)
-              onEdit()
-            }}
-          >
-            Edit
-          </button>
-          <button
-            type="button"
-            className="cu-kebab__item cu-kebab__item--danger"
-            role="menuitem"
-            disabled={removing}
-            onClick={() => {
-              setOpen(false)
-              onRemove()
-            }}
-          >
-            {removing ? 'Removing...' : 'Remove'}
-          </button>
+          {canManage ? (
+            <>
+              <button
+                type="button"
+                className="cu-kebab__item"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false)
+                  onEdit()
+                }}
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                className="cu-kebab__item cu-kebab__item--danger"
+                role="menuitem"
+                disabled={removing}
+                onClick={() => {
+                  setOpen(false)
+                  onRemove()
+                }}
+              >
+                {removing ? 'Removing...' : 'Remove'}
+              </button>
+            </>
+          ) : null}
         </div>
       ) : null}
     </div>
@@ -133,6 +144,14 @@ function RegistryEntryDetailContent() {
   const [actionError, setActionError] = useState('')
   const { confirm, confirmDialog } = useConfirmDialog()
   const { showToast } = useToast()
+  const { capability } = useRegistryCapability()
+  // Management (edit/remove) belongs to the entry's owner, or to a curator who
+  // administers the shared catalog (design spec §5.4). Ownership is derived from
+  // the org-scope prefix on the entry name (publishes are stored as `@org/name`).
+  const orgScope = capability?.scope ?? null
+  const canManageEntry =
+    !!entry &&
+    (capability?.isCurator === true || (!!orgScope && entry.name.startsWith(`${orgScope}/`)))
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -271,6 +290,7 @@ function RegistryEntryDetailContent() {
                       onRemove={() => void handleRemove()}
                       removing={removing}
                       sourceRepoUrl={sourceRepoUrl}
+                      canManage={canManageEntry}
                     />
                   </>
                 ) : undefined

--- a/control-ui/app/registry/install/page.tsx
+++ b/control-ui/app/registry/install/page.tsx
@@ -259,12 +259,18 @@ function RegistryRecipeInstallPreview({
     ? (validation?.issues.filter(issue => issue.severity === 'error') ?? [])
     : []
   const egressErrors = egressFindings.filter(finding => finding.severity === 'error')
+  // A promptBridge recipe must resolve an agent before install, or it fails
+  // after install. When the recipe's allowedModels[0] is not in the operator
+  // catalog, providerForModel() returns '' and no spec.agent is injected — so
+  // block the submit until a provider + model are actually chosen.
+  const agentReady = !agentReq.needsAgent || (Boolean(agentProvider) && Boolean(agentModel))
   const canInstall =
     recipeText.length > 0 &&
     !parseResult.error &&
     validationErrors.length === 0 &&
     egressErrors.length === 0 &&
     !egressEditError &&
+    agentReady &&
     !submitting
   const canContinue = step === 0 ? Boolean(recipeText.trim()) && !parseResult.error : canInstall
 

--- a/control-ui/app/registry/install/page.tsx
+++ b/control-ui/app/registry/install/page.tsx
@@ -13,6 +13,7 @@ import { EgressEditor } from '@components/EgressEditor'
 import { RegistryInstallForm } from '@components/RegistryInstallForm'
 import { IconStore } from '@components/Sidebar/icons'
 import { useToast } from '@components/Toast'
+import { SelectInput } from '@components/ui'
 import { CREATE_FLOW_LOADING } from '@constants/createFlowLoading'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { DEFAULT_WORKFLOW_RECIPE_NAMESPACE } from '@constants/workflowRecipes'
@@ -113,6 +114,87 @@ function applyWorkflowWorkloadEgress(
   return JSON.stringify(next, null, 2)
 }
 
+// spec.agent.provider enum (WorkflowRecipe CRD).
+const AGENT_PROVIDERS = [
+  'openai',
+  'claude',
+  'zai',
+  'bailian',
+  'vertex',
+  'openrouter',
+  'gemini',
+  'deepseek',
+  'groq',
+  'together',
+  'fireworks',
+  'mistral',
+  'xai',
+  'cerebras',
+  'deepinfra',
+  'perplexity',
+  'moonshot',
+  'nebius',
+  'novita',
+] as const
+
+// Best-effort provider guess from a model id; the user can override it.
+function providerForModel(model: string): string {
+  const m = model.toLowerCase()
+  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('chatgpt'))
+    return 'openai'
+  if (m.includes('claude')) return 'claude'
+  if (m.includes('glm')) return 'zai'
+  if (m.includes('gemini')) return 'gemini'
+  if (m.includes('deepseek')) return 'deepseek'
+  if (m.includes('grok')) return 'xai'
+  if (m.includes('mistral') || m.includes('mixtral')) return 'mistral'
+  return 'openai'
+}
+
+// A recipe whose plugin SDK enables promptBridge must resolve an agent
+// (spec.agent or a step agent with provider + model) or it fails after install.
+function recipeAgentRequirement(parsed: Record<string, unknown> | null): {
+  needsAgent: boolean
+  allowedModels: string[]
+} {
+  if (!isPlainObject(parsed) || !isPlainObject(parsed.spec)) {
+    return { needsAgent: false, allowedModels: [] }
+  }
+  const spec = parsed.spec
+  const sdk = isPlainObject(spec.pluginWorkloadSdk) ? spec.pluginWorkloadSdk : null
+  const promptBridge = sdk && isPlainObject(sdk.promptBridge) ? sdk.promptBridge : null
+  if (!promptBridge) return { needsAgent: false, allowedModels: [] }
+  const agent = isPlainObject(spec.agent) ? spec.agent : null
+  const hasSpecAgent =
+    !!agent && typeof agent.provider === 'string' && typeof agent.model === 'string'
+  const steps =
+    isPlainObject(spec.workflow) && Array.isArray(spec.workflow.steps) ? spec.workflow.steps : []
+  const hasStepAgent = steps.some(
+    s =>
+      isPlainObject(s) &&
+      isPlainObject(s.agent) &&
+      typeof s.agent.provider === 'string' &&
+      typeof s.agent.model === 'string'
+  )
+  const allowedModels = Array.isArray(promptBridge.allowedModels)
+    ? promptBridge.allowedModels.filter((m): m is string => typeof m === 'string')
+    : []
+  return { needsAgent: !(hasSpecAgent || hasStepAgent), allowedModels }
+}
+
+// Inject spec.agent into the parsed recipe, returning the JSON manifest (same
+// serialization the egress editor uses).
+function applyRecipeAgent(
+  parsed: Record<string, unknown>,
+  provider: string,
+  model: string
+): string {
+  const next = JSON.parse(JSON.stringify(parsed)) as Record<string, unknown>
+  if (!isPlainObject(next.spec)) throw new Error('Recipe spec must be an object')
+  next.spec.agent = { provider, model }
+  return JSON.stringify(next, null, 2)
+}
+
 function RegistryRecipeInstallPreview({
   entry,
   onCancel,
@@ -130,6 +212,9 @@ function RegistryRecipeInstallPreview({
   const [recipeText, setRecipeText] = useState(
     typeof entry.recipe_meta?.recipeYaml === 'string' ? entry.recipe_meta.recipeYaml : ''
   )
+  // Agent to inject when the recipe's promptBridge needs one (provider + model).
+  const [agentModel, setAgentModel] = useState('')
+  const [agentProvider, setAgentProvider] = useState('')
 
   useEffect(() => {
     setRecipeText(
@@ -145,6 +230,22 @@ function RegistryRecipeInstallPreview({
     [parseResult.parsed]
   )
   const parsedRecipe = validation?.parsed ?? parseResult.parsed
+  const agentReq = useMemo(
+    () => recipeAgentRequirement((parsedRecipe as Record<string, unknown> | null) ?? null),
+    [parsedRecipe]
+  )
+  const allowedModelsKey = agentReq.allowedModels.join('\n')
+  useEffect(() => {
+    if (agentReq.needsAgent && agentReq.allowedModels.length > 0) {
+      const first = agentReq.allowedModels[0]
+      setAgentModel(first)
+      setAgentProvider(providerForModel(first))
+    } else {
+      setAgentModel('')
+      setAgentProvider('')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentReq.needsAgent, allowedModelsKey])
   const transportEgressTargets = useMemo(
     () => workflowTransportWorkloads(parsedRecipe as Record<string, unknown> | null),
     [parsedRecipe]
@@ -190,10 +291,15 @@ function RegistryRecipeInstallPreview({
     setSubmitting(true)
     setSubmitError('')
     try {
+      // Inject the chosen agent when the recipe's promptBridge requires one.
+      const manifest =
+        agentReq.needsAgent && agentProvider && agentModel && isPlainObject(parsedRecipe)
+          ? applyRecipeAgent(parsedRecipe, agentProvider, agentModel)
+          : recipeText
       const result = await installRecipeFromRegistry({
         registryEntryName: entry.name,
         registryEntryVersion: entry.version,
-        recipeManifest: recipeText,
+        recipeManifest: manifest,
       })
       showToast(`Installed ${entry.name} v${entry.version}.`, { tone: 'success' })
       onInstalled(result.recipeName)
@@ -229,15 +335,73 @@ function RegistryRecipeInstallPreview({
 
               <div className="cu-card">
                 <div className="cu-card__body">
-                  <strong>
-                    {entry.name} v{entry.version}
-                  </strong>
+                  <div className="cu-table-actions" style={{ justifyContent: 'flex-start' }}>
+                    <strong>
+                      {entry.name} v{entry.version}
+                    </strong>
+                    {entry.visibility ? (
+                      <span
+                        className={`cu-registry-chip cu-registry-chip--visibility-${entry.visibility}`}
+                      >
+                        {entry.visibility === 'private' ? 'Private' : 'Public'}
+                      </span>
+                    ) : null}
+                  </div>
                   <p className="cu-muted" style={{ margin: '6px 0 0' }}>
                     {entry.description}
                   </p>
                 </div>
               </div>
             </div>
+
+            {agentReq.needsAgent ? (
+              <div className="cu-form-section">
+                <div className="cu-form-section__header">
+                  <h3 className="cu-form-section__title">Agent</h3>
+                  <p className="cu-form-section__description">
+                    This plugin uses the prompt bridge, so it needs an LLM agent (provider + model).
+                  </p>
+                </div>
+                <p className="cu-banner cu-banner--warn" role="status">
+                  Pick an agent for this plugin — without one it will fail after install.
+                </p>
+                <div className="cu-field">
+                  <label htmlFor="install-agent-model">Model</label>
+                  <SelectInput
+                    id="install-agent-model"
+                    value={agentModel}
+                    onChange={e => {
+                      const m = e.target.value
+                      setAgentModel(m)
+                      setAgentProvider(providerForModel(m))
+                    }}
+                  >
+                    {agentReq.allowedModels.length === 0 ? (
+                      <option value="">(no models listed)</option>
+                    ) : null}
+                    {agentReq.allowedModels.map(m => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                  </SelectInput>
+                </div>
+                <div className="cu-field">
+                  <label htmlFor="install-agent-provider">Provider</label>
+                  <SelectInput
+                    id="install-agent-provider"
+                    value={agentProvider}
+                    onChange={e => setAgentProvider(e.target.value)}
+                  >
+                    {AGENT_PROVIDERS.map(p => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                  </SelectInput>
+                </div>
+              </div>
+            ) : null}
           </div>
         ) : null}
 
@@ -326,6 +490,14 @@ function RegistryRecipeInstallPreview({
                     <div style={{ marginTop: 4 }}>
                       Bindings: {finding.bindingCount}. Mode: {finding.mode}.
                     </div>
+                    {finding.targets && finding.targets.length > 0 ? (
+                      <div style={{ marginTop: 4 }}>
+                        Hosts: {finding.targets.join(', ')}
+                        {finding.ports && finding.ports.length > 0
+                          ? ` · Ports: ${finding.ports.join(', ')}`
+                          : ''}
+                      </div>
+                    ) : null}
                   </div>
                 ))}
               </div>
@@ -428,6 +600,17 @@ function RegistryInstallPageContent() {
     void loadEntry()
   }, [entryName, entryVersion])
 
+  const isPrivate = entry?.visibility === 'private'
+  const kindLabel = entry?.entry_type === 'recipe' ? 'plugin' : 'connector'
+  // Scoped names are stored as `@org/name`; surface the org for a private entry.
+  const orgScope = entry ? (entry.name.match(/^(@[^/]+)\//)?.[1] ?? null) : null
+  const headerTitle = isPrivate ? `Install a private ${kindLabel}` : 'Install from Marketplace'
+  const headerSubtitle = isPrivate
+    ? `Install ${entry?.name}, a private ${kindLabel} from your organization${
+        orgScope ? ` ${orgScope}` : ''
+      }, into your cluster and bind it to a context.`
+    : 'Install a Marketplace entry into your cluster and bind it to a context.'
+
   return (
     <AuthGate>
       <DashboardLayout isDetailPage>
@@ -442,8 +625,8 @@ function RegistryInstallPageContent() {
             header={
               <CreatePageHeader
                 icon={<IconStore />}
-                title="Install from Marketplace"
-                subtitle="Install a Marketplace entry into your cluster and bind it to a context."
+                title={headerTitle}
+                subtitle={headerSubtitle}
                 backLabel="Back to Marketplace"
                 onBack={() => router.push(CONTROL_ROUTES.marketplace.root)}
               />

--- a/control-ui/app/registry/install/page.tsx
+++ b/control-ui/app/registry/install/page.tsx
@@ -153,7 +153,8 @@ function providerForModel(model: string): string {
 
 // A recipe whose plugin SDK enables promptBridge must resolve an agent
 // (spec.agent or a step agent with provider + model) or it fails after install.
-function recipeAgentRequirement(parsed: Record<string, unknown> | null): {
+// Exported for direct unit coverage of the agent-resolution rule.
+export function recipeAgentRequirement(parsed: Record<string, unknown> | null): {
   needsAgent: boolean
   allowedModels: string[]
 } {
@@ -167,8 +168,11 @@ function recipeAgentRequirement(parsed: Record<string, unknown> | null): {
   const agent = isPlainObject(spec.agent) ? spec.agent : null
   const hasSpecAgent =
     !!agent && typeof agent.provider === 'string' && typeof agent.model === 'string'
-  const steps =
-    isPlainObject(spec.workflow) && Array.isArray(spec.workflow.steps) ? spec.workflow.steps : []
+  // Steps live at spec.steps in the CRD (charts/clerum-crds/crds/workflowrecipe.yaml),
+  // NOT spec.workflow.steps (no such property). Mirror the canonical resolver in
+  // workflow-recipes/src/workflow/agentResolution.ts (resolveMcpHostAgent) so this
+  // wizard check can't drift from the reconciler and silently override a step agent.
+  const steps = Array.isArray(spec.steps) ? spec.steps : []
   const hasStepAgent = steps.some(
     s =>
       isPlainObject(s) &&

--- a/control-ui/app/registry/install/page.tsx
+++ b/control-ui/app/registry/install/page.tsx
@@ -18,9 +18,10 @@ import { CREATE_FLOW_LOADING } from '@constants/createFlowLoading'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { DEFAULT_WORKFLOW_RECIPE_NAMESPACE } from '@constants/workflowRecipes'
 import { getRegistryEntryVersion, installRecipeFromRegistry } from '@lib/api'
-import type { RegistryEntry } from '@lib/api'
+import type { LlmAllowedModel, RegistryEntry } from '@lib/api'
 import { analyzeWorkflowRecipeEgress } from '@lib/egressModel'
 import type { EgressBinding, EgressEditorStatus } from '@lib/egressModel'
+import { useLlmAllowedModels } from '@lib/hooks/useLlmAllowedModels'
 import { validateRecipe } from '@lib/recipeValidator'
 
 type TransportWorkloadEditorTarget = {
@@ -114,41 +115,26 @@ function applyWorkflowWorkloadEgress(
   return JSON.stringify(next, null, 2)
 }
 
-// spec.agent.provider enum (WorkflowRecipe CRD).
-const AGENT_PROVIDERS = [
-  'openai',
-  'claude',
-  'zai',
-  'bailian',
-  'vertex',
-  'openrouter',
-  'gemini',
-  'deepseek',
-  'groq',
-  'together',
-  'fireworks',
-  'mistral',
-  'xai',
-  'cerebras',
-  'deepinfra',
-  'perplexity',
-  'moonshot',
-  'nebius',
-  'novita',
-] as const
+// Resolve a model's provider from the operator's authoritative model allowlist
+// (useLlmAllowedModels → /admin/llm-models) — the single source of the exact
+// model→provider mapping. Returns '' when the model isn't in the catalog so the
+// user picks a provider explicitly instead of being handed a wrong guess; this
+// follows the "no hardcoded fallback" rule the rest of the LLM UI uses
+// (lib/llm.ts, spec R4.5.1). A string heuristic mis-derived roughly half the
+// providers (e.g. groq/cerebras/moonshot/perplexity/bailian models → openai).
+export function providerForModel(model: string, catalog: LlmAllowedModel[]): string {
+  return catalog.find(row => row.model === model)?.provider ?? ''
+}
 
-// Best-effort provider guess from a model id; the user can override it.
-function providerForModel(model: string): string {
-  const m = model.toLowerCase()
-  if (m.startsWith('gpt') || m.startsWith('o1') || m.startsWith('o3') || m.startsWith('chatgpt'))
-    return 'openai'
-  if (m.includes('claude')) return 'claude'
-  if (m.includes('glm')) return 'zai'
-  if (m.includes('gemini')) return 'gemini'
-  if (m.includes('deepseek')) return 'deepseek'
-  if (m.includes('grok')) return 'xai'
-  if (m.includes('mistral') || m.includes('mixtral')) return 'mistral'
-  return 'openai'
+// Distinct providers the operator has enabled, for the override dropdown. Keeps
+// the picker honest — only providers with configured credentials are offered,
+// instead of a static enum of all 21.
+export function enabledProviders(catalog: LlmAllowedModel[]): string[] {
+  const seen = new Set<string>()
+  for (const row of catalog) {
+    if (row.enabled) seen.add(row.provider)
+  }
+  return Array.from(seen).sort()
 }
 
 // A recipe whose plugin SDK enables promptBridge must resolve an agent
@@ -219,6 +205,10 @@ function RegistryRecipeInstallPreview({
   // Agent to inject when the recipe's promptBridge needs one (provider + model).
   const [agentModel, setAgentModel] = useState('')
   const [agentProvider, setAgentProvider] = useState('')
+  // Operator-declared model allowlist (/admin/llm-models): the authoritative
+  // model→provider map and the set of providers enabled in this deployment.
+  const { models: llmCatalog } = useLlmAllowedModels()
+  const catalogKey = llmCatalog.map(r => `${r.provider}:${r.model}:${r.enabled}`).join('\n')
 
   useEffect(() => {
     setRecipeText(
@@ -243,13 +233,20 @@ function RegistryRecipeInstallPreview({
     if (agentReq.needsAgent && agentReq.allowedModels.length > 0) {
       const first = agentReq.allowedModels[0]
       setAgentModel(first)
-      setAgentProvider(providerForModel(first))
+      setAgentProvider(providerForModel(first, llmCatalog))
     } else {
       setAgentModel('')
       setAgentProvider('')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentReq.needsAgent, allowedModelsKey])
+  }, [agentReq.needsAgent, allowedModelsKey, catalogKey])
+  const agentProviderOptions = useMemo(() => {
+    const opts = enabledProviders(llmCatalog)
+    // Keep the derived/selected provider selectable even if the operator has not
+    // enabled it yet, so the value is never silently dropped from the picker.
+    return agentProvider && !opts.includes(agentProvider) ? [agentProvider, ...opts] : opts
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogKey, agentProvider])
   const transportEgressTargets = useMemo(
     () => workflowTransportWorkloads(parsedRecipe as Record<string, unknown> | null),
     [parsedRecipe]
@@ -377,7 +374,7 @@ function RegistryRecipeInstallPreview({
                     onChange={e => {
                       const m = e.target.value
                       setAgentModel(m)
-                      setAgentProvider(providerForModel(m))
+                      setAgentProvider(providerForModel(m, llmCatalog))
                     }}
                   >
                     {agentReq.allowedModels.length === 0 ? (
@@ -397,7 +394,10 @@ function RegistryRecipeInstallPreview({
                     value={agentProvider}
                     onChange={e => setAgentProvider(e.target.value)}
                   >
-                    {AGENT_PROVIDERS.map(p => (
+                    {agentProviderOptions.length === 0 ? (
+                      <option value="">(no providers enabled)</option>
+                    ) : null}
+                    {agentProviderOptions.map(p => (
                       <option key={p} value={p}>
                         {p}
                       </option>

--- a/control-ui/app/registry/org/connection/page.tsx
+++ b/control-ui/app/registry/org/connection/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { AuthGate } from '@components/AuthGate'
+import { DashboardLayout } from '@components/DashboardLayout'
+import { MarketplaceOrgArea } from '@components/MarketplaceOrgArea'
+
+export default function MarketplaceOrgConnectionPage() {
+  return (
+    <AuthGate>
+      <DashboardLayout isDetailPage>
+        <MarketplaceOrgArea activeTab="connection" />
+      </DashboardLayout>
+    </AuthGate>
+  )
+}

--- a/control-ui/app/registry/org/credentials/page.tsx
+++ b/control-ui/app/registry/org/credentials/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { AuthGate } from '@components/AuthGate'
+import { DashboardLayout } from '@components/DashboardLayout'
+import { MarketplaceOrgArea } from '@components/MarketplaceOrgArea'
+
+export default function MarketplaceOrgCredentialsPage() {
+  return (
+    <AuthGate>
+      <DashboardLayout isDetailPage>
+        <MarketplaceOrgArea activeTab="credentials" />
+      </DashboardLayout>
+    </AuthGate>
+  )
+}

--- a/control-ui/app/registry/org/entries/page.tsx
+++ b/control-ui/app/registry/org/entries/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { AuthGate } from '@components/AuthGate'
+import { DashboardLayout } from '@components/DashboardLayout'
+import { MarketplaceOrgArea } from '@components/MarketplaceOrgArea'
+
+export default function MarketplaceOrgEntriesPage() {
+  return (
+    <AuthGate>
+      <DashboardLayout isDetailPage>
+        <MarketplaceOrgArea activeTab="entries" />
+      </DashboardLayout>
+    </AuthGate>
+  )
+}

--- a/control-ui/app/registry/org/images/page.tsx
+++ b/control-ui/app/registry/org/images/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { AuthGate } from '@components/AuthGate'
+import { DashboardLayout } from '@components/DashboardLayout'
+import { MarketplaceOrgArea } from '@components/MarketplaceOrgArea'
+
+export default function MarketplaceOrgImagesPage() {
+  return (
+    <AuthGate>
+      <DashboardLayout isDetailPage>
+        <MarketplaceOrgArea activeTab="images" />
+      </DashboardLayout>
+    </AuthGate>
+  )
+}

--- a/control-ui/app/registry/org/page.tsx
+++ b/control-ui/app/registry/org/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+import { CONTROL_ROUTES } from '@constants/routes'
+
+export default function MarketplaceOrgPage() {
+  redirect(CONTROL_ROUTES.marketplace.orgCredentials)
+}

--- a/control-ui/app/workflow-recipes/page.tsx
+++ b/control-ui/app/workflow-recipes/page.tsx
@@ -69,7 +69,7 @@ function WorkflowRecipesPageContent() {
         items={recipes}
         loading={loading}
         error={surfaceError}
-        onInstall={() => router.push(CONTROL_ROUTES.marketplace.org)}
+        onInstall={() => router.push(CONTROL_ROUTES.marketplace.orgEntries)}
         onRefresh={refresh}
       />
     </DashboardLayout>

--- a/control-ui/app/workflow-recipes/page.tsx
+++ b/control-ui/app/workflow-recipes/page.tsx
@@ -1,16 +1,11 @@
 'use client'
 
-import { Suspense, useEffect, useRef, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@components/AuthContext'
-import { CreateFlowSkeleton } from '@components/CreateFlowSkeleton'
-import { CreatePageHeader } from '@components/CreatePageHeader'
 import { DashboardLayout } from '@components/DashboardLayout'
 import { LoadingScreen } from '@components/LoadingScreen'
-import { RecipeEditor } from '@components/RecipeEditor'
 import { RecipesTab } from '@components/RecipesTab'
-import { IconWorkflow } from '@components/Sidebar/icons'
-import { CREATE_FLOW_LOADING } from '@constants/createFlowLoading'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { isSilentApiError } from '@lib/api'
 import { buildControlUiLoginPath, getCurrentControlUiPath } from '@lib/authRedirect'
@@ -32,9 +27,6 @@ function WorkflowRecipesPageContent() {
   const searchParams = useSearchParams()
 
   const [pageError, setPageError] = useState('')
-  const [installerOpen, setInstallerOpen] = useState(false)
-  const [installerStarting, setInstallerStarting] = useState(false)
-  const installerTimerRef = useRef<number | null>(null)
   const { recipes, loading, error, refresh } = useRecipePolling({
     enabled: authState.isLoggedIn && !authState.isLoading,
     onError: fetchError => {
@@ -63,23 +55,6 @@ function WorkflowRecipesPageContent() {
     }
   }, [authState.isLoading, authState.isLoggedIn, router])
 
-  useEffect(() => {
-    if (!installerStarting) return
-    // Keep the skeleton visible briefly so the install drawer transition can settle
-    // before the heavier installer content renders, avoiding a one-frame layout flash.
-    installerTimerRef.current = window.setTimeout(() => {
-      setInstallerOpen(true)
-      setInstallerStarting(false)
-      installerTimerRef.current = null
-    }, 120)
-    return () => {
-      if (installerTimerRef.current !== null) {
-        window.clearTimeout(installerTimerRef.current)
-        installerTimerRef.current = null
-      }
-    }
-  }, [installerStarting])
-
   if (authState.isLoading) {
     return <LoadingScreen />
   }
@@ -89,52 +64,14 @@ function WorkflowRecipesPageContent() {
   }
 
   return (
-    <DashboardLayout isDetailPage={installerOpen || installerStarting}>
-      {installerStarting ? (
-        <CreateFlowSkeleton
-          {...CREATE_FLOW_LOADING.installPlugin}
-          onBack={() => {
-            setPageError('')
-            setInstallerStarting(false)
-          }}
-          backDisabled={false}
-        />
-      ) : installerOpen ? (
-        <RecipeEditor
-          onSaved={() => {
-            setPageError('')
-            setInstallerOpen(false)
-            void refresh()
-          }}
-          onCancel={() => {
-            setPageError('')
-            setInstallerOpen(false)
-          }}
-          pageHeader={
-            <CreatePageHeader
-              icon={<IconWorkflow />}
-              title="Install Plugin"
-              subtitle="Prepare a plugin manifest, validate policy, and deploy it."
-              backLabel="Back to plugins"
-              onBack={() => {
-                setPageError('')
-                setInstallerOpen(false)
-              }}
-            />
-          }
-        />
-      ) : (
-        <RecipesTab
-          items={recipes}
-          loading={loading}
-          error={surfaceError}
-          onInstall={() => {
-            setPageError('')
-            setInstallerStarting(true)
-          }}
-          onRefresh={refresh}
-        />
-      )}
+    <DashboardLayout>
+      <RecipesTab
+        items={recipes}
+        loading={loading}
+        error={surfaceError}
+        onInstall={() => router.push(CONTROL_ROUTES.marketplace.org)}
+        onRefresh={refresh}
+      />
     </DashboardLayout>
   )
 }

--- a/control-ui/components/AuthContext.tsx
+++ b/control-ui/components/AuthContext.tsx
@@ -12,6 +12,7 @@ import {
   setGlobalAuthErrorHandler,
 } from '../lib/api'
 import { buildControlUiLoginPath, getCurrentControlUiPath } from '../lib/authRedirect'
+import { invalidateRegistryCapabilityCache } from '../lib/hooks/useRegistryCapability'
 import { useToast } from './Toast'
 
 type AuthState = {
@@ -102,6 +103,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       await logoutControlUI()
     } finally {
       sessionExpiredToastShownRef.current = false
+      // Drop the module-level registry-capability cache so a same-tab
+      // logout→login doesn't serve the previous user's org identity.
+      invalidateRegistryCapabilityCache()
       setAuthState({ id: '', isLoggedIn: false, isLoading: false, username: '', email: '' })
       router.replace(CONTROL_ROUTES.login)
     }

--- a/control-ui/components/DashboardLayout.tsx
+++ b/control-ui/components/DashboardLayout.tsx
@@ -52,9 +52,6 @@ export function DashboardLayout({ children, isDetailPage = false }: DashboardLay
     if (isControlRouteSection(pathname, CONTROL_ROUTES.marketplace.root)) {
       return 'registry-catalog'
     }
-    if (isControlRouteSection(pathname, CONTROL_ROUTES.publisher.root)) {
-      return 'publisher'
-    }
     if (isControlRouteSection(pathname, CONTROL_ROUTES.llmModels.root)) {
       return 'llm-models'
     }

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -6,7 +6,6 @@ import { useInboundGrants } from '../../lib/hooks/useInboundGrants'
 import { useRegistryCapability } from '../../lib/hooks/useRegistryCapability'
 import { MarketplaceOrgImages } from '../MarketplaceOrgImages'
 import { MarketplaceTabs } from '../MarketplaceTabs'
-import { DockerCredentialsPanel } from '../PublisherView/DockerCredentials'
 import { OwnedEntries } from '../PublisherView/OwnedEntries'
 import { RetryBanner } from '../PublisherView/RetryBanner'
 import RegistryApiKeysPanel from '../RegistryApiKeysPanel'
@@ -82,12 +81,10 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
 
           {/* Entries is a publishing surface, so it follows the publishing-UI
               toggle (canManageOrg). Credentials and Connection do NOT — turning
-              publishing off must not remove push credentials or the connection
-              status (design spec §6). The Credentials tab renders the registry
-              API keys (self-gating) and, once the org scope is known, the Docker
-              push credential — the target of the Images tab's "get a push
-              credential from the API Keys tab" pointer. Design spec §5.1 folds
-              both into a unified RegistryCredentials view in Phase 5. */}
+              publishing off must not remove API keys or the connection status
+              (design spec §6). The Credentials tab is the single registry-key
+              surface (self-gating); a registry:publish key doubles as the Docker
+              push credential, surfaced in the key's reveal dialog. */}
           {activeTab === 'entries' ? (
             loading ? (
               <p>Loading…</p>
@@ -118,15 +115,7 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
             )
           ) : null}
 
-          {activeTab === 'credentials' ? (
-            <>
-              <RegistryApiKeysPanel />
-              {/* Gated on the org scope (needed to build the push coordinates),
-                  not on the publishing toggle — push credentials survive
-                  publishing being turned off (§6). */}
-              {orgScope ? <DockerCredentialsPanel orgScope={orgScope} /> : null}
-            </>
-          ) : null}
+          {activeTab === 'credentials' ? <RegistryApiKeysPanel /> : null}
 
           {activeTab === 'connection' ? <RegistryConnectPanel /> : null}
         </div>

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -8,6 +8,7 @@ import { MarketplaceOrgImages } from '../MarketplaceOrgImages'
 import { MarketplaceTabs } from '../MarketplaceTabs'
 import { DockerCredentialsPanel } from '../PublisherView/DockerCredentials'
 import { OwnedEntries } from '../PublisherView/OwnedEntries'
+import { RetryBanner } from '../PublisherView/RetryBanner'
 import RegistryApiKeysPanel from '../RegistryApiKeysPanel'
 import RegistryConnectPanel from '../RegistryConnectPanel'
 import { TabBar } from '../TabBar'
@@ -45,7 +46,7 @@ function NotClaimed({ action }: { action: string }) {
  * connection status, so those sub-tabs are always reachable.
  */
 export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
-  const { capability, loading } = useRegistryCapability()
+  const { capability, loading, error, reload } = useRegistryCapability()
   const inbound = useInboundGrants()
 
   const orgName = capability?.orgName ?? null
@@ -90,6 +91,10 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
           {activeTab === 'entries' ? (
             loading ? (
               <p>Loading…</p>
+            ) : error ? (
+              // A transient capability-probe failure must NOT be read as an
+              // unclaimed org — that would falsely prompt a re-claim. Offer Retry.
+              <RetryBanner message="Couldn’t load your organization." onRetry={reload} />
             ) : canManageOrg && orgScope ? (
               <OwnedEntries
                 orgScope={orgScope}
@@ -104,6 +109,8 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
           {activeTab === 'images' ? (
             loading ? (
               <p>Loading…</p>
+            ) : error ? (
+              <RetryBanner message="Couldn’t load your organization." onRetry={reload} />
             ) : canManageOrg && orgScope ? (
               <MarketplaceOrgImages orgScope={orgScope} />
             ) : (

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -6,6 +6,7 @@ import { useInboundGrants } from '../../lib/hooks/useInboundGrants'
 import { useRegistryCapability } from '../../lib/hooks/useRegistryCapability'
 import { MarketplaceOrgImages } from '../MarketplaceOrgImages'
 import { MarketplaceTabs } from '../MarketplaceTabs'
+import { DockerCredentialsPanel } from '../PublisherView/DockerCredentials'
 import { OwnedEntries } from '../PublisherView/OwnedEntries'
 import RegistryApiKeysPanel from '../RegistryApiKeysPanel'
 import RegistryConnectPanel from '../RegistryConnectPanel'
@@ -81,8 +82,11 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
           {/* Entries is a publishing surface, so it follows the publishing-UI
               toggle (canManageOrg). Credentials and Connection do NOT — turning
               publishing off must not remove push credentials or the connection
-              status (design spec §6). DockerCredentialsPanel self-gates via the
-              keys API, so it renders regardless. */}
+              status (design spec §6). The Credentials tab renders the registry
+              API keys (self-gating) and, once the org scope is known, the Docker
+              push credential — the target of the Images tab's "get a push
+              credential from the API Keys tab" pointer. Design spec §5.1 folds
+              both into a unified RegistryCredentials view in Phase 5. */}
           {activeTab === 'entries' ? (
             loading ? (
               <p>Loading…</p>
@@ -107,7 +111,15 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
             )
           ) : null}
 
-          {activeTab === 'credentials' ? <RegistryApiKeysPanel /> : null}
+          {activeTab === 'credentials' ? (
+            <>
+              <RegistryApiKeysPanel />
+              {/* Gated on the org scope (needed to build the push coordinates),
+                  not on the publishing toggle — push credentials survive
+                  publishing being turned off (§6). */}
+              {orgScope ? <DockerCredentialsPanel orgScope={orgScope} /> : null}
+            </>
+          ) : null}
 
           {activeTab === 'connection' ? <RegistryConnectPanel /> : null}
         </div>

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { CONTROL_ROUTES } from '@constants/routes'
+import { useInboundGrants } from '../../lib/hooks/useInboundGrants'
+import { useRegistryCapability } from '../../lib/hooks/useRegistryCapability'
+import { MarketplaceOrgImages } from '../MarketplaceOrgImages'
+import { MarketplaceTabs } from '../MarketplaceTabs'
+import { OwnedEntries } from '../PublisherView/OwnedEntries'
+import RegistryApiKeysPanel from '../RegistryApiKeysPanel'
+import RegistryConnectPanel from '../RegistryConnectPanel'
+import { TabBar } from '../TabBar'
+import { TablePanelHeader } from '../TablePanelHeader'
+
+export type OrgAreaTab = 'entries' | 'images' | 'credentials' | 'connection'
+
+const SUB_TABS: { value: OrgAreaTab; href: string; label: string }[] = [
+  { value: 'credentials', href: CONTROL_ROUTES.marketplace.orgCredentials, label: 'API Keys' },
+  { value: 'entries', href: CONTROL_ROUTES.marketplace.orgEntries, label: 'Entries' },
+  { value: 'images', href: CONTROL_ROUTES.marketplace.orgImages, label: 'Images' },
+  // Connection sub-tab hidden for now: once connected it only shows a static,
+  // non-actionable status. Claiming still lives at the standalone connect page,
+  // and Phase 3 replaces it with an inline claim. Restore to bring it back.
+  // { value: 'connection', href: CONTROL_ROUTES.marketplace.orgConnection, label: 'Connection' },
+]
+
+function NotClaimed({ action }: { action: string }) {
+  return (
+    <p className="cu-banner cu-banner--info">
+      Name your organization to {action}.{' '}
+      <a className="cu-link" href={CONTROL_ROUTES.marketplace.connect}>
+        Connect to the registry
+      </a>{' '}
+      to get started.
+    </p>
+  )
+}
+
+/**
+ * The org-named Marketplace tab (design spec §4): a single home for everything
+ * this deployment owns — its published entries, push credentials, and its
+ * registry connection. This folds the standalone Publisher console into the
+ * Marketplace. Publishing being disabled must not hide credentials or the
+ * connection status, so those sub-tabs are always reachable.
+ */
+export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
+  const { capability, loading } = useRegistryCapability()
+  const inbound = useInboundGrants()
+
+  const orgName = capability?.orgName ?? null
+  const orgLabel = orgName ? `@${orgName}` : loading ? 'Organization' : 'Your org'
+  const orgScope = capability?.scope ?? null
+  const canManageOrg = capability?.canManageOrg === true
+  // Cross-org sharing availability, mirrored from the inbound-grants probe.
+  const canShare = inbound.status === 'available' || inbound.status === 'error'
+  const sharingUnavailable = inbound.status === 'unavailable'
+
+  return (
+    <section>
+      <div className="cu-card cu-card--viewport-fill">
+        <MarketplaceTabs active="org" />
+        <TablePanelHeader title={orgLabel} subtitle="Everything your org owns on the registry" />
+        <div className="cu-card__body">
+          <TabBar<OrgAreaTab>
+            ariaLabel="Organization sections"
+            activeValue={activeTab}
+            className="cu-tabs--flush-top"
+            options={SUB_TABS}
+          />
+
+          {/* Entries is a publishing surface, so it follows the publishing-UI
+              toggle (canManageOrg). Credentials and Connection do NOT — turning
+              publishing off must not remove push credentials or the connection
+              status (design spec §6). DockerCredentialsPanel self-gates via the
+              keys API, so it renders regardless. */}
+          {activeTab === 'entries' ? (
+            loading ? (
+              <p>Loading…</p>
+            ) : canManageOrg && orgScope ? (
+              <OwnedEntries
+                orgScope={orgScope}
+                canShare={canShare}
+                sharingUnavailable={sharingUnavailable}
+              />
+            ) : (
+              <NotClaimed action="publish and manage entries" />
+            )
+          ) : null}
+
+          {activeTab === 'images' ? (
+            loading ? (
+              <p>Loading…</p>
+            ) : canManageOrg && orgScope ? (
+              <MarketplaceOrgImages orgScope={orgScope} />
+            ) : (
+              <NotClaimed action="push and manage images" />
+            )
+          ) : null}
+
+          {activeTab === 'credentials' ? <RegistryApiKeysPanel /> : null}
+
+          {activeTab === 'connection' ? <RegistryConnectPanel /> : null}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { useInboundGrants } from '../../lib/hooks/useInboundGrants'
 import { useRegistryCapability } from '../../lib/hooks/useRegistryCapability'
@@ -48,6 +49,16 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
 
   const orgName = capability?.orgName ?? null
   const orgLabel = orgName ? `@${orgName}` : loading ? 'Organization' : 'Your org'
+  // Once we know the org, its name is a shortcut into the org's own published
+  // plugins (the Entries tab). While the name is still resolving, keep it plain
+  // text so we don't link a placeholder label.
+  const orgTitle = orgName ? (
+    <Link className="cu-link" href={CONTROL_ROUTES.marketplace.orgEntries}>
+      {orgLabel}
+    </Link>
+  ) : (
+    orgLabel
+  )
   const orgScope = capability?.scope ?? null
   const canManageOrg = capability?.canManageOrg === true
   // Cross-org sharing availability, mirrored from the inbound-grants probe.
@@ -58,7 +69,7 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
     <section>
       <div className="cu-card cu-card--viewport-fill">
         <MarketplaceTabs active="org" />
-        <TablePanelHeader title={orgLabel} subtitle="Everything your org owns on the registry" />
+        <TablePanelHeader title={orgTitle} subtitle="Everything your org owns on the registry" />
         <div className="cu-card__body">
           <TabBar<OrgAreaTab>
             ariaLabel="Organization sections"

--- a/control-ui/components/MarketplaceOrgImages/index.tsx
+++ b/control-ui/components/MarketplaceOrgImages/index.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { CONTROL_ROUTES } from '@constants/routes'
+import { type OrgImage, listOrgImages } from '../../lib/api'
+import { RetryBanner } from '../PublisherView/RetryBanner'
+import {
+  DEFAULT_REGISTRY_HOST,
+  buildImageCoordinate,
+  dockerNamespace,
+} from '../PublisherView/dockerCredential'
+import { TableHeaderRow } from '../TableHeaderRow'
+import type { TableHeaderColumn } from '../TableHeaderRow/types'
+
+const COLUMNS: TableHeaderColumn[] = [
+  { key: 'image', label: 'Image' },
+  { key: 'tag', label: 'Tag' },
+  { key: 'coordinate', label: 'Coordinate' },
+]
+
+type View =
+  | { kind: 'loading' }
+  | { kind: 'ready'; images: OrgImage[] }
+  | { kind: 'unavailable' } // registry hasn't exposed the image-listing endpoint yet
+  | { kind: 'error' }
+
+/**
+ * Images area (design spec §4/§5.5). Lists the org's actual container image
+ * repositories from the registry with their fully-qualified coordinate. Until
+ * the registry exposes the listing endpoint, this shows an "unavailable" notice
+ * rather than failing.
+ */
+export function MarketplaceOrgImages({ orgScope }: { orgScope: string }) {
+  const [view, setView] = useState<View>({ kind: 'loading' })
+
+  const load = useCallback(async () => {
+    setView({ kind: 'loading' })
+    try {
+      const { images } = await listOrgImages()
+      setView({ kind: 'ready', images })
+    } catch (e) {
+      const status = (e as { status?: number }).status
+      // The registry image-listing endpoint may not be deployed yet.
+      if (status === 404 || status === 501) setView({ kind: 'unavailable' })
+      else setView({ kind: 'error' })
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const namespace = dockerNamespace(orgScope)
+
+  // One row per (image, tag). The registry lists repos without tags today, so a
+  // tag-less repo renders with a `<tag>` placeholder in its coordinate.
+  const rows =
+    view.kind === 'ready'
+      ? (view.images ?? []).flatMap(img =>
+          (img.tags ?? []).length > 0
+            ? img.tags.map(tag => ({ name: img.name, tag }))
+            : [{ name: img.name, tag: '<tag>' }]
+        )
+      : []
+
+  return (
+    <div>
+      <p className="cu-field__hint">
+        Your connectors and plugins push container images to{' '}
+        <code>
+          {DEFAULT_REGISTRY_HOST}/{namespace}/
+        </code>
+        . Authenticate with a push credential from the{' '}
+        <a className="cu-link" href={CONTROL_ROUTES.marketplace.orgCredentials}>
+          API Keys
+        </a>{' '}
+        tab; each image&apos;s full coordinate is below.
+      </p>
+
+      {view.kind === 'loading' ? <p>Loading your images…</p> : null}
+      {view.kind === 'error' ? (
+        <RetryBanner message="Could not load your images." onRetry={() => void load()} />
+      ) : null}
+      {view.kind === 'unavailable' ? (
+        <p className="cu-banner cu-banner--info">
+          Image listing isn’t available on this registry yet. Your pushed images still work — the
+          list will appear here once the registry exposes it.
+        </p>
+      ) : null}
+
+      {view.kind === 'ready' && rows.length === 0 ? (
+        <p>
+          No images yet. Push a connector or plugin image under{' '}
+          <code>
+            {DEFAULT_REGISTRY_HOST}/{namespace}/
+          </code>{' '}
+          and it appears here.
+        </p>
+      ) : null}
+
+      {view.kind === 'ready' && rows.length > 0 ? (
+        <>
+          <div className="cu-table-wrap">
+            <table className="cu-table">
+              <thead>
+                <TableHeaderRow columns={COLUMNS} />
+              </thead>
+              <tbody>
+                {rows.map(r => (
+                  <tr key={`${r.name}:${r.tag}`}>
+                    <td>
+                      <code>{r.name}</code>
+                    </td>
+                    <td>{r.tag}</td>
+                    <td>
+                      <code>
+                        {buildImageCoordinate(DEFAULT_REGISTRY_HOST, orgScope, r.name, r.tag)}
+                      </code>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="cu-muted-note">
+            A push can still be rejected if the credential lacks publish permission or the org has
+            reached its image quota — those surface at push time.
+          </p>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/control-ui/components/MarketplaceTabs.tsx
+++ b/control-ui/components/MarketplaceTabs.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { CONTROL_ROUTES } from '@constants/routes'
+import { useRegistryCapability } from '../lib/hooks/useRegistryCapability'
+import { TabBar } from './TabBar'
+
+export type MarketplaceSection = 'connectors' | 'org'
+
+/**
+ * Top-level Marketplace navigation (design spec §4): browse (Connectors) and
+ * own (the org-named tab). The org tab is labelled with the organization name,
+ * or "Your org" before the deployment is claimed — a single element that
+ * answers "who are we on the registry".
+ */
+export function MarketplaceTabs({ active }: { active: MarketplaceSection }) {
+  const { capability, loading } = useRegistryCapability()
+  // Avoid flashing the misleading "Your org" (which reads as unclaimed) before
+  // the identity resolves; show a neutral label while loading instead.
+  const orgLabel = capability?.orgName
+    ? `@${capability.orgName}`
+    : loading
+      ? 'Organization'
+      : 'Your org'
+
+  return (
+    <TabBar<MarketplaceSection>
+      ariaLabel="Marketplace sections"
+      activeValue={active}
+      className="cu-tabs--flush-top"
+      options={[
+        {
+          value: 'connectors',
+          href: CONTROL_ROUTES.marketplace.connectors,
+          label: 'Marketplace',
+        },
+        {
+          value: 'org',
+          href: CONTROL_ROUTES.marketplace.orgCredentials,
+          label: orgLabel,
+        },
+      ]}
+    />
+  )
+}

--- a/control-ui/components/PluginsEmptyState.tsx
+++ b/control-ui/components/PluginsEmptyState.tsx
@@ -61,21 +61,21 @@ export function PluginsEmptyState() {
         <p>
           {orgTag ? (
             <>
-              Your organization <strong>{orgTag}</strong> is connected
+              Your organization{' '}
+              <a className="cu-link" href={CONTROL_ROUTES.marketplace.orgEntries}>
+                {orgTag}
+              </a>{' '}
+              is connected
             </>
           ) : (
             'Your organization is connected'
           )}
-          {setup.hasKeys === true ? ' and already has API keys' : ''}. Publish a plugin
-          {orgTag ? (
-            <>
-              {' '}
-              under <strong>{orgTag}</strong>
-            </>
-          ) : (
-            ''
-          )}
-          , then install it across your cluster with <strong>Install Plugin</strong>.
+          {setup.hasKeys === true ? ' and already has API keys' : ''}. Publish a plugin, then
+          install it across your cluster with{' '}
+          <a className="cu-link" href={CONTROL_ROUTES.marketplace.org}>
+            Install Plugin
+          </a>
+          .
           {setup.hasKeys === false ? (
             <>
               {' '}

--- a/control-ui/components/PluginsEmptyState.tsx
+++ b/control-ui/components/PluginsEmptyState.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { CONTROL_ROUTES } from '@constants/routes'
+import { listRegistryApiKeys } from '../lib/api'
+
+const PLUGIN_DOCS_URL =
+  'https://github.com/evenfire-ai/evenfire/blob/main/docs/how-to/publish-plugin-to-registry.md'
+
+// A single listRegistryApiKeys() answers everything the copy needs: success
+// means this deployment is connected to an org (and whether it already has
+// keys); a 403 means the org is connected but this admin isn't an owner (keys
+// unknown); a 409 (no_org / auth_disabled / url_not_configured) means there is
+// no org yet, so we show the onboarding path.
+type Setup =
+  | { kind: 'loading' }
+  | { kind: 'onboarding' }
+  | { kind: 'connected'; org?: string; hasKeys: boolean | null }
+
+/**
+ * Empty-state explainer for the Plugins list. Explains what a plugin is, and
+ * adapts the call to action: an already-connected org with keys is told it is
+ * ready to publish, rather than being walked through setup it has done.
+ */
+export function PluginsEmptyState() {
+  const [setup, setSetup] = useState<Setup>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    listRegistryApiKeys().then(
+      ({ org, keys }) => {
+        if (!cancelled) setSetup({ kind: 'connected', org, hasKeys: keys.length > 0 })
+      },
+      (e: unknown) => {
+        if (cancelled) return
+        if ((e as { status?: number }).status === 403) {
+          setSetup({ kind: 'connected', org: (e as { org?: string }).org, hasKeys: null })
+        } else {
+          setSetup({ kind: 'onboarding' })
+        }
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const orgTag = setup.kind === 'connected' && setup.org ? `@${setup.org}` : null
+
+  return (
+    <div className="cu-empty__explainer">
+      <p>
+        <strong>Plugins</strong> are packaged, versioned workflows that run in your cluster. A
+        plugin bundles one or more workloads and how they fire — on a <strong>schedule</strong>{' '}
+        (recurring jobs), from an incoming <strong>webhook</strong>, on a chat message, or on demand
+        — and those workloads can serve a <strong>UI</strong>, expose tools to your agents, or run
+        background automation.
+      </p>
+
+      {setup.kind === 'connected' ? (
+        <p>
+          {orgTag ? (
+            <>
+              Your organization <strong>{orgTag}</strong> is connected
+            </>
+          ) : (
+            'Your organization is connected'
+          )}
+          {setup.hasKeys === true ? ' and already has API keys' : ''}. Publish a plugin
+          {orgTag ? (
+            <>
+              {' '}
+              under <strong>{orgTag}</strong>
+            </>
+          ) : (
+            ''
+          )}
+          , then install it across your cluster with <strong>Install Plugin</strong>.
+          {setup.hasKeys === false ? (
+            <>
+              {' '}
+              To publish from CI or scripts, create an{' '}
+              <a className="cu-link" href={CONTROL_ROUTES.marketplace.keys}>
+                org API key
+              </a>
+              .
+            </>
+          ) : null}
+        </p>
+      ) : (
+        <p>
+          Plugins here are <strong>private to your organization</strong> and shared across it:
+          publish a plugin under your org, then install it across your cluster with{' '}
+          <strong>Install Plugin</strong>. First, name your organization in the registry by{' '}
+          <a className="cu-link" href={CONTROL_ROUTES.marketplace.connect}>
+            connecting
+          </a>{' '}
+          and creating an{' '}
+          <a className="cu-link" href={CONTROL_ROUTES.marketplace.keys}>
+            org API key
+          </a>
+          .
+        </p>
+      )}
+
+      <p>
+        <a className="cu-link" href={PLUGIN_DOCS_URL} target="_blank" rel="noreferrer">
+          Learn more about plugins →
+        </a>
+      </p>
+    </div>
+  )
+}

--- a/control-ui/components/PluginsEmptyState.tsx
+++ b/control-ui/components/PluginsEmptyState.tsx
@@ -72,7 +72,7 @@ export function PluginsEmptyState() {
           )}
           {setup.hasKeys === true ? ' and already has API keys' : ''}. Publish a plugin, then
           install it across your cluster with{' '}
-          <a className="cu-link" href={CONTROL_ROUTES.marketplace.org}>
+          <a className="cu-link" href={CONTROL_ROUTES.marketplace.orgEntries}>
             Install Plugin
           </a>
           .

--- a/control-ui/components/PublishToRegistryForm.tsx
+++ b/control-ui/components/PublishToRegistryForm.tsx
@@ -84,16 +84,13 @@ type EntryType = 'mcp-server' | 'recipe'
 type ServerMode = 'local' | 'remote'
 type CredKeyRow = { name: string; label: string; kind: string }
 
-export function PublishToRegistryForm({
-  initialEntryType = 'mcp-server',
-  onPublished,
-  onCancel,
-  pageHeader,
-}: Props) {
+export function PublishToRegistryForm({ onPublished, onCancel, pageHeader }: Props) {
   const { showToast } = useToast()
   const [step, setStep] = useState(0)
-  // Common fields
-  const [entryType, setEntryType] = useState<EntryType>(initialEntryType)
+  // Common fields. Publishing is Connector-only for now under the distribution
+  // strategy narrowing (plugins are org-private, not user-published), so the
+  // type picker is hidden below and entryType is pinned to 'mcp-server'.
+  const [entryType] = useState<EntryType>('mcp-server')
   const [name, setName] = useState('')
   const [version, setVersion] = useState('1.0.0')
   const [description, setDescription] = useState('')
@@ -274,6 +271,9 @@ export function PublishToRegistryForm({
       >
         {step === 0 ? (
           <div className="cu-form-stack cu-agent-form-stack">
+            {/* Entry-type picker hidden for now: publishing is Connector-only
+                under the distribution strategy narrowing (plugins are org-private,
+                not user-published). Restore with both options to re-enable.
             <SegmentedControl<EntryType>
               ariaLabel="Marketplace entry type"
               value={entryType}
@@ -283,7 +283,7 @@ export function PublishToRegistryForm({
                 { value: 'mcp-server', label: 'Connector' },
                 { value: 'recipe', label: 'Plugin' },
               ]}
-            />
+            /> */}
             <div className="cu-field">
               <label htmlFor="pub-name">
                 Name <span className="cu-field__required">*</span>
@@ -591,9 +591,10 @@ export function PublishToRegistryForm({
                   </p>
                 </div>
               ))}
-            {/* Visibility is fixed for the curated @clerum catalog — the registry forces
-                public, so we surface a locked, read-only indicator rather than a toggle.
-                This is informational only and does not affect the submitted payload. */}
+            {/* Visibility indicator hidden for now under the distribution strategy
+                narrowing: it hardcoded "Public" even for org-scoped publishes, which
+                is misleading (users publish org-private, not public). Restore with a
+                correct per-target value when public publishing returns.
             <div className="cu-field">
               <label htmlFor="pub-visibility">Visibility</label>
               <div className="cu-field__readonly" id="pub-visibility" aria-readonly="true">
@@ -601,6 +602,7 @@ export function PublishToRegistryForm({
               </div>
               <p className="cu-field__hint">Curated catalog entries are always public.</p>
             </div>
+            */}
           </div>
         ) : null}
 

--- a/control-ui/components/PublisherView/DockerCredentials.tsx
+++ b/control-ui/components/PublisherView/DockerCredentials.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { CONTROL_ROUTES } from '@constants/routes'
 import {
   type CreatedRegistryApiKey,
   type RegistryApiKey,
   createRegistryApiKey,
+  getRegistryConnection,
   listRegistryApiKeys,
   revokeRegistryApiKey,
 } from '../../lib/api'
@@ -63,6 +65,14 @@ export function DockerCredentialsPanel({ orgScope }: { orgScope: string }) {
   const [generating, setGenerating] = useState(false)
   const [formError, setFormError] = useState('')
   const [revealed, setRevealed] = useState<CreatedRegistryApiKey | null>(null)
+  // Same best-effort mode probe RegistryApiKeysPanel uses: the auth-disabled
+  // stated fact must lead somewhere, and the path differs by mode (self-hosted
+  // → connect; managed → an operator env-var). getRegistryConnection() 409s
+  // not_self_hosted in managed mode. Fail-open to 'self-hosted' on any other
+  // outcome so a transient probe error still offers the connect path.
+  const [connectionMode, setConnectionMode] = useState<'self-hosted' | 'managed' | 'unknown'>(
+    'unknown'
+  )
 
   const load = useCallback(async () => {
     setView({ kind: 'loading' })
@@ -83,9 +93,19 @@ export function DockerCredentialsPanel({ orgScope }: { orgScope: string }) {
     }
   }, [])
 
+  const loadConnectionMode = useCallback(async () => {
+    try {
+      await getRegistryConnection()
+      setConnectionMode('self-hosted')
+    } catch (e) {
+      setConnectionMode((e as { code?: string }).code === 'not_self_hosted' ? 'managed' : 'unknown')
+    }
+  }, [])
+
   useEffect(() => {
     void load()
-  }, [load])
+    void loadConnectionMode()
+  }, [load, loadConnectionMode])
 
   const isReady = view.kind === 'ready'
 
@@ -180,7 +200,20 @@ export function DockerCredentialsPanel({ orgScope }: { orgScope: string }) {
         </p>
       ) : null}
       {view.kind === 'auth-disabled' ? (
-        <p className="cu-banner">Registry authentication is disabled in this environment.</p>
+        <p className="cu-banner cu-banner--info">
+          {connectionMode === 'managed' ? (
+            <>
+              Registry authentication for this deployment is controlled by{' '}
+              <code>CLERUM_REGISTRY_AUTH_ENABLED</code>. An operator must enable it and restart
+              control-api before push credentials can be created here.
+            </>
+          ) : (
+            <>
+              Push credentials become available once this deployment is connected to the registry.{' '}
+              <a href={CONTROL_ROUTES.marketplace.connect}>Connect to Evenfire Registry</a>.
+            </>
+          )}
+        </p>
       ) : null}
       {view.kind === 'unavailable' ? (
         <p className="cu-banner cu-banner--warn">

--- a/control-ui/components/PublisherView/OwnedEntries.tsx
+++ b/control-ui/components/PublisherView/OwnedEntries.tsx
@@ -1,14 +1,26 @@
 'use client'
 
-import React, { useCallback, useEffect, useState } from 'react'
-import { type OwnedRegistryEntry, getOwnedRegistryEntries } from '../../lib/api'
+import React, { Fragment, useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { IconChevronRight } from '@components/icons'
+import { CONTROL_ROUTES } from '@constants/routes'
+import {
+  type OwnedRegistryEntry,
+  deleteRegistryEntry,
+  getOwnedRegistryEntries,
+  getRegistryCatalog,
+} from '../../lib/api'
+import { useConfirmDialog } from '../ConfirmDialog'
+import { type RowAction, RowActionsMenu } from '../RowActionsMenu'
 import { TableHeaderRow } from '../TableHeaderRow'
 import type { TableHeaderColumn } from '../TableHeaderRow/types'
+import { useToast } from '../Toast'
 import { Button } from '../ui'
 import { GrantAccessModal } from './GrantAccessModal'
 import { RetryBanner } from './RetryBanner'
 
 const COLUMNS: TableHeaderColumn[] = [
+  { key: 'expand', ariaLabel: 'Expand versions' },
   { key: 'name', label: 'Name' },
   { key: 'type', label: 'Type' },
   { key: 'version', label: 'Version' },
@@ -21,6 +33,38 @@ function entryKey(e: OwnedRegistryEntry): string {
   return `${e.name}@${e.version}`
 }
 
+// Descending semver-ish sort so the latest version leads each group. Falls back
+// to a reverse lexical compare when a segment isn't numeric.
+function compareVersionDesc(a: string, b: string): number {
+  const pa = a.split('.')
+  const pb = b.split('.')
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = Number.parseInt(pa[i] ?? '0', 10)
+    const y = Number.parseInt(pb[i] ?? '0', 10)
+    if (Number.isNaN(x) || Number.isNaN(y)) return b.localeCompare(a)
+    if (x !== y) return y - x
+  }
+  return b.localeCompare(a)
+}
+
+// Collapse same-named entries into one group. `latest` leads the collapsed row;
+// `versions` holds every version (latest first) so the expanded row can offer
+// the previous ones individually.
+function groupByName(
+  entries: OwnedRegistryEntry[]
+): { latest: OwnedRegistryEntry; versions: OwnedRegistryEntry[] }[] {
+  const byName = new Map<string, OwnedRegistryEntry[]>()
+  for (const e of entries) {
+    const list = byName.get(e.name)
+    if (list) list.push(e)
+    else byName.set(e.name, [e])
+  }
+  return Array.from(byName.values()).map(list => {
+    const versions = [...list].sort((a, b) => compareVersionDesc(a.version, b.version))
+    return { latest: versions[0], versions }
+  })
+}
+
 // The registry's owned-entries payload carries `serverMode` but not `entry_type`
 // (mcp-servers always have a serverMode; recipes don't). Prefer an explicit
 // entry_type if the registry ever starts sending it, else infer from serverMode.
@@ -30,18 +74,54 @@ function entryTypeLabel(e: OwnedRegistryEntry): string {
   return kind === 'mcp-server' ? 'Connector' : 'Plugin'
 }
 
-export function OwnedEntries({ orgScope }: { orgScope: string }) {
+/**
+ * The org's own published entries — the home for the edit/remove that discovery
+ * surfaces no longer offer (design spec §5.4). Sharing is capability-gated:
+ *
+ * - `canShare` (the deployment holds `registry:grant`) → offer the Share control.
+ * - `sharingUnavailable` (a self-hosted org can never share cross-org) → state
+ *   the limit once rather than offering a control that would be refused (§1.2).
+ *
+ * Both derive from the parent's inbound-grants probe, so no extra fetch is made.
+ */
+export function OwnedEntries({
+  orgScope,
+  canShare = true,
+  sharingUnavailable = false,
+}: {
+  orgScope: string
+  canShare?: boolean
+  sharingUnavailable?: boolean
+}) {
+  const router = useRouter()
+  const { showToast } = useToast()
+  const { confirm, confirmDialog } = useConfirmDialog()
   const [entries, setEntries] = useState<OwnedRegistryEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [grantTarget, setGrantTarget] = useState<string | null>(null)
+  const [expandedNames, setExpandedNames] = useState<Set<string>>(new Set())
+  // Installed cluster resources (same source the catalog uses to show
+  // "Installed"). Best-effort: a catalog fetch failure just means no entry is
+  // marked installed, never an error on the entries list.
+  const [installedCatalogKeys, setInstalledCatalogKeys] = useState<Set<string>>(new Set())
+  const [installedServerNames, setInstalledServerNames] = useState<Set<string>>(new Set())
+  const [installedRecipeKeys, setInstalledRecipeKeys] = useState<Set<string>>(new Set())
 
   const load = useCallback(async () => {
     setLoading(true)
     setError(false)
     try {
-      const { data } = await getOwnedRegistryEntries()
+      const [{ data }, catalog] = await Promise.all([
+        getOwnedRegistryEntries(),
+        getRegistryCatalog({ limit: '500' }).catch(() => null),
+      ])
       setEntries(data)
+      if (catalog) {
+        setInstalledCatalogKeys(new Set(catalog.installed.catalogKeys))
+        setInstalledServerNames(new Set(catalog.installed.serverNames))
+        setInstalledRecipeKeys(new Set(catalog.installed.recipeKeys))
+      }
     } catch {
       setError(true)
     } finally {
@@ -53,6 +133,63 @@ export function OwnedEntries({ orgScope }: { orgScope: string }) {
     void load()
   }, [load])
 
+  const handleRemove = useCallback(
+    async (e: OwnedRegistryEntry) => {
+      const ok = await confirm({
+        title: 'Remove from Marketplace',
+        message: `Remove ${e.name} v${e.version} from the Marketplace? Already-installed copies stay running. This cannot be undone.`,
+        confirmLabel: 'Remove',
+        tone: 'danger',
+      })
+      if (!ok) return
+      try {
+        await deleteRegistryEntry(e.name, e.version)
+        showToast(`Removed ${e.name} v${e.version} from the Marketplace.`, { tone: 'success' })
+        await load()
+      } catch {
+        showToast(`Could not remove ${e.name}.`, { tone: 'error' })
+      }
+    },
+    [confirm, showToast, load]
+  )
+
+  const toggleExpanded = useCallback((name: string) => {
+    setExpandedNames(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }, [])
+
+  function isInstalled(e: OwnedRegistryEntry): boolean {
+    const kind = e.entry_type ?? (e.serverMode != null ? 'mcp-server' : 'recipe')
+    const key = `${e.name}@${e.version}`
+    if (kind === 'mcp-server') {
+      return installedCatalogKeys.has(key) || installedServerNames.has(e.name)
+    }
+    return installedRecipeKeys.has(key)
+  }
+
+  function renderInstall(e: OwnedRegistryEntry) {
+    return isInstalled(e) ? (
+      <Button type="button" variant="ghost" size="sm" disabled>
+        Installed
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        variant="primary"
+        size="sm"
+        onClick={() =>
+          router.push(CONTROL_ROUTES.marketplace.install({ entry: e.name, version: e.version }))
+        }
+      >
+        Install
+      </Button>
+    )
+  }
+
   if (loading) return <p>Loading your published entries…</p>
   if (error) {
     return (
@@ -63,50 +200,149 @@ export function OwnedEntries({ orgScope }: { orgScope: string }) {
     return <p>You haven’t published any registry entries yet.</p>
   }
 
+  const hasPrivateEntries = entries.some(e => e.visibility === 'private')
+  // Collapse same-named entries into one row (latest leads); expanding a row
+  // reveals the previous versions, each individually installable.
+  const grouped = groupByName(entries)
+
   return (
     <>
+      {sharingUnavailable && hasPrivateEntries ? (
+        <p className="cu-banner cu-banner--info">
+          Cross-org sharing isn’t available on this deployment, so private entries stay visible only
+          to your org.
+        </p>
+      ) : null}
       <div className="cu-table-wrap">
         <table className="cu-table">
           <thead>
             <TableHeaderRow columns={COLUMNS} />
           </thead>
           <tbody>
-            {entries.map(e => {
-              const k = entryKey(e)
+            {grouped.map(({ latest: e, versions }) => {
               const isPrivate = e.visibility === 'private'
               const isGranting = grantTarget === e.name
+              const expanded = expandedNames.has(e.name)
+              const hasPrevious = versions.length > 1
+              const rowActions: RowAction[] = [
+                {
+                  key: 'edit',
+                  label: 'Edit',
+                  onClick: () =>
+                    router.push(CONTROL_ROUTES.marketplace.editEntry(e.name, e.version)),
+                },
+                {
+                  key: 'remove',
+                  label: 'Remove from Marketplace',
+                  danger: true,
+                  onClick: () => void handleRemove(e),
+                },
+              ]
               return (
-                <tr key={k}>
-                  <td>
-                    <code>{e.name}</code>
-                  </td>
-                  <td>{entryTypeLabel(e)}</td>
-                  <td>{e.version}</td>
-                  <td>
-                    <span
-                      className={`cu-registry-chip cu-registry-chip--visibility-${e.visibility}`}
-                    >
-                      {e.visibility}
-                    </span>
-                  </td>
-                  <td>{e.status}</td>
-                  <td style={{ textAlign: 'right' }}>
-                    {isPrivate ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        aria-haspopup="dialog"
-                        aria-expanded={isGranting}
-                        onClick={() => setGrantTarget(e.name)}
+                <Fragment key={e.name}>
+                  <tr
+                    className={
+                      hasPrevious
+                        ? 'cu-table__row cu-table__row--clickable cu-expandable-row'
+                        : undefined
+                    }
+                    onClick={hasPrevious ? () => toggleExpanded(e.name) : undefined}
+                    onKeyDown={
+                      hasPrevious
+                        ? event => {
+                            if (event.key === 'Enter' || event.key === ' ') {
+                              event.preventDefault()
+                              toggleExpanded(e.name)
+                            }
+                          }
+                        : undefined
+                    }
+                    tabIndex={hasPrevious ? 0 : undefined}
+                    aria-expanded={hasPrevious ? expanded : undefined}
+                  >
+                    <td className="cu-expandable-row__chevron" aria-hidden="true">
+                      {hasPrevious ? (
+                        <IconChevronRight
+                          className={expanded ? 'is-expanded' : undefined}
+                          width={18}
+                          height={18}
+                        />
+                      ) : null}
+                    </td>
+                    <td>
+                      <code>{e.name}</code>
+                    </td>
+                    <td>{entryTypeLabel(e)}</td>
+                    <td>
+                      {e.version}
+                      {hasPrevious ? (
+                        <span className="cu-muted"> +{versions.length - 1} more</span>
+                      ) : null}
+                    </td>
+                    <td>
+                      <span
+                        className={`cu-registry-chip cu-registry-chip--visibility-${e.visibility}`}
                       >
-                        Share access
-                      </Button>
-                    ) : (
-                      <span className="cu-muted-note--compact">Public — no grant needed</span>
-                    )}
-                  </td>
-                </tr>
+                        {e.visibility}
+                      </span>
+                    </td>
+                    <td>{e.status}</td>
+                    <td
+                      onClick={hasPrevious ? event => event.stopPropagation() : undefined}
+                      onKeyDown={hasPrevious ? event => event.stopPropagation() : undefined}
+                    >
+                      <div className="cu-table-actions">
+                        {renderInstall(e)}
+                        {isPrivate ? (
+                          canShare ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              aria-haspopup="dialog"
+                              aria-expanded={isGranting}
+                              onClick={() => setGrantTarget(e.name)}
+                            >
+                              Share access
+                            </Button>
+                          ) : null
+                        ) : (
+                          <span className="cu-muted-note--compact">Public — no grant needed</span>
+                        )}
+                        <RowActionsMenu
+                          ariaLabel={`Actions for ${e.name} v${e.version}`}
+                          actions={rowActions}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                  {expanded && hasPrevious ? (
+                    <tr className="cu-expandable-detail-row">
+                      <td colSpan={COLUMNS.length}>
+                        <div className="cu-expandable-detail">
+                          <div className="cu-marketplace-versions">
+                            <span className="cu-expandable-field__label">Previous versions</span>
+                            {versions.slice(1).map(v => (
+                              <div
+                                key={entryKey(v)}
+                                className="cu-table-actions"
+                                style={{ justifyContent: 'space-between' }}
+                              >
+                                <code className="cu-code-text">
+                                  {v.version}
+                                  {isInstalled(v) ? (
+                                    <span className="cu-muted"> · installed</span>
+                                  ) : null}
+                                </code>
+                                {renderInstall(v)}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
               )
             })}
           </tbody>
@@ -119,6 +355,7 @@ export function OwnedEntries({ orgScope }: { orgScope: string }) {
           onClose={() => setGrantTarget(null)}
         />
       ) : null}
+      {confirmDialog}
     </>
   )
 }

--- a/control-ui/components/PublisherView/dockerCredential.ts
+++ b/control-ui/components/PublisherView/dockerCredential.ts
@@ -20,6 +20,38 @@ export function buildPushCoordinate(registry: string, orgScope: string): string 
   return `${registry}/${dockerNamespace(orgScope)}/<name>:<tag>`
 }
 
+/**
+ * The fully-qualified image coordinate for a specific entry — the user never
+ * composes this by hand (design spec §5.5), so malformed-path pushes become
+ * unreachable rather than documented.
+ */
+export function buildImageCoordinate(
+  registry: string,
+  orgScope: string,
+  name: string,
+  tag: string
+): string {
+  return `${registry}/${dockerNamespace(orgScope)}/${name}:${tag}`
+}
+
+export function buildDockerTagCommand(
+  registry: string,
+  orgScope: string,
+  name: string,
+  tag: string
+): string {
+  return `docker tag <local-image> ${buildImageCoordinate(registry, orgScope, name, tag)}`
+}
+
+export function buildDockerPushCommand(
+  registry: string,
+  orgScope: string,
+  name: string,
+  tag: string
+): string {
+  return `docker push ${buildImageCoordinate(registry, orgScope, name, tag)}`
+}
+
 export function deriveDockerconfigjson(registry: string, key: string): string {
   return JSON.stringify(
     {

--- a/control-ui/components/PublisherView/index.tsx
+++ b/control-ui/components/PublisherView/index.tsx
@@ -53,6 +53,13 @@ export function PublisherView({ activeTab }: { activeTab: PublisherTab }) {
       ? TABS
       : TABS.filter(t => t.value !== 'shared')
 
+  // Cross-org sharing needs the registry `registry:grant` scope. The inbound
+  // probe is the proxy: `available`/`error` means the scope is present (offer
+  // sharing), while `unavailable` (403) is a self-hosted org that can never
+  // share — state the limit rather than offering a control that gets refused.
+  const canShare = inbound.status === 'available' || inbound.status === 'error'
+  const sharingUnavailable = inbound.status === 'unavailable'
+
   return (
     <section>
       <div className="cu-card cu-card--viewport-fill">
@@ -65,7 +72,13 @@ export function PublisherView({ activeTab }: { activeTab: PublisherTab }) {
             className="cu-tabs--flush-top"
             options={tabs}
           />
-          {activeTab === 'entries' ? <OwnedEntries orgScope={orgScope} /> : null}
+          {activeTab === 'entries' ? (
+            <OwnedEntries
+              orgScope={orgScope}
+              canShare={canShare}
+              sharingUnavailable={sharingUnavailable}
+            />
+          ) : null}
           {activeTab === 'shared' ? (
             <GrantedToMe status={inbound.status} grants={inbound.grants} reload={inbound.reload} />
           ) : null}

--- a/control-ui/components/RecipesTab.tsx
+++ b/control-ui/components/RecipesTab.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { DEFAULT_WORKFLOW_RECIPE_NAMESPACE } from '@constants/workflowRecipes'
 import type { WorkflowRecipeResource } from '../lib/api'
+import { PluginsEmptyState } from './PluginsEmptyState'
 import { SectionSearchInput } from './SectionSearchInput'
 import { IconWorkflow } from './Sidebar/icons'
 import { SkeletonTableRows } from './SkeletonTableRows'
@@ -124,13 +125,7 @@ export function RecipesTab({ items, loading, error, onInstall, onRefresh }: Prop
         </div>
       ) : filteredItems.length === 0 ? (
         <div className="cu-empty">
-          {normalizedSearch ? (
-            'No plugins match this search.'
-          ) : (
-            <>
-              No plugins installed. Select <strong>Install Plugin</strong> to deploy one.
-            </>
-          )}
+          {normalizedSearch ? 'No plugins match this search.' : <PluginsEmptyState />}
         </div>
       ) : (
         <div className="cu-table-wrap">

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -55,7 +55,7 @@ export default function RegistryApiKeysPanel() {
   const { confirm, confirmDialog } = useConfirmDialog()
   const [view, setView] = useState<View>({ kind: 'loading' })
   const [creating, setCreating] = useState(false)
-  const [revealed, setRevealed] = useState<string | null>(null)
+  const [revealed, setRevealed] = useState<CreatedRegistryApiKey | null>(null)
   // The auth-disabled view needs mode-specific copy: self-hosted fixes it by
   // connecting, managed fixes it via CLERUM_REGISTRY_AUTH_ENABLED (no connect
   // flow exists there). Same best-effort detection RegistryCatalog uses for its
@@ -102,7 +102,7 @@ export default function RegistryApiKeysPanel() {
   async function handleCreate(input: CreateRegistryApiKeyInput) {
     const created: CreatedRegistryApiKey = await createRegistryApiKey(input)
     setCreating(false)
-    setRevealed(created.key)
+    setRevealed(created)
     await load()
   }
 
@@ -155,8 +155,7 @@ export default function RegistryApiKeysPanel() {
         ) : null}
         {view.kind === 'no-org' ? (
           <p className="cu-banner cu-banner--warn">
-            This deployment is not bound to a registry org, so there are no org API keys to
-            manage.
+            This deployment is not bound to a registry org, so there are no org API keys to manage.
           </p>
         ) : null}
         {view.kind === 'auth-disabled' ? (
@@ -239,7 +238,13 @@ export default function RegistryApiKeysPanel() {
       {creating ? (
         <CreateApiKeyModal onCreate={handleCreate} onCancel={() => setCreating(false)} />
       ) : null}
-      {revealed ? <RevealApiKeyModal apiKey={revealed} onClose={() => setRevealed(null)} /> : null}
+      {revealed ? (
+        <RevealApiKeyModal
+          created={revealed}
+          orgScope={view.kind === 'ready' ? view.org : ''}
+          onClose={() => setRevealed(null)}
+        />
+      ) : null}
       {confirmDialog}
     </section>
   )

--- a/control-ui/components/RegistryCatalog.tsx
+++ b/control-ui/components/RegistryCatalog.tsx
@@ -4,11 +4,11 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { FilterSelect } from '@components/FilterSelect'
+import { MarketplaceTabs } from '@components/MarketplaceTabs'
 import { type RowAction, RowActionsMenu } from '@components/RowActionsMenu'
 import { SectionSearchInput } from '@components/SectionSearchInput'
 import { IconStore } from '@components/Sidebar/icons'
 import { SkeletonTableRows } from '@components/SkeletonTableRows'
-import { TabBar } from '@components/TabBar'
 import { TableHeaderRow } from '@components/TableHeaderRow'
 import type { TableHeaderColumn } from '@components/TableHeaderRow/types'
 import { TablePanelHeader } from '@components/TablePanelHeader'
@@ -16,24 +16,15 @@ import { useToast } from '@components/Toast'
 import { IconChevronRight, IconX } from '@components/icons'
 import { CONTROL_ROUTES } from '@constants/routes'
 import {
-  type RegistryConnectionState,
   type RegistryEntry,
   deleteRegistryEntry,
   getRegistryCatalog,
-  getRegistryConnection,
   installRecipeFromRegistry,
 } from '../lib/api'
+import { useRegistryCapability } from '../lib/hooks/useRegistryCapability'
 import { trustBgColor, trustColor } from '../lib/trustLevel'
 
 type MarketplaceTab = 'connectors' | 'plugins'
-
-const MODE_FILTER_OPTIONS = [
-  { value: 'all', label: 'All Modes' },
-  { value: 'local', label: 'Local' },
-  { value: 'remote', label: 'Remote' },
-  { value: 'workflow', label: 'Workflow' },
-  { value: 'only-workloads', label: 'Only Workloads' },
-]
 
 const REGISTRY_COLUMNS: TableHeaderColumn[] = [
   { key: 'expand', ariaLabel: 'Expand Marketplace entry' },
@@ -63,40 +54,27 @@ export default function RegistryCatalog() {
   const [installError, setInstallError] = useState('')
   const [search, setSearch] = useState('')
   const [categoryFilter, setCategoryFilter] = useState('all')
-  const [modeFilter, setModeFilter] = useState('all')
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set())
   const [removeTarget, setRemoveTarget] = useState<RegistryEntry | null>(null)
   const [removing, setRemoving] = useState(false)
   const [removeError, setRemoveError] = useState('')
-  // Registry-connect discoverability: an independent, best-effort fetch that
-  // derives whether this deployment is self-hosted and (if so) its connection
-  // state, so the Marketplace can surface a "Connect" entry point. Initial mode
-  // is 'unknown' (fail-open) so the entry point isn't hidden while the request
-  // is in flight or if it errors for a reason other than a managed deployment.
-  const [connectionMode, setConnectionMode] = useState<'self-hosted' | 'managed' | 'unknown'>(
-    'unknown'
-  )
-  const [connectionState, setConnectionState] = useState<RegistryConnectionState | null>(null)
+  // Capability + connection signals for rendering only controls this deployment
+  // can actually use (design spec §5.1). The hook composes publish-scope
+  // (identity / curator) with the connect probe (mode / state), so the catalog
+  // no longer fetches the connection separately. Fail-open: while unresolved,
+  // mode is 'unknown' so the connect entry point isn't hidden.
+  const { capability } = useRegistryCapability()
+  const isCurator = capability?.isCurator === true
+  const orgScope = capability?.scope ?? null
+  const connectionMode = capability?.mode ?? 'unknown'
+  const connectionState = capability?.connectionState ?? null
+  // Curators administer the shared catalog, so they keep inline edit/remove;
+  // everyone else manages their own entries from the ownership area (§5.4).
+  const columns = isCurator ? REGISTRY_COLUMNS : REGISTRY_COLUMNS.filter(c => c.key !== 'actions')
 
   useEffect(() => {
     void loadData()
-    void loadConnectionMode()
   }, [])
-
-  async function loadConnectionMode() {
-    // Independent of the catalog browse: a browse failure must not hide the
-    // connect entry point. Fail-open — any non-managed outcome keeps it visible.
-    try {
-      const status = await getRegistryConnection()
-      setConnectionMode('self-hosted')
-      setConnectionState(status.state)
-    } catch (err) {
-      setConnectionMode(
-        (err as { code?: unknown }).code === 'not_self_hosted' ? 'managed' : 'unknown'
-      )
-      setConnectionState(null)
-    }
-  }
 
   async function loadData() {
     setLoading(true)
@@ -166,12 +144,6 @@ export default function RegistryCatalog() {
   const filtered = useMemo(() => {
     return tabEntries.filter(entry => {
       if (categoryFilter !== 'all' && entry.category !== categoryFilter) return false
-      if (modeFilter !== 'all') {
-        if (modeFilter === 'local' && entry.server_mode !== 'local') return false
-        if (modeFilter === 'remote' && entry.server_mode !== 'remote') return false
-        if (modeFilter === 'workflow' && entry.recipe_type !== 'workflow') return false
-        if (modeFilter === 'only-workloads' && entry.recipe_type !== 'only-workloads') return false
-      }
       if (!search) return true
       const query = search.toLowerCase()
       return (
@@ -180,7 +152,7 @@ export default function RegistryCatalog() {
         entry.tags.some(tag => tag.toLowerCase().includes(query))
       )
     })
-  }, [categoryFilter, modeFilter, search, tabEntries])
+  }, [categoryFilter, search, tabEntries])
 
   const isInitialLoad = loading && entries.length === 0
 
@@ -192,6 +164,53 @@ export default function RegistryCatalog() {
       )
     }
     return installedRecipeKeys.has(`${entry.name}@${entry.version}`)
+  }
+
+  function renderInstallButton(entry: RegistryEntry) {
+    const installed = isEntryInstalled(entry)
+    const installing = installingRecipeKey === `${entry.name}@${entry.version}`
+    if (entry.entry_type === 'mcp-server') {
+      return installed ? (
+        <button type="button" className="cu-btn cu-btn--sm" disabled>
+          Installed
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="cu-btn cu-btn--sm cu-btn--primary"
+          onClick={() =>
+            router.push(
+              CONTROL_ROUTES.marketplace.install({ entry: entry.name, version: entry.version })
+            )
+          }
+        >
+          Install
+        </button>
+      )
+    }
+    if (entry.recipe_meta?.recipeYaml) {
+      return installed ? (
+        <button type="button" className="cu-btn cu-btn--sm" disabled>
+          Installed
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="cu-btn cu-btn--sm cu-btn--primary"
+          disabled={installing}
+          onClick={() => void handleInstallRecipe(entry)}
+        >
+          {installing ? 'Installing...' : 'Install'}
+        </button>
+      )
+    }
+    return <span className="cu-registry-missing">No plugin data</span>
+  }
+
+  // An entry belongs to this deployment's org when its name carries the org
+  // scope prefix (publishes are stored as `@org/name`, see applyPublishScope).
+  function isOwnedEntry(entry: RegistryEntry): boolean {
+    return !!orgScope && entry.name.startsWith(`${orgScope}/`)
   }
 
   function toggleExpanded(key: string) {
@@ -254,34 +273,23 @@ export default function RegistryCatalog() {
       ) : null}
       {connectBanner}
       <div className="cu-card cu-card--viewport-fill cu-section-card">
+        <MarketplaceTabs active="connectors" />
         <TablePanelHeader
           title={
             <>
               <IconStore />
-              {isInitialLoad ? 'Marketplace' : `Marketplace (${filtered.length})`}
+              Connectors
             </>
           }
-          titleActions={
-            <RowActionsMenu
-              ariaLabel="Marketplace actions"
-              actions={[
-                {
-                  key: 'api-keys',
-                  label: 'Manage API keys',
-                  onClick: () => router.push(CONTROL_ROUTES.marketplace.keys),
-                },
-              ]}
-            />
-          }
-          subtitle="Discover and install connectors and plugins from the Marketplace."
+          subtitle="Discover and install connectors from the Marketplace."
           actionsClassName="cu-registry-toolbar"
           actions={
             <>
               <SectionSearchInput
                 value={search}
                 onChange={setSearch}
-                placeholder={`Search ${activeTab}...`}
-                ariaLabel={`Search Marketplace ${activeTab}`}
+                placeholder="Search connectors..."
+                ariaLabel="Search the Marketplace"
                 disabled={isInitialLoad}
               />
               <div className="cu-registry-filter-group">
@@ -295,15 +303,8 @@ export default function RegistryCatalog() {
                   disabled={isInitialLoad}
                   ariaLabel="Filter by category"
                 />
-                <FilterSelect
-                  value={modeFilter}
-                  onChange={setModeFilter}
-                  options={MODE_FILTER_OPTIONS}
-                  disabled={isInitialLoad}
-                  ariaLabel="Filter by mode"
-                />
               </div>
-              {connectionMode !== 'managed' ? (
+              {connectionMode !== 'managed' && connectionState !== 'connected' ? (
                 <button
                   type="button"
                   className="cu-btn cu-btn--ghost cu-btn--sm"
@@ -313,47 +314,39 @@ export default function RegistryCatalog() {
                   Connect
                 </button>
               ) : null}
-              <button
-                type="button"
-                className="cu-btn cu-btn--primary cu-btn--sm"
-                onClick={() =>
-                  router.push(CONTROL_ROUTES.marketplace.publish({ type: activeEntryType }))
-                }
-                disabled={isInitialLoad}
-              >
-                + Publish to Marketplace
-              </button>
+              {/* Publish-to-Marketplace hidden for now under the distribution
+                  strategy narrowing (plugins are org-private only; users cannot
+                  publish to a public catalog). Commented out — restore when
+                  public/org publishing returns to discovery.
+              {canManageOrg || isCurator ? (
+                <button
+                  type="button"
+                  className="cu-btn cu-btn--primary cu-btn--sm"
+                  onClick={() =>
+                    router.push(CONTROL_ROUTES.marketplace.publish({ type: activeEntryType }))
+                  }
+                  disabled={isInitialLoad}
+                >
+                  + Publish to Marketplace
+                </button>
+              ) : null}
+              */}
             </>
           }
-        />
-
-        <TabBar<MarketplaceTab>
-          ariaLabel="Marketplace entry types"
-          activeValue={activeTab}
-          className="cu-tabs--flush-top"
-          options={[
-            {
-              value: 'connectors',
-              href: CONTROL_ROUTES.marketplace.connectors,
-              label: 'Connectors',
-            },
-          ]}
         />
 
         <div className="cu-table-wrap cu-marketplace-table-wrap">
           <table className="cu-table cu-table--header-band cu-expandable-table cu-marketplace-table">
             <thead>
-              <TableHeaderRow columns={REGISTRY_COLUMNS} />
+              <TableHeaderRow columns={columns} />
             </thead>
             <tbody>
               {isInitialLoad ? (
-                <SkeletonTableRows columns={REGISTRY_COLUMNS.length} rows={5} />
+                <SkeletonTableRows columns={columns.length} rows={5} />
               ) : (
                 filtered.map(entry => {
-                  const installed = isEntryInstalled(entry)
-                  const entryKey = `${entry.name}@${entry.version}`
-                  const installing = installingRecipeKey === entryKey
-                  const expanded = expandedKeys.has(entryKey)
+                  const expandKey = `${entry.name}@${entry.version}`
+                  const expanded = expandedKeys.has(expandKey)
                   const typeMeta = entry.server_mode
                     ? `${entry.server_mode}${entry.transport ? ` / ${entry.transport}` : ''}`
                     : entry.recipe_type || '—'
@@ -361,11 +354,11 @@ export default function RegistryCatalog() {
                     <Fragment key={entry.id}>
                       <tr
                         className="cu-table__row cu-table__row--clickable cu-expandable-row"
-                        onClick={() => toggleExpanded(entryKey)}
+                        onClick={() => toggleExpanded(expandKey)}
                         onKeyDown={event => {
                           if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault()
-                            toggleExpanded(entryKey)
+                            toggleExpanded(expandKey)
                           }
                         }}
                         tabIndex={0}
@@ -391,6 +384,18 @@ export default function RegistryCatalog() {
                           <div className="cu-registry-description" title={entry.description}>
                             {entry.description}
                           </div>
+                          {!isCurator && isOwnedEntry(entry) ? (
+                            <div className="cu-registry-owned">
+                              <Link
+                                className="cu-link"
+                                href={CONTROL_ROUTES.publisher.entries}
+                                onClick={event => event.stopPropagation()}
+                                onKeyDown={event => event.stopPropagation()}
+                              >
+                                You own this
+                              </Link>
+                            </div>
+                          ) : null}
                         </td>
                         <td className="cu-code-text">{entry.version}</td>
                         <td>
@@ -410,87 +415,50 @@ export default function RegistryCatalog() {
                           onClick={event => event.stopPropagation()}
                           onKeyDown={event => event.stopPropagation()}
                         >
-                          {entry.entry_type === 'mcp-server' ? (
-                            installed ? (
-                              <button type="button" className="cu-btn cu-btn--sm" disabled>
-                                Installed
-                              </button>
-                            ) : (
-                              <button
-                                type="button"
-                                className="cu-btn cu-btn--sm cu-btn--primary"
-                                onClick={() => {
-                                  const params = new URLSearchParams({
-                                    entry: entry.name,
-                                    version: entry.version,
-                                  })
-                                  router.push(
-                                    CONTROL_ROUTES.marketplace.install(Object.fromEntries(params))
-                                  )
-                                }}
-                              >
-                                Install
-                              </button>
-                            )
-                          ) : entry.recipe_meta?.recipeYaml ? (
-                            installed ? (
-                              <button type="button" className="cu-btn cu-btn--sm" disabled>
-                                Installed
-                              </button>
-                            ) : (
-                              <button
-                                type="button"
-                                className="cu-btn cu-btn--sm cu-btn--primary"
-                                disabled={installing}
-                                onClick={() => void handleInstallRecipe(entry)}
-                              >
-                                {installing ? 'Installing...' : 'Install'}
-                              </button>
-                            )
-                          ) : (
-                            <span className="cu-registry-missing">No plugin data</span>
-                          )}
+                          {renderInstallButton(entry)}
                         </td>
-                        <td
-                          className="cu-table__cell-actions cu-marketplace-action-cell"
-                          onClick={event => event.stopPropagation()}
-                          onKeyDown={event => event.stopPropagation()}
-                        >
-                          <RowActionsMenu
-                            ariaLabel={`Actions for ${entry.name} v${entry.version}`}
-                            actions={
-                              [
-                                {
-                                  key: 'edit',
-                                  label: 'Edit',
-                                  onClick: () =>
-                                    router.push(
-                                      CONTROL_ROUTES.marketplace.editEntry(
-                                        entry.name,
-                                        entry.version
-                                      )
-                                    ),
-                                },
-                                {
-                                  key: 'remove',
-                                  label: 'Remove from Marketplace',
-                                  danger: true,
-                                  onClick: () => {
-                                    setRemoveError('')
-                                    setRemoveTarget(entry)
+                        {isCurator ? (
+                          <td
+                            className="cu-table__cell-actions cu-marketplace-action-cell"
+                            onClick={event => event.stopPropagation()}
+                            onKeyDown={event => event.stopPropagation()}
+                          >
+                            <RowActionsMenu
+                              ariaLabel={`Actions for ${entry.name} v${entry.version}`}
+                              actions={
+                                [
+                                  {
+                                    key: 'edit',
+                                    label: 'Edit',
+                                    onClick: () =>
+                                      router.push(
+                                        CONTROL_ROUTES.marketplace.editEntry(
+                                          entry.name,
+                                          entry.version
+                                        )
+                                      ),
                                   },
-                                },
-                              ] satisfies RowAction[]
-                            }
-                          />
-                        </td>
+                                  {
+                                    key: 'remove',
+                                    label: 'Remove from Marketplace',
+                                    danger: true,
+                                    onClick: () => {
+                                      setRemoveError('')
+                                      setRemoveTarget(entry)
+                                    },
+                                  },
+                                ] satisfies RowAction[]
+                              }
+                            />
+                          </td>
+                        ) : null}
                       </tr>
                       {expanded ? (
                         <tr
                           id={`marketplace-details-${entry.id}`}
                           className="cu-expandable-detail-row"
                         >
-                          <td colSpan={REGISTRY_COLUMNS.length}>
+                          <td colSpan={columns.length}>
                             <div className="cu-expandable-detail cu-marketplace-row-detail">
                               <div className="cu-expandable-detail__fields">
                                 <div className="cu-expandable-field">
@@ -532,7 +500,7 @@ export default function RegistryCatalog() {
               )}
               {!isInitialLoad && filtered.length === 0 ? (
                 <tr>
-                  <td colSpan={REGISTRY_COLUMNS.length} className="cu-empty">
+                  <td colSpan={columns.length} className="cu-empty">
                     No entries match your filters.
                   </td>
                 </tr>

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CONTROL_ROUTES } from '@constants/routes'
 import {
   type RegistryRecoveryError,
   disconnectRegistryConnection,
@@ -33,6 +35,7 @@ type View =
 
 export default function RegistryConnectPanel() {
   const { showToast } = useToast()
+  const router = useRouter()
   const { confirm, confirmDialog } = useConfirmDialog()
   const [view, setView] = useState<View>({ kind: 'loading' })
   // request-form fields
@@ -460,10 +463,18 @@ export default function RegistryConnectPanel() {
                 deployment can now publish entries and push/pull images.
               </p>
               <p className="cu-muted-note">
-                This connection is permanent: the organization name is bound to this deployment.
-                Severing a live connection is an operator action against the cluster plus a support
-                request, not a self-service step.
+                This connection is permanent: the organization name is tied to this deployment.
+                Removing it later takes a change to the cluster.
               </p>
+              <div>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => router.push(CONTROL_ROUTES.marketplace.orgEntries)}
+                >
+                  Go to your organization
+                </Button>
+              </div>
             </div>
           ) : null}
         </div>

--- a/control-ui/components/RegistryConnectPanel.tsx
+++ b/control-ui/components/RegistryConnectPanel.tsx
@@ -252,10 +252,11 @@ export default function RegistryConnectPanel() {
   }
 
   // From the `connecting` view: with re-registration blocked server-side by
-  // recovery_in_progress, this DELETE is now the ONLY remaining path that can
+  // recovery_in_progress, this DELETE is the ONLY remaining path that can
   // destroy a recoverable deployment — it deletes the keypair and permanently
-  // squats the org name at the registry. Route it through the same confirm
-  // dialog as handleDisconnect instead of a bare button.
+  // squats the org name at the registry. It is a broken-state recovery action
+  // (the connection never completed), so unlike the removed connected-state
+  // Disconnect it is kept — but gated behind a danger confirm, never a bare button.
   async function handleStartOverFromConnecting() {
     const ok = await confirm({
       title: 'Start over',
@@ -278,42 +279,10 @@ export default function RegistryConnectPanel() {
     setView({ kind: 'request' })
   }
 
-  async function handleDisconnect() {
-    const ok = await confirm({
-      title: 'Disconnect from the Evenfire Registry',
-      message:
-        'This deletes this deployment’s stored registry credentials. It will stop publishing and pulling private images until you connect again. This cannot be undone.',
-      confirmLabel: 'Disconnect',
-      tone: 'danger',
-    })
-    if (!ok) return
-    try {
-      await disconnectRegistryConnection()
-      showToast('Disconnected from the Evenfire Registry.', { tone: 'success' })
-    } catch {
-      showToast('Could not disconnect.', { tone: 'error' })
-    }
-    setView({ kind: 'request' })
-  }
-
   return (
     <section>
       <div className="cu-card cu-card--viewport-fill">
-        <TablePanelHeader
-          title="Connect to Evenfire Registry"
-          actions={
-            view.kind === 'connected' ? (
-              <Button
-                type="button"
-                variant="danger"
-                size="sm"
-                onClick={() => void handleDisconnect()}
-              >
-                Disconnect
-              </Button>
-            ) : null
-          }
-        />
+        <TablePanelHeader title="Connect to Evenfire Registry" />
 
         <div className="cu-card__body">
           {view.kind === 'loading' ? <p>Loading…</p> : null}
@@ -485,10 +454,17 @@ export default function RegistryConnectPanel() {
           ) : null}
 
           {view.kind === 'connected' ? (
-            <p className="cu-banner cu-banner--ok">
-              Connected to the Evenfire Registry{view.org ? ` as @${view.org}` : ''}. This
-              deployment can now publish entries and push/pull images.
-            </p>
+            <div className="cu-form-stack">
+              <p className="cu-banner cu-banner--ok">
+                Connected to the Evenfire Registry{view.org ? ` as @${view.org}` : ''}. This
+                deployment can now publish entries and push/pull images.
+              </p>
+              <p className="cu-muted-note">
+                This connection is permanent: the organization name is bound to this deployment.
+                Severing a live connection is an operator action against the cluster plus a support
+                request, not a self-service step.
+              </p>
+            </div>
           ) : null}
         </div>
       </div>

--- a/control-ui/components/RevealApiKeyModal.tsx
+++ b/control-ui/components/RevealApiKeyModal.tsx
@@ -1,13 +1,22 @@
 'use client'
+
 import { useEffect, useRef, useState } from 'react'
+import type { CreatedRegistryApiKey } from '../lib/api'
+import {
+  buildDockerLoginCommand,
+  buildPushCoordinate,
+  resolveDockerCredential,
+} from './PublisherView/dockerCredential'
 import { useToast } from './Toast'
 import { Button } from './ui'
 
 export default function RevealApiKeyModal({
-  apiKey,
+  created,
+  orgScope,
   onClose,
 }: {
-  apiKey: string
+  created: CreatedRegistryApiKey
+  orgScope: string
   onClose: () => void
 }) {
   const { showToast } = useToast()
@@ -15,24 +24,44 @@ export default function RevealApiKeyModal({
   const [copyFailed, setCopyFailed] = useState(false)
   const copyRef = useRef<HTMLButtonElement>(null)
 
+  const apiKey = created.key
+  // Only a registry:publish key can push images, and only then does the registry
+  // return the push-credential fields — so the Docker section shows for those.
+  const isPushCredential = created.scopes.includes('registry:publish')
+  const { registry, dockerconfigjson } = resolveDockerCredential(created)
+  const loginCmd = buildDockerLoginCommand(registry, apiKey)
+  const pushCoordinate = buildPushCoordinate(registry, orgScope)
+
   useEffect(() => {
     copyRef.current?.focus()
   }, [])
 
-  async function copy() {
+  async function copy(value: string, label: string) {
     try {
-      await navigator.clipboard.writeText(apiKey)
-      showToast('Copied to clipboard.', { tone: 'success' })
+      await navigator.clipboard.writeText(value)
+      showToast(`${label} copied.`, { tone: 'success' })
       setCopyFailed(false)
     } catch {
       setCopyFailed(true)
     }
   }
 
+  function downloadDockerconfig() {
+    const blob = new Blob([dockerconfigjson], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'dockerconfigjson.json'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+
   return (
     <div className="cu-modal-overlay" role="presentation">
       <div
-        className="cu-modal"
+        className={`cu-modal${isPushCredential ? ' cu-modal--wide' : ''}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="reveal-key-title"
@@ -54,7 +83,7 @@ export default function RevealApiKeyModal({
             ref={copyRef}
             type="button"
             className="cu-btn cu-btn--ghost cu-btn--sm"
-            onClick={copy}
+            onClick={() => copy(apiKey, 'API key')}
           >
             Copy
           </button>
@@ -64,6 +93,40 @@ export default function RevealApiKeyModal({
             Could not copy to clipboard. Reveal the key, then select and copy manually.
           </p>
         ) : null}
+
+        {isPushCredential ? (
+          <div className="cu-field">
+            <label>Use with Docker</label>
+            <p className="cu-field__hint">
+              This key is also a Docker push credential — publish images to your org.
+            </p>
+
+            <span className="cu-field__hint">1. Log in to the registry</span>
+            <pre className="cu-code-block">{loginCmd}</pre>
+            <button
+              type="button"
+              className="cu-btn cu-btn--ghost cu-btn--sm"
+              onClick={() => copy(loginCmd, 'Login command')}
+            >
+              Copy login command
+            </button>
+
+            <span className="cu-field__hint">2. Tag and push to this coordinate</span>
+            <pre className="cu-code-block">{pushCoordinate}</pre>
+
+            <span className="cu-field__hint">
+              Or hand the credential to a build system as a Docker config file:
+            </span>
+            <button
+              type="button"
+              className="cu-btn cu-btn--ghost cu-btn--sm"
+              onClick={downloadDockerconfig}
+            >
+              Download dockerconfigjson
+            </button>
+          </div>
+        ) : null}
+
         <div className="cu-modal-actions">
           <Button type="button" variant="primary" onClick={onClose}>
             I&apos;ve saved it

--- a/control-ui/components/Sidebar/constants.tsx
+++ b/control-ui/components/Sidebar/constants.tsx
@@ -11,7 +11,6 @@ import {
   IconLlmPrices,
   IconModels,
   IconOutputs,
-  IconPublish,
   IconRobot,
   IconRunReplay,
   IconSettings,
@@ -89,11 +88,10 @@ export const SIDEBAR_TABS: Record<SidebarTab, SidebarItem> = {
     icon: <IconStore />,
   },
   'workflow-recipes': {
-    label: 'Plugins',
+    label: 'Installed plugins',
     href: CONTROL_ROUTES.plugins.root,
     icon: <IconWorkflow />,
   },
-  publisher: { label: 'Publisher', href: CONTROL_ROUTES.publisher.root, icon: <IconPublish /> },
   'llm-secrets': { label: 'Secrets', href: CONTROL_ROUTES.secrets.llm, icon: <IconKey /> },
   traces: {
     label: 'Traces',

--- a/control-ui/components/Sidebar/index.tsx
+++ b/control-ui/components/Sidebar/index.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { isPublisherEnabled, usePublishScope } from '../../lib/hooks/usePublishScope'
 import packageJson from '../../package.json'
 import { IconChevronRight } from '../icons'
 import { activeSidebarChildHref } from './activeChild'
@@ -14,16 +13,11 @@ import type { SidebarItem, SidebarProps, SidebarTab } from './types'
 
 export function Sidebar({ currentTab, isOpen = false, onNavigate, onLogout }: SidebarProps) {
   const pathname = usePathname()
-  const { scope } = usePublishScope()
-  const publisherEnabled = isPublisherEnabled(scope)
   const [expandedGroups, setExpandedGroups] = useState<Set<SidebarTab>>(
     () => new Set(SIDEBAR_TABS[currentTab].children?.length ? [currentTab] : [])
   )
   const entries = (Object.entries(SIDEBAR_TABS) as Array<[SidebarTab, SidebarItem]>)
-    .filter(
-      ([tabKey, item]) =>
-        !item.hidden && tabKey !== 'settings' && (tabKey !== 'publisher' || publisherEnabled)
-    )
+    .filter(([tabKey, item]) => !item.hidden && tabKey !== 'settings')
     .sort(([, first], [, second]) => first.label.localeCompare(second.label))
   const settings = SIDEBAR_TABS.settings
 

--- a/control-ui/components/Sidebar/types.ts
+++ b/control-ui/components/Sidebar/types.ts
@@ -10,7 +10,6 @@ export type SidebarTab =
   | 'llm-models'
   | 'profile-admin'
   | 'workflow-recipes'
-  | 'publisher'
   | 'cost'
   | 'registry-catalog'
   | 'settings'

--- a/control-ui/components/__tests__/DockerCredentials.test.tsx
+++ b/control-ui/components/__tests__/DockerCredentials.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../lib/api', () => ({
   listRegistryApiKeys: vi.fn(),
   createRegistryApiKey: vi.fn(),
   revokeRegistryApiKey: vi.fn(),
+  getRegistryConnection: vi.fn(),
 }))
 vi.mock('../ConfirmDialog', () => ({ useConfirmDialog: vi.fn() }))
 
@@ -114,11 +115,27 @@ describe('DockerCredentialsPanel', () => {
     expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
   })
 
-  it('409 registry_auth_disabled → dev-mode notice', async () => {
+  it('409 registry_auth_disabled (self-hosted) → connect path forward, not a dead-end', async () => {
     vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
       Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
     )
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'disconnected' })
     render(<DockerCredentialsPanel orgScope="acme" />)
-    expect(await screen.findByText(/registry authentication is disabled/i)).toBeInTheDocument()
+    const link = await screen.findByRole('link', { name: /connect to evenfire registry/i })
+    expect(link).toHaveAttribute('href', '/marketplace/connect')
+    // Structurally absent, not transient — no Retry (design spec §5.1).
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+  })
+
+  it('409 registry_auth_disabled (managed) → operator env-var notice', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 409, code: 'registry_auth_disabled' })
+    )
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('x'), { code: 'not_self_hosted' })
+    )
+    render(<DockerCredentialsPanel orgScope="acme" />)
+    expect(await screen.findByText(/CLERUM_REGISTRY_AUTH_ENABLED/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
   })
 })

--- a/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import * as grantsHook from '../../lib/hooks/useInboundGrants'
+import * as capHook from '../../lib/hooks/useRegistryCapability'
+import type {
+  RegistryCapability,
+  RegistryCapabilityState,
+} from '../../lib/hooks/useRegistryCapability'
+import { MarketplaceOrgArea } from '../MarketplaceOrgArea'
+
+vi.mock('../../lib/hooks/useRegistryCapability', () => ({ useRegistryCapability: vi.fn() }))
+vi.mock('../../lib/hooks/useInboundGrants', () => ({ useInboundGrants: vi.fn() }))
+vi.mock('../MarketplaceTabs', () => ({ MarketplaceTabs: () => <div>marketplace-tabs</div> }))
+vi.mock('../MarketplaceOrgImages', () => ({
+  MarketplaceOrgImages: () => <div>org-images</div>,
+}))
+vi.mock('../PublisherView/OwnedEntries', () => ({
+  OwnedEntries: () => <div>owned-entries</div>,
+}))
+vi.mock('../RegistryApiKeysPanel', () => ({ default: () => <div>api-keys-panel</div> }))
+vi.mock('../RegistryConnectPanel', () => ({ default: () => <div>connect-panel</div> }))
+
+function cap(overrides: Partial<RegistryCapability>): RegistryCapabilityState {
+  return {
+    capability: {
+      orgName: null,
+      scope: null,
+      isCurator: false,
+      mode: 'unknown',
+      authEnabled: false,
+      connectionState: null,
+      canManageOrg: false,
+      ...overrides,
+    },
+    loading: false,
+    error: false,
+    reload: vi.fn(),
+  }
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(grantsHook.useInboundGrants).mockReturnValue({
+    status: 'available',
+    grants: [],
+    reload: vi.fn(),
+  })
+})
+
+describe('MarketplaceOrgArea', () => {
+  it('labels the area with the org name when connected', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(
+      cap({ orgName: 'acme', scope: '@acme', canManageOrg: true })
+    )
+    render(<MarketplaceOrgArea activeTab="entries" />)
+    expect(screen.getByText('@acme')).toBeInTheDocument()
+  })
+
+  it('labels the area "Your org" before the deployment is claimed', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(cap({}))
+    render(<MarketplaceOrgArea activeTab="entries" />)
+    expect(screen.getByText('Your org')).toBeInTheDocument()
+  })
+
+  it('entries: shows OwnedEntries when the org can manage', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(
+      cap({ orgName: 'acme', scope: '@acme', canManageOrg: true })
+    )
+    render(<MarketplaceOrgArea activeTab="entries" />)
+    expect(screen.getByText('owned-entries')).toBeInTheDocument()
+  })
+
+  it('entries: shows a claim prompt when the org cannot manage', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(cap({ canManageOrg: false }))
+    render(<MarketplaceOrgArea activeTab="entries" />)
+    expect(screen.getByText(/Name your organization/i)).toBeInTheDocument()
+    expect(screen.queryByText('owned-entries')).toBeNull()
+  })
+
+  it('images: shows the images area when the org can manage', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(
+      cap({ orgName: 'acme', scope: '@acme', canManageOrg: true })
+    )
+    render(<MarketplaceOrgArea activeTab="images" />)
+    expect(screen.getByText('org-images')).toBeInTheDocument()
+  })
+
+  it('credentials: renders the API keys panel even when publishing is off (§6 decision)', () => {
+    // canManageOrg false (e.g. publishing UI disabled), but API keys must stay.
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(cap({ canManageOrg: false }))
+    render(<MarketplaceOrgArea activeTab="credentials" />)
+    expect(screen.getByText('api-keys-panel')).toBeInTheDocument()
+    expect(screen.queryByText(/Name your organization/i)).toBeNull()
+  })
+
+  it('connection: always renders the connect panel', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(cap({}))
+    render(<MarketplaceOrgArea activeTab="connection" />)
+    expect(screen.getByText('connect-panel')).toBeInTheDocument()
+  })
+})

--- a/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
@@ -49,18 +49,20 @@ beforeEach(() => {
 })
 
 describe('MarketplaceOrgArea', () => {
-  it('labels the area with the org name when connected', () => {
+  it('labels the area with the org name, linked to the Entries tab', () => {
     vi.mocked(capHook.useRegistryCapability).mockReturnValue(
       cap({ orgName: 'acme', scope: '@acme', canManageOrg: true })
     )
     render(<MarketplaceOrgArea activeTab="entries" />)
-    expect(screen.getByText('@acme')).toBeInTheDocument()
+    const orgLink = screen.getByRole('link', { name: '@acme' })
+    expect(orgLink).toHaveAttribute('href', '/marketplace/org/entries')
   })
 
-  it('labels the area "Your org" before the deployment is claimed', () => {
+  it('labels the area "Your org" (plain text, not a link) before the deployment is claimed', () => {
     vi.mocked(capHook.useRegistryCapability).mockReturnValue(cap({}))
     render(<MarketplaceOrgArea activeTab="entries" />)
     expect(screen.getByText('Your org')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Your org' })).toBeNull()
   })
 
   it('entries: shows OwnedEntries when the org can manage', () => {

--- a/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import * as grantsHook from '../../lib/hooks/useInboundGrants'
 import * as capHook from '../../lib/hooks/useRegistryCapability'
 import type {
@@ -89,6 +89,37 @@ describe('MarketplaceOrgArea', () => {
     )
     render(<MarketplaceOrgArea activeTab="images" />)
     expect(screen.getByText('org-images')).toBeInTheDocument()
+  })
+
+  it('entries: shows Retry, not the claim prompt, on a transient capability-probe error', () => {
+    // A failed getPublishScope() probe must not be read as an unclaimed org —
+    // that falsely prompts a re-claim (the "unclaimed latch" bug).
+    const reload = vi.fn()
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue({
+      capability: null,
+      loading: false,
+      error: true,
+      reload,
+    })
+    render(<MarketplaceOrgArea activeTab="entries" />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.queryByText(/Name your organization/i)).toBeNull()
+    expect(screen.queryByText('owned-entries')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('images: shows Retry, not the claim prompt, on a transient capability-probe error', () => {
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue({
+      capability: null,
+      loading: false,
+      error: true,
+      reload: vi.fn(),
+    })
+    render(<MarketplaceOrgArea activeTab="images" />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+    expect(screen.queryByText(/Name your organization/i)).toBeNull()
+    expect(screen.queryByText('org-images')).toBeNull()
   })
 
   it('credentials: renders the API keys panel even when publishing is off (§6 decision)', () => {

--- a/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
@@ -18,6 +18,9 @@ vi.mock('../PublisherView/OwnedEntries', () => ({
   OwnedEntries: () => <div>owned-entries</div>,
 }))
 vi.mock('../RegistryApiKeysPanel', () => ({ default: () => <div>api-keys-panel</div> }))
+vi.mock('../PublisherView/DockerCredentials', () => ({
+  DockerCredentialsPanel: () => <div>docker-credentials-panel</div>,
+}))
 vi.mock('../RegistryConnectPanel', () => ({ default: () => <div>connect-panel</div> }))
 
 function cap(overrides: Partial<RegistryCapability>): RegistryCapabilityState {
@@ -94,6 +97,19 @@ describe('MarketplaceOrgArea', () => {
     render(<MarketplaceOrgArea activeTab="credentials" />)
     expect(screen.getByText('api-keys-panel')).toBeInTheDocument()
     expect(screen.queryByText(/Name your organization/i)).toBeNull()
+    // No org scope yet → the Docker push-credential panel can't build coordinates.
+    expect(screen.queryByText('docker-credentials-panel')).toBeNull()
+  })
+
+  it('credentials: also renders the Docker push credential once the org scope is known', () => {
+    // canManageOrg false (publishing UI off) but a claimed scope — push
+    // credentials are gated on the scope, not the publishing toggle (§6).
+    vi.mocked(capHook.useRegistryCapability).mockReturnValue(
+      cap({ orgName: 'acme', scope: '@acme', canManageOrg: false })
+    )
+    render(<MarketplaceOrgArea activeTab="credentials" />)
+    expect(screen.getByText('api-keys-panel')).toBeInTheDocument()
+    expect(screen.getByText('docker-credentials-panel')).toBeInTheDocument()
   })
 
   it('connection: always renders the connect panel', () => {

--- a/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgArea.test.tsx
@@ -18,9 +18,6 @@ vi.mock('../PublisherView/OwnedEntries', () => ({
   OwnedEntries: () => <div>owned-entries</div>,
 }))
 vi.mock('../RegistryApiKeysPanel', () => ({ default: () => <div>api-keys-panel</div> }))
-vi.mock('../PublisherView/DockerCredentials', () => ({
-  DockerCredentialsPanel: () => <div>docker-credentials-panel</div>,
-}))
 vi.mock('../RegistryConnectPanel', () => ({ default: () => <div>connect-panel</div> }))
 
 function cap(overrides: Partial<RegistryCapability>): RegistryCapabilityState {
@@ -128,19 +125,6 @@ describe('MarketplaceOrgArea', () => {
     render(<MarketplaceOrgArea activeTab="credentials" />)
     expect(screen.getByText('api-keys-panel')).toBeInTheDocument()
     expect(screen.queryByText(/Name your organization/i)).toBeNull()
-    // No org scope yet → the Docker push-credential panel can't build coordinates.
-    expect(screen.queryByText('docker-credentials-panel')).toBeNull()
-  })
-
-  it('credentials: also renders the Docker push credential once the org scope is known', () => {
-    // canManageOrg false (publishing UI off) but a claimed scope — push
-    // credentials are gated on the scope, not the publishing toggle (§6).
-    vi.mocked(capHook.useRegistryCapability).mockReturnValue(
-      cap({ orgName: 'acme', scope: '@acme', canManageOrg: false })
-    )
-    render(<MarketplaceOrgArea activeTab="credentials" />)
-    expect(screen.getByText('api-keys-panel')).toBeInTheDocument()
-    expect(screen.getByText('docker-credentials-panel')).toBeInTheDocument()
   })
 
   it('connection: always renders the connect panel', () => {

--- a/control-ui/components/__tests__/MarketplaceOrgImages.test.tsx
+++ b/control-ui/components/__tests__/MarketplaceOrgImages.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import * as api from '../../lib/api'
+import { MarketplaceOrgImages } from '../MarketplaceOrgImages'
+
+vi.mock('../../lib/api', () => ({ listOrgImages: vi.fn() }))
+
+afterEach(cleanup)
+beforeEach(() => vi.clearAllMocks())
+
+describe('MarketplaceOrgImages', () => {
+  it('lists real image repos + tags with their full coordinate (read-only)', async () => {
+    vi.mocked(api.listOrgImages).mockResolvedValue({
+      org: 'acme',
+      images: [
+        { name: 'orchestrator', visibility: 'private', createdAt: 'x', tags: ['0.1.0', 'latest'] },
+        { name: 'api', visibility: 'private', createdAt: 'x', tags: ['0.1.0'] },
+      ],
+    })
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+
+    // One row per (repo, tag); coordinate is generated.
+    const orchRow = (
+      await screen.findByText('registry.evenfire.ai/acme/orchestrator:0.1.0')
+    ).closest('tr')!
+    expect(within(orchRow).getByText('orchestrator')).toBeInTheDocument()
+    expect(screen.getByText('registry.evenfire.ai/acme/orchestrator:latest')).toBeInTheDocument()
+    expect(screen.getByText('registry.evenfire.ai/acme/api:0.1.0')).toBeInTheDocument()
+
+    // No Push CTA / generated commands.
+    expect(screen.queryByRole('button', { name: /push/i })).toBeNull()
+    expect(screen.queryByText(/docker push/i)).toBeNull()
+  })
+
+  it('renders a tag-less repo with a <tag> placeholder coordinate', async () => {
+    vi.mocked(api.listOrgImages).mockResolvedValue({
+      org: 'acme',
+      images: [{ name: 'analyzer', visibility: 'private', createdAt: 'x', tags: [] }],
+    })
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+    const row = (await screen.findByText('analyzer')).closest('tr')!
+    expect(within(row).getByText('registry.evenfire.ai/acme/analyzer:<tag>')).toBeInTheDocument()
+    expect(within(row).queryByRole('button', { name: /push/i })).toBeNull()
+  })
+
+  it('empty state when the org has no image repos', async () => {
+    vi.mocked(api.listOrgImages).mockResolvedValue({ org: 'acme', images: [] })
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+    expect(await screen.findByText(/No images yet/i)).toBeInTheDocument()
+  })
+
+  it('shows an "unavailable" notice when the registry endpoint is not deployed (404)', async () => {
+    vi.mocked(api.listOrgImages).mockRejectedValue(Object.assign(new Error('x'), { status: 404 }))
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+    expect(await screen.findByText(/Image listing isn.t available/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+  })
+
+  it('shows a retry banner on a transient load failure', async () => {
+    vi.mocked(api.listOrgImages).mockRejectedValue(
+      Object.assign(new Error('boom'), { status: 500 })
+    )
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+    expect(await screen.findByText(/Could not load your images/i)).toBeInTheDocument()
+  })
+
+  it('states the deferred push failures (permission / quota) honestly', async () => {
+    vi.mocked(api.listOrgImages).mockResolvedValue({
+      org: 'acme',
+      images: [{ name: 'c', visibility: 'private', createdAt: 'x', tags: ['1.0.0'] }],
+    })
+    render(<MarketplaceOrgImages orgScope="@acme" />)
+    await screen.findByText('c')
+    expect(
+      screen.getByText(/publish permission or the org has reached its image quota/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/control-ui/components/__tests__/OwnedEntries.test.tsx
+++ b/control-ui/components/__tests__/OwnedEntries.test.tsx
@@ -1,25 +1,45 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import * as api from '../../lib/api'
 import { OwnedEntries } from '../PublisherView/OwnedEntries'
 import { ToastProvider } from '../Toast'
 
 vi.mock('../../lib/api', () => ({
   getOwnedRegistryEntries: vi.fn(),
+  getRegistryCatalog: vi.fn(),
+  deleteRegistryEntry: vi.fn(),
   // GrantAccessModal deps (mounted lazily when Share access is clicked):
   listOrgGrants: vi.fn().mockResolvedValue({ grants: [] }),
   createOrgGrant: vi.fn(),
   revokeOrgGrant: vi.fn(),
 }))
+
+const EMPTY_INSTALLED = {
+  data: [],
+  categories: [],
+  installed: { catalogKeys: [], serverNames: [], recipeKeys: [] },
+}
+
+const confirmMock = vi.hoisted(() => vi.fn())
 vi.mock('../ConfirmDialog', () => ({
-  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(false), confirmDialog: null }),
+  useConfirmDialog: () => ({ confirm: confirmMock, confirmDialog: null }),
+}))
+
+const navigation = vi.hoisted(() => ({ push: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navigation.push }),
 }))
 
 function render(ui: React.ReactNode) {
   return rtlRender(<ToastProvider>{ui}</ToastProvider>)
 }
 afterEach(cleanup)
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+  confirmMock.mockResolvedValue(false)
+  // Default: nothing installed, so entries show the Install CTA.
+  vi.mocked(api.getRegistryCatalog).mockResolvedValue(EMPTY_INSTALLED as never)
+})
 
 describe('OwnedEntries', () => {
   it('renders owned entries with visibility + status', async () => {
@@ -130,5 +150,121 @@ describe('OwnedEntries', () => {
     render(<OwnedEntries orgScope="acme" />)
     fireEvent.click(await screen.findByRole('button', { name: /retry/i }))
     expect(await screen.findByText(/haven’t published/i)).toBeInTheDocument()
+  })
+
+  it('offers Edit from the row actions menu, routing to the entry editor', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+    })
+    render(<OwnedEntries orgScope="acme" />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for @acme/db v1.0.0' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }))
+    // The scoped name is URL-encoded so its '/' stays inside one path segment.
+    expect(navigation.push).toHaveBeenCalledWith('/marketplace/entries/%40acme%2Fdb/1.0.0/edit')
+  })
+
+  it('offers Install, routing to the install wizard for the entry', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+    })
+    render(<OwnedEntries orgScope="acme" />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Install' }))
+    expect(navigation.push).toHaveBeenCalledWith(expect.stringContaining('/marketplace/install'))
+  })
+
+  it('shows "Installed" (disabled) for an entry already installed in the cluster', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+    })
+    vi.mocked(api.getRegistryCatalog).mockResolvedValue({
+      data: [],
+      categories: [],
+      installed: { catalogKeys: [], serverNames: [], recipeKeys: ['@acme/db@1.0.0'] },
+    } as never)
+    render(<OwnedEntries orgScope="acme" />)
+    expect(await screen.findByRole('button', { name: 'Installed' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Install' })).toBeNull()
+  })
+
+  it('removes an entry from the row actions menu after confirmation', async () => {
+    confirmMock.mockResolvedValue(true)
+    vi.mocked(api.getOwnedRegistryEntries)
+      .mockResolvedValueOnce({
+        data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+      })
+      .mockResolvedValueOnce({ data: [] })
+    vi.mocked(api.deleteRegistryEntry).mockResolvedValue({ deleted: true })
+    render(<OwnedEntries orgScope="acme" />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for @acme/db v1.0.0' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove from Marketplace' }))
+    await waitFor(() => expect(api.deleteRegistryEntry).toHaveBeenCalledWith('@acme/db', '1.0.0'))
+  })
+
+  it('does not remove when the confirmation is declined', async () => {
+    confirmMock.mockResolvedValue(false)
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+    })
+    render(<OwnedEntries orgScope="acme" />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Actions for @acme/db v1.0.0' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Remove from Marketplace' }))
+    await waitFor(() => expect(confirmMock).toHaveBeenCalled())
+    expect(api.deleteRegistryEntry).not.toHaveBeenCalled()
+  })
+
+  it('collapses same-named versions into one row showing the latest, expandable to previous', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [
+        { name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' },
+        { name: '@acme/db', version: '1.2.0', visibility: 'private', status: 'published' },
+        { name: '@acme/db', version: '1.1.0', visibility: 'private', status: 'published' },
+      ],
+    })
+    render(<OwnedEntries orgScope="acme" />)
+    await screen.findByText('@acme/db')
+    // One collapsed row: latest version leads, previous count summarized.
+    expect(screen.getByText('1.2.0')).toBeInTheDocument()
+    expect(screen.getByText('+2 more')).toBeInTheDocument()
+    // Previous versions are hidden until the row is expanded.
+    expect(screen.queryByText('1.1.0')).toBeNull()
+    expect(screen.queryByText('1.0.0')).toBeNull()
+
+    fireEvent.click(screen.getByText('@acme/db'))
+    expect(await screen.findByText('Previous versions')).toBeInTheDocument()
+    expect(screen.getByText('1.1.0')).toBeInTheDocument()
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+  })
+
+  it('row Install targets the latest version; expanded rows install previous versions', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [
+        { name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' },
+        { name: '@acme/db', version: '2.0.0', visibility: 'private', status: 'published' },
+      ],
+    })
+    render(<OwnedEntries orgScope="acme" />)
+    await screen.findByText('@acme/db')
+    // Collapsed row's Install goes to the latest version.
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }))
+    expect(navigation.push).toHaveBeenCalledWith(expect.stringContaining('version=2.0.0'))
+
+    navigation.push.mockClear()
+    fireEvent.click(screen.getByText('@acme/db'))
+    await screen.findByText('Previous versions')
+    // Now there are two Installs: the latest (main row) then the previous (detail).
+    const installs = screen.getAllByRole('button', { name: 'Install' })
+    expect(installs).toHaveLength(2)
+    fireEvent.click(installs[1])
+    expect(navigation.push).toHaveBeenCalledWith(expect.stringContaining('version=1.0.0'))
+  })
+
+  it('states the sharing limit and hides Share when sharing is unavailable', async () => {
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '1.0.0', visibility: 'private', status: 'published' }],
+    })
+    render(<OwnedEntries orgScope="acme" canShare={false} sharingUnavailable />)
+    await screen.findByText('@acme/db')
+    expect(screen.queryByRole('button', { name: /share access/i })).toBeNull()
+    expect(screen.getByText(/Cross-org sharing/i)).toBeInTheDocument()
   })
 })

--- a/control-ui/components/__tests__/PluginsEmptyState.test.tsx
+++ b/control-ui/components/__tests__/PluginsEmptyState.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import * as api from '../../lib/api'
+import { PluginsEmptyState } from '../PluginsEmptyState'
+
+vi.mock('../../lib/api', () => ({ listRegistryApiKeys: vi.fn() }))
+
+const DOCS_URL =
+  'https://github.com/evenfire-ai/evenfire/blob/main/docs/how-to/publish-plugin-to-registry.md'
+
+afterEach(cleanup)
+beforeEach(() => vi.clearAllMocks())
+
+describe('PluginsEmptyState', () => {
+  it('always explains what a plugin is, with its trigger/workload capabilities', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 409, code: 'no_org' })
+    )
+    render(<PluginsEmptyState />)
+    expect(screen.getByText(/packaged, versioned workflows/i)).toBeInTheDocument()
+    expect(screen.getByText(/recurring jobs/i)).toBeInTheDocument()
+    expect(screen.getByText(/webhook/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /learn more about plugins/i })).toHaveAttribute(
+      'href',
+      DOCS_URL
+    )
+  })
+
+  it('no org (409) → onboarding path: name the org + create a key', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 409, code: 'no_org' })
+    )
+    render(<PluginsEmptyState />)
+    await waitFor(() =>
+      expect(screen.getByText(/private to your organization/i)).toBeInTheDocument()
+    )
+    expect(screen.getByRole('link', { name: /connecting/i })).toHaveAttribute(
+      'href',
+      '/marketplace/connect'
+    )
+    expect(screen.getByRole('link', { name: /org API key/i })).toHaveAttribute(
+      'href',
+      '/marketplace/keys'
+    )
+  })
+
+  it('connected with keys → points out it is already set up, no onboarding steps', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockResolvedValue({
+      org: 'acme',
+      keys: [{ id: 'k1' }],
+    } as unknown as Awaited<ReturnType<typeof api.listRegistryApiKeys>>)
+    render(<PluginsEmptyState />)
+    expect(await screen.findByText(/already has API keys/i)).toBeInTheDocument()
+    expect(screen.getAllByText('@acme').length).toBeGreaterThan(0)
+    // No setup walkthrough for an already-configured org.
+    expect(screen.queryByText(/name your organization/i)).toBeNull()
+    expect(screen.queryByText(/To publish from CI or scripts/i)).toBeNull()
+  })
+
+  it('connected without keys → prompts to create an org API key', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockResolvedValue({ org: 'acme', keys: [] })
+    render(<PluginsEmptyState />)
+    expect(await screen.findByText(/is connected/i)).toBeInTheDocument()
+    expect(screen.getByText(/To publish from CI or scripts/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /org API key/i })).toHaveAttribute(
+      'href',
+      '/marketplace/keys'
+    )
+    expect(screen.queryByText(/already has API keys/i)).toBeNull()
+  })
+
+  it('connected but not an owner (403) → connected copy without a keys prompt', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockRejectedValue(
+      Object.assign(new Error('x'), { status: 403, org: 'acme' })
+    )
+    render(<PluginsEmptyState />)
+    await waitFor(() => expect(screen.getByText(/is connected/i)).toBeInTheDocument())
+    expect(screen.getAllByText('@acme').length).toBeGreaterThan(0)
+    // Keys are unknown for a non-owner — don't prompt to create one, don't claim they exist.
+    expect(screen.queryByText(/To publish from CI or scripts/i)).toBeNull()
+    expect(screen.queryByText(/already has API keys/i)).toBeNull()
+  })
+})

--- a/control-ui/components/__tests__/PluginsEmptyState.test.tsx
+++ b/control-ui/components/__tests__/PluginsEmptyState.test.tsx
@@ -51,7 +51,17 @@ describe('PluginsEmptyState', () => {
     } as unknown as Awaited<ReturnType<typeof api.listRegistryApiKeys>>)
     render(<PluginsEmptyState />)
     expect(await screen.findByText(/already has API keys/i)).toBeInTheDocument()
-    expect(screen.getAllByText('@acme').length).toBeGreaterThan(0)
+    // Org name appears once (no longer repeated) and links to the Entries tab.
+    expect(screen.getAllByText('@acme')).toHaveLength(1)
+    expect(screen.getByRole('link', { name: '@acme' })).toHaveAttribute(
+      'href',
+      '/marketplace/org/entries'
+    )
+    // "Install Plugin" is a link to the org area.
+    expect(screen.getByRole('link', { name: 'Install Plugin' })).toHaveAttribute(
+      'href',
+      '/marketplace/org'
+    )
     // No setup walkthrough for an already-configured org.
     expect(screen.queryByText(/name your organization/i)).toBeNull()
     expect(screen.queryByText(/To publish from CI or scripts/i)).toBeNull()

--- a/control-ui/components/__tests__/PluginsEmptyState.test.tsx
+++ b/control-ui/components/__tests__/PluginsEmptyState.test.tsx
@@ -57,10 +57,11 @@ describe('PluginsEmptyState', () => {
       'href',
       '/marketplace/org/entries'
     )
-    // "Install Plugin" is a link to the org area.
+    // "Install Plugin" links to the org's Entries tab (install owned plugins),
+    // not /marketplace/org, which redirects to the API Keys tab.
     expect(screen.getByRole('link', { name: 'Install Plugin' })).toHaveAttribute(
       'href',
-      '/marketplace/org'
+      '/marketplace/org/entries'
     )
     // No setup walkthrough for an already-configured org.
     expect(screen.queryByText(/name your organization/i)).toBeNull()

--- a/control-ui/components/__tests__/RecipesTab.test.tsx
+++ b/control-ui/components/__tests__/RecipesTab.test.tsx
@@ -8,6 +8,12 @@ const pushSpy = vi.fn()
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushSpy }),
 }))
+// The empty-state explainer is capability-aware and fetches on mount; its copy
+// is covered by PluginsEmptyState.test. Stub it here so RecipesTab tests stay
+// focused on the table/list behavior.
+vi.mock('../PluginsEmptyState', () => ({
+  PluginsEmptyState: () => <div>plugins-empty-state</div>,
+}))
 
 afterEach(() => {
   cleanup()
@@ -142,9 +148,11 @@ describe('RecipesTab — render', () => {
     expect(screen.getByLabelText('Reload plugins')).toBeInTheDocument()
   })
 
-  it('renders empty state when no items', () => {
+  it('renders the plugins empty-state explainer when no items and not searching', () => {
     render(<RecipesTab {...DEFAULT_PROPS} items={[]} />)
-    expect(screen.getByText(/No plugins installed/)).toBeInTheDocument()
+    // Copy/branches are covered by PluginsEmptyState.test; here we only assert
+    // the explainer is shown for the no-plugins (non-search) empty state.
+    expect(screen.getByText('plugins-empty-state')).toBeInTheDocument()
   })
 
   it('shows loading state in Refresh button', () => {

--- a/control-ui/components/__tests__/RegistryCatalog.test.tsx
+++ b/control-ui/components/__tests__/RegistryCatalog.test.tsx
@@ -10,12 +10,14 @@ import {
 } from '@testing-library/react'
 import * as api from '../../lib/api'
 import type { RegistryEntry, RegistryInstalledState } from '../../lib/api'
+import { __resetRegistryCapabilityCacheForTests } from '../../lib/hooks/useRegistryCapability'
 import RegistryCatalog from '../RegistryCatalog'
 import { ToastProvider } from '../Toast'
 
 vi.mock('../../lib/api', () => ({
   getRegistryCatalog: vi.fn(),
   getRegistryConnection: vi.fn(),
+  getPublishScope: vi.fn(),
   deleteRegistryEntry: vi.fn(),
   installRecipeFromRegistry: vi.fn(),
 }))
@@ -108,8 +110,14 @@ function mockApiSuccess(
 }
 
 beforeEach(() => {
-  // Default: managed deployment (not_self_hosted) so the large pre-existing
-  // catalog suite is undisturbed. Connect-discoverability tests override per case.
+  __resetRegistryCapabilityCacheForTests()
+  // Default persona: curator (administers the shared catalog), which keeps
+  // inline edit/remove + Publish visible so the large pre-existing suite is
+  // undisturbed. canManageOrg stays false for a curator, so the API-key and
+  // ownership-badge cases set an org-bound scope explicitly.
+  vi.mocked(api.getPublishScope).mockResolvedValue({ scope: null, curator: true, orgName: null })
+  // Default: managed deployment (not_self_hosted) so the connect surfaces stay
+  // hidden. Connect-discoverability tests override per case.
   vi.mocked(api.getRegistryConnection).mockRejectedValue(
     Object.assign(new Error('409 not_self_hosted'), { code: 'not_self_hosted' })
   )
@@ -129,7 +137,9 @@ describe('RegistryCatalog tabs and columns', () => {
     expect(await screen.findByText('brave-search')).toBeInTheDocument()
     expect(screen.queryByText('market-report')).not.toBeInTheDocument()
     expect(screen.getByText('Brave web search')).toBeInTheDocument()
-    expect(screen.getByText('Marketplace (1)')).toBeInTheDocument()
+    // Panel title is "Connectors" (the "Marketplace" tab labels the section); no count.
+    expect(screen.getByText('Connectors')).toBeInTheDocument()
+    expect(screen.queryByText(/Marketplace \(/)).not.toBeInTheDocument()
   })
 
   it('shows only plugin entries on the plugins route', async () => {
@@ -139,7 +149,6 @@ describe('RegistryCatalog tabs and columns', () => {
 
     expect(await screen.findByText('market-report')).toBeInTheDocument()
     expect(screen.queryByText('brave-search')).not.toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Search plugins...')).toBeInTheDocument()
   })
 
   it('uses the same compact columns for both tabs', async () => {
@@ -159,12 +168,12 @@ describe('RegistryCatalog tabs and columns', () => {
     }
   })
 
-  it('shows only the connectors Marketplace tab', async () => {
+  it('shows the top-level Marketplace tab, no public Plugins tab', async () => {
     mockApiSuccess()
     render(<RegistryCatalog />)
     await screen.findByText('brave-search')
 
-    expect(screen.getByRole('tab', { name: 'Connectors' })).toHaveAttribute(
+    expect(screen.getByRole('tab', { name: 'Marketplace' })).toHaveAttribute(
       'href',
       '/marketplace/connectors'
     )
@@ -271,73 +280,50 @@ describe('RegistryCatalog expansion and actions', () => {
 })
 
 describe('RegistryCatalog controls', () => {
-  it('searches and filters only the current tab', async () => {
-    mockApiSuccess([
-      MOCK_MCP_ENTRY,
-      { ...MOCK_MCP_ENTRY, id: '3', name: 'private-search', visibility: 'private' },
-      MOCK_RECIPE_ENTRY,
-    ])
+  it('filters the catalog by the search box', async () => {
+    mockApiSuccess([MOCK_MCP_ENTRY, { ...MOCK_MCP_ENTRY, id: '3', name: 'private-search' }])
     render(<RegistryCatalog />)
     await screen.findByText('brave-search')
 
     fireEvent.change(screen.getByPlaceholderText('Search connectors...'), {
       target: { value: 'private' },
     })
-
     expect(screen.queryByText('brave-search')).not.toBeInTheDocument()
     expect(screen.getByText('private-search')).toBeInTheDocument()
-    expect(screen.queryByText('market-report')).not.toBeInTheDocument()
   })
 
-  it('applies category and mode filters to the current tab', async () => {
+  it('applies the category filter to the current tab', async () => {
     mockApiSuccess([
-      MOCK_MCP_ENTRY,
-      {
-        ...MOCK_MCP_ENTRY,
-        id: '3',
-        name: 'remote-db',
-        category: 'database',
-        server_mode: 'remote',
-      },
+      MOCK_MCP_ENTRY, // category 'search'
+      { ...MOCK_MCP_ENTRY, id: '3', name: 'analytics-db', category: 'analytics' },
     ])
     render(<RegistryCatalog />)
     await screen.findByText('brave-search')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Filter by mode' }))
-    fireEvent.click(screen.getByRole('option', { name: 'Remote' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Filter by category' }))
+    fireEvent.click(screen.getByRole('option', { name: 'analytics' }))
     expect(screen.queryByText('brave-search')).not.toBeInTheDocument()
-    expect(screen.getByText('remote-db')).toBeInTheDocument()
+    expect(screen.getByText('analytics-db')).toBeInTheDocument()
   })
 
-  it('preselects the publish type from the active tab', async () => {
-    navigation.pathname = '/marketplace/plugins'
-    mockApiSuccess()
-    render(<RegistryCatalog />)
-    await screen.findByText('market-report')
+  // Publish-to-Marketplace is commented out under the distribution strategy
+  // narrowing (users don't publish to a public catalog), so the preselect-type
+  // test was removed with it.
 
-    fireEvent.click(screen.getByRole('button', { name: '+ Publish to Marketplace' }))
-    expect(navigation.push).toHaveBeenCalledWith('/marketplace/publish?type=recipe')
-  })
-
-  it('opens API-key management from the Marketplace title menu', async () => {
-    mockApiSuccess()
-    render(<RegistryCatalog />)
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Marketplace actions' }))
-    fireEvent.click(screen.getByRole('menuitem', { name: 'Manage API keys' }))
-
-    expect(navigation.push).toHaveBeenCalledWith('/marketplace/keys')
-  })
-
+  // API-key management moved to the org tab's "API Keys" sub-tab; the single-item
+  // catalog title kebab was removed, so its menu test was removed with it.
 })
 
 describe('RegistryCatalog state handling', () => {
-  it('renders thirty-five skeleton cells for the seven-column table', () => {
+  it('renders a skeleton across the compact columns while capability is resolving', () => {
     vi.mocked(api.getRegistryCatalog).mockReturnValue(new Promise(() => {}))
+    // Role is unknown while capability resolves, so the curator-only actions
+    // column is absent and the six visible columns render 30 skeleton cells
+    // across five rows.
+    vi.mocked(api.getPublishScope).mockReturnValue(new Promise(() => {}))
     const { container } = render(<RegistryCatalog />)
 
-    expect(container.querySelectorAll('.cu-skeleton')).toHaveLength(35)
-    expect(screen.getByPlaceholderText('Search connectors...')).toBeDisabled()
+    expect(container.querySelectorAll('.cu-skeleton')).toHaveLength(30)
   })
 
   it('shows an API error', async () => {
@@ -347,15 +333,10 @@ describe('RegistryCatalog state handling', () => {
     expect(await screen.findByText('Error: Network error')).toBeInTheDocument()
   })
 
-  it('shows the empty filter state', async () => {
-    mockApiSuccess()
+  it('shows the empty state when no entries match', async () => {
+    mockApiSuccess([MOCK_RECIPE_ENTRY])
     render(<RegistryCatalog />)
-    await screen.findByText('brave-search')
-
-    fireEvent.change(screen.getByPlaceholderText('Search connectors...'), {
-      target: { value: 'not-present' },
-    })
-    expect(screen.getByText('No entries match your filters.')).toBeInTheDocument()
+    expect(await screen.findByText('No entries match your filters.')).toBeInTheDocument()
   })
 })
 
@@ -376,13 +357,17 @@ describe('RegistryCatalog - connect discoverability', () => {
     expect(navigation.push).toHaveBeenCalledWith('/marketplace/connect')
   })
 
-  it('self-hosted + connected → no banner, header Connect button present', async () => {
+  it('self-hosted + connected → no banner and no header Connect button (nothing to connect)', async () => {
     mockApiSuccess()
     vi.mocked(api.getRegistryConnection).mockResolvedValue({ state: 'connected' })
     render(<RegistryCatalog />)
     await waitFor(() => expect(screen.getByText('brave-search')).toBeInTheDocument())
 
-    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument()
+    // A connected deployment has nothing to connect, so the "Connect" control is
+    // removed rather than presented as a no-op (design spec §5.1).
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Connect' })).not.toBeInTheDocument()
+    )
     expect(screen.queryByText(/This deployment isn't connected/i)).not.toBeInTheDocument()
   })
 
@@ -430,5 +415,57 @@ describe('RegistryCatalog - connect discoverability', () => {
     // The banner CTA still routes to the connect flow even inside the error branch.
     fireEvent.click(screen.getByRole('button', { name: 'Connect to registry' }))
     expect(navigation.push).toHaveBeenCalledWith('/marketplace/connect')
+  })
+})
+
+describe('RegistryCatalog - capability-gated controls (§5.1)', () => {
+  const ORG_OWNER = { scope: '@acme', curator: false, orgName: 'acme' }
+
+  it('org owner: publish + API-key kebab hidden, inline edit/remove hidden', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getPublishScope).mockResolvedValue(ORG_OWNER)
+    render(<RegistryCatalog />)
+    const row = (await screen.findByText('brave-search')).closest('tr')!
+
+    // Publishing is commented out under the distribution strategy narrowing, and
+    // API-key management moved to the org tab — the catalog title kebab is gone.
+    expect(
+      screen.queryByRole('button', { name: '+ Publish to Marketplace' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Marketplace actions' })).not.toBeInTheDocument()
+    // Editing/removing moves to the ownership area, so the discovery row no
+    // longer offers them (design spec §5.4).
+    expect(
+      within(row).queryByRole('button', { name: 'Actions for brave-search v1.0.0' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Edit or remove' })).not.toBeInTheDocument()
+  })
+
+  it('org owner: owned entries are badged and lead to the ownership area', async () => {
+    mockApiSuccess([{ ...MOCK_MCP_ENTRY, id: '9', name: '@acme/internal-tool' }, MOCK_MCP_ENTRY])
+    vi.mocked(api.getPublishScope).mockResolvedValue(ORG_OWNER)
+    render(<RegistryCatalog />)
+
+    const ownedRow = (await screen.findByText('@acme/internal-tool')).closest('tr')!
+    expect(within(ownedRow).getByRole('link', { name: 'You own this' })).toHaveAttribute(
+      'href',
+      '/publisher/entries'
+    )
+    // A catalog entry the org does not own carries no ownership badge.
+    const otherRow = screen.getByText('brave-search').closest('tr')!
+    expect(within(otherRow).queryByRole('link', { name: 'You own this' })).not.toBeInTheDocument()
+  })
+
+  it('browse-only (unbound, non-curator): no Publish, no API-key menu, no inline actions', async () => {
+    mockApiSuccess()
+    vi.mocked(api.getPublishScope).mockResolvedValue({ scope: null, curator: false, orgName: null })
+    render(<RegistryCatalog />)
+    await screen.findByText('brave-search')
+
+    expect(
+      screen.queryByRole('button', { name: '+ Publish to Marketplace' })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Marketplace actions' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('columnheader', { name: 'Edit or remove' })).not.toBeInTheDocument()
   })
 })

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -167,14 +167,20 @@ describe('RegistryConnectPanel', () => {
     expect(screen.queryByText(/Try again shortly/i)).toBeNull()
   })
 
-  it('shows connected + Disconnect when already connected', async () => {
+  it('connected view has no Disconnect control and states the connection is permanent', async () => {
     vi.mocked(api.getRegistryConnection).mockResolvedValue({
       state: 'connected',
       deploymentId: 'd',
       org: 'acme',
     })
     render(<RegistryConnectPanel />)
-    await waitFor(() => expect(screen.getByText('Disconnect')).toBeInTheDocument())
+    await waitFor(() =>
+      expect(screen.getByText(/Connected to the Evenfire Registry/)).toBeInTheDocument()
+    )
+    // Disconnect was removed (design spec §5.6): a claim is permanent, so no
+    // self-service teardown control is offered — the copy states this instead.
+    expect(screen.queryByRole('button', { name: /^disconnect$/i })).toBeNull()
+    expect(screen.getByText(/connection is permanent/i)).toBeInTheDocument()
   })
 
   // Regression guard: the panel used to render an env-var banner

--- a/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryConnectPanel.test.tsx
@@ -15,6 +15,8 @@ vi.mock('../../lib/api', () => ({
   recoverRegistryConnection: vi.fn(),
 }))
 vi.mock('../ConfirmDialog', () => ({ useConfirmDialog: vi.fn() }))
+const { mockPush } = vi.hoisted(() => ({ mockPush: vi.fn() }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mockPush }) }))
 
 function render(ui: React.ReactNode) {
   return rtlRender(<ToastProvider>{ui}</ToastProvider>)
@@ -181,6 +183,18 @@ describe('RegistryConnectPanel', () => {
     // self-service teardown control is offered — the copy states this instead.
     expect(screen.queryByRole('button', { name: /^disconnect$/i })).toBeNull()
     expect(screen.getByText(/connection is permanent/i)).toBeInTheDocument()
+  })
+
+  it('connected view offers a "Go to your organization" CTA → org entries', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      deploymentId: 'd',
+      org: 'acme',
+    })
+    render(<RegistryConnectPanel />)
+    const cta = await screen.findByRole('button', { name: /go to your organization/i })
+    fireEvent.click(cta)
+    expect(mockPush).toHaveBeenCalledWith('/marketplace/org/entries')
   })
 
   // Regression guard: the panel used to render an env-var banner

--- a/control-ui/components/__tests__/RegistryEntryDetailPage.test.tsx
+++ b/control-ui/components/__tests__/RegistryEntryDetailPage.test.tsx
@@ -33,6 +33,24 @@ vi.mock('../../lib/api', () => ({
   getRegistryCatalog: vi.fn(),
   installRecipeFromRegistry: vi.fn(),
 }))
+// The detail page gates edit/remove on capability (§5.4). Default to a curator
+// so the actions menu stays visible for the existing management assertions.
+vi.mock('../../lib/hooks/useRegistryCapability', () => ({
+  useRegistryCapability: () => ({
+    capability: {
+      orgName: 'acme',
+      scope: '@acme',
+      isCurator: true,
+      mode: 'managed',
+      authEnabled: true,
+      connectionState: null,
+      canManageOrg: true,
+    },
+    loading: false,
+    error: false,
+    reload: () => {},
+  }),
+}))
 
 const mockGetRegistryCatalog = vi.mocked(getRegistryCatalog)
 const mockInstallRecipeFromRegistry = vi.mocked(installRecipeFromRegistry)

--- a/control-ui/components/__tests__/RegistryInstallPage.test.tsx
+++ b/control-ui/components/__tests__/RegistryInstallPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
-import RegistryInstallPage from '../../app/registry/install/page'
+import RegistryInstallPage, { recipeAgentRequirement } from '../../app/registry/install/page'
 import { getRegistryEntryVersion, installRecipeFromRegistry } from '../../lib/api'
 import type { RegistryEntry } from '../../lib/api'
 import { ToastProvider } from '../Toast'
@@ -221,5 +221,54 @@ describe('RegistryInstallPage — WorkflowRecipe preview egress editor', () => {
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled()
 
     expect(installRecipeFromRegistry).not.toHaveBeenCalled()
+  })
+})
+
+describe('recipeAgentRequirement — step agent resolution reads spec.steps', () => {
+  const promptBridgeSpec = (extra: Record<string, unknown>) => ({
+    spec: {
+      pluginWorkloadSdk: {
+        promptBridge: { allowedModels: ['gpt-4o-mini'], maxOutputTokens: 4096 },
+      },
+      ...extra,
+    },
+  })
+
+  it('does not need an agent when a step agent is declared at spec.steps', () => {
+    // Regression guard: the wizard previously read spec.workflow.steps (no such
+    // CRD property), so a declared step agent was never seen — the wizard would
+    // inject spec.agent and override the author's step agent.
+    const parsed = promptBridgeSpec({
+      steps: [{ id: 'research', agent: { provider: 'claude', model: 'claude-sonnet-4-6' } }],
+    })
+    expect(recipeAgentRequirement(parsed).needsAgent).toBe(false)
+  })
+
+  it('needs an agent when promptBridge is set but neither spec.agent nor a step agent exists', () => {
+    const parsed = promptBridgeSpec({ steps: [{ id: 'research', run: { type: 'snippet' } }] })
+    const result = recipeAgentRequirement(parsed)
+    expect(result.needsAgent).toBe(true)
+    expect(result.allowedModels).toEqual(['gpt-4o-mini'])
+  })
+
+  it('does not need an agent when spec.agent is present', () => {
+    const parsed = promptBridgeSpec({ agent: { provider: 'openai', model: 'gpt-4o-mini' } })
+    expect(recipeAgentRequirement(parsed).needsAgent).toBe(false)
+  })
+
+  it('ignores a step agent at the non-CRD spec.workflow.steps path', () => {
+    // Guards against reverting to the wrong path: the reconciler resolves agents
+    // from spec.steps, so an agent under spec.workflow.steps must NOT satisfy it.
+    const parsed = promptBridgeSpec({
+      workflow: {
+        steps: [{ id: 'x', agent: { provider: 'claude', model: 'claude-sonnet-4-6' } }],
+      },
+      steps: [{ id: 'x', run: { type: 'snippet' } }],
+    })
+    expect(recipeAgentRequirement(parsed).needsAgent).toBe(true)
+  })
+
+  it('does not require an agent without promptBridge', () => {
+    expect(recipeAgentRequirement({ spec: { steps: [] } }).needsAgent).toBe(false)
   })
 })

--- a/control-ui/components/__tests__/RegistryInstallPage.test.tsx
+++ b/control-ui/components/__tests__/RegistryInstallPage.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 import type { ReactNode } from 'react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
-import RegistryInstallPage, { recipeAgentRequirement } from '../../app/registry/install/page'
-import { getRegistryEntryVersion, installRecipeFromRegistry } from '../../lib/api'
+import RegistryInstallPage, {
+  enabledProviders,
+  providerForModel,
+  recipeAgentRequirement,
+} from '../../app/registry/install/page'
+import type { LlmAllowedModel } from '../../lib/api'
+import { getLlmModels, getRegistryEntryVersion, installRecipeFromRegistry } from '../../lib/api'
 import type { RegistryEntry } from '../../lib/api'
 import { ToastProvider } from '../Toast'
 
@@ -28,8 +33,31 @@ vi.mock('../../lib/api', async () => {
     ...actual,
     getRegistryEntryVersion: vi.fn(),
     installRecipeFromRegistry: vi.fn(),
+    getLlmModels: vi.fn(),
   }
 })
+
+// Build an operator model-allowlist row; only provider/model/enabled matter to
+// the code under test, so the catalog-lifecycle fields are filled with stubs.
+const catalogRow = (provider: string, model: string, enabled = true): LlmAllowedModel =>
+  ({
+    id: `${provider}:${model}`,
+    provider,
+    model,
+    vendor: null,
+    display_name: null,
+    context_window_tokens: null,
+    enabled,
+    source: 'manual',
+    stale: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }) as LlmAllowedModel
+
+const DEFAULT_LLM_CATALOG: LlmAllowedModel[] = [
+  catalogRow('openai', 'gpt-4o-mini'),
+  catalogRow('claude', 'claude-3-5-sonnet'),
+]
 
 const RECIPE_ENTRY: RegistryEntry = {
   id: 'recipe-1',
@@ -86,6 +114,12 @@ const RECIPE_ENTRY: RegistryEntry = {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  // Every page render mounts useLlmAllowedModels → getLlmModels; default it so
+  // the picker derives providers from a catalog instead of throwing.
+  vi.mocked(getLlmModels).mockResolvedValue({ rows: DEFAULT_LLM_CATALOG })
 })
 
 function render(children: ReactNode) {
@@ -188,7 +222,8 @@ describe('RegistryInstallPage — WorkflowRecipe preview egress editor', () => {
 
     // Agent picker appears with the recipe's allowedModels + derived provider.
     expect(await screen.findByLabelText('Model')).toHaveValue('gpt-4o-mini')
-    expect(screen.getByLabelText('Provider')).toHaveValue('openai')
+    // Provider is derived from the operator catalog (loaded async), not a guess.
+    await waitFor(() => expect(screen.getByLabelText('Provider')).toHaveValue('openai'))
 
     fireEvent.click(screen.getByRole('button', { name: 'Continue' })) // Package -> Security
     fireEvent.click(await screen.findByRole('button', { name: 'Continue' })) // Security -> Install
@@ -270,5 +305,47 @@ describe('recipeAgentRequirement — step agent resolution reads spec.steps', ()
 
   it('does not require an agent without promptBridge', () => {
     expect(recipeAgentRequirement({ spec: { steps: [] } }).needsAgent).toBe(false)
+  })
+})
+
+describe('providerForModel — resolved from the operator catalog, not a heuristic', () => {
+  const catalog: LlmAllowedModel[] = [
+    catalogRow('openai', 'gpt-4o-mini'),
+    catalogRow('groq', 'llama-3.3-70b-versatile'),
+    catalogRow('cerebras', 'gpt-oss-120b'),
+    catalogRow('moonshot', 'kimi-k2.6'),
+    catalogRow('bailian', 'qwen3-coder-plus', false),
+  ]
+
+  // Each of these was mis-derived by the old string heuristic (→ openai).
+  it.each([
+    ['llama-3.3-70b-versatile', 'groq'],
+    ['gpt-oss-120b', 'cerebras'],
+    ['kimi-k2.6', 'moonshot'],
+    ['gpt-4o-mini', 'openai'],
+    ['qwen3-coder-plus', 'bailian'], // resolved even when the row is disabled
+  ])('maps %s → %s from the catalog', (model, provider) => {
+    expect(providerForModel(model, catalog)).toBe(provider)
+  })
+
+  it('returns "" for a model not in the catalog, so the user picks explicitly', () => {
+    expect(providerForModel('some-unlisted-model', catalog)).toBe('')
+    expect(providerForModel('anything', [])).toBe('')
+  })
+})
+
+describe('enabledProviders — distinct, sorted, enabled-only', () => {
+  it('excludes disabled rows and de-dupes providers', () => {
+    const catalog: LlmAllowedModel[] = [
+      catalogRow('openai', 'gpt-4o-mini'),
+      catalogRow('openai', 'gpt-4o'),
+      catalogRow('groq', 'llama-3.3-70b-versatile'),
+      catalogRow('bailian', 'qwen3-coder-plus', false),
+    ]
+    expect(enabledProviders(catalog)).toEqual(['groq', 'openai'])
+  })
+
+  it('returns [] for an empty catalog', () => {
+    expect(enabledProviders([])).toEqual([])
   })
 })

--- a/control-ui/components/__tests__/RegistryInstallPage.test.tsx
+++ b/control-ui/components/__tests__/RegistryInstallPage.test.tsx
@@ -136,6 +136,70 @@ describe('RegistryInstallPage — WorkflowRecipe preview egress editor', () => {
     expect(mockPush).toHaveBeenCalledWith('/plugins/sandbox-recipes/recipe-market-report')
   })
 
+  it('prompts for an agent and injects spec.agent when the recipe uses promptBridge', async () => {
+    const promptBridgeEntry: RegistryEntry = {
+      ...RECIPE_ENTRY,
+      recipe_meta: {
+        recipeYaml: JSON.stringify(
+          {
+            apiVersion: 'clerum.io/v1alpha1',
+            kind: 'WorkflowRecipe',
+            metadata: { name: 'market-report' },
+            spec: {
+              triggers: { onDemand: { requiresApproval: false, allowedActors: ['user'] } },
+              pluginWorkloadSdk: {
+                allowedCallers: ['orchestrator'],
+                promptBridge: {
+                  allowedModels: ['gpt-4o-mini', 'claude-3-5-sonnet'],
+                  maxOutputTokens: 4096,
+                },
+              },
+              workloads: [
+                {
+                  id: 'web-search',
+                  type: 'deployment',
+                  image: 'clerum/web-search:test',
+                  port: 3000,
+                  transport: { type: 'streamableHttp', path: '/mcp' },
+                },
+              ],
+              steps: [
+                {
+                  id: 'research',
+                  run: { type: 'snippet', language: 'typescript', code: 'return { ok: true }' },
+                },
+              ],
+            },
+          },
+          null,
+          2
+        ),
+      },
+    }
+    vi.mocked(getRegistryEntryVersion).mockResolvedValueOnce(promptBridgeEntry)
+    vi.mocked(installRecipeFromRegistry).mockResolvedValueOnce({
+      recipeName: 'recipe-market-report',
+      registryEntry: 'market-report',
+      registryVersion: '1.0.0',
+      correlationId: 'corr-1',
+    })
+
+    render(<RegistryInstallPage />)
+
+    // Agent picker appears with the recipe's allowedModels + derived provider.
+    expect(await screen.findByLabelText('Model')).toHaveValue('gpt-4o-mini')
+    expect(screen.getByLabelText('Provider')).toHaveValue('openai')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' })) // Package -> Security
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue' })) // Security -> Install
+    fireEvent.click(await screen.findByRole('button', { name: 'Install plugin' }))
+
+    await waitFor(() => expect(installRecipeFromRegistry).toHaveBeenCalledTimes(1))
+    const payload = vi.mocked(installRecipeFromRegistry).mock.calls[0][0]
+    const manifest = JSON.parse(payload.recipeManifest as string)
+    expect(manifest.spec.agent).toEqual({ provider: 'openai', model: 'gpt-4o-mini' })
+  })
+
   it('blocks registry recipe install when edited egress exceeds CRD cardinality', async () => {
     vi.mocked(getRegistryEntryVersion).mockResolvedValueOnce(RECIPE_ENTRY)
     render(<RegistryInstallPage />)

--- a/control-ui/components/__tests__/RegistryInstallPage.test.tsx
+++ b/control-ui/components/__tests__/RegistryInstallPage.test.tsx
@@ -235,6 +235,59 @@ describe('RegistryInstallPage — WorkflowRecipe preview egress editor', () => {
     expect(manifest.spec.agent).toEqual({ provider: 'openai', model: 'gpt-4o-mini' })
   })
 
+  it('keeps Install blocked when the promptBridge model is not in the operator catalog', async () => {
+    // Finding A: allowedModels is author-controlled, not constrained to the
+    // operator catalog. An unlisted model resolves to no provider, so no
+    // spec.agent is injected — Install must stay disabled, not submit a manifest
+    // that fails after install.
+    const unlistedEntry: RegistryEntry = {
+      ...RECIPE_ENTRY,
+      recipe_meta: {
+        recipeYaml: JSON.stringify(
+          {
+            apiVersion: 'clerum.io/v1alpha1',
+            kind: 'WorkflowRecipe',
+            metadata: { name: 'market-report' },
+            spec: {
+              triggers: { onDemand: { requiresApproval: false, allowedActors: ['user'] } },
+              pluginWorkloadSdk: {
+                allowedCallers: ['orchestrator'],
+                promptBridge: { allowedModels: ['unlisted-model'], maxOutputTokens: 4096 },
+              },
+              workloads: [
+                {
+                  id: 'web-search',
+                  type: 'deployment',
+                  image: 'clerum/web-search:test',
+                  port: 3000,
+                  transport: { type: 'streamableHttp', path: '/mcp' },
+                },
+              ],
+              steps: [
+                {
+                  id: 'research',
+                  run: { type: 'snippet', language: 'typescript', code: 'return { ok: true }' },
+                },
+              ],
+            },
+          },
+          null,
+          2
+        ),
+      },
+    }
+    vi.mocked(getRegistryEntryVersion).mockResolvedValueOnce(unlistedEntry)
+
+    render(<RegistryInstallPage />)
+
+    // Model prefills from the recipe, but the provider can't be derived (unlisted).
+    expect(await screen.findByLabelText('Model')).toHaveValue('unlisted-model')
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' })) // Package -> Security
+    // Security -> Install is gated on a resolved agent, so it stays disabled.
+    expect(await screen.findByRole('button', { name: 'Continue' })).toBeDisabled()
+    expect(installRecipeFromRegistry).not.toHaveBeenCalled()
+  })
+
   it('blocks registry recipe install when edited egress exceeds CRD cardinality', async () => {
     vi.mocked(getRegistryEntryVersion).mockResolvedValueOnce(RECIPE_ENTRY)
     render(<RegistryInstallPage />)

--- a/control-ui/components/__tests__/RevealApiKeyModal.test.tsx
+++ b/control-ui/components/__tests__/RevealApiKeyModal.test.tsx
@@ -1,6 +1,7 @@
 // control-ui/components/__tests__/RevealApiKeyModal.test.tsx
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render as rtlRender, screen } from '@testing-library/react'
+import type { CreatedRegistryApiKey } from '../../lib/api'
 import RevealApiKeyModal from '../RevealApiKeyModal'
 import { ToastProvider } from '../Toast'
 
@@ -9,37 +10,52 @@ function render(ui: React.ReactNode) {
 }
 afterEach(cleanup)
 
+const key = (scopes: string[], over: Partial<CreatedRegistryApiKey> = {}): CreatedRegistryApiKey =>
+  ({
+    id: 'k1',
+    key: 'efrk_secret',
+    key_prefix: 'efrk_',
+    scopes,
+    expires_at: null,
+    ...over,
+  }) as CreatedRegistryApiKey
+
+const readKey = key(['registry:read'])
+const pushKey = key(['registry:read', 'registry:publish'])
+
 describe('RevealApiKeyModal', () => {
   it('warns it is shown once and masks the key by default', () => {
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={() => {}} />)
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
     expect(screen.getByRole('alert')).toHaveTextContent(/only time/i)
     expect(screen.queryByText('efrk_secret')).toBeNull()
   })
 
   it('reveals on toggle', () => {
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={() => {}} />)
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /reveal/i }))
     expect(screen.getByText('efrk_secret')).toBeInTheDocument()
   })
 
-  it('copies to clipboard', async () => {
+  it('copies the key to clipboard', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={() => {}} />)
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /^copy$/i }))
     expect(writeText).toHaveBeenCalledWith('efrk_secret')
   })
 
   it('shows a fallback message when clipboard fails', async () => {
-    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('x')) } })
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={() => {}} />)
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }))
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('x')) },
+    })
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /^copy$/i }))
     expect(await screen.findByText(/select.*copy manually/i)).toBeInTheDocument()
   })
 
   it('calls onClose only via the explicit button', () => {
     const onClose = vi.fn()
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={onClose} />)
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={onClose} />)
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).not.toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: /saved it|close|done/i }))
@@ -47,8 +63,22 @@ describe('RevealApiKeyModal', () => {
   })
 
   it('focuses the Copy button on open', () => {
-    render(<RevealApiKeyModal apiKey="efrk_secret" onClose={() => {}} />)
-    const copyButton = screen.getByRole('button', { name: /copy/i })
-    expect(document.activeElement).toBe(copyButton)
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /^copy$/i }))
+  })
+
+  it('hides the Docker section for a non-publish key', () => {
+    render(<RevealApiKeyModal created={readKey} orgScope="acme" onClose={() => {}} />)
+    expect(screen.queryByText(/use with docker/i)).toBeNull()
+  })
+
+  it('shows Docker push instructions for a registry:publish key', () => {
+    render(<RevealApiKeyModal created={pushKey} orgScope="acme" onClose={() => {}} />)
+    expect(screen.getByText(/use with docker/i)).toBeInTheDocument()
+    expect(screen.getByText(/docker login/i)).toBeInTheDocument()
+    // push coordinate carries the org namespace
+    expect(screen.getByText(/registry\.evenfire\.ai\/acme/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy login command/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /download dockerconfigjson/i })).toBeInTheDocument()
   })
 })

--- a/control-ui/components/__tests__/Sidebar.test.tsx
+++ b/control-ui/components/__tests__/Sidebar.test.tsx
@@ -23,41 +23,16 @@ afterEach(() => {
 beforeEach(() => vi.clearAllMocks())
 
 describe('Sidebar publisher gating', () => {
-  it('shows the Publisher entry for an org-bound non-curator deploy', async () => {
+  it('does not render a Publisher entry (folded into the Marketplace org tab)', () => {
     vi.mocked(hook.usePublishScope).mockReturnValue({
       scope: { scope: 'acme', curator: false, orgName: 'Acme' },
       loading: false,
       error: false,
     })
     render(<Sidebar currentTab="hosts" />)
-    const link = await screen.findByRole('link', { name: /publisher/i })
-    expect(link).toHaveAttribute('href', '/publisher')
-  })
-
-  it('hides the Publisher entry when publisherUiEnabled is false (self-hosted default), even for an org-bound non-curator deploy', () => {
-    vi.mocked(hook.usePublishScope).mockReturnValue({
-      scope: { scope: 'acme', curator: false, orgName: 'Acme', publisherUiEnabled: false },
-      loading: false,
-      error: false,
-    })
-    render(<Sidebar currentTab="hosts" />)
+    // Publisher was folded into the org-named Marketplace tab (design spec §4).
     expect(screen.queryByRole('link', { name: /publisher/i })).toBeNull()
-  })
-
-  it('hides the Publisher entry on a curator deploy', () => {
-    vi.mocked(hook.usePublishScope).mockReturnValue({
-      scope: { scope: null, curator: true, orgName: null },
-      loading: false,
-      error: false,
-    })
-    render(<Sidebar currentTab="hosts" />)
-    expect(screen.queryByRole('link', { name: /publisher/i })).toBeNull()
-  })
-
-  it('hides the Publisher entry while publish-scope is loading', () => {
-    vi.mocked(hook.usePublishScope).mockReturnValue({ scope: null, loading: true, error: false })
-    render(<Sidebar currentTab="hosts" />)
-    expect(screen.queryByRole('link', { name: /publisher/i })).toBeNull()
+    expect(screen.getByRole('link', { name: /marketplace/i })).toBeInTheDocument()
   })
 
   it('still renders the other navigation entries', () => {

--- a/control-ui/components/__tests__/dockerCredential.test.ts
+++ b/control-ui/components/__tests__/dockerCredential.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildDockerLoginCommand,
+  buildDockerPushCommand,
+  buildDockerTagCommand,
+  buildImageCoordinate,
   buildPushCoordinate,
   deriveDockerconfigjson,
   resolveDockerCredential,
@@ -61,5 +64,20 @@ describe('dockerCredential helpers', () => {
     })
     expect(out.registry).toBe('registry.evenfire.ai')
     expect(JSON.parse(out.dockerconfigjson).auths['registry.evenfire.ai'].password).toBe('efrk_x')
+  })
+
+  it('builds a per-entry image coordinate, dropping the @ from the namespace', () => {
+    expect(buildImageCoordinate('registry.evenfire.ai', '@acme', 'my-connector', '1.2.0')).toBe(
+      'registry.evenfire.ai/acme/my-connector:1.2.0'
+    )
+  })
+
+  it('generates docker tag and push commands from the entry name + org scope', () => {
+    expect(buildDockerTagCommand('registry.evenfire.ai', '@acme', 'my-connector', '1.2.0')).toBe(
+      'docker tag <local-image> registry.evenfire.ai/acme/my-connector:1.2.0'
+    )
+    expect(buildDockerPushCommand('registry.evenfire.ai', '@acme', 'my-connector', '1.2.0')).toBe(
+      'docker push registry.evenfire.ai/acme/my-connector:1.2.0'
+    )
   })
 })

--- a/control-ui/lib/__tests__/egressModel.test.ts
+++ b/control-ui/lib/__tests__/egressModel.test.ts
@@ -155,6 +155,34 @@ describe('egressModel', () => {
     })
   })
 
+  it('reports egress for non-transport workloads that declare egressBindings', () => {
+    const findings = analyzeWorkflowRecipeEgress({
+      spec: {
+        workloads: [
+          {
+            id: 'analyzer',
+            type: 'deployment',
+            egressBindings: [
+              { dns: 'api.github.com', port: 443, protocol: 'TCP' },
+              { dns: 'mirror.gcr.io', port: 443, protocol: 'TCP' },
+            ],
+          },
+          // A plain workload with no egress stays silent (no default-deny noise).
+          { id: 'db', type: 'statefulset', image: 'postgres:16' },
+        ],
+      },
+    })
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      label: 'Workload "analyzer"',
+      mode: 'exact-host',
+      bindingCount: 2,
+    })
+    expect(findings[0].targets).toEqual(['api.github.com', 'mirror.gcr.io'])
+    expect(findings[0].ports).toEqual([443])
+  })
+
   it('reports exact-host, public-web, and over-limit workload egress findings', () => {
     const findings = analyzeWorkflowRecipeEgress({
       spec: {

--- a/control-ui/lib/api.ts
+++ b/control-ui/lib/api.ts
@@ -3376,6 +3376,21 @@ export async function revokeRegistryApiKey(id: string): Promise<void> {
   await registryCodedRequest('DELETE', `/api/v1/admin/registry/keys/${encodeURIComponent(id)}`)
 }
 
+// ─── Org container images (real repos + tags from the registry) ────────────
+export type OrgImage = {
+  name: string
+  visibility: string
+  createdAt: string
+  tags: string[]
+}
+export async function listOrgImages(): Promise<{ org: string; images: OrgImage[] }> {
+  const raw = (await registryCodedRequest('GET', '/api/v1/admin/registry/images')) as {
+    org?: string
+    images?: OrgImage[]
+  }
+  return { org: raw?.org ?? '', images: raw?.images ?? [] }
+}
+
 // ─── Self-hosted registry connect flow (spec §6.1/§6.3) ───────────────────────
 // Drives control-api's /api/v1/admin/registry/connect endpoints
 // (control-api/src/routes/admin/registryConnect.ts). GET is READ-ONLY and polls

--- a/control-ui/lib/egressModel.ts
+++ b/control-ui/lib/egressModel.ts
@@ -474,13 +474,20 @@ export function analyzeWorkflowRecipeEgress(
     ? (spec.workloads as Record<string, unknown>[])
     : []
   workloads.forEach((workload, index) => {
-    if (!workload.transport) return
+    const isTransport = !!workload.transport
+    const hasBindings = Array.isArray(workload.egressBindings) && workload.egressBindings.length > 0
+    // Review every transport workload (to state default-deny even when closed) and
+    // any non-transport workload that declares egressBindings. Plain deployments,
+    // cronjobs, and stateful sets that reach the internet (or cluster-internal
+    // hosts) must surface their rules too — not only MCP transports.
+    if (!isTransport && !hasBindings) return
     const id = typeof workload.id === 'string' ? workload.id : `workload-${index}`
+    const label = isTransport ? `Transport workload "${id}"` : `Workload "${id}"`
     const summary = summarizeBindings(workload.egressBindings)
     if (summary.mode === 'none') {
       findings.push({
         key: `workload-${index}-default-deny`,
-        label: `Transport workload "${id}"`,
+        label,
         mode: 'none',
         bindingCount: 0,
         severity: 'info',
@@ -492,7 +499,7 @@ export function analyzeWorkflowRecipeEgress(
     if (summary.bindingCount > MAX_EGRESS_BINDINGS) {
       findings.push({
         key: `workload-${index}-too-many`,
-        label: `Transport workload "${id}"`,
+        label,
         mode: summary.mode,
         bindingCount: summary.bindingCount,
         severity: 'error',
@@ -504,7 +511,7 @@ export function analyzeWorkflowRecipeEgress(
     }
     findings.push({
       key: `workload-${index}-${summary.mode}`,
-      label: `Transport workload "${id}"`,
+      label,
       mode: summary.mode,
       bindingCount: summary.bindingCount,
       severity: summary.mode === 'public-web' ? 'warning' : 'info',

--- a/control-ui/lib/hooks/__tests__/useRegistryCapability.test.tsx
+++ b/control-ui/lib/hooks/__tests__/useRegistryCapability.test.tsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import * as api from '../../api'
+import {
+  __resetRegistryCapabilityCacheForTests,
+  useRegistryCapability,
+} from '../useRegistryCapability'
+
+vi.mock('../../api', async orig => {
+  const actual = await orig<typeof import('../../api')>()
+  return { ...actual, getPublishScope: vi.fn(), getRegistryConnection: vi.fn() }
+})
+
+function Probe() {
+  const { capability, loading, error } = useRegistryCapability()
+  if (loading) return <div>loading</div>
+  if (error) return <div>error</div>
+  if (!capability) return <div>none</div>
+  return (
+    <div>
+      <span data-testid="mode">{capability.mode}</span>
+      <span data-testid="org">{capability.orgName ?? '-'}</span>
+      <span data-testid="curator">{String(capability.isCurator)}</span>
+      <span data-testid="auth">{String(capability.authEnabled)}</span>
+      <span data-testid="manage">{String(capability.canManageOrg)}</span>
+    </div>
+  )
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetRegistryCapabilityCacheForTests()
+})
+
+describe('useRegistryCapability', () => {
+  it('self-hosted, org-bound, auth active → canManageOrg true', async () => {
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@acme',
+      curator: false,
+      orgName: 'acme',
+    })
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      authEnabled: true,
+    })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('mode').textContent).toBe('self-hosted'))
+    expect(screen.getByTestId('org').textContent).toBe('acme')
+    expect(screen.getByTestId('auth').textContent).toBe('true')
+    expect(screen.getByTestId('manage').textContent).toBe('true')
+  })
+
+  it('self-hosted, org-bound, but auth NOT active → canManageOrg false', async () => {
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@acme',
+      curator: false,
+      orgName: 'acme',
+    })
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'disconnected',
+      authEnabled: false,
+    })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('manage').textContent).toBe('false'))
+    expect(screen.getByTestId('mode').textContent).toBe('self-hosted')
+  })
+
+  it('managed deploy (not_self_hosted) with org scope → mode managed, canManageOrg true without authEnabled', async () => {
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@acme',
+      curator: false,
+      orgName: 'acme',
+    })
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('nope'), { status: 409, code: 'not_self_hosted' })
+    )
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('mode').textContent).toBe('managed'))
+    expect(screen.getByTestId('manage').textContent).toBe('true')
+  })
+
+  it('curator → canManageOrg false (catalog is their admin surface)', async () => {
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: null,
+      curator: true,
+      orgName: null,
+    })
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('nope'), { status: 409, code: 'not_self_hosted' })
+    )
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('curator').textContent).toBe('true'))
+    expect(screen.getByTestId('manage').textContent).toBe('false')
+  })
+
+  it('connection probe failing (non-managed) leaves mode unknown but identity intact', async () => {
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@acme',
+      curator: false,
+      orgName: 'acme',
+    })
+    vi.mocked(api.getRegistryConnection).mockRejectedValue(
+      Object.assign(new Error('boom'), { status: 500 })
+    )
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('mode').textContent).toBe('unknown'))
+    expect(screen.getByTestId('org').textContent).toBe('acme')
+    // unknown mode is not managed and has no authEnabled → cannot manage
+    expect(screen.getByTestId('manage').textContent).toBe('false')
+  })
+
+  it('publish-scope failing (transient) → error surface for Retry', async () => {
+    vi.mocked(api.getPublishScope).mockRejectedValue(
+      Object.assign(new Error('boom'), { status: 500 })
+    )
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      authEnabled: true,
+    })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByText('error')).toBeInTheDocument())
+  })
+})

--- a/control-ui/lib/hooks/__tests__/useRegistryCapability.test.tsx
+++ b/control-ui/lib/hooks/__tests__/useRegistryCapability.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import * as api from '../../api'
 import {
   __resetRegistryCapabilityCacheForTests,
+  invalidateRegistryCapabilityCache,
   useRegistryCapability,
 } from '../useRegistryCapability'
 
@@ -120,5 +121,45 @@ describe('useRegistryCapability', () => {
     })
     render(<Probe />)
     await waitFor(() => expect(screen.getByText('error')).toBeInTheDocument())
+  })
+
+  it('silent auth error → stops loading without surfacing an error (global handler navigates away)', async () => {
+    vi.mocked(api.getPublishScope).mockRejectedValue(
+      Object.assign(new Error('unauthorized'), { silent: true })
+    )
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      authEnabled: true,
+    })
+    render(<Probe />)
+    // Must not get stuck on "loading", and must not surface the Retry error.
+    await waitFor(() => expect(screen.getByText('none')).toBeInTheDocument())
+    expect(screen.queryByText('loading')).toBeNull()
+    expect(screen.queryByText('error')).toBeNull()
+  })
+
+  it('invalidateRegistryCapabilityCache clears the cached identity so the next mount refetches', async () => {
+    vi.mocked(api.getRegistryConnection).mockResolvedValue({
+      state: 'connected',
+      authEnabled: true,
+    })
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@acme',
+      curator: false,
+      orgName: 'acme',
+    })
+    const first = render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('org').textContent).toBe('acme'))
+    first.unmount()
+
+    // Logout clears the cache; a different user then logs in.
+    invalidateRegistryCapabilityCache()
+    vi.mocked(api.getPublishScope).mockResolvedValue({
+      scope: '@beta',
+      curator: false,
+      orgName: 'beta',
+    })
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('org').textContent).toBe('beta'))
   })
 })

--- a/control-ui/lib/hooks/useRegistryCapability.ts
+++ b/control-ui/lib/hooks/useRegistryCapability.ts
@@ -1,0 +1,146 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  type RegistryConnectionState,
+  getPublishScope,
+  getRegistryConnection,
+  isSilentApiError,
+} from '../api'
+import { isPublisherEnabled } from './usePublishScope'
+
+export type RegistryDeploymentMode = 'self-hosted' | 'managed' | 'unknown'
+
+export type RegistryCapability = {
+  orgName: string | null
+  scope: string | null // '@org', or null for curator / unbound
+  isCurator: boolean
+  mode: RegistryDeploymentMode
+  authEnabled: boolean
+  connectionState: RegistryConnectionState | null
+  /**
+   * Org-owned management surfaces (publish, entry edit/remove, API keys) may
+   * render. A self-hosted deploy must also have registry auth active; managed
+   * deploys gate on publisher-UI enablement + scope alone.
+   */
+  canManageOrg: boolean
+}
+
+export type RegistryCapabilityState = {
+  capability: RegistryCapability | null
+  loading: boolean
+  /** Transient failure of the publish-scope probe — safe to offer Retry (§5.1). */
+  error: boolean
+  reload: () => void
+}
+
+// Session-stable identity cache + in-flight de-duplication. The org/curator/
+// connection signals do not change while the console is open, and refetching
+// on every mount both flickered the org-tab label ("Your org" → "@org") and
+// fanned out getRegistryConnection() calls from every component that reads
+// capability — enough, with React StrictMode double-invoke, to trip the
+// registry connect-status rate limit (30/min). The first resolve populates the
+// cache; concurrent mounts share one in-flight request; reload() clears both.
+let capabilityCache: RegistryCapability | null = null
+let inflight: Promise<RegistryCapability> | null = null
+
+async function loadCapability(): Promise<RegistryCapability> {
+  // Connection probe is soft: resolve to a mode + auth state, never reject.
+  const connection = getRegistryConnection().then(
+    status => ({
+      mode: 'self-hosted' as RegistryDeploymentMode,
+      authEnabled: status.authEnabled === true,
+      connectionState: status.state as RegistryConnectionState | null,
+    }),
+    err => ({
+      mode: ((err as { code?: unknown }).code === 'not_self_hosted'
+        ? 'managed'
+        : 'unknown') as RegistryDeploymentMode,
+      authEnabled: false,
+      connectionState: null as RegistryConnectionState | null,
+    })
+  )
+  const [scope, conn] = await Promise.all([getPublishScope(), connection])
+  const managed = conn.mode === 'managed'
+  const next: RegistryCapability = {
+    orgName: scope.orgName,
+    scope: scope.scope,
+    isCurator: scope.curator,
+    mode: conn.mode,
+    authEnabled: conn.authEnabled,
+    connectionState: conn.connectionState,
+    canManageOrg: isPublisherEnabled(scope) && (managed || conn.authEnabled),
+  }
+  capabilityCache = next
+  return next
+}
+
+function sharedLoad(): Promise<RegistryCapability> {
+  if (!inflight) {
+    inflight = loadCapability().finally(() => {
+      inflight = null
+    })
+  }
+  return inflight
+}
+
+/** Test hook: drop the module cache + in-flight request so each test is isolated. */
+export function __resetRegistryCapabilityCacheForTests(): void {
+  capabilityCache = null
+  inflight = null
+}
+
+/**
+ * Compose the two capability probes the registry redesign renders controls from
+ * (design spec §5.1: render from capability, not role guesses).
+ *
+ * - `getPublishScope()` is authoritative for identity (org, curator) and is the
+ *   retryable signal — a hard failure here surfaces as `error` so the caller can
+ *   offer Retry.
+ * - `getRegistryConnection()` gives deployment mode + auth state. It fails OPEN:
+ *   `not_self_hosted` (409) means managed; any other failure leaves `mode`
+ *   'unknown' and never blocks the identity signal.
+ *
+ * A silent 401 (session expiry) is left to the global auth handler.
+ */
+export function useRegistryCapability(): RegistryCapabilityState {
+  const [capability, setCapability] = useState<RegistryCapability | null>(capabilityCache)
+  const [loading, setLoading] = useState(capabilityCache === null)
+  const [error, setError] = useState(false)
+  const [nonce, setNonce] = useState(0)
+  const reload = useCallback(() => {
+    capabilityCache = null
+    inflight = null
+    setNonce(n => n + 1)
+  }, [])
+
+  useEffect(() => {
+    // Serve the session-stable identity synchronously when we already have it,
+    // so the org-tab label doesn't flicker and no request is made.
+    if (capabilityCache && nonce === 0) {
+      setCapability(capabilityCache)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setError(false)
+    sharedLoad().then(
+      next => {
+        if (cancelled) return
+        setCapability(next)
+        setLoading(false)
+      },
+      err => {
+        if (cancelled || isSilentApiError(err)) return
+        setError(true)
+        setLoading(false)
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [nonce])
+
+  return { capability, loading, error, reload }
+}

--- a/control-ui/lib/hooks/useRegistryCapability.ts
+++ b/control-ui/lib/hooks/useRegistryCapability.ts
@@ -84,10 +84,19 @@ function sharedLoad(): Promise<RegistryCapability> {
   return inflight
 }
 
-/** Test hook: drop the module cache + in-flight request so each test is isolated. */
-export function __resetRegistryCapabilityCacheForTests(): void {
+/**
+ * Clear the session-stable identity cache + any in-flight probe. Call on auth
+ * changes (logout) so a same-tab logout→login does not serve the previous user's
+ * org identity until a manual reload.
+ */
+export function invalidateRegistryCapabilityCache(): void {
   capabilityCache = null
   inflight = null
+}
+
+/** Test hook: drop the module cache + in-flight request so each test is isolated. */
+export function __resetRegistryCapabilityCacheForTests(): void {
+  invalidateRegistryCapabilityCache()
 }
 
 /**
@@ -132,7 +141,14 @@ export function useRegistryCapability(): RegistryCapabilityState {
         setLoading(false)
       },
       err => {
-        if (cancelled || isSilentApiError(err)) return
+        if (cancelled) return
+        // A silent 401 is handled by the global auth handler (it navigates away),
+        // so don't surface an error — but still clear loading so the surface can't
+        // spin if that handler ever no-ops.
+        if (isSilentApiError(err)) {
+          setLoading(false)
+          return
+        }
         setError(true)
         setLoading(false)
       }

--- a/control-ui/next.config.js
+++ b/control-ui/next.config.js
@@ -88,6 +88,22 @@ const nextConfig = {
       },
       { source: '/registry', destination: '/marketplace/connectors', permanent: true },
       { source: '/registry/:path*', destination: '/marketplace/:path*', permanent: true },
+      // The Publisher console folded into the org-named Marketplace tab (§4).
+      // Keep old bookmarks working. Specific routes precede the catch-all.
+      { source: '/publisher/api-keys', destination: '/marketplace/keys', permanent: true },
+      {
+        source: '/publisher/credentials',
+        destination: '/marketplace/org/credentials',
+        permanent: true,
+      },
+      {
+        source: '/publisher/shared-with-me',
+        destination: '/marketplace/org/entries',
+        permanent: true,
+      },
+      { source: '/publisher/entries', destination: '/marketplace/org/entries', permanent: true },
+      { source: '/publisher', destination: '/marketplace/org/entries', permanent: true },
+      { source: '/publisher/:path*', destination: '/marketplace/org/entries', permanent: true },
       { source: '/cost', destination: '/cost-and-usage/usage', permanent: true },
       { source: '/cost/:path*', destination: '/cost-and-usage/:path*', permanent: true },
       { source: '/marketplace', destination: '/marketplace/connectors', permanent: true },

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.369",
+  "version": "0.1.370",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.369",
+      "version": "0.1.370",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.364",
+  "version": "0.1.365",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.364",
+      "version": "0.1.365",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.374",
+  "version": "0.1.375",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.374",
+      "version": "0.1.375",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.377",
+      "version": "0.1.378",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.361",
+  "version": "0.1.362",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.361",
+      "version": "0.1.362",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.372",
+      "version": "0.1.373",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.370",
+  "version": "0.1.371",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.370",
+      "version": "0.1.371",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.373",
+  "version": "0.1.374",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.373",
+      "version": "0.1.374",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.375",
+  "version": "0.1.376",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.375",
+      "version": "0.1.376",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.376",
+  "version": "0.1.377",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.376",
+      "version": "0.1.377",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.371",
+  "version": "0.1.372",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.371",
+      "version": "0.1.372",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.363",
+  "version": "0.1.364",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.363",
+      "version": "0.1.364",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.371",
+  "version": "0.1.372",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.363",
+  "version": "0.1.364",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.374",
+  "version": "0.1.375",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.373",
+  "version": "0.1.374",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.372",
+  "version": "0.1.373",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.377",
+  "version": "0.1.378",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.364",
+  "version": "0.1.365",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.370",
+  "version": "0.1.371",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.376",
+  "version": "0.1.377",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.361",
+  "version": "0.1.362",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.375",
+  "version": "0.1.376",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.369",
+  "version": "0.1.370",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/docs/features/self-hosted-registry-ux-redesign.md
+++ b/docs/features/self-hosted-registry-ux-redesign.md
@@ -1,0 +1,339 @@
+# Self-hosted Registry UX Redesign — Implementation Map
+
+> **Status:** Phase 1 planned in detail and ready to execute. Phases 2–5 mapped to
+> files/functions here but not yet broken down into tickets.
+>
+> **Source design spec:** _Self-hosted Registry UX Redesign — Design Spec_ (7-page PDF).
+> This document is the engineering change-map for that spec: every file and
+> function that changes, grouped by the spec's five phases.
+>
+> **Scope boundary:** control-ui only. Confirmed **zero new backend endpoints**
+> are required for phases 1–5 (see [Backend: no new endpoints](#backend-no-new-endpoints)).
+
+---
+
+## 0. Orientation — facts every phase depends on
+
+### 0.1 Routing model (filesystem vs. public URL)
+
+The App Router tree uses `app/registry/**` and `app/publisher/**`, but the
+**public URLs are `/marketplace/*` and `/publisher/*`** via Next rewrites/redirects.
+
+- `control-ui/next.config.js:34-36` — rewrites `/marketplace/connectors`, `/marketplace/plugins`, `/marketplace/:path*` → `/registry/:path*`. **So `app/registry/**` _is_ the Marketplace.**
+- `control-ui/next.config.js:89-93` — permanent redirects `/registry` → `/marketplace/connectors`, `/registry/:path*` → `/marketplace/:path*`, `/marketplace` → `/marketplace/connectors`.
+- `control-ui/app/constants/routes.ts:70-82` — `CONTROL_ROUTES.marketplace.*` (root, connectors, plugins, install, publish, keys, connect, entry, editEntry).
+- `control-ui/app/constants/routes.ts:100-105` — `CONTROL_ROUTES.publisher.*` (root, entries, sharedWithMe, credentials) — **the routes folded away in Phase 2**.
+- `control-ui/app/constants/routes.ts:89-99` — `CONTROL_ROUTES.plugins.*` — the "Plugins" sidebar item points here, **not** to the Marketplace.
+
+### 0.2 Capability signals already in the browser
+
+The redesign's core rule — _render controls from capability, not role guesses_
+(§5.1) — is satisfiable with two calls that already exist and are already
+fetched. **No new signal, no new endpoint.**
+
+| Signal | Client fn (`lib/api.ts`) | Endpoint | Fields |
+| --- | --- | --- | --- |
+| Who am I / do I administer the catalog | `getPublishScope()` `:2835` | `GET /admin/registry/publish-scope` | `scope: string\|null`, `curator: boolean`, `orgName: string\|null`, `publisherUiEnabled?: boolean` (type `PublishScope` `:2826`) |
+| Self-hosted vs managed / connection state / auth on | `getRegistryConnection()` `:3426` | `GET /admin/registry/connect` | `state`, `authEnabled`, `org`/`requestedOrgName`, `recoveryError?` (type `RegistryConnectionStatus` `:3417`); `not_self_hosted` (409) ⇒ managed |
+
+Derived rules (enforced identically server-side, so a client guess only costs a typed 409/400):
+- **Cross-org sharing available** ⇔ `authEnabled && !curator && orgName != null`. Server guards: `resolveSelfServiceOrg` (`control-api/src/routes/admin/registry.ts:2274`) → 400 `registry_self_service_unavailable`; grants 403 → client `unavailable` (`lib/hooks/useInboundGrants.ts`).
+- **Key/publish management available** ⇔ same predicate; server guard `prepareKeysRequest` (`registry.ts:2165`) → 409 `no_org` / `registry_auth_disabled` / `registry_url_not_configured`.
+- **Curator (administers shared catalog)** keeps existing catalog management controls — for a curator "the catalog _is_ the administration surface" (§5.4).
+
+Existing consumers of these signals: `usePublishScope()` (`lib/hooks/usePublishScope.ts:18`) + gate `isPublisherEnabled(scope)` (`:50`); `Sidebar/index.tsx:17`, `PublisherView/index.tsx:20`, `PublishToRegistryForm.tsx:130`, `RegistryCatalog.tsx:86`, `RegistryApiKeysPanel.tsx:88`, `RegistryConnectPanel.tsx:55`.
+
+### 0.3 The §5.1 rule to encode once
+
+> **structurally absent** (a capability this deployment can never have) → state the fact once, **remove the control**.
+> **transient** (a call that could succeed on retry) → keep the control, **offer Retry**.
+
+Today these are collapsed — e.g. `RegistryApiKeysPanel` shows a `not-owner`/`auth-disabled`
+banner where a Retry-style affordance sits next to a permission error that can
+never change. **Recommended shared primitive:** a small `useRegistryCapability()`
+hook (new, `control-ui/lib/hooks/useRegistryCapability.ts`) that composes
+`getPublishScope()` + `getRegistryConnection()` into a typed capability object
+(`{ canManageOrg, canShare, isCurator, isSelfHosted, authEnabled, orgName }`),
+consumed everywhere a control is conditionally rendered. This is the backbone of
+Phases 1 and 3.
+
+### 0.4 Backend: no new endpoints
+
+Verified against `control-api/src/routes/admin/registry.ts`,
+`registryConnect.ts`, and the registry services. The two failure causes the spec
+defers are genuinely undetectable client-side today and **stay deferred**:
+
+1. **Missing publish/push permission** — no introspection endpoint; the registry's 403 only surfaces reactively (`handleKeysError` `registry.ts:2208`, `handleRegistryProxyError` `:2325`).
+2. **Quota exceeded** — no per-org image quota field/endpoint exists anywhere.
+
+Both get "one honest sentence" in the UI (§5.5), not proactive rendering.
+
+**Disconnect endpoint disposition:** `DELETE /admin/registry/connect`
+(`registryConnect.ts:715` → `deleteConnection()` `registryConnectionDb.ts:173`)
+**stays** — it is intentionally reachable even without a configured registry URL
+(`requireSelfHostedAdmin(..., { requireRegistryUrl: false })`) and is the only
+self-service reset for a wedged connection. Phase 1 removes the **UI control**,
+not the endpoint (§5.6).
+
+---
+
+## Phase 1 — Ownership moves; discovery stops offering failing actions; sharing stated; Disconnect removed
+
+**Delivers (from spec §7):** ownership actions move off discovery surfaces into
+the Publisher; discovery surfaces stop offering actions that fail; sharing limits
+are _stated_ not _offered_; Disconnect is removed. **No route moves yet** (that's
+Phase 2), so this phase is purely control-visibility + copy.
+
+### 1.1 Remove management actions from the catalog (discovery surface)
+
+File: `control-ui/components/RegistryCatalog.tsx`
+
+| Location | Current | Change |
+| --- | --- | --- |
+| `:459-486` per-row `RowActionsMenu` (Edit → `editEntry`, **Remove from Marketplace** danger) | offered on every row | Remove Edit/Remove from the catalog rows. Owned entries get a non-actioning **"You own this"** badge that links to the ownership area (Publisher today; org tab in Phase 2). Keep Edit/Remove _only_ when `isCurator` (curator administers the catalog, §5.4). |
+| `:38-46 REGISTRY_COLUMNS` `actions` column | edit/remove column | Drop the management `actions` column for non-curators; badge lives in the name cell. |
+| `:119-138 handleConfirmRemove` + `:544-589` remove-confirm modal | delete from catalog | Move to ownership area (`OwnedEntries`), remove from catalog for non-curators. |
+| `:264-274` header "Manage API keys" (`RowActionsMenu` → `marketplace.keys`) | always shown | Gate behind `canManageOrg`; otherwise omit (structurally absent). |
+| `:316-325` "+ Publish to Marketplace" | always shown | Gate behind `canManageOrg`. |
+| `:306-315` "Connect" toolbar button + `:211` connect banner (`:86 loadConnectionMode`) | shown unless `managed` | Keep for now (claim-at-first-use is Phase 3); ensure it's hidden when `authEnabled` (already connected) so it can't present a no-op. |
+
+Detail page mirrors the same removal:
+- `control-ui/app/registry/entries/[name]/[version]/page.tsx:28 RegistryEntryActionsMenu` (Edit/Remove/Source repo) and `:206 handleRemove` → gate Edit/Remove behind ownership/curator; keep the source-repo link and install button (`:259-267`).
+
+### 1.2 State sharing limits instead of offering them (§5.4)
+
+Cross-org sharing is impossible for a self-hosted org. Where the UI currently
+_offers_ a share control that will 403:
+
+- `control-ui/components/PublisherView/OwnedEntries.tsx:94-104` — "Share access" button on private entries → `GrantAccessModal`. **Change:** when `!canShare` (self-hosted / no grant capability), replace the button with a one-line stated fact ("Cross-org sharing isn't available on this deployment"), per §5.1 _structurally absent_. Keep the button only when `canShare`.
+- `control-ui/components/PublisherView/index.tsx:51-54` already hides the "Shared with me" tab when inbound grants are `unavailable` — keep; this is the correct pattern to generalize.
+
+### 1.3 Remove the Disconnect control (§5.6)
+
+File: `control-ui/components/RegistryConnectPanel.tsx`
+
+- **Remove:** `:281 handleDisconnect` and the Disconnect button `:305-314` in the `connected` view (its confirm dialog wrongly implied reversibility).
+- **Keep:** the broken-connection recovery paths that also call `disconnectRegistryConnection()` — `:240 handleStartOver` (from `rejected`) and `:259 handleStartOverFromConnecting` (confirm-gated, from `connecting`). Per spec: _"Recovery paths survive only where the connection is already broken and there is nothing left to preserve."_
+- `control-ui/lib/api.ts:3451 disconnectRegistryConnection()` — **keep** (still used by the two recovery paths; backend endpoint unchanged).
+- Copy: the `connected` view should state the claim is permanent (no undo button).
+
+### 1.4 Encode the capability rule once (§5.1)
+
+- **New:** `control-ui/lib/hooks/useRegistryCapability.ts` (see §0.3).
+- **Refactor consumers** to distinguish structurally-absent (remove control + state fact) from transient (keep control + Retry):
+  - `control-ui/components/RegistryApiKeysPanel.tsx:23-30` view states — `not-owner`/`no-org`/`auth-disabled`/`url-not-configured` are structurally absent → no Retry; only `error` (transient) keeps Retry (`:146-153`).
+  - `control-ui/components/PublisherView/DockerCredentials.tsx:24-31` — same treatment.
+  - `control-ui/components/PublisherView/RetryBanner.tsx` — reserve strictly for transient failures.
+
+### 1.5 Phase 1 file summary
+
+| Action | Files |
+| --- | --- |
+| **Modify** | `components/RegistryCatalog.tsx`, `app/registry/entries/[name]/[version]/page.tsx`, `components/PublisherView/OwnedEntries.tsx`, `components/PublisherView/index.tsx`, `components/RegistryConnectPanel.tsx`, `components/RegistryApiKeysPanel.tsx`, `components/PublisherView/DockerCredentials.tsx`, `components/PublisherView/RetryBanner.tsx` |
+| **Create** | `lib/hooks/useRegistryCapability.ts` (+ test) |
+| **Delete** | none (controls hidden, not files removed) |
+| **Untouched** | all install-flow files (§Phase 3 note), backend |
+
+---
+
+## Phase 2 — Org-named tab, folded Publisher, route redirects, docs
+
+**Delivers:** fold the standalone Publisher console into the Marketplace as a
+**third tab labelled with the org name** (`@acme`; reads `Your org` before a claim,
+pressing it starts the claim — Phase 3). Add route redirects and update operator
+docs. **Named cost (spec §7):** moving these surfaces changes published URLs;
+redirects keep old paths working and operator guides that reference them must be
+updated in the same change.
+
+### 2.1 Add the tabs to the Marketplace
+
+Target IA (spec §4): `Marketplace › Connectors | @acme`, where the org tab holds
+plugins, images, mcp servers, credentials, connection.
+
+- `control-ui/components/RegistryCatalog.tsx:48-54` — today derives `connectors|plugins` tabs from pathname. **Add** a third destination `@<orgName>` (label from `getPublishScope().orgName`, or `Your org` when null). New route segment `app/registry/org/**` (public `/marketplace/<org>` or `/marketplace/org`).
+- **New:** `control-ui/app/registry/org/page.tsx` (org area shell) rendering the folded Publisher content (below).
+
+### 2.2 Fold the Publisher console into the org tab
+
+Relocate — not rewrite — `components/PublisherView/**` under the org tab.
+
+| Folded from | Into |
+| --- | --- |
+| `app/publisher/page.tsx` (redirect `/publisher` → `/publisher/entries`) | redirect → `/marketplace/<org>` |
+| `app/publisher/entries/page.tsx` (`PublisherView activeTab="entries"`) | org tab › **Plugins/Entries** sub-view |
+| `app/publisher/shared-with-me/page.tsx` (`activeTab="shared"`) | org tab › **Shared with me** (hidden when `!canShare`) |
+| `app/publisher/credentials/page.tsx` (`activeTab="credentials"` → `DockerCredentialsPanel`) | org tab › **Credentials** (unified in Phase 5) |
+| `app/publisher/api-keys/page.tsx` — **already redirects to `marketplace.keys`** | precedent for the fold; keep redirect |
+| `components/PublisherView/index.tsx:60` header `Publisher — ${orgScope}` | reframed as the org tab header (`@org`) |
+| `components/Sidebar/constants.tsx:96` `publisher` nav item + `Sidebar/index.tsx:17-25` gating | **remove** the standalone Publisher sidebar entry |
+
+Components carried over as-is (behavior unchanged, parent changes): `OwnedEntries.tsx`, `GrantedToMe.tsx`, `DockerCredentials.tsx`, `DockerCredentialModal.tsx`, `GrantAccessModal/**`, `RetryBanner.tsx`, `dockerCredential.ts`, `types.ts`.
+
+### 2.3 Sidebar relabel
+
+- `control-ui/components/Sidebar/constants.tsx:91-95` — `workflow-recipes` item `label: 'Plugins'` → **`Installed plugins`** (spec §4: three plugin-shaped concepts each need their own verb — running here, browsable in catalog, authored by you).
+- `control-ui/components/Sidebar/constants.tsx:86-90` — Marketplace item stays; it now owns the org tab.
+
+### 2.4 Routes + redirects + docs
+
+- `control-ui/app/constants/routes.ts:100-105` — repoint/retire `CONTROL_ROUTES.publisher.*`; add `CONTROL_ROUTES.marketplace.org`.
+- `control-ui/next.config.js` — add **permanent redirects** `/publisher`, `/publisher/entries`, `/publisher/shared-with-me`, `/publisher/credentials` → the new `/marketplace/<org>` sub-views (mirror the existing `:89-93` pattern).
+- **Docs to update in the same change** (operator guides referencing `/publisher/*`): grep `docs/**` and `control-ui/README.md:32,47` (Publisher/RegistryCatalog descriptions), `control-ui/README.md:31` sidebar table.
+
+### 2.5 Phase 2 file summary
+
+| Action | Files |
+| --- | --- |
+| **Create** | `app/registry/org/page.tsx` (+ any `org/[tab]` segments) |
+| **Modify** | `components/RegistryCatalog.tsx`, `components/PublisherView/index.tsx`, `components/Sidebar/constants.tsx`, `components/Sidebar/index.tsx`, `app/constants/routes.ts`, `next.config.js`, `control-ui/README.md`, `docs/**` operator guides |
+| **Convert to redirect** | `app/publisher/page.tsx`, `app/publisher/entries/page.tsx`, `app/publisher/shared-with-me/page.tsx`, `app/publisher/credentials/page.tsx` (keep `api-keys` redirect) |
+| **Delete** | standalone Publisher sidebar entry (`Sidebar/constants.tsx:96`) |
+
+---
+
+## Phase 3 — Claim-at-first-use component replacing the connect flow
+
+**Delivers:** a single reusable claim component that swaps into whichever surface
+needs identity and hands control back when done. **Never a destination** — no setup
+page to find, no ceremony to finish before working (§5.2).
+
+### 3.1 Build the reusable claim component
+
+- **New:** `control-ui/components/RegistryClaimInline/index.tsx` — one field (org name) + submit; on success returns control to the caller. Reuses the existing request/claim/recover machinery but **not** as a page.
+- Org name stays a human decision (permanent publish scope + image-path namespace — a generated name would hand someone a public identity they never chose, §5.2).
+- Approval wording is **server-driven** (§5.3): render success vs. "an operator must approve" _only_ from the returned `state`, never a hardcoded promise. Source states from `getRegistryConnection()` / `requestRegistryConnection()` responses (`state ∈ pending|connecting|approved|rejected|connected`).
+
+### 3.2 Rewire surfaces to claim inline
+
+Replace "go to the connect page" affordances with an inline claim that triggers
+the first time identity is needed (install-private / publish / open org tab):
+
+- `control-ui/components/RegistryCatalog.tsx:306-315` Connect button + `:211` banner → inline claim trigger (`Your org` tab press, spec §4).
+- `control-ui/components/RegistryApiKeysPanel.tsx:162-177` "Connect" link (self-hosted `auth-disabled`) → inline claim.
+- Org tab `Your org` label (Phase 2) → pressing starts the claim.
+
+### 3.3 Retire the connect page (keep the API)
+
+- `control-ui/app/registry/connect/page.tsx` + `components/RegistryConnectPanel.tsx` — demote from a destination. Keep the request/claim/recover **logic** (extract into the inline component or a shared hook); keep broken-state recovery reachable.
+- `control-ui/lib/api.ts:3426-3460` — `getRegistryConnection` / `requestRegistryConnection` / `submitRegistryClaim` / `recoverRegistryConnection` / `disconnectRegistryConnection` all **stay** (now called by the inline component).
+- `next.config.js` — redirect `/marketplace/connect` appropriately (into the org tab).
+
+### 3.4 Phase 3 file summary
+
+| Action | Files |
+| --- | --- |
+| **Create** | `components/RegistryClaimInline/index.tsx` (+ types, test); optionally `lib/hooks/useRegistryClaim.ts` |
+| **Modify** | `components/RegistryCatalog.tsx`, `components/RegistryApiKeysPanel.tsx`, the org-tab shell, `next.config.js` |
+| **Demote/retire** | `app/registry/connect/page.tsx`, `components/RegistryConnectPanel.tsx` (logic extracted, not deleted wholesale) |
+| **Untouched** | connect/claim/recover API fns and all backend routes |
+
+---
+
+## Phase 4 — Images area + generated push commands
+
+**Delivers:** an images area under the org tab that **generates** `docker login` /
+`tag` / `push` commands from the entry name + org scope, so the user never composes
+a registry path by hand and malformed-path failures become unreachable (§5.5).
+
+**New-build**, but reuse the existing docker builders and reveal modal.
+
+### 4.1 Reuse / extend the existing builders
+
+File: `control-ui/components/PublisherView/dockerCredential.ts` (already present)
+
+- Existing: `DEFAULT_REGISTRY_HOST = 'registry.evenfire.ai'` (`:3`), `buildDockerLoginCommand` (`:5`), `dockerNamespace` (`:15`), `buildPushCoordinate` (`:19`, returns `registry/namespace/<name>:<tag>` template), `deriveDockerconfigjson` (`:23`), `resolveDockerCredential` (`:44`).
+- **Add:** `buildDockerTagCommand(localRef, registry, orgScope, name, tag)` and `buildDockerPushCommand(registry, orgScope, name, tag)` — filling `<name>`/`<tag>` from the **entry**, not free text.
+- Reuse `components/PublisherView/DockerCredentialModal.tsx` as the reveal/copy presentation pattern (it already renders `docker login` + downloadable `dockerconfigjson` + push coordinate).
+
+### 4.2 Build the images area
+
+- **New:** `control-ui/app/registry/org/images/page.tsx` (or an org-tab sub-view) + `components/RegistryImages/**` — lists the org's image-backed entries and, per entry, shows copy-ready `login`/`tag`/`push` commands generated from `entry.name` + `getPublishScope().scope`.
+- Source data from existing catalog/owned-entries: `getOwnedRegistryEntries()` (`lib/api.ts:2917`), `RegistryEntry` image ref fields; push creds from `createRegistryApiKey` (`:3366`, `CreatedRegistryApiKey.dockerconfigjson`/`registry` `:3304-3305`).
+- **Two undetectable failures** (missing publish permission, quota exceeded) get **one honest sentence each** — no proactive gating (§0.4, §5.5).
+
+### 4.3 Reconcile host/namespace strings (cleanup)
+
+Flagged inconsistency to resolve while building: builder host is
+`registry.evenfire.ai` (`dockerCredential.ts:3`) but publish placeholders still show
+`us-central1-docker.pkg.dev/...` (`PublishToRegistryForm.tsx:410-421`,
+`CreateMcpServerForm/index.tsx:402`) and org naming mixes `@clerum`/`clerum`. Pick
+one source of truth (prefer the server-provided `created.registry`).
+
+### 4.4 Phase 4 file summary
+
+| Action | Files |
+| --- | --- |
+| **Create** | `app/registry/org/images/page.tsx`, `components/RegistryImages/**` (+ tests) |
+| **Modify/extend** | `components/PublisherView/dockerCredential.ts` (add tag/push builders), reuse `DockerCredentialModal.tsx` |
+| **Cleanup** | reconcile registry host strings in `PublishToRegistryForm.tsx`, `CreateMcpServerForm/index.tsx` |
+| **No new** | backend endpoints (quota/push introspection stay deferred) |
+
+---
+
+## Phase 5 — Credentials unified into one list
+
+**Delivers:** the org tab's registry API keys and docker push credentials become
+**one credentials list** (§4 IA: `credentials — one key list for CI and docker push`).
+
+Today there are two surfaces over the **same** `efrk_` keys:
+- `control-ui/components/RegistryApiKeysPanel.tsx` (`/marketplace/keys`) — CI/publish keys.
+- `control-ui/components/PublisherView/DockerCredentials.tsx` — docker push credentials.
+
+Both call the identical API (`listRegistryApiKeys`/`createRegistryApiKey`/`revokeRegistryApiKey`, `lib/api.ts:3360-3376`); a created key carries docker push fields iff it has `registry:publish` (`CreatedRegistryApiKey.dockerconfigjson` `:3304`).
+
+### 5.1 Merge into one panel
+
+- **New/merged:** `control-ui/components/RegistryCredentials/**` — one table of keys; each row shows its scopes and, when `registry:publish` is present, the docker-push affordance (reveal via `DockerCredentialModal` pattern, commands via `dockerCredential.ts`).
+- **Retire/absorb:** `RegistryApiKeysPanel.tsx`, `DockerCredentials.tsx`, `DockerCredentialModal.tsx`, `RevealApiKeyModal.tsx`, `CreateApiKeyModal.tsx` — consolidate create/reveal/revoke into the unified panel.
+- Live under the org tab's **Credentials** sub-view (Phase 2 slot).
+- `next.config.js` — redirect `/marketplace/keys` into the unified credentials view.
+
+### 5.2 Phase 5 file summary
+
+| Action | Files |
+| --- | --- |
+| **Create** | `components/RegistryCredentials/**` (+ tests) |
+| **Absorb/retire** | `components/RegistryApiKeysPanel.tsx`, `components/CreateApiKeyModal.tsx`, `components/RevealApiKeyModal.tsx`, `components/PublisherView/DockerCredentials.tsx`, `components/PublisherView/DockerCredentialModal.tsx` |
+| **Reuse** | `dockerCredential.ts`, `lib/api.ts` key fns (unchanged) |
+| **Modify** | org-tab shell, `next.config.js` |
+
+---
+
+## Explicitly out of scope / untouched
+
+- **Plugin install wizard** — `app/registry/install/page.tsx` (incl. `RegistryRecipeInstallPreview` `:116`, `RegistryInstallPageContent` `:392`, `RegistryInstallPage` `:477`), `app/registry/install/loading.tsx`, `components/RegistryInstallForm/**`, `components/registryInstallHelpers.ts`, and install API fns (`installFromRegistry`, `installRecipeFromRegistry`, `getRegistryCredentialSchema`). Spec §6: "its own piece of work, deliberately untouched."
+- **Live quota / permission introspection** — needs registry-side endpoints that don't exist (§0.4).
+- **All backend routes/services** — no changes required.
+
+### Incidental cleanup (optional, any phase)
+
+- `control-ui/components/RegistryInstallModal.tsx:22 RegistryInstallModal` — dead code (no non-test imports); the live install path is `RegistryInstallForm` + `RegistryRecipeInstallPreview`. Safe to delete.
+
+---
+
+## Decisions carried from the design spec (§6)
+
+| Decision | Rationale | Phase |
+| --- | --- | --- |
+| Fold Publisher into a Marketplace tab labelled with the org name | one destination for the catalog; ownership + identity stop being separate | 2 |
+| Claim identity inline at first use, one reusable component | removes the setup gate; built once, not per-flow | 3 |
+| Disconnect removed entirely | irreversible, no benefit, its confirmation was wrong | 1 |
+| Approval wording driven by server state | correct across registry configs without knowing any | 3 |
+| Publishing-UI toggle narrows to publishing actions only | turning publishing off must not remove push creds or connection status | 1–2 |
+| Image visibility & cross-org sharing stated, not offered | neither possible for a self-hosted org | 1 (sharing), 4 (image visibility) |
+| Live quota & permission introspection deferred | needs registry-side endpoints that don't exist | — |
+| Plugin install wizard unchanged | its own work | — |
+
+---
+
+## Open items before coding
+
+1. **HTML scaffolds not yet obtained.** The spec references two static scaffolds
+   (`marketplace-catalog-scaffold.html`, `claim-and-images-scaffold.html`) as
+   `attachment:` links; they were not in the PDF and aren't on disk. They pin down
+   the exact layout/copy for the catalog tabs (Phase 2), the claim step (Phase 3),
+   and the images area (Phase 4). **Needed before finalizing those phases' UI.**
+2. **Org-tab URL shape** — decide `/marketplace/<org>` vs. a fixed `/marketplace/org`
+   segment (affects redirect table and how `orgName` maps to a route).
+3. **Curator experience** — confirm curators keep full catalog management (§5.4);
+   the capability hook must branch on `isCurator`.

--- a/docs/how-to/publish-plugin-to-registry.md
+++ b/docs/how-to/publish-plugin-to-registry.md
@@ -1,42 +1,207 @@
-# How to: publish a plugin to the registry
+# Publish your first plugin — a beginner's guide
 
-Once your deployment is [connected](connect-to-registry.md), an **org owner** can
-publish connectors and recipes under your `@<org>/` scope. You can import an
-entry by hand from the Control UI, or — for scripts and CI — publish with an
-**org API key** (`efrk_…`). This guide covers the API-key path.
+New to Evenfire plugins? Start here. This guide walks you all the way from "I
+have some code" to "my plugin is installed and running in my cluster," with no
+prior knowledge assumed. By the end you'll have published a private plugin under
+your organization and installed it from the Control UI.
 
-## Prerequisites
+If you already know the ropes and just want the API details, jump to
+[Reference: the publish API](#reference-the-publish-api) at the bottom.
 
-- A [connected deployment](connect-to-registry.md) — publishing is scoped to
-  your org, which connecting establishes.
-- You are an **org owner** (only owners mint publish keys).
+---
 
-## 1. Mint an org API key (`efrk_…`)
+## What is a plugin?
 
-In **Control UI → your org → API keys**, create a key. It is:
+A **plugin** is a small application that runs on the Evenfire platform. Under the
+hood it's a single file called a **WorkflowRecipe** — a YAML document that
+describes what your plugin is made of. A plugin can include any mix of:
 
-- **org-scoped** — it can publish only under your `@<org>/` scope;
-- long-lived, opaque, and **revocable** (rotate or revoke on the same screen);
-- sent as `Authorization: Bearer efrk_…`.
+- **MCP servers** — tools your AI agents can call (search, lookups, actions).
+- **A web UI** — a page embedded in the app.
+- **Background jobs** — work that runs on a schedule (e.g. a nightly scan).
+- **Webhooks** — endpoints that react to outside events.
+- **LLM access** — steps that call a language model through the platform.
 
-Pass the key via an **environment variable or CI secret** only — never a CLI
-flag, a Makefile, a committed file, or logs.
+Each of those pieces is a **workload** — a container image plus a bit of config.
+You write the recipe, push your images, publish it, and the platform turns it
+into the right Kubernetes objects, wires up networking, and runs it for you.
 
-Check the key and learn your org scope:
+> You don't need to know Kubernetes. The recipe hides it. If a term here is new,
+> keep going — the steps are copy-pasteable.
+
+## The big picture
+
+Publishing a plugin is four steps:
+
+```
+  1. Write            2. Push               3. Publish            4. Install
+  ┌──────────┐        ┌──────────┐          ┌──────────┐         ┌──────────┐
+  │ recipe   │        │ your     │          │ register │         │ from the │
+  │ .yaml    │  ───▶  │ images → │   ───▶   │ under    │  ───▶   │ Control  │
+  │          │        │ registry │          │ @your-org│         │ UI       │
+  └──────────┘        └──────────┘          └──────────┘         └──────────┘
+   describe it         ship the code         list it in           run it in
+                       (containers)          your Marketplace     your cluster
+```
+
+Do them in order the first time. After that, shipping an update is just
+"push new images → publish a new version."
+
+## Before you start
+
+You need:
+
+- A **connected deployment.** Publishing is scoped to your organization, and
+  connecting is what establishes that. See
+  [Connect to the registry](connect-to-registry.md).
+- To be an **org owner.** Only owners can create publish keys.
+- **Docker** installed locally (to build and push your images).
+
+That's it. Let's go.
+
+---
+
+## Step 1 — Get your organization API key
+
+Everything you publish is authenticated with one **org API key** (it starts with
+`efrk_…`). This single key does two jobs: it lets you **push images** and
+**publish entries**, both only under your own `@your-org` scope.
+
+1. Open the **Control UI**.
+2. Go to **Marketplace → your org (`@your-org`) → API Keys**.
+3. Create a key and copy it somewhere safe — you won't see it again.
+
+Keep the key in an environment variable, never in a file you commit or a command
+you paste into chat:
+
+```bash
+export REGISTRY_API_KEY="efrk_…"
+```
+
+Quick sanity check — this also tells you your exact org name:
 
 ```bash
 curl -s -H "Authorization: Bearer $REGISTRY_API_KEY" \
   https://registry.evenfire.ai/api/v1/whoami
-# → {"type":"machine","orgName":"<org>","scopes":["registry:publish", …]}
+# → {"type":"machine","orgName":"your-org","scopes":["registry:publish", …]}
 ```
 
-## 2. Publish — `POST /api/v1/entries`
+The `orgName` it prints (without the `@`) is what you'll use everywhere below.
+We'll call it `your-org`.
 
-Required fields: `name` (**`@<org>/<name>`**), `version` (semver), `entryType`
-(`recipe` | `mcp-server`), `description`, `author`, `origin`, `category`,
-`contentCreatorTag`, `configCreatorTag`. For a recipe, also send `recipe` — the
-recipe document as a **string** (≤ 100 KB). Optional: `tags`, `visibility`
-(`public` | `private`).
+## Step 2 — Write your recipe
+
+The recipe is a YAML file describing your plugin. The simplest useful plugin is
+a single MCP server. Save this as `recipe.yaml` and change the names to yours:
+
+```yaml
+apiVersion: clerum.io/v1alpha1
+kind: WorkflowRecipe
+metadata:
+  name: hello-plugin          # ← your plugin's identity (lowercase, no spaces)
+spec:
+  description: My first plugin — a single MCP server.
+  contextRef: context1        # required whenever a workload has a transport
+  workloads:
+    - id: server
+      type: deployment
+      image: registry.evenfire.ai/your-org/hello-plugin:0.1.0  # ← set in Step 3
+      port: 3000
+      transport:
+        type: streamableHttp
+        path: /mcp
+```
+
+Two things a beginner must get right:
+
+- **`metadata.name`** is your plugin's identity. Use lowercase letters, numbers,
+  and dashes (like a domain name). You'll reuse it when you publish.
+- **`image`** must point at your organization's registry namespace:
+  `registry.evenfire.ai/your-org/<something>:<tag>`. We create that image next.
+
+Want a plugin with a web UI, a nightly job, or an LLM step instead? Copy one of
+the ready-made examples and adapt it — see
+[Where to go next](#where-to-go-next). The rules are the same; only the `spec`
+grows.
+
+## Step 3 — Build and push your images
+
+Your workloads run from **container images**. Each `image:` in the recipe has to
+actually exist in your org's registry namespace. Log in once with your API key
+(the username is a literal underscore, `_`):
+
+```bash
+docker login registry.evenfire.ai -u _ -p "$REGISTRY_API_KEY"
+```
+
+Then build, tag with the **exact coordinate** you put in the recipe, and push:
+
+```bash
+# from the folder with your app's Dockerfile
+docker build -t registry.evenfire.ai/your-org/hello-plugin:0.1.0 .
+docker push registry.evenfire.ai/your-org/hello-plugin:0.1.0
+```
+
+The image coordinate is always:
+
+```
+registry.evenfire.ai/<your-org>/<name>:<tag>
+```
+
+Repeat for every workload in your recipe. The `image:` in the recipe and the tag
+you push must match character-for-character.
+
+> Tip: the Control UI's **Marketplace → your org → API Keys** page shows the
+> exact `docker login`, `docker tag`, and `docker push` commands prefilled for
+> your org, so you can copy them instead of typing.
+
+## Step 4 — Publish the entry
+
+Publishing registers your recipe in the Marketplace under your org. Create an
+`entry.json` describing it:
+
+```json
+{
+  "name": "@your-org/hello-plugin",
+  "version": "0.1.0",
+  "entryType": "recipe",
+  "description": "My first plugin — a single MCP server.",
+  "author": "your-org",
+  "contactEmail": "you@example.com",
+  "origin": "human-authored",
+  "category": "utility",
+  "tags": ["mcp", "example"],
+  "visibility": "private",
+  "contentCreatorTag": "community",
+  "configCreatorTag": "community",
+  "recipe": "<paste your recipe.yaml here, as a single JSON string>"
+}
+```
+
+A few of these fields are short controlled labels — the values above come
+straight from a real published entry, so they're safe to reuse:
+
+- **`origin`** — where the recipe came from; `human-authored` for one you wrote.
+- **`contentCreatorTag`** / **`configCreatorTag`** — who authored it; `community`
+  for a plugin published by your org (as opposed to a first-party one).
+- **`category`** — a one-word bucket like `utility`, `workflow`, `research`, or
+  `security`. Pick the closest fit; you can see what others use in the
+  Marketplace's category filter.
+
+The `recipe` field is your whole `recipe.yaml` as one JSON string. You don't have
+to escape it by hand — build the file with a one-liner:
+
+```bash
+jq -n --arg recipe "$(cat recipe.yaml)" \
+  '{name:"@your-org/hello-plugin", version:"0.1.0", entryType:"recipe",
+    description:"My first plugin — a single MCP server.", author:"your-org",
+    contactEmail:"you@example.com", origin:"human-authored", category:"utility",
+    tags:["mcp","example"], visibility:"private",
+    contentCreatorTag:"community", configCreatorTag:"community",
+    recipe:$recipe}' > entry.json
+```
+
+Then publish:
 
 ```bash
 curl -s -X POST https://registry.evenfire.ai/api/v1/entries \
@@ -44,40 +209,104 @@ curl -s -X POST https://registry.evenfire.ai/api/v1/entries \
   -H "Content-Type: application/json" -d @entry.json
 ```
 
-Two gotchas for org-key callers:
+Get these two right and the rest is easy:
 
-1. The name **must** be scoped `@<org>/<name>` — a bare name is rejected
-   (`400 scope_required`). `@clerum` / `@evenfire` names are curator-only.
-2. The bare `<name>` **must equal** the recipe's `metadata.name` — a mismatch is
-   `400 INVALID_INPUT`. Use `metadata.name`, not your repo name.
+- **`name` must be `@your-org/<plugin>`** — a bare name is rejected. The `@clerum`
+  and `@evenfire` scopes are reserved.
+- **The `<plugin>` part of `name` must equal `metadata.name` in your recipe.** Here
+  both are `hello-plugin`. A mismatch is rejected.
 
-To build the recipe itself, see the
-[`@clerum/workflow-sdk`](../../packages/workflow-sdk/README.md) and the
-[WorkflowRecipe CRD reference](../crds/workflowrecipe.md).
+`visibility: private` means the plugin is shared with **your organization's own
+clusters and members** — exactly what you want for an internal plugin. It won't
+appear in any public catalog.
 
-## 3. Verify
+## Step 5 — Install it
 
-A `private` entry is hidden from the default listing — pass `?visibility=all`:
+Now install what you just published, right from the UI:
+
+1. **Control UI → Marketplace → your org (`@your-org`) → Entries.**
+2. Find your plugin (`hello-plugin`) in the list. Multiple versions of the same
+   plugin collapse into one row showing the latest — expand the row to install an
+   older version if you need to.
+3. Click **Install**. Step through the short wizard — review the package, confirm
+   external network access (egress) if your plugin needs it, and pick a model if
+   it uses an LLM — then finish.
+
+Your plugin appears under **Plugins**, where you can watch it start and check its
+status.
+
+That's the whole loop: **write → push → publish → install.**
+
+## Shipping an update
+
+A published `name` + `version` is permanent — you can't overwrite `0.1.0`. To ship
+a change:
+
+1. Rebuild and push new images with a new tag (e.g. `:0.2.0`).
+2. Update the `image:` tags and bump `version` in your recipe/entry to `0.2.0`.
+3. Publish again.
+
+The Entries list will show the new version as the latest; installs pick it up.
+
+You *can* tweak an entry's description, tags, or visibility in place without a new
+version — see the reference below.
+
+## When something goes wrong
+
+- **Plugin doesn't appear after publishing?** Private entries are hidden from the
+  default catalog listing — look under **Marketplace → your org → Entries**, not
+  the general catalog.
+- **Publish rejected with a name error?** The `<plugin>` part of `@your-org/<plugin>`
+  must exactly equal `metadata.name` in the recipe.
+- **Publish rejected as a conflict?** That `name` + `version` already exists — bump
+  the version.
+- **Plugin installs but a workload won't start?** Open the plugin on the **Plugins**
+  page and read the workload status; most first-time issues are a typo in an
+  `image:` coordinate (it must match exactly what you pushed).
+
+## Where to go next
+
+- **Full authoring reference** — every recipe field, the security model, web UIs,
+  webhooks, scheduled jobs, and LLM/agent steps: the
+  `WORKFLOW_RECIPE_GUIDE.md` in the Evenfire Recipe Guide.
+- **Ready-made examples** to copy and adapt: `examples/mcp-server.yaml`,
+  `examples/sandbox-ui.yaml`, `examples/snippet-workflow.yaml`,
+  `examples/agentic-workflow.yaml`.
+- **Connecting your deployment** (if you haven't yet):
+  [Connect to the registry](connect-to-registry.md).
+
+---
+
+## Reference: the publish API
+
+For scripts and CI. All requests use your org API key as
+`Authorization: Bearer efrk_…`.
+
+**Publish** — `POST /api/v1/entries`
+
+Required: `name` (`@<org>/<name>`), `version` (semver), `entryType`
+(`recipe` | `mcp-server`), `description`, `author`, `origin`, `category`,
+`contentCreatorTag`, `configCreatorTag`. For a recipe, also `recipe` (the recipe
+document as a string, ≤ 100 KB). Optional: `tags`, `visibility`
+(`public` | `private`).
+
+**Verify** — a `private` entry needs `?visibility=all`:
 
 ```bash
 curl -s -H "Authorization: Bearer $REGISTRY_API_KEY" \
   "https://registry.evenfire.ai/api/v1/entries?q=<name>&visibility=all"
 ```
 
-## 4. Update
+**Update / retire**
 
-- Re-publishing the **same `name` + `version` → `409 CONFLICT`.** Bump the
-  version to ship a change.
-- Change metadata in place (visibility, tags, description) with
-  `PUT …/entries/@<org>%2F<name>/versions/<version>`; delete a version with
-  `DELETE …/versions/<version>`.
+- Re-publishing the same `name` + `version` → `409 CONFLICT`. Bump the version.
+- Edit metadata in place: `PUT …/entries/@<org>%2F<name>/versions/<version>`.
+- Remove a version: `DELETE …/versions/<version>`.
 
-## Scope & visibility
+**Scope & visibility.** An org key publishes **only** under `@<org>/`. A
+`@<org>/`-scoped entry is surfaced to your org's own clusters and members, not the
+global anonymous marketplace.
 
-An org key publishes **only** under `@<org>/`. A `@<org>/`-scoped entry — even
-`public` — is surfaced to your org's own clusters and members, not the global
-anonymous marketplace.
-
-> The registry API above (`registry.evenfire.ai`) is the shared registry
-> service, which is not part of this repository; connecting to it is covered in
+> The registry API (`registry.evenfire.ai`) is the shared registry service, which
+> is not part of this repository; connecting to it is covered in
 > [Connect to the registry](connect-to-registry.md).


### PR DESCRIPTION
## feat(registry): self-hosted Marketplace UX redesign + org area

Reworks the Marketplace/registry surfaces around the narrowed distribution
strategy (private, org-scoped plugins; first-party connectors) and adds an org
management area for entries, images, and API keys.

### control-ui

**Marketplace catalog**
- Connectors/Plugins tabs with search + category filters, all capability-gated
  via a new `useRegistryCapability` hook (composes publish-scope + connection
  probe; module-cached and in-flight-deduped to avoid rate-limit storms).
- Public "Publish to Marketplace" surfaces commented out under the distribution
  narrowing (restore when public/org publishing returns).

**Org area (`/marketplace/org`)**
- Sub-tabs: **API Keys**, **Entries**, **Images**.
- **Images** tab lists real org image repos from a new control-api endpoint
  (read-only; loading/ready/unavailable/error states).
- **Entries** (`OwnedEntries`): collapse same-named private plugins into one row
  showing the latest version, expandable to install previous versions
  individually. Per-row **Install** CTA + **Installed** (disabled) state driven
  by the installed-resources catalog.

**Install wizard**
- Injects `spec.agent` for recipes whose `pluginWorkloadSdk.promptBridge`
  requires a resolvable agent (model picker from `allowedModels` +
  preventing the post-install "promptBridge requires a resolvable agent" failure.
- Private-plugin header/chip so an org-scoped install reads as private.
- **Egress review now covers non-transport workloads.** Previously only MCP
  *transport* workloads were inspected, so a plugin's real egress
  plain deployments/cronjobs — e.g. GitHub + Trivy CDN hosts) was invisible.
  The analyzer now reviews any workload that declares `egressBindi
  review renders the concrete hosts/ports.

**Misc**
- `PluginsEmptyState` explaining what a plugin is (recurring jobs, UI, webhooks).
- Spacing fix for the previous-versions list.

### control-api
- `GET /admin/registry/images` — lists the org's image repos via the
  voucher-exchanged per-admin user token (`orgApiKeyClient.listIma
  the registry's `repos` payload). No changes to the registry itself.

### Testing
- control-ui: full suite green (1176 tests), `tsc --noEmit` clean
  in this change.
- control-api: `tsc` clean for the touched files (`registry.ts`,
  `orgApiKeyClient.ts`).
- control-api image built + rolled out to minikube; `/admin/registry/images`
  verified returning real org repos.

### Notes
- Merged latest `origin/dev` into this branch (one conflict in `Ow
  around the Share-modal `opener` refactor, resolved to keep both dev's
  focus-return handling and this branch's version-collapsing).
- Pre-existing on `dev` (verified reproducing on a clean `origin/dev` checkout,
  **not** introduced here): 1 `tsc` error in `LlmDiscoveryPanel.te
  (`source: 'fallback'` vs a `'live' | 'vendored'` type) and 5 failing tests in
  `GfsBrowser.test.tsx` / `LlmModelTable.test.tsx`. Flagged for the dev owners.