### PR TITLE
feat(control-api): self-provision the evenfire-registry-pull image-pull secret

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.406",
+  "version": "0.1.407",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.406",
+      "version": "0.1.407",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.399",
+      "version": "0.1.400",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.398",
+  "version": "0.1.399",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.398",
+      "version": "0.1.399",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.401",
+  "version": "0.1.402",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.401",
+      "version": "0.1.402",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.408",
+  "version": "0.1.409",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.408",
+      "version": "0.1.409",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.403",
+  "version": "0.1.404",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.403",
+      "version": "0.1.404",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.409",
+  "version": "0.1.410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.409",
+      "version": "0.1.410",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.402",
+  "version": "0.1.403",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.402",
+      "version": "0.1.403",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.405",
+  "version": "0.1.406",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.405",
+      "version": "0.1.406",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.407",
+  "version": "0.1.408",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.407",
+      "version": "0.1.408",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.410",
+  "version": "0.1.411",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.410",
+      "version": "0.1.411",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.411",
+  "version": "0.1.412",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.411",
+      "version": "0.1.412",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.400",
+      "version": "0.1.401",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.412",
+      "version": "0.1.413",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.404",
+  "version": "0.1.405",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.404",
+      "version": "0.1.405",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.398",
+  "version": "0.1.399",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.402",
+  "version": "0.1.403",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.410",
+  "version": "0.1.411",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.407",
+  "version": "0.1.408",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.405",
+  "version": "0.1.406",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.408",
+  "version": "0.1.409",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.406",
+  "version": "0.1.407",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.404",
+  "version": "0.1.405",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.411",
+  "version": "0.1.412",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.403",
+  "version": "0.1.404",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.409",
+  "version": "0.1.410",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.401",
+  "version": "0.1.402",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -59,7 +59,7 @@ type Config = {
    */
   registryVoucherPrivateKey: string
   // The registry-assigned key_id (uuid) used as the voucher `kid` header in
-  // MANAGED mode (spec §14.2). Delivered by MCC in the registry-voucher Secret
+  // MANAGED mode (spec §14.2). Delivered by the managed operator in the registry-voucher Secret
   // as CONTROL_API_REGISTRY_VOUCHER_KID. Self-hosted reads kid from the DB row.
   registryVoucherKid: string
   // Registry consumer config — added in Path A.
@@ -747,7 +747,7 @@ export const config: Config = {
   //
   // v1 invariant: SharedFileSystem CRDs always live with the Hosts that mount
   // their PVCs read-only, i.e. in the Hosts namespace. So this MUST default to
-  // HOSTS_NAMESPACE (not a hardcoded `mcp-host`): on a per-tenant MCC cluster
+  // HOSTS_NAMESPACE (not a hardcoded `mcp-host`): on a per-tenant managed cluster
   // the Hosts namespace is `mcp-host-<slug>`, and the SharedFilesystems admin
   // route + the granted RBAC both target that tenant namespace. Defaulting to
   // a bare `mcp-host` made the route query the untenanted namespace and 403

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -102,6 +102,7 @@ type Config = {
   usageRollupDailyIntervalMs: number
   usageRetentionIntervalMs: number
   budgetReservationSweepIntervalMs: number
+  registryPullSecretReconcileIntervalMs: number
   budgetReservationTtlSeconds: number
   approvalRetentionDays: number
   userApprovalRequestArchiveCronEnabled: boolean
@@ -598,6 +599,15 @@ export const config: Config = {
   // filter, so a coarse interval (default 60s) is fine.
   budgetReservationSweepIntervalMs: Number(
     process.env.BUDGET_RESERVATION_SWEEP_INTERVAL_MS || 60_000
+  ),
+  // How often to re-assert the platform image-pull credential. This is a standing
+  // invariant, not a fast path: a WorkflowRecipe created by `kubectl apply` or the WRC
+  // `deploy_recipe` tool never touches control-api, so the credential has to be there
+  // already. Installs still provision synchronously, so this interval only bounds how long
+  // a CRD created OUTSIDE control-api waits. Coarse (10 min) on purpose — each tick is a
+  // few reads and no mint once the cluster is healthy.
+  registryPullSecretReconcileIntervalMs: Number(
+    process.env.REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS || 600_000
   ),
   // Danger-zone reservation TTL (§9.8a: ~2-3× the rollup lag, ~5 min). Short
   // enough that a hung reservation auto-frees; long enough that real spend has

--- a/control-api/src/config.ts
+++ b/control-api/src/config.ts
@@ -279,6 +279,24 @@ function boundedIntegerFromEnv(name: string, defaultValue: number, maxValue: num
   return value
 }
 
+/**
+ * A background-loop interval: a positive integer of milliseconds that must also clear a
+ * floor.
+ *
+ * The floor is the part `positiveIntegerFromEnv` cannot express. `1` parses perfectly and
+ * still reconciles a thousand times a second, so for a value handed straight to
+ * `setInterval` "positive" is not the same as "sane". Refused at boot rather than clamped,
+ * for the same reason every other invalid value here is refused: a silently corrected
+ * interval leaves the operator's setting and the running behaviour disagreeing forever.
+ */
+function intervalMsFromEnv(name: string, defaultValue: number, minValue: number): number {
+  const value = positiveIntegerFromEnv(name, defaultValue)
+  if (value < minValue) {
+    throw new Error(`${name} must be an integer >= ${minValue} (milliseconds)`)
+  }
+  return value
+}
+
 // Also the target namespace for the allowlist ConfigMap (cross-service contract):
 // mcp-host + WRC read `clerum-llm-allowed-models` from here — see
 // services/llmAllowedModelsConfigMap.ts.
@@ -288,6 +306,7 @@ const SANDBOX_NAMESPACE = process.env.CONTROL_API_SANDBOX_NAMESPACE || 'sandbox-
 const SANDBOX_UI_NAMESPACE = process.env.CONTROL_API_SANDBOX_UI_NAMESPACE || 'sandbox-ui'
 const DEFAULT_MCP_HOST_JWT_MAX_HOST_REFS = 32
 const DEFAULT_MCP_HOST_JWT_MAX_HOST_REF_LENGTH = 63 + 1 + 253
+const REGISTRY_PULL_SECRET_RECONCILE_MIN_INTERVAL_MS = 10_000
 const WORKFLOW_MAX_WORKLOADS_PER_RECIPE_CEILING = 25
 const WORKFLOW_UI_EGRESS_INTERNAL_MAX_ITEMS_CEILING = 25
 const WORKFLOW_MAX_STEPS_CEILING = 100
@@ -606,8 +625,15 @@ export const config: Config = {
   // already. Installs still provision synchronously, so this interval only bounds how long
   // a CRD created OUTSIDE control-api waits. Coarse (10 min) on purpose — each tick is a
   // few reads and no mint once the cluster is healthy.
-  registryPullSecretReconcileIntervalMs: Number(
-    process.env.REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS || 600_000
+  //
+  // Validated, not merely parsed: this value goes straight into `setInterval`, and each tick
+  // costs a Postgres advisory-lock transaction plus a Secret read per platform namespace. A
+  // 10s floor is still two orders of magnitude below the default and far above anything that
+  // could pass for a hot loop.
+  registryPullSecretReconcileIntervalMs: intervalMsFromEnv(
+    'REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS',
+    600_000,
+    REGISTRY_PULL_SECRET_RECONCILE_MIN_INTERVAL_MS
   ),
   // Danger-zone reservation TTL (§9.8a: ~2-3× the rollup lag, ~5 min). Short
   // enough that a hung reservation auto-frees; long enough that real spend has

--- a/control-api/src/http/k8sError.ts
+++ b/control-api/src/http/k8sError.ts
@@ -1,0 +1,34 @@
+/**
+ * Extract HTTP status + message from K8s client errors.
+ *
+ * The @kubernetes/client-node errors carry the apiserver's explanation in `body` (a JSON
+ * string on most paths, an object on some), not in `message` — so a bare `err.message`
+ * turns "Secret is immutable" into "HTTP request failed". Lives here rather than inside a
+ * route file because more than one route module now maps these onto responses.
+ */
+export function extractK8sError(err: unknown): { status: number; message: string } | null {
+  if (err && typeof err === 'object') {
+    const e = err as {
+      code?: number
+      body?: string | { message?: string }
+      httpStatus?: number
+      statusCode?: number
+      message?: string
+    }
+    const status = e.code ?? e.statusCode ?? e.httpStatus
+    if (typeof status === 'number' && status >= 400 && status < 600) {
+      let msg = ''
+      if (typeof e.body === 'string') {
+        try {
+          msg = (JSON.parse(e.body) as { message?: string }).message ?? e.body
+        } catch {
+          msg = e.body
+        }
+      } else if (e.body && typeof e.body === 'object') {
+        msg = e.body.message ?? ''
+      }
+      return { status, message: msg || e.message || `K8s error ${status}` }
+    }
+  }
+  return null
+}

--- a/control-api/src/k8s.ts
+++ b/control-api/src/k8s.ts
@@ -8,7 +8,12 @@ import {
 } from './services/llmAllowedModelsConfigMap.js'
 import { ResourceService, mergeAnnotationsForReplace } from './services/resourceService.js'
 import { SecretService } from './services/secretService.js'
-import { ClerumResourceType, HostOverview, SecretUpsertRequest } from './types.js'
+import {
+  ClerumResourceType,
+  HostOverview,
+  SecretPreconditions,
+  SecretUpsertRequest,
+} from './types.js'
 
 /**
  * Namespaces where exec operations are permitted.
@@ -394,8 +399,12 @@ export class K8sGateway {
     return this.secrets.createSecret(req)
   }
 
-  async updateSecret(req: SecretUpsertRequest): Promise<unknown> {
-    return this.secrets.updateSecret(req)
+  /** `precondition` makes the replace ownership-bound; see `SecretPreconditions`. */
+  async updateSecret(
+    req: SecretUpsertRequest,
+    precondition?: SecretPreconditions
+  ): Promise<unknown> {
+    return this.secrets.updateSecret(req, precondition)
   }
 
   async mergeSecret(req: SecretUpsertRequest): Promise<unknown> {
@@ -406,8 +415,13 @@ export class K8sGateway {
     return this.secrets.removeSecretKey(req)
   }
 
-  async deleteSecret(name: string, namespace?: string): Promise<unknown> {
-    return this.secrets.deleteSecret(name, namespace)
+  /** `precondition` binds the delete to a specific object; see `SecretPreconditions`. */
+  async deleteSecret(
+    name: string,
+    namespace?: string,
+    precondition?: SecretPreconditions
+  ): Promise<unknown> {
+    return this.secrets.deleteSecret(name, namespace, precondition)
   }
 
   async getHostOverview(hostName: string, namespace?: string): Promise<HostOverview> {

--- a/control-api/src/k8s.ts
+++ b/control-api/src/k8s.ts
@@ -494,7 +494,7 @@ export class K8sGateway {
    * "reconcile applied" vs "kubelet is happy" gap).
    *
    * Listed per-namespace, NOT via listPodForAllNamespaces: a cluster-wide
-   * list needs cluster-scoped RBAC that MCC shared tenants do not (and must
+   * list needs cluster-scoped RBAC that managed shared tenants do not (and must
    * not) grant, and the recipe label carries no tenant scoping — an
    * all-namespaces list on a shared cluster would return other tenants'
    * pods for a same-named recipe.

--- a/control-api/src/main.ts
+++ b/control-api/src/main.ts
@@ -19,6 +19,10 @@ import {
 } from './services/pluginWorkloadSdkMaintenanceCron.js'
 import { startRateLimiterCleanup, stopRateLimiterCleanup } from './services/rateLimiterService.js'
 import {
+  reconcileRegistryPullSecret,
+  startRegistryPullSecretReconcileCron,
+} from './services/registryPullSecretReconcileCron.js'
+import {
   startWorkflowApprovalTraceProjector,
   stopWorkflowApprovalTraceProjector,
 } from './services/tracing/workflowApprovalTraceProjector.js'
@@ -87,6 +91,13 @@ async function main(): Promise<void> {
   }
 
   const gateway = new K8sGateway(config.namespace)
+
+  // Assert the platform image-pull credential up front and then on a timer. WRC injects
+  // the reference for ANY WorkflowRecipe, including ones created by `kubectl apply` or the
+  // `deploy_recipe` tool that control-api never sees — so provisioning cannot only happen
+  // on our own install routes. Non-fatal: an unconnected cluster logs and retries.
+  void reconcileRegistryPullSecret(gateway)
+  startRegistryPullSecretReconcileCron(gateway, config.registryPullSecretReconcileIntervalMs)
 
   if (config.workflowRunsArchiveCronEnabled) {
     startWorkflowRunsArchiveCron({

--- a/control-api/src/routes/admin/auth.ts
+++ b/control-api/src/routes/admin/auth.ts
@@ -153,7 +153,7 @@ export function createAdminAuthRouter(): Router {
       const passwordHash = await bcrypt.hash(password, 12)
       // Only a literal false opts out (fail-safe toward the human first-run
       // flow, where one credential for Control UI + desktop is the feature).
-      // MCC-driven installs send false: the desktop password then comes only
+      // Managed installs send false: the desktop password then comes only
       // from the directory invitation email.
       const seedDesktopPassword = req.body?.seedDesktopPassword !== false
       const created = await setupInitialAdminCredentials(
@@ -586,7 +586,7 @@ export function createAdminAuthRouter(): Router {
           role: admin.role,
         },
         // The recipe-secret namespaces this control-api enforces (see
-        // WORKFLOW_RECIPE_SECRET_NAMESPACES in the recipes route). In an MCC
+        // WORKFLOW_RECIPE_SECRET_NAMESPACES in the recipes route). In a managed
         // per-tenant deployment these are suffixed (sandbox-recipes-<slug> /
         // mcp-server-<slug>); control-ui needs them to write recipe-secret VALUES
         // to the correct namespace at CREATE time (the recipe namespace does not

--- a/control-api/src/routes/admin/recipes.ts
+++ b/control-api/src/routes/admin/recipes.ts
@@ -1849,22 +1849,25 @@ export function createAdminRecipesRouter(gateway: K8sGateway): Router {
         return
       }
       const pendingCredentials = workflowSecretResult.pendingCredentials
-      // Same guard as create: an update is how a recipe FIRST acquires a platform image
-      // (edit the workload's image, keep the name), and the stored CRD is what WRC
-      // reconciles. Provision before the write, never after — a failure must leave the
-      // persisted recipe as it was.
-      if (recipeReferencesPlatformImage(body.spec ?? {})) {
-        try {
-          await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
-        } catch (err) {
-          const mapped = pullSecretErrorResponse(err)
-          res.status(mapped.status).json(mapped.body)
-          return
-        }
-      }
       // Discover the canonical recipe resource and update it in sandbox-recipes.
       try {
         const { ns, resource } = await findRecipeNamespace(req.params.name)
+        // Same guard as create: an update is how a recipe FIRST acquires a platform image
+        // (edit the workload's image, keep the name), and the stored CRD is what WRC
+        // reconciles. Provision AFTER the existence lookup, so a PUT naming a recipe that
+        // does not exist 404s without minting — the mint is rotate-on-call, and it would
+        // revoke the org key every other namespace's Secret is already carrying. And
+        // before the write, never after — a failure must leave the persisted recipe as
+        // it was.
+        if (recipeReferencesPlatformImage(body.spec ?? {})) {
+          try {
+            await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+          } catch (provisionErr) {
+            const mapped = pullSecretErrorResponse(provisionErr)
+            res.status(mapped.status).json(mapped.body)
+            return
+          }
+        }
         const currentLabels = isPlainObject(resource)
           ? stringLabels(isPlainObject(resource.metadata) ? resource.metadata.labels : undefined)
           : undefined

--- a/control-api/src/routes/admin/recipes.ts
+++ b/control-api/src/routes/admin/recipes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { isWorkflowRecipeDefaultAllowedCapability } from '@clerum/workflow-recipe-capability-policy'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
 import { config } from '../../config.js'
 import { asyncHandler } from '../../http/asyncHandler.js'
 import { CONTENT_TYPES } from '../../http/contentTypes.js'
@@ -14,6 +15,10 @@ import {
   type SecretOwnership,
   parseSecretOwnership,
 } from '../../secretOwnership.js'
+import {
+  ensureRegistryPullSecrets,
+  platformWorkloadNamespaces,
+} from '../../services/registryPullSecretService.js'
 import { K8sNotFoundError } from '../../services/resourceService.js'
 import { invalidSecretDataKeyReason } from '../../services/secretKeys.js'
 import {
@@ -22,6 +27,10 @@ import {
 } from '../../services/workflowRecipeLimits.js'
 import { buildWrcWorkflowArtifactsUrl } from '../../services/workflows/wrcClient.js'
 import { signWrcDelegationToken } from '../../utils/auth/delegationToken.js'
+import {
+  pullSecretErrorResponse,
+  recipeReferencesPlatformImage,
+} from './registryPullSecretProvisioning.js'
 
 // Timeout for the proxied artifact fetch — short enough that a hung WRC
 // cannot tie up a control-api worker indefinitely, long enough that a
@@ -228,8 +237,19 @@ function sensitiveInputRefsInEnvValue(value: unknown): string[] {
   return [...refs]
 }
 
+/**
+ * Names a recipe may not reference or write.
+ *
+ * `wf-` covers the coordinator/runtime Secrets the platform materializes per recipe.
+ * `evenfire-registry-pull` is the org's registry pull credential: control-api writes it
+ * into the platform workload namespaces and WRC injects the reference itself, AFTER the
+ * #637 ownership filter — so a declared copy is stripped and re-injected anyway, and the
+ * same name in an `envSecret` would read that credential into a container's environment.
+ * Reject it here rather than appear to honor a declaration we ignore
+ * (docs/architecture/registry-pull-secret-recipe-workloads.md §6.1).
+ */
 function isPlatformManagedWorkflowSecretName(name: string): boolean {
-  return name.startsWith('wf-')
+  return name.startsWith('wf-') || name === EVENFIRE_REGISTRY_PULL_SECRET_NAME
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -1735,6 +1755,23 @@ export function createAdminRecipesRouter(gateway: K8sGateway): Router {
         return
       }
       const pendingCredentials = workflowSecretResult.pendingCredentials
+      // Provision the platform pull credential before the CRD that will need it.
+      //
+      // A recipe authored here is indistinguishable, at reconcile time, from one installed
+      // off the registry: WRC injects the pull-secret reference into any workload whose
+      // image is ours, so an unprovisioned Secret means ImagePullBackOff behind a 201.
+      // Recipe workloads split across all three platform namespaces by kind, hence the
+      // full set — one pass, one mint (see registryPullSecretService). Idempotent and
+      // mint-free once every namespace already holds a current credential.
+      if (recipeReferencesPlatformImage(body.spec ?? {})) {
+        try {
+          await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+        } catch (err) {
+          const mapped = pullSecretErrorResponse(err)
+          res.status(mapped.status).json(mapped.body)
+          return
+        }
+      }
       // The CRD always goes to RECIPE_CRD_NAMESPACE. Any namespace present in
       // the author YAML is deliberately discarded here because infra owns
       // placement; WorkflowRecipe YAML is not a namespace contract.
@@ -1812,6 +1849,19 @@ export function createAdminRecipesRouter(gateway: K8sGateway): Router {
         return
       }
       const pendingCredentials = workflowSecretResult.pendingCredentials
+      // Same guard as create: an update is how a recipe FIRST acquires a platform image
+      // (edit the workload's image, keep the name), and the stored CRD is what WRC
+      // reconciles. Provision before the write, never after — a failure must leave the
+      // persisted recipe as it was.
+      if (recipeReferencesPlatformImage(body.spec ?? {})) {
+        try {
+          await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+        } catch (err) {
+          const mapped = pullSecretErrorResponse(err)
+          res.status(mapped.status).json(mapped.body)
+          return
+        }
+      }
       // Discover the canonical recipe resource and update it in sandbox-recipes.
       try {
         const { ns, resource } = await findRecipeNamespace(req.params.name)

--- a/control-api/src/routes/admin/recipes.ts
+++ b/control-api/src/routes/admin/recipes.ts
@@ -1609,6 +1609,22 @@ export function createAdminRecipesRouter(gateway: K8sGateway): Router {
         res.status(400).json({ error: 'at least one secret key/value is required' })
         return
       }
+      // This endpoint writes `type: Opaque` (below). The kubelet only honors
+      // `kubernetes.io/dockerconfigjson` / `dockercfg` Secrets for image pulls, so a
+      // pull-secret-shaped payload written here would be accepted, stored, and then
+      // SILENTLY ignored at pull time — surfacing much later as an unexplained
+      // ImagePullBackOff. Refuse it instead of writing an object that cannot work.
+      if (Object.keys(stringData).some(k => k === '.dockerconfigjson' || k === '.dockercfg')) {
+        res.status(400).json({
+          error:
+            'this endpoint creates Opaque secrets, which Kubernetes ignores for image pulls. ' +
+            'Images on the evenfire registry are handled automatically — no pull secret is ' +
+            'needed. For a third-party registry, create a kubernetes.io/dockerconfigjson ' +
+            'Secret in the workload namespace and label it clerum.io/owner-recipe=<recipe>.',
+          key: '.dockerconfigjson',
+        })
+        return
+      }
       const ownershipParse = parseWorkflowSecretOwnershipBody(body)
       if (!ownershipParse.ok) {
         res.status(400).json({ error: ownershipParse.error })

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -35,6 +35,10 @@ import {
 } from '../../services/registryClient.js'
 import { isRegistryAuthActive } from '../../services/registryConnectionDb.js'
 import {
+  PullSecretProvisionError,
+  ensureRegistryPullSecret,
+} from '../../services/registryPullSecretService.js'
+import {
   validateWorkflowRecipeEgressPreflight,
   validateWorkflowRecipeLimits,
 } from '../../services/workflowRecipeLimits.js'
@@ -43,7 +47,6 @@ import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   shouldAttachEvenfirePullSecret,
 } from './registryImagePullSecret.js'
-import { ensureRegistryPullSecret } from '../../services/registryPullSecretService.js'
 import { checkEvenfireImageRefMatchesEntry } from './registryImageRefIdentity.js'
 
 /** Validate a Kubernetes resource name (RFC 1123 DNS subdomain). */
@@ -298,6 +301,56 @@ async function loadRegistryCredentialSchema(entry: {
     return isValidCredentialSchema(raw) ? raw : null
   } catch {
     return embeddedCredentialSchema
+  }
+}
+
+/**
+ * Map an image-pull-secret provisioning failure onto an actionable HTTP response.
+ *
+ * The three classes are meaningfully different to an operator, and collapsing them all to
+ * a bare 500 (as a generic K8s-error mapping does — `extractK8sError` cannot read
+ * `RegistryProxyError.status`) makes a deploy-ordering or connect-flow problem look like a
+ * control-api bug:
+ *   - PullSecretProvisionError → a precondition the operator can fix (wrong namespace,
+ *     registry not connected, org not yet bound); carries its own status + reason code.
+ *   - RegistryProxyError       → the registry rejected us (e.g. 403 because the
+ *     pull-credential endpoint has not been upgraded, or this client lacks
+ *     `registry:manage-keys`); surfaced as 502 with the upstream status.
+ *   - anything else            → 500.
+ */
+function pullSecretErrorResponse(err: unknown): {
+  status: number
+  body: Record<string, unknown>
+} {
+  if (err instanceof PullSecretProvisionError) {
+    return {
+      status: err.status,
+      body: {
+        error: 'registry_pull_secret_provision_failed',
+        reason: err.reason,
+        detail: err.message,
+      },
+    }
+  }
+  if (err instanceof RegistryProxyError) {
+    return {
+      status: 502,
+      body: {
+        error: 'registry_pull_secret_provision_failed',
+        reason: 'registry_rejected',
+        upstreamStatus: err.status,
+        detail: `the registry rejected the image-pull credential request (${err.status}); confirm the registry supports tenant pull-credential minting and that this deployment holds registry:manage-keys`,
+      },
+    }
+  }
+  const k8sErr = extractK8sError(err)
+  return {
+    status: 500,
+    body: {
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'unexpected_error',
+      detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
+    },
   }
 }
 
@@ -1224,11 +1277,8 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           try {
             await ensureRegistryPullSecret(gateway, targetNs)
           } catch (err) {
-            const k8sErr = extractK8sError(err)
-            res.status(k8sErr?.status && k8sErr.status < 500 ? 502 : 500).json({
-              error: 'registry_pull_secret_provision_failed',
-              detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
-            })
+            const mapped = pullSecretErrorResponse(err)
+            res.status(mapped.status).json(mapped.body)
             return
           }
         }
@@ -1836,21 +1886,6 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           delete updatedSpec.imagePullSecrets
         }
 
-        // Ensure the shared pull secret exists before the CRD update references it
-        // (self-hosted self-provision; namespace-shared, idempotent, fail-loud).
-        if (attachEvenfirePullSecret) {
-          try {
-            await ensureRegistryPullSecret(gateway, namespace)
-          } catch (err) {
-            const k8sErr = extractK8sError(err)
-            res.status(k8sErr?.status && k8sErr.status < 500 ? 502 : 500).json({
-              error: 'registry_pull_secret_provision_failed',
-              detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
-            })
-            return
-          }
-        }
-
         const preflightErrors = await validateMcpServerSpecPreflight(updatedSpec, {
           allowedImagePrefixes: config.allowedPluginImagePrefixes,
           enforceImageAllowlist: config.enforcePluginImageAllowlist,
@@ -1858,6 +1893,20 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
         if (preflightErrors.length > 0) {
           res.status(422).json({ errors: preflightErrors })
           return
+        }
+
+        // Ensure the shared pull secret exists before the CRD update references it
+        // (self-hosted self-provision; namespace-shared, idempotent, fail-loud). Runs
+        // AFTER preflight — matching install — so a request that will 422 never mints a
+        // rotate-on-call credential.
+        if (attachEvenfirePullSecret) {
+          try {
+            await ensureRegistryPullSecret(gateway, namespace)
+          } catch (err) {
+            const mapped = pullSecretErrorResponse(err)
+            res.status(mapped.status).json(mapped.body)
+            return
+          }
         }
 
         // 4. Update credentials if provided

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -5,6 +5,7 @@ import { isIP } from 'node:net'
 import { parse as parseYaml } from 'yaml'
 import { config } from '../../config.js'
 import { asyncHandler } from '../../http/asyncHandler.js'
+import { extractK8sError } from '../../http/k8sError.js'
 import { validateMcpServerSpecPreflight } from '../../http/validateMcpServerSpec.js'
 import { K8sGateway } from '../../k8s.js'
 import type { UiAuthedRequest } from '../../middleware/controlUIAuth.js'
@@ -35,7 +36,6 @@ import {
 } from '../../services/registryClient.js'
 import { isRegistryAuthActive } from '../../services/registryConnectionDb.js'
 import {
-  PullSecretProvisionError,
   ensureRegistryPullSecret,
   ensureRegistryPullSecrets,
   platformWorkloadNamespaces,
@@ -47,10 +47,13 @@ import {
 import { SecretUpsertRequest } from '../../types.js'
 import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
-  isPlatformRegistryImage,
   shouldAttachEvenfirePullSecret,
 } from './registryImagePullSecret.js'
 import { checkEvenfireImageRefMatchesEntry } from './registryImageRefIdentity.js'
+import {
+  pullSecretErrorResponse,
+  recipeReferencesPlatformImage,
+} from './registryPullSecretProvisioning.js'
 
 /** Validate a Kubernetes resource name (RFC 1123 DNS subdomain). */
 function isValidK8sName(name: string): boolean {
@@ -307,73 +310,6 @@ async function loadRegistryCredentialSchema(entry: {
   }
 }
 
-/**
- * Map an image-pull-secret provisioning failure onto an actionable HTTP response.
- *
- * The three classes are meaningfully different to an operator, and collapsing them all to
- * a bare 500 (as a generic K8s-error mapping does — `extractK8sError` cannot read
- * `RegistryProxyError.status`) makes a deploy-ordering or connect-flow problem look like a
- * control-api bug:
- *   - PullSecretProvisionError → a precondition the operator can fix (wrong namespace,
- *     registry not connected, org not yet bound); carries its own status + reason code.
- *   - RegistryProxyError       → the registry rejected us (e.g. 403 because the
- *     pull-credential endpoint has not been upgraded, or this client lacks
- *     `registry:manage-keys`); surfaced as 502 with the upstream status.
- *   - anything else            → 500.
- */
-function pullSecretErrorResponse(err: unknown): {
-  status: number
-  body: Record<string, unknown>
-} {
-  if (err instanceof PullSecretProvisionError) {
-    return {
-      status: err.status,
-      body: {
-        error: 'registry_pull_secret_provision_failed',
-        reason: err.reason,
-        detail: err.message,
-      },
-    }
-  }
-  if (err instanceof RegistryProxyError) {
-    return {
-      status: 502,
-      body: {
-        error: 'registry_pull_secret_provision_failed',
-        reason: 'registry_rejected',
-        upstreamStatus: err.status,
-        detail: `the registry rejected the image-pull credential request (${err.status}); confirm the registry supports tenant pull-credential minting and that this deployment holds registry:manage-keys`,
-      },
-    }
-  }
-  const k8sErr = extractK8sError(err)
-  return {
-    status: 500,
-    body: {
-      error: 'registry_pull_secret_provision_failed',
-      reason: 'unexpected_error',
-      detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
-    },
-  }
-}
-
-/**
- * True when any workload in a recipe spec runs an image hosted on our own registry, and
- * therefore needs the platform pull credential.
- *
- * Uses the same shared predicate WRC applies at reconcile time
- * (`isPlatformRegistryImage`), so control-api cannot decide to provision for a workload
- * WRC will not attach the secret to, or vice versa — that mismatch would surface as an
- * ImagePullBackOff with no failing request to attribute it to.
- */
-function recipeReferencesPlatformImage(recipeSpec: Record<string, unknown>): boolean {
-  const workloads = recipeSpec.workloads
-  if (!Array.isArray(workloads)) return false
-  return workloads.some(w =>
-    isPlatformRegistryImage((w as { image?: unknown } | null)?.image, config.registryUrl)
-  )
-}
-
 /** Audit log for security-sensitive operations (finding #10). */
 function auditLog(action: string, details: Record<string, unknown>): void {
   const safe: Record<string, unknown> = { timestamp: new Date().toISOString(), action, ...details }
@@ -618,34 +554,6 @@ function deriveRegistryEgressBindings(options: {
   return egressSummary.domains.flatMap(dns =>
     egressSummary.ports.map(port => ({ dns, port, protocol: 'TCP' as const }))
   )
-}
-
-/** Extract HTTP status + message from K8s client errors. */
-function extractK8sError(err: unknown): { status: number; message: string } | null {
-  if (err && typeof err === 'object') {
-    const e = err as {
-      code?: number
-      body?: string | { message?: string }
-      httpStatus?: number
-      statusCode?: number
-      message?: string
-    }
-    const status = e.code ?? e.statusCode ?? e.httpStatus
-    if (typeof status === 'number' && status >= 400 && status < 600) {
-      let msg = ''
-      if (typeof e.body === 'string') {
-        try {
-          msg = (JSON.parse(e.body) as { message?: string }).message ?? e.body
-        } catch {
-          msg = e.body
-        }
-      } else if (e.body && typeof e.body === 'object') {
-        msg = e.body.message ?? ''
-      }
-      return { status, message: msg || e.message || `K8s error ${status}` }
-    }
-  }
-  return null
 }
 
 function sleep(ms: number): Promise<void> {

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -2144,6 +2144,20 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           body.registryEntryVersion
         )
 
+        // Ensure the platform pull credential before the CRD that will reference it.
+        // Keyed on the INCOMING spec: an upgrade is exactly how a recipe moves from a
+        // public image to a private one, and without this the new CRD persists and then
+        // fails at pull time while the request returns 200.
+        if (recipeReferencesPlatformImage(recipeSpec)) {
+          try {
+            await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+          } catch (err) {
+            const mapped = pullSecretErrorResponse(err)
+            res.status(mapped.status).json(mapped.body)
+            return
+          }
+        }
+
         await updateResourceWithConflictRetry(
           gateway,
           'workflowrecipes',

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -37,6 +37,8 @@ import { isRegistryAuthActive } from '../../services/registryConnectionDb.js'
 import {
   PullSecretProvisionError,
   ensureRegistryPullSecret,
+  ensureRegistryPullSecrets,
+  platformWorkloadNamespaces,
 } from '../../services/registryPullSecretService.js'
 import {
   validateWorkflowRecipeEgressPreflight,
@@ -45,6 +47,7 @@ import {
 import { SecretUpsertRequest } from '../../types.js'
 import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  isPlatformRegistryImage,
   shouldAttachEvenfirePullSecret,
 } from './registryImagePullSecret.js'
 import { checkEvenfireImageRefMatchesEntry } from './registryImageRefIdentity.js'
@@ -352,6 +355,23 @@ function pullSecretErrorResponse(err: unknown): {
       detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
     },
   }
+}
+
+/**
+ * True when any workload in a recipe spec runs an image hosted on our own registry, and
+ * therefore needs the platform pull credential.
+ *
+ * Uses the same shared predicate WRC applies at reconcile time
+ * (`isPlatformRegistryImage`), so control-api cannot decide to provision for a workload
+ * WRC will not attach the secret to, or vice versa — that mismatch would surface as an
+ * ImagePullBackOff with no failing request to attribute it to.
+ */
+function recipeReferencesPlatformImage(recipeSpec: Record<string, unknown>): boolean {
+  const workloads = recipeSpec.workloads
+  if (!Array.isArray(workloads)) return false
+  return workloads.some(w =>
+    isPlatformRegistryImage((w as { image?: unknown } | null)?.image, config.registryUrl)
+  )
 }
 
 /** Audit log for security-sensitive operations (finding #10). */
@@ -1580,6 +1600,24 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           body.registryEntryName,
           body.registryEntryVersion
         )
+
+        // Ensure the platform pull credential before the CRD that will need it.
+        //
+        // Recipe workloads do NOT all land in the plugin namespace — they split by kind
+        // (transport -> mcp-server, spec.ui.workloadRef -> sandbox-ui, rest ->
+        // sandbox-recipes) — and WRC injects the pull-secret reference at reconcile time
+        // for any workload whose image is ours. So provision the whole platform set: the
+        // credential is per-org and the mint is rotate-on-call, so one pass covers every
+        // namespace with a single mint (see registryPullSecretService).
+        if (recipeReferencesPlatformImage(recipeSpec)) {
+          try {
+            await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+          } catch (err) {
+            const mapped = pullSecretErrorResponse(err)
+            res.status(mapped.status).json(mapped.body)
+            return
+          }
+        }
 
         // Step 4: Apply WorkflowRecipe CRD
         try {

--- a/control-api/src/routes/admin/registry.ts
+++ b/control-api/src/routes/admin/registry.ts
@@ -43,6 +43,7 @@ import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   shouldAttachEvenfirePullSecret,
 } from './registryImagePullSecret.js'
+import { ensureRegistryPullSecret } from '../../services/registryPullSecretService.js'
 import { checkEvenfireImageRefMatchesEntry } from './registryImageRefIdentity.js'
 
 /** Validate a Kubernetes resource name (RFC 1123 DNS subdomain). */
@@ -1111,16 +1112,17 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           transport: transportSpec,
         }
 
-        // Phase 2.4-delivery: local plugins whose image lives on the evenfire
-        // registry pull with the tenant's per-org pull secret (provisioned by
-        // MCC in the plugin namespace). Attach the reference; HCC propagates it.
-        if (
-          shouldAttachEvenfirePullSecret({
-            isLocal,
-            image: mcpServerSpec.image,
-            registryUrl: config.registryUrl,
-          })
-        ) {
+        // Local plugins whose image lives on the evenfire registry pull with the
+        // per-org `evenfire-registry-pull` secret. control-api self-provisions that
+        // secret in self-hosted mode (see ensureRegistryPullSecret below); it may
+        // also be pre-provisioned by an external operator. Attach the reference here;
+        // HCC propagates it to the pod.
+        const attachEvenfirePullSecret = shouldAttachEvenfirePullSecret({
+          isLocal,
+          image: mcpServerSpec.image,
+          registryUrl: config.registryUrl,
+        })
+        if (attachEvenfirePullSecret) {
           mcpServerSpec.imagePullSecrets = [{ name: EVENFIRE_REGISTRY_PULL_SECRET_NAME }]
         }
 
@@ -1211,6 +1213,25 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           body.registryEntryName,
           body.registryEntryVersion
         )
+
+        // ── Ensure the shared registry pull secret (self-hosted) ───────────
+        // Must run when a private evenfire-hosted image is in play — independent of
+        // whether the plugin needs credentials (a credential-less plugin still needs
+        // to pull). Runs BEFORE the per-plugin credentials Secret so a failure leaves
+        // nothing to roll back, and BEFORE the McpServer CRD that references it.
+        // Namespace-shared, so it is NOT part of the per-plugin rollback below.
+        if (attachEvenfirePullSecret) {
+          try {
+            await ensureRegistryPullSecret(gateway, targetNs)
+          } catch (err) {
+            const k8sErr = extractK8sError(err)
+            res.status(k8sErr?.status && k8sErr.status < 500 ? 502 : 500).json({
+              error: 'registry_pull_secret_provision_failed',
+              detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
+            })
+            return
+          }
+        }
 
         // ── Step 3: Create K8s Secret if credentials provided ─────────────
         let secretCreated = false
@@ -1800,21 +1821,34 @@ export function createAdminRegistryRouter(gateway?: K8sGateway): Router {
           return
         }
 
-        // Phase 2.4-delivery: recompute imagePullSecrets on every upgrade. The
-        // spread of ...existingSpec above carries a prior ref forward, so we
-        // must set it when the new image is evenfire-hosted and DELETE it
-        // otherwise (host change evenfire→GCP-AR, or local→remote) to avoid a
-        // stale, unresolvable pull-secret reference.
-        if (
-          shouldAttachEvenfirePullSecret({
-            isLocal,
-            image: updatedSpec.image,
-            registryUrl: config.registryUrl,
-          })
-        ) {
+        // Recompute imagePullSecrets on every upgrade. The spread of ...existingSpec
+        // above carries a prior ref forward, so we must set it when the new image is
+        // evenfire-hosted and DELETE it otherwise (host change evenfire→GCP-AR, or
+        // local→remote) to avoid a stale, unresolvable pull-secret reference.
+        const attachEvenfirePullSecret = shouldAttachEvenfirePullSecret({
+          isLocal,
+          image: updatedSpec.image,
+          registryUrl: config.registryUrl,
+        })
+        if (attachEvenfirePullSecret) {
           updatedSpec.imagePullSecrets = [{ name: EVENFIRE_REGISTRY_PULL_SECRET_NAME }]
         } else {
           delete updatedSpec.imagePullSecrets
+        }
+
+        // Ensure the shared pull secret exists before the CRD update references it
+        // (self-hosted self-provision; namespace-shared, idempotent, fail-loud).
+        if (attachEvenfirePullSecret) {
+          try {
+            await ensureRegistryPullSecret(gateway, namespace)
+          } catch (err) {
+            const k8sErr = extractK8sError(err)
+            res.status(k8sErr?.status && k8sErr.status < 500 ? 502 : 500).json({
+              error: 'registry_pull_secret_provision_failed',
+              detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
+            })
+            return
+          }
         }
 
         const preflightErrors = await validateMcpServerSpecPreflight(updatedSpec, {

--- a/control-api/src/routes/admin/registryImagePullSecret.ts
+++ b/control-api/src/routes/admin/registryImagePullSecret.ts
@@ -1,54 +1,31 @@
 /**
  * evenfire pull-secret attach classification.
  *
- * Pure, dependency-free helpers deciding whether an installed local-mode
- * McpServer image should carry the `evenfire-registry-pull` imagePullSecret,
- * i.e. when the image lives on the configured evenfire registry host. The Secret
- * itself is self-provisioned by control-api in self-hosted mode
- * (`registryPullSecretService`) and may also be pre-provisioned by an external
- * operator; this file only decides when to reference it by name.
+ * Decides whether an installed local-mode McpServer image should carry the
+ * `evenfire-registry-pull` imagePullSecret — i.e. when the image lives on the configured
+ * evenfire registry host. The Secret itself is self-provisioned by control-api in
+ * self-hosted mode (`registryPullSecretService`) and may also be pre-provisioned by an
+ * external operator; this file only decides when to reference it by name.
+ *
+ * The identity primitives now live in `@clerum/workflow-runtime-core`, because WRC asks
+ * the same question of recipe workloads and a second copy would drift. They are
+ * re-exported here so existing imports keep working against one definition.
  */
+import { isPlatformRegistryImage } from '@clerum/workflow-runtime-core'
 
-/**
- * Name of the dockerconfigjson Secret referenced by local-mode McpServers whose
- * image lives on the evenfire registry. The single source of truth for the name —
- * `registryPullSecretService` writes it, this file references it. Never inline.
- */
-export const EVENFIRE_REGISTRY_PULL_SECRET_NAME = 'evenfire-registry-pull'
-
-/**
- * Extract the host (including any :port) from the configured registry URL.
- * The registry URL always carries a scheme, so `new URL()` is correct here.
- * Returns null when unset/whitespace/unparseable.
- */
-export function registryHostFromUrl(registryUrl: string): string | null {
-  if (!registryUrl || !registryUrl.trim()) return null
-  try {
-    return new URL(registryUrl).host || null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Parse the registry host of a BARE OCI image reference (no scheme). Splits on
- * the first `/`; the first component is a registry host only if it contains
- * `.` or `:` (mirrors Docker/OCI semantics that distinguish a host from a
- * docker-hub library/org path). Returns null when the ref has no explicit host
- * (docker-hub `org/name` or a single-segment `name[:tag]`).
- */
-export function imageRefHost(image: string): string | null {
-  const trimmed = (image ?? '').trim()
-  if (!trimmed) return null
-  const slash = trimmed.indexOf('/')
-  if (slash === -1) return null
-  const first = trimmed.slice(0, slash)
-  return first.includes('.') || first.includes(':') ? first : null
-}
+export {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  imageRefHost,
+  isPlatformRegistryImage,
+  registryHostFromUrl,
+} from '@clerum/workflow-runtime-core'
 
 /**
  * True when a built McpServer spec should carry the evenfire pull secret:
  * a local-mode entry whose image host equals the configured registry host.
+ *
+ * Remote-mode entries run a fixed egress-proxy image, never a registry-hosted one, so the
+ * `isLocal` term is what keeps this narrower than the shared predicate.
  */
 export function shouldAttachEvenfirePullSecret(params: {
   isLocal: boolean
@@ -56,8 +33,5 @@ export function shouldAttachEvenfirePullSecret(params: {
   registryUrl: string
 }): boolean {
   if (!params.isLocal) return false
-  if (typeof params.image !== 'string') return false
-  const registryHost = registryHostFromUrl(params.registryUrl)
-  if (!registryHost) return false
-  return imageRefHost(params.image) === registryHost
+  return isPlatformRegistryImage(params.image, params.registryUrl)
 }

--- a/control-api/src/routes/admin/registryImagePullSecret.ts
+++ b/control-api/src/routes/admin/registryImagePullSecret.ts
@@ -1,16 +1,18 @@
 /**
- * Registry Phase 2.4-delivery — evenfire pull-secret attach classification.
+ * evenfire pull-secret attach classification.
  *
  * Pure, dependency-free helpers deciding whether an installed local-mode
- * McpServer image should carry the `evenfire-registry-pull` imagePullSecret.
- * The secret is provisioned onto the tenant cluster by MCC (out of this repo);
- * control-api only references it by name when the image lives on the configured
- * evenfire registry host.
+ * McpServer image should carry the `evenfire-registry-pull` imagePullSecret,
+ * i.e. when the image lives on the configured evenfire registry host. The Secret
+ * itself is self-provisioned by control-api in self-hosted mode
+ * (`registryPullSecretService`) and may also be pre-provisioned by an external
+ * operator; this file only decides when to reference it by name.
  */
 
 /**
- * Name of the dockerconfigjson Secret MCC provisions in the tenant plugin
- * namespace. Must stay in sync with the MCC install step. Never inline.
+ * Name of the dockerconfigjson Secret referenced by local-mode McpServers whose
+ * image lives on the evenfire registry. The single source of truth for the name —
+ * `registryPullSecretService` writes it, this file references it. Never inline.
  */
 export const EVENFIRE_REGISTRY_PULL_SECRET_NAME = 'evenfire-registry-pull'
 

--- a/control-api/src/routes/admin/registryPullSecretProvisioning.ts
+++ b/control-api/src/routes/admin/registryPullSecretProvisioning.ts
@@ -1,0 +1,82 @@
+/**
+ * Route-layer helpers for provisioning the platform image-pull Secret: "does this recipe
+ * need the credential?" and "how does a provisioning failure become a response?".
+ *
+ * Shared, not duplicated, because two route modules write WorkflowRecipe CRDs whose
+ * workloads WRC will inject the pull-secret reference into — the registry install path
+ * (`registry.ts`) and the generic recipe CRUD path (`recipes.ts`). Both must decide the
+ * same way and fail the same way; a second copy of either rule would let one route persist
+ * a recipe the other would have refused.
+ */
+import { config } from '../../config.js'
+import { extractK8sError } from '../../http/k8sError.js'
+import { RegistryProxyError } from '../../services/registryClient.js'
+import { PullSecretProvisionError } from '../../services/registryPullSecretService.js'
+import { isPlatformRegistryImage } from './registryImagePullSecret.js'
+
+/**
+ * True when any workload in a recipe spec runs an image hosted on our own registry, and
+ * therefore needs the platform pull credential.
+ *
+ * Uses the same shared predicate WRC applies at reconcile time
+ * (`isPlatformRegistryImage`), so control-api cannot decide to provision for a workload
+ * WRC will not attach the secret to, or vice versa — that mismatch would surface as an
+ * ImagePullBackOff with no failing request to attribute it to.
+ */
+export function recipeReferencesPlatformImage(recipeSpec: Record<string, unknown>): boolean {
+  const workloads = recipeSpec.workloads
+  if (!Array.isArray(workloads)) return false
+  return workloads.some(w =>
+    isPlatformRegistryImage((w as { image?: unknown } | null)?.image, config.registryUrl)
+  )
+}
+
+/**
+ * Map an image-pull-secret provisioning failure onto an actionable HTTP response.
+ *
+ * The three classes are meaningfully different to an operator, and collapsing them all to
+ * a bare 500 (as a generic K8s-error mapping does — `extractK8sError` cannot read
+ * `RegistryProxyError.status`) makes a deploy-ordering or connect-flow problem look like a
+ * control-api bug:
+ *   - PullSecretProvisionError → a precondition the operator can fix (wrong namespace,
+ *     registry not connected, org not yet bound); carries its own status + reason code.
+ *   - RegistryProxyError       → the registry rejected us (e.g. 403 because the
+ *     pull-credential endpoint has not been upgraded, or this client lacks
+ *     `registry:manage-keys`); surfaced as 502 with the upstream status.
+ *   - anything else            → 500.
+ */
+export function pullSecretErrorResponse(err: unknown): {
+  status: number
+  body: Record<string, unknown>
+} {
+  if (err instanceof PullSecretProvisionError) {
+    return {
+      status: err.status,
+      body: {
+        error: 'registry_pull_secret_provision_failed',
+        reason: err.reason,
+        detail: err.message,
+      },
+    }
+  }
+  if (err instanceof RegistryProxyError) {
+    return {
+      status: 502,
+      body: {
+        error: 'registry_pull_secret_provision_failed',
+        reason: 'registry_rejected',
+        upstreamStatus: err.status,
+        detail: `the registry rejected the image-pull credential request (${err.status}); confirm the registry supports tenant pull-credential minting and that this deployment holds registry:manage-keys`,
+      },
+    }
+  }
+  const k8sErr = extractK8sError(err)
+  return {
+    status: 500,
+    body: {
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'unexpected_error',
+      detail: k8sErr?.message || (err instanceof Error ? err.message : 'unknown error'),
+    },
+  }
+}

--- a/control-api/src/routes/admin/secrets.ts
+++ b/control-api/src/routes/admin/secrets.ts
@@ -411,6 +411,16 @@ export function createAdminSecretsRouter(gateway: K8sGateway): Router {
         })
         return
       }
+      // The reserved name is guarded on POST and DELETE below; without it here the merge
+      // path was the way through. The recipe-secret label check further down does NOT cover
+      // it — the platform Secret carries `clerum.io/managed-by`, not the recipe label, so it
+      // passes that gate — and `mergeSecret` replaces any key it is given, including
+      // `.dockerconfigjson`. That is every private image pull in this namespace, broken by
+      // a route whose whole job is to refuse this name.
+      if (isPlatformManagedSecretName(name)) {
+        res.status(400).json({ error: PLATFORM_MANAGED_SECRET_ERROR })
+        return
+      }
       if (!data || typeof data !== 'object' || Object.keys(data).length === 0) {
         res
           .status(400)

--- a/control-api/src/routes/admin/secrets.ts
+++ b/control-api/src/routes/admin/secrets.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express'
 import { PROVIDER_CREDENTIAL_SLOTS } from '@clerum/llm-providers'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
 import { config } from '../../config.js'
 import { asyncHandler } from '../../http/asyncHandler.js'
 import { enforceNamespace } from '../../http/namespaceAudit.js'
@@ -30,6 +31,23 @@ const VERTEX_SERVICE_ACCOUNT_KEY: string = PROVIDER_CREDENTIAL_SLOTS.vertex[0].d
 // stop the guard from firing the day the other one changes.
 const RECIPE_SECRET_LABEL_KEY = 'clerum.io/recipe-secret'
 const RECIPE_SECRET_LABEL_VALUE = 'true'
+
+// `evenfire-registry-pull` is control-api's own image-pull credential, self-provisioned
+// into every platform workload namespace (registryPullSecretService). The mcp-secret and
+// recipe-secret routes below write into that SAME set of namespaces, so the name is
+// reachable from here — and the damage is not recoverable in place: the provisioner's
+// first invariant is "never write a Secret we do not own", so an operator who deletes the
+// platform Secret and creates an `Opaque` one under the reserved name makes every
+// private-image install into that namespace fail with `foreign_secret_unusable`, forever.
+// Reserve the name on the write and delete surfaces, exactly as the recipe surfaces do
+// (`isPlatformManagedWorkflowSecretName` in routes/admin/recipes.ts).
+function isPlatformManagedSecretName(name: unknown): boolean {
+  return typeof name === 'string' && name.trim() === EVENFIRE_REGISTRY_PULL_SECRET_NAME
+}
+
+const PLATFORM_MANAGED_SECRET_ERROR =
+  `Secret "${EVENFIRE_REGISTRY_PULL_SECRET_NAME}" is platform-managed (the evenfire ` +
+  'registry image-pull credential) and cannot be created, modified, or deleted here'
 
 // The plaintext data being written, merging base64 `data` and plaintext
 // `stringData` (stringData wins, matching Kubernetes Secret semantics).
@@ -318,6 +336,10 @@ export function createAdminSecretsRouter(gateway: K8sGateway): Router {
         })
         return
       }
+      if (isPlatformManagedSecretName(name)) {
+        res.status(400).json({ error: PLATFORM_MANAGED_SECRET_ERROR })
+        return
+      }
       if (!data || typeof data !== 'object' || Object.keys(data).length === 0) {
         res
           .status(400)
@@ -506,6 +528,12 @@ export function createAdminSecretsRouter(gateway: K8sGateway): Router {
     '/admin/mcp-secrets/:name',
     enforceNamespace(config.mcpServersNamespace),
     asyncHandler(async (req, res) => {
+      // This route deletes by name with no ownership guard, so the reserved name is the
+      // only thing standing between a rollback call and the platform pull credential.
+      if (isPlatformManagedSecretName(req.params.name)) {
+        res.status(400).json({ error: PLATFORM_MANAGED_SECRET_ERROR })
+        return
+      }
       const deleted = await gateway.deleteSecret(req.params.name, config.mcpServersNamespace)
       res.status(200).json(deleted)
     })
@@ -689,6 +717,10 @@ export function createAdminSecretsRouter(gateway: K8sGateway): Router {
         res.status(400).json({
           error: 'Invalid secret name: must be lowercase alphanumeric and hyphens, max 253 chars',
         })
+        return
+      }
+      if (isPlatformManagedSecretName(name)) {
+        res.status(400).json({ error: PLATFORM_MANAGED_SECRET_ERROR })
         return
       }
       if (!data || typeof data !== 'object' || Object.keys(data).length === 0) {

--- a/control-api/src/services/directory/adminProvisioning.ts
+++ b/control-api/src/services/directory/adminProvisioning.ts
@@ -92,7 +92,7 @@ export async function provisionAdminDesktopWorkspace(input: {
   agentNames: string[]
   contextIds: string[]
   /** When false, skip writing users.password_hash — the desktop password then
-   *  comes only from the invitation flow (MCC-driven installs). Defaults to
+   *  comes only from the invitation flow (managed installs). Defaults to
    *  true: the Control-UI human first-run keeps one credential for both apps. */
   seedPassword?: boolean
 }): Promise<void> {

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -606,12 +606,21 @@ export async function createOrgGrant(
  * Rotate-on-call: each call revokes the org's prior pull key, so callers MUST
  * read-before-mint (only call when the on-cluster Secret is absent or broken) or they
  * orphan a working credential.
+ *
+ * Carries an explicit timeout: `authedFetch` only bounds GETs, and this POST sits on the
+ * install path behind an in-process dedupe — a stalled origin would otherwise hang every
+ * concurrent install for that namespace. The response is validated because a missing
+ * `key` would otherwise render a valid-LOOKING dockerconfigjson (`_:undefined`) that gets
+ * written as a permanently unusable credential which later reads classify as healthy.
  */
 export async function mintOrgPullCredential(orgName: string): Promise<{ key: string }> {
   const res = await orgRegistryFetch<{ username: string; key: string; dockerconfigjson: string }>(
     `/org/${encodeURIComponent(orgName)}/registry-pull-credential`,
-    { method: 'POST' }
+    { method: 'POST', signal: AbortSignal.timeout(READ_TIMEOUT_MS) }
   )
+  if (!res || typeof res.key !== 'string' || res.key.length === 0) {
+    throw new Error('registry returned no pull key for the image-pull credential')
+  }
   return { key: res.key }
 }
 

--- a/control-api/src/services/registryClient.ts
+++ b/control-api/src/services/registryClient.ts
@@ -592,6 +592,29 @@ export async function createOrgGrant(
   })
 }
 
+/**
+ * Mint a PULL-ONLY registry credential for `orgName` using our machine identity.
+ *
+ * Hits the registry's `POST /org/:org/registry-pull-credential`, which — once the
+ * companion registry change ships — authorizes an org-bound machine holding
+ * `registry:manage-keys` (our tenant client's standing scope) to mint a pull-only,
+ * rotate-on-call key for its OWN org. The endpoint also returns a `dockerconfigjson`,
+ * but we DELIBERATELY ignore it: it is keyed on the registry's own token-issuer host,
+ * whereas the kubelet matches on the image host (our configured registry URL host).
+ * The caller builds the dockerconfigjson locally from `key`, keyed on that host.
+ *
+ * Rotate-on-call: each call revokes the org's prior pull key, so callers MUST
+ * read-before-mint (only call when the on-cluster Secret is absent or broken) or they
+ * orphan a working credential.
+ */
+export async function mintOrgPullCredential(orgName: string): Promise<{ key: string }> {
+  const res = await orgRegistryFetch<{ username: string; key: string; dockerconfigjson: string }>(
+    `/org/${encodeURIComponent(orgName)}/registry-pull-credential`,
+    { method: 'POST' }
+  )
+  return { key: res.key }
+}
+
 export async function listOrgGrants(orgName: string): Promise<unknown> {
   return orgRegistryFetch(`/org/${encodeURIComponent(orgName)}/grants`)
 }

--- a/control-api/src/services/registryPullSecretReconcileCron.ts
+++ b/control-api/src/services/registryPullSecretReconcileCron.ts
@@ -1,0 +1,92 @@
+/**
+ * Keeps the platform image-pull credential present as a STANDING INVARIANT, rather than
+ * as a side effect of control-api's own install routes.
+ *
+ * Why this exists (see docs/architecture/registry-pull-secret-recipe-workloads.md §13.1):
+ * the two halves of the feature have different triggers. WRC injects the
+ * `evenfire-registry-pull` reference on every reconcile, for ANY WorkflowRecipe whose
+ * workload image is ours — but control-api only provisions the Secret on its own
+ * install/upgrade routes. A WorkflowRecipe has three documented creation paths
+ * (docs/crds/workflowrecipe.md): control-api, `kubectl apply`, and the WRC `deploy_recipe`
+ * MCP tool. For the latter two, control-api never sees the CRD, so without this loop the
+ * pod would reference a credential nobody created.
+ *
+ * FAILURE SEMANTICS ARE DELIBERATELY DIFFERENT FROM THE INSTALL PATH.
+ * An install THROWS on a precondition failure, because a user asked for something we
+ * cannot deliver and must be told. This loop LOGS and retries on the next tick: a cluster
+ * that has not finished the registry connect flow is in a normal, expected state, and must
+ * not emit an error every interval or crash-loop. `ensureRegistryPullSecrets` already
+ * distinguishes the two — legitimate no-ops return `skipped`, everything else throws — so
+ * this file's only job is to swallow the throw and try again later.
+ *
+ * Serialization across replicas is handled inside the service by a per-org advisory lock.
+ * That lock is what makes a PERIODIC loop safe at all: without it, two pods on a timer do
+ * not race occasionally, they fight continuously — each pod's mint revokes the other's key
+ * and the fingerprint check then sees divergence, forever.
+ */
+import type { K8sGateway } from '../k8s.js'
+import { rootLogger } from '../observability/logger.js'
+import {
+  ensureRegistryPullSecrets,
+  platformWorkloadNamespaces,
+} from './registryPullSecretService.js'
+
+const log = rootLogger.child({ service: 'registry_pull_secret_reconcile' })
+
+/**
+ * Run one reconcile pass. Never throws — a failure here is a logged warning, because the
+ * cluster may legitimately not be ready to provision yet (no connect flow completed, no
+ * org bound). Returns true when the pass completed without error.
+ */
+export async function reconcileRegistryPullSecret(gateway: K8sGateway): Promise<boolean> {
+  try {
+    const results = await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+    const changed = [...results.entries()].filter(([, r]) => r === 'created' || r === 'repaired')
+    if (changed.length > 0) {
+      log.info(
+        {
+          event: 'registry_pull_secret_reconciled',
+          namespaces: changed.map(([ns]) => ns),
+        },
+        'provisioned the registry pull secret outside an install'
+      )
+    }
+    return true
+  } catch (err) {
+    // Expected while a cluster is unconnected or has no org bound yet. Warn, do not throw:
+    // this loop must not turn a normal pre-connect state into recurring errors.
+    log.warn(
+      {
+        event: 'registry_pull_secret_reconcile_skipped',
+        reason: (err as { reason?: string })?.reason,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      'registry pull secret reconcile did not complete; will retry on the next tick'
+    )
+    return false
+  }
+}
+
+let intervalHandle: ReturnType<typeof setInterval> | null = null
+
+export function startRegistryPullSecretReconcileCron(
+  gateway: K8sGateway,
+  intervalMs: number
+): void {
+  if (intervalHandle) return
+  intervalHandle = setInterval(() => {
+    void reconcileRegistryPullSecret(gateway)
+  }, intervalMs)
+  // Never hold the process open for this.
+  intervalHandle.unref()
+  log.info(
+    { event: 'registry_pull_secret_reconcile_started', intervalMs },
+    'registry pull secret reconcile cron started'
+  )
+}
+
+export function stopRegistryPullSecretReconcileCron(): void {
+  if (!intervalHandle) return
+  clearInterval(intervalHandle)
+  intervalHandle = null
+}

--- a/control-api/src/services/registryPullSecretReconcileCron.ts
+++ b/control-api/src/services/registryPullSecretReconcileCron.ts
@@ -40,7 +40,16 @@ const log = rootLogger.child({ service: 'registry_pull_secret_reconcile' })
  */
 export async function reconcileRegistryPullSecret(gateway: K8sGateway): Promise<boolean> {
   try {
-    const results = await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces())
+    // `required: []` — this loop needs no namespace on its own behalf. Unlike an install it
+    // is not about to persist a CRD referencing one, so a namespace it cannot fill (or, on a
+    // managed cluster, one the operator has not populated) is not ITS failure to report; the
+    // install that actually lands there raises it, with the namespaces that caller needs.
+    // Without this the loop would report a failed pass on every tick of a managed cluster,
+    // where control-api legitimately has nothing to do. Conditions worth an operator's
+    // attention are already logged by the service itself, on every pass.
+    const results = await ensureRegistryPullSecrets(gateway, platformWorkloadNamespaces(), {
+      required: [],
+    })
     const changed = [...results.entries()].filter(([, r]) => r === 'created' || r === 'repaired')
     if (changed.length > 0) {
       log.info(

--- a/control-api/src/services/registryPullSecretReconcileCron.ts
+++ b/control-api/src/services/registryPullSecretReconcileCron.ts
@@ -19,6 +19,11 @@
  * distinguishes the two — legitimate no-ops return `skipped`, everything else throws — so
  * this file's only job is to swallow the throw and try again later.
  *
+ * The LEVEL carries that distinction, because "swallow it" and "hide it" are not the same
+ * thing. A known precondition on an unconnected cluster logs below warn; anything
+ * unexpected, or a known precondition that has held for many consecutive ticks and is
+ * therefore no longer plausibly transient, warns. See EXPECTED_PRECONDITION_REASONS.
+ *
  * Serialization across replicas is handled inside the service by a per-org advisory lock.
  * That lock is what makes a PERIODIC loop safe at all: without it, two pods on a timer do
  * not race occasionally, they fight continuously — each pod's mint revokes the other's key
@@ -32,6 +37,31 @@ import {
 } from './registryPullSecretService.js'
 
 const log = rootLogger.child({ service: 'registry_pull_secret_reconcile' })
+
+/**
+ * Precondition failures that are a NORMAL state for a cluster, not a fault: the registry
+ * connect flow has not been completed, or the registry has not bound this deployment to an
+ * org yet. Both resolve themselves the moment an operator finishes the flow.
+ *
+ * They are the two reasons `ensureInner` raises before it touches anything, and this loop
+ * runs on every cluster whether or not anyone has asked it to — so warning on them means 144
+ * warnings a day (at the 10-minute default) on a cluster where nothing is wrong, which
+ * teaches operators to ignore this logger.
+ */
+const EXPECTED_PRECONDITION_REASONS: ReadonlySet<string> = new Set([
+  'registry_not_connected',
+  'org_unresolved',
+])
+
+/**
+ * How many consecutive ticks an expected precondition may hold before it stops being
+ * "expected" and warns. ~1h at the default interval — long enough to cover a connect flow in
+ * progress, short enough that a cluster genuinely stuck this way is findable by an operator
+ * grepping for warnings rather than silently unable to install private plugins.
+ */
+const PRECONDITION_WARN_AFTER_TICKS = 6
+
+let consecutiveExpectedFailures = 0
 
 /**
  * Run one reconcile pass. Never throws — a failure here is a logged warning, because the
@@ -60,18 +90,40 @@ export async function reconcileRegistryPullSecret(gateway: K8sGateway): Promise<
         'provisioned the registry pull secret outside an install'
       )
     }
+    // A completed pass means whatever was blocking is gone. The streak has to reset with it,
+    // or one bad hour makes every later blip look persistent.
+    consecutiveExpectedFailures = 0
     return true
   } catch (err) {
-    // Expected while a cluster is unconnected or has no org bound yet. Warn, do not throw:
-    // this loop must not turn a normal pre-connect state into recurring errors.
-    log.warn(
-      {
-        event: 'registry_pull_secret_reconcile_skipped',
-        reason: (err as { reason?: string })?.reason,
-        err: err instanceof Error ? err.message : String(err),
-      },
-      'registry pull secret reconcile did not complete; will retry on the next tick'
-    )
+    // Never thrown, always logged — but not always at the same level. The level is the whole
+    // difference between "this cluster has not been connected yet", which is normal and
+    // recurs on a timer, and "something is wrong", which an operator has to find.
+    const reason = (err as { reason?: string })?.reason
+    const expected = reason !== undefined && EXPECTED_PRECONDITION_REASONS.has(reason)
+    consecutiveExpectedFailures = expected ? consecutiveExpectedFailures + 1 : 0
+    const persistent = consecutiveExpectedFailures >= PRECONDITION_WARN_AFTER_TICKS
+    const payload = {
+      event: 'registry_pull_secret_reconcile_skipped',
+      reason,
+      err: err instanceof Error ? err.message : String(err),
+      ...(expected && { consecutiveTicks: consecutiveExpectedFailures }),
+    }
+    if (expected && !persistent) {
+      log.debug(
+        payload,
+        'registry pull secret reconcile skipped a known precondition; will retry on the next tick'
+      )
+    } else if (expected) {
+      log.warn(
+        payload,
+        'registry pull secret reconcile has been blocked on the same precondition for many ticks; private plugin installs cannot provision their pull credential until it clears'
+      )
+    } else {
+      log.warn(
+        payload,
+        'registry pull secret reconcile did not complete; will retry on the next tick'
+      )
+    }
     return false
   }
 }
@@ -95,6 +147,9 @@ export function startRegistryPullSecretReconcileCron(
 }
 
 export function stopRegistryPullSecretReconcileCron(): void {
+  // Before the early return: a stopped loop has no history, so a later start must not
+  // inherit a stale streak and warn on its first tick.
+  consecutiveExpectedFailures = 0
   if (!intervalHandle) return
   clearInterval(intervalHandle)
   intervalHandle = null

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -166,10 +166,43 @@ function dockerconfigMatchesHost(blob: string | undefined, host: string): boolea
     const parsed = JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
       auths?: Record<string, unknown>
     }
-    return !!parsed?.auths && Object.prototype.hasOwnProperty.call(parsed.auths, host)
+    if (!parsed?.auths || !Object.prototype.hasOwnProperty.call(parsed.auths, host)) return false
+    return dockerconfigEntryCarriesCredential(parsed.auths[host])
   } catch {
     return false
   }
+}
+
+/**
+ * Does an `auths[<host>]` entry carry something the kubelet can actually present?
+ *
+ * Host presence alone is not enough. `{"auths":{"registry.example":{}}}` parses cleanly,
+ * matches the host, and is entirely unusable — the kubelet finds no credential to send and
+ * the pull goes out anonymous. Accepting it is wrong in BOTH directions:
+ *
+ *  - for a Secret we own, it classifies an empty copy as healthy instead of repairing it;
+ *  - for a FOREIGN copy it is worse, because the all-or-nothing gate reads "usable foreign"
+ *    as "somebody's live credential is sealed in here" and refuses to mint at all. Nothing
+ *    was ever served through an empty entry, so that is a self-inflicted outage: every
+ *    private install fails closed on account of a Secret that could never pull.
+ *
+ * Accepted forms, all of which the kubelet understands: `auth` (base64 `user:password`, what
+ * Docker writes), the split `username`/`password` form some tools emit, and the
+ * `identitytoken` / `registrytoken` fields credential helpers use. Any ONE non-empty string
+ * suffices — this is a usability check, not a validity check. Whether the credential still
+ * WORKS is the registry's answer to give, costs a round trip per install, and belongs to
+ * the out-of-band-revocation problem, which is tracked separately.
+ */
+function dockerconfigEntryCarriesCredential(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false
+  const e = entry as Record<string, unknown>
+  const nonEmpty = (v: unknown): boolean => typeof v === 'string' && v.trim() !== ''
+  return (
+    nonEmpty(e.auth) ||
+    nonEmpty(e.password) ||
+    nonEmpty(e.identitytoken) ||
+    nonEmpty(e.registrytoken)
+  )
 }
 
 /**
@@ -464,7 +497,9 @@ function foreignUsabilityProblem(current: SecretView, host: string): string | nu
     return `its type is "${current.type ?? 'unset'}", not ${DOCKERCONFIG_TYPE} — the kubelet ignores it for image pulls`
   }
   if (!dockerconfigMatchesHost(current.dockerconfig, host)) {
-    return `its ${DOCKERCONFIG_KEY} carries no entry for "${host}", so the kubelet will never select it`
+    // Two different repairs, so name which one it is: a missing entry is usually the wrong
+    // registry host, an empty one is usually a half-written or template-generated Secret.
+    return `its ${DOCKERCONFIG_KEY} carries no usable credential for "${host}" (the entry is absent, or present but carries no auth/password/token), so the kubelet will never select it`
   }
   return null
 }

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -6,17 +6,30 @@
  * provisions it itself. Design: docs/architecture/registry-pull-secret-self-provisioning.md.
  *
  * Contract (must match what the managed operator writes, so either satisfies the same
- * McpServer.spec.imagePullSecrets reference):
+ * imagePullSecrets reference):
  *   name  = 'evenfire-registry-pull'         (EVENFIRE_REGISTRY_PULL_SECRET_NAME)
- *   ns    = the McpServer's own namespace    (imagePullSecrets are namespace-local)
+ *   ns    = EVERY platform workload namespace (see below; imagePullSecrets are ns-local)
  *   type  = kubernetes.io/dockerconfigjson
  *   data['.dockerconfigjson'] = base64 payload, keyed on OUR image host (registryUrl),
  *                               NOT the registry's token-issuer
  *   label clerum.io/managed-by = control-api  (ownership marker; absent ⇒ externally owned)
  *
+ * Namespaces — the reference is NOT confined to an McpServer's own namespace. WRC injects
+ * `imagePullSecrets: [evenfire-registry-pull]` into every workload whose image host equals
+ * the configured registry host, wherever CLERUM_REGISTRY_URL is set, and recipe workloads
+ * split across all three platform workload namespaces by kind (transport → mcp-server,
+ * spec.ui.workloadRef → sandbox-ui, everything else → sandbox-recipes). So the Secret must
+ * exist in ALL of them — `platformWorkloadNamespaces()`, the one allowlist writes are
+ * confined to. On a MANAGED cluster control-api writes none of them (provisioning
+ * short-circuits to 'skipped'), which makes populating all three the external operator's
+ * job: a managed cluster that provisions only mcp-server leaves recipe pods in
+ * ImagePullBackOff with nothing in the API trail to explain it.
+ *
  * Two invariants make this safe to run repeatedly:
  *   1. NEVER write a Secret we do not own. An unlabeled Secret belongs to an external
- *      operator; we return `exists-foreign` and leave it alone even if it looks broken.
+ *      operator; we return `exists-foreign` and leave it alone. Not owning it does not
+ *      mean waving the caller through, though: if it cannot serve an image pull at all we
+ *      fail the install (`foreign_secret_unusable`) rather than let a CRD reference it.
  *   2. Mint ONLY when we are already committed to a write we know can succeed. The
  *      registry's pull-credential mint is rotate-on-call — it revokes the org's previous
  *      key — so a mint that is followed by a failed write strands every other namespace's
@@ -167,7 +180,17 @@ async function mintCredential(orgName: string, host: string): Promise<MintedCred
 }
 
 // Collapse concurrent ensure passes WITHIN this replica so two in-flight installs cannot
-// both mint. Keyed on the whole target set, since a pass is atomic over its namespaces.
+// both mint. Keyed on the whole target set, since a pass is atomic over its namespaces —
+// which means every caller must pass the SAME set or the dedupe silently does nothing.
+// That is why the single-namespace wrapper below delegates to the full platform set: two
+// mints against a rotate-on-call registry leave the loser's namespaces on a revoked key,
+// and (because the loser rewrites the winner's namespaces too) with FINGERPRINTS THAT
+// AGREE — so the divergence check in ensureInner cannot see it and no later pass re-mints.
+//
+// Correct only at ONE replica (deploy/base/control-plane/control-api.yaml pins
+// `replicas: 1`). An in-process Map cannot see another replica's pass, so scaling out
+// would require an org-scoped distributed lock around the mint — control-api has Postgres
+// available for that. Not implemented: single-replica is the deployed shape today.
 const inflight = new Map<string, Promise<Map<string, EnsurePullSecretResult>>>()
 
 /** The platform workload namespaces a pull credential may legitimately be written into. */
@@ -209,28 +232,66 @@ export function ensureRegistryPullSecrets(
 /**
  * Single-namespace convenience wrapper, for the McpServer install/upgrade paths that
  * provision exactly the namespace their workload lands in.
+ *
+ * It still runs the FULL platform-namespace pass and then picks its own namespace out of
+ * the result, because the inflight dedupe is keyed on the target set: a pass over just
+ * `[targetNs]` would never collapse with a concurrent recipe install over all three, and
+ * both would mint (see the note on `inflight`). `targetNs` stays in the list so an
+ * unsupported namespace is still rejected by ensureInner's allowlist — same reason code,
+ * same status, same point in the sequence.
+ *
+ * Costs two extra Secret reads per MCP install. Buys the mint-once guarantee across route
+ * paths, and makes every install a full-set pass, so a diverged cluster converges on
+ * whichever install runs next.
  */
 export async function ensureRegistryPullSecret(
   gateway: K8sGateway,
   targetNs: string
 ): Promise<EnsurePullSecretResult> {
-  const results = await ensureRegistryPullSecrets(gateway, [targetNs])
+  const results = await ensureRegistryPullSecrets(gateway, [
+    targetNs,
+    ...platformWorkloadNamespaces(),
+  ])
   return results.get(targetNs) ?? 'skipped'
 }
 
 /** Classification of one namespace's current Secret, decided before anything is minted. */
 type TargetState =
-  | { kind: 'foreign' }
+  | { kind: 'foreign'; unusable: string | null }
   | { kind: 'valid'; fingerprint: string }
   | { kind: 'absent' }
   | { kind: 'broken'; wrongType: boolean }
+
+/**
+ * Why a Secret we do NOT own cannot serve an image pull, or null when it can.
+ *
+ * Read-only by construction — the same two checks `classify` applies to our own copies,
+ * with no fingerprint requirement (that annotation is ours; an external operator has no
+ * reason to write it) and no write of any kind.
+ *
+ * Deliberately shape-only: a well-formed blob whose key the registry has since revoked
+ * still passes here. Proving liveness would take a registry round-trip on every install,
+ * which this check does not do.
+ */
+function foreignUsabilityProblem(current: SecretView, host: string): string | null {
+  if (current.type !== DOCKERCONFIG_TYPE) {
+    return `its type is "${current.type ?? 'unset'}", not ${DOCKERCONFIG_TYPE} — the kubelet ignores it for image pulls`
+  }
+  if (!dockerconfigMatchesHost(current.dockerconfig, host)) {
+    return `its ${DOCKERCONFIG_KEY} carries no entry for "${host}", so the kubelet will never select it`
+  }
+  return null
+}
 
 function classify(current: SecretView | null, host: string): TargetState {
   if (!current) return { kind: 'absent' }
   // INVARIANT 1: never write a Secret we do not own — even a broken one. Adopting it would
   // seize an external operator's credential; repairing it in place would rotate the org
-  // key out from under them.
-  if (current.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) return { kind: 'foreign' }
+  // key out from under them. We still inspect it: not-ours decides who WRITES, not whether
+  // the caller may attach a reference to it (see ensureInner).
+  if (current.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) {
+    return { kind: 'foreign', unusable: foreignUsabilityProblem(current, host) }
+  }
   const wrongType = current.type !== DOCKERCONFIG_TYPE
   // Presence alone is not enough: a blob keyed on a previous registry host can never be
   // selected by the kubelet, and a copy with no fingerprint cannot be compared across
@@ -294,15 +355,28 @@ async function ensureInner(
     states.set(ns, classify(await readCurrent(gateway, ns), host))
   }
 
+  // ── Foreign targets: hands off, but not a free pass ───────────────────────
+  // Every caller of this service is about to attach an `imagePullSecrets` reference to
+  // this name and persist a CRD, so a foreign Secret the kubelet cannot use is exactly as
+  // fatal as a missing one — and we may not repair it. Fail the install instead, naming
+  // the namespace, before anything is minted (so the org's live key is untouched).
+  // A well-shaped foreign Secret still proceeds: external pre-provisioning is supported.
   const ours = targets.filter(ns => states.get(ns)!.kind !== 'foreign')
   for (const ns of targets) {
-    if (states.get(ns)!.kind === 'foreign') {
-      logger.warn(
-        { namespace: ns },
-        'externally-owned evenfire-registry-pull Secret present; leaving it untouched (remove it to let control-api manage this namespace)'
+    const state = states.get(ns)!
+    if (state.kind !== 'foreign') continue
+    if (state.unusable) {
+      throw new PullSecretProvisionError(
+        `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}" is externally owned and cannot serve an image pull: ${state.unusable}. Fix it in place, or delete it to let control-api manage that namespace. (A well-shaped foreign Secret is accepted even if its key has since been revoked — checking that would take a registry round-trip.)`,
+        'foreign_secret_unusable',
+        409
       )
-      out.set(ns, 'exists-foreign')
     }
+    logger.warn(
+      { namespace: ns },
+      'externally-owned evenfire-registry-pull Secret present; leaving it untouched (remove it to let control-api manage this namespace)'
+    )
+    out.set(ns, 'exists-foreign')
   }
   if (ours.length === 0) return out
 
@@ -378,9 +452,13 @@ async function writeCredential(
       return 'created'
     } catch (err) {
       if (k8sStatus(err) !== 409) throw err
-      // Lost a create race. The winner's Secret is authoritative for its own content, but
-      // OUR mint has already revoked whatever key it holds — so overwrite it with ours
-      // rather than adopting a now-dead credential. Skip if the winner is foreign.
+      // Lost a create race — but NOT against ourselves: concurrent passes in this replica
+      // collapse on the `inflight` key. The winner is therefore another writer (a second
+      // replica, which this design does not support, or an out-of-band actor), and which
+      // key is live is not knowable here — ours revoked theirs only if we minted last.
+      // Write ours anyway, so this pass leaves every namespace it owns on ONE key;
+      // adopting the winner's would split this namespace from the rest for a credential we
+      // can verify no better. Skip if the winner is foreign — invariant 1 still holds.
       const winner = await readCurrent(gateway, ns)
       if (winner && winner.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) return 'exists-foreign'
       await gateway.updateSecret(buildSecretReq(ns, cred))

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -191,7 +191,20 @@ async function mintCredential(orgName: string, host: string): Promise<MintedCred
 // `replicas: 1`). An in-process Map cannot see another replica's pass, so scaling out
 // would require an org-scoped distributed lock around the mint — control-api has Postgres
 // available for that. Not implemented: single-replica is the deployed shape today.
-const inflight = new Map<string, Promise<Map<string, EnsurePullSecretResult>>>()
+//
+// The cached value carries the unusable-foreign REASONS alongside the results rather than
+// throwing for them inside the pass. Whether an unusable foreign Secret is fatal depends on
+// which namespaces the CALLER needs, and the dedupe key deliberately does not encode that —
+// folding the required set into the key would stop an MCP install and a recipe install from
+// collapsing, which is the very race this map exists to prevent. So the pass records, and
+// each caller applies its own policy on the shared result.
+const inflight = new Map<string, Promise<EnsurePass>>()
+
+/** One pass's outcome: per-namespace results, plus why any foreign Secret is unusable. */
+type EnsurePass = {
+  results: Map<string, EnsurePullSecretResult>
+  unusable: Map<string, string>
+}
 
 /** The platform workload namespaces a pull credential may legitimately be written into. */
 export function platformWorkloadNamespaces(): string[] {
@@ -216,17 +229,36 @@ export function platformWorkloadNamespaces(): string[] {
  * THROWS `PullSecretProvisionError`, so a caller about to attach an imagePullSecrets
  * reference fails the install loudly instead of persisting an unresolvable one.
  */
-export function ensureRegistryPullSecrets(
+export async function ensureRegistryPullSecrets(
   gateway: K8sGateway,
-  namespaces: string[]
+  namespaces: string[],
+  opts: { required?: string[] } = {}
 ): Promise<Map<string, EnsurePullSecretResult>> {
   const targets = [...new Set(namespaces)].sort()
   const dedupeKey = targets.join(',')
-  const existing = inflight.get(dedupeKey)
-  if (existing) return existing
-  const run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
-  inflight.set(dedupeKey, run)
-  return run
+  let run = inflight.get(dedupeKey)
+  if (!run) {
+    run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
+    inflight.set(dedupeKey, run)
+  }
+  const { results, unusable } = await run
+
+  // An unusable foreign Secret is fatal only to a caller that needs THAT namespace. A pass
+  // covers the whole platform set (for the mint-once collapse), so an MCP install must not
+  // be failed by a squatter in a sandbox namespace it never references — while a recipe
+  // install, which does land there, still fails loudly. `required` defaults to every target,
+  // so a caller that asks for a set is asserting it needs all of it.
+  for (const ns of opts.required ?? targets) {
+    const why = unusable.get(ns)
+    if (why) {
+      throw new PullSecretProvisionError(
+        `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}" is externally owned and cannot serve an image pull: ${why}. Fix it in place, or delete it to let control-api manage that namespace. (A well-shaped foreign Secret is accepted even if its key has since been revoked — checking that would take a registry round-trip.)`,
+        'foreign_secret_unusable',
+        409
+      )
+    }
+  }
+  return results
 }
 
 /**
@@ -248,10 +280,14 @@ export async function ensureRegistryPullSecret(
   gateway: K8sGateway,
   targetNs: string
 ): Promise<EnsurePullSecretResult> {
-  const results = await ensureRegistryPullSecrets(gateway, [
-    targetNs,
-    ...platformWorkloadNamespaces(),
-  ])
+  const results = await ensureRegistryPullSecrets(
+    gateway,
+    [targetNs, ...platformWorkloadNamespaces()],
+    // Only this caller's own namespace is load-bearing: the siblings are swept along for
+    // the mint-once collapse, so a foreign squatter in one of them must not fail an install
+    // that never references it.
+    { required: [targetNs] }
+  )
   return results.get(targetNs) ?? 'skipped'
 }
 
@@ -303,18 +339,16 @@ function classify(current: SecretView | null, host: string): TargetState {
   return { kind: 'valid', fingerprint }
 }
 
-async function ensureInner(
-  gateway: K8sGateway,
-  targets: string[]
-): Promise<Map<string, EnsurePullSecretResult>> {
+async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<EnsurePass> {
   const out = new Map<string, EnsurePullSecretResult>()
+  const unusable = new Map<string, string>()
 
   // ── Legitimate no-ops ─────────────────────────────────────────────────────
   // Managed clusters: the operator owns this Secret; never contend with it.
   const host = registryHostFromUrl(config.registryUrl)
   if (config.registryConnectionMode !== 'self-hosted' || !host) {
     for (const ns of targets) out.set(ns, 'skipped')
-    return out
+    return { results: out, unusable }
   }
 
   // ── Hard preconditions: from here on we MUST provision or fail loudly ─────
@@ -358,27 +392,31 @@ async function ensureInner(
   // ── Foreign targets: hands off, but not a free pass ───────────────────────
   // Every caller of this service is about to attach an `imagePullSecrets` reference to
   // this name and persist a CRD, so a foreign Secret the kubelet cannot use is exactly as
-  // fatal as a missing one — and we may not repair it. Fail the install instead, naming
-  // the namespace, before anything is minted (so the org's live key is untouched).
-  // A well-shaped foreign Secret still proceeds: external pre-provisioning is supported.
+  // fatal as a missing one — and we may not repair it. We RECORD that here rather than
+  // throwing: the pass spans the whole platform set for the mint-once collapse, but only a
+  // caller that actually references the namespace should be failed by it (see
+  // `ensureRegistryPullSecrets`, which raises `foreign_secret_unusable` for its own
+  // required set). A well-shaped foreign Secret proceeds untouched either way: external
+  // pre-provisioning is a supported contract.
   const ours = targets.filter(ns => states.get(ns)!.kind !== 'foreign')
   for (const ns of targets) {
     const state = states.get(ns)!
     if (state.kind !== 'foreign') continue
     if (state.unusable) {
-      throw new PullSecretProvisionError(
-        `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}" is externally owned and cannot serve an image pull: ${state.unusable}. Fix it in place, or delete it to let control-api manage that namespace. (A well-shaped foreign Secret is accepted even if its key has since been revoked — checking that would take a registry round-trip.)`,
-        'foreign_secret_unusable',
-        409
+      unusable.set(ns, state.unusable)
+      logger.warn(
+        { namespace: ns, problem: state.unusable },
+        'externally-owned evenfire-registry-pull Secret cannot serve an image pull; leaving it untouched — installs that reference this namespace will fail until it is fixed or removed'
+      )
+    } else {
+      logger.warn(
+        { namespace: ns },
+        'externally-owned evenfire-registry-pull Secret present; leaving it untouched (remove it to let control-api manage this namespace)'
       )
     }
-    logger.warn(
-      { namespace: ns },
-      'externally-owned evenfire-registry-pull Secret present; leaving it untouched (remove it to let control-api manage this namespace)'
-    )
     out.set(ns, 'exists-foreign')
   }
-  if (ours.length === 0) return out
+  if (ours.length === 0) return { results: out, unusable }
 
   // A mint is needed when any namespace we own lacks a usable credential, OR when the
   // copies have diverged — divergence means an earlier pass wrote some namespaces and
@@ -392,7 +430,7 @@ async function ensureInner(
 
   if (!needsMint) {
     for (const ns of ours) out.set(ns, 'exists-ours')
-    return out
+    return { results: out, unusable }
   }
   if (diverged) {
     logger.warn(
@@ -429,7 +467,7 @@ async function ensureInner(
     fingerprint: cred.fingerprint,
   })
   logger.info({ namespaces: ours, orgName }, 'registry pull secret provisioned')
-  return out
+  return { results: out, unusable }
 }
 
 /** Write `cred` into one namespace, choosing create/update/recreate from its prior state. */

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -22,6 +22,7 @@
  *      key — so a mint that is followed by a failed write strands every other namespace's
  *      Secret on a revoked credential.
  */
+import { createHash } from 'node:crypto'
 import { config } from '../config.js'
 import type { K8sGateway } from '../k8s.js'
 import { rootLogger } from '../observability/logger.js'
@@ -49,6 +50,7 @@ const MANAGED_BY_LABEL = 'clerum.io/managed-by'
 const MANAGED_BY_VALUE = 'control-api'
 const DOCKERCONFIG_KEY = '.dockerconfigjson'
 const DOCKERCONFIG_TYPE = 'kubernetes.io/dockerconfigjson'
+const FINGERPRINT_ANNOTATION = 'clerum.io/pull-key-fingerprint'
 
 export type EnsurePullSecretResult =
   | 'created'
@@ -115,79 +117,154 @@ function dockerconfigMatchesHost(blob: string | undefined, host: string): boolea
 
 interface SecretView {
   labels: Record<string, string>
+  annotations: Record<string, string>
   type: string | undefined
   dockerconfig: string | undefined
 }
 
 function readSecret(raw: unknown): SecretView {
   const s = (raw ?? {}) as {
-    metadata?: { labels?: Record<string, string> }
+    metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> }
     type?: string
     data?: Record<string, string>
   }
   return {
     labels: s.metadata?.labels ?? {},
+    annotations: s.metadata?.annotations ?? {},
     type: s.type,
     dockerconfig: s.data?.[DOCKERCONFIG_KEY],
   }
 }
 
-function buildSecretReq(targetNs: string, dockerconfigjson: string): SecretUpsertRequest {
+function buildSecretReq(targetNs: string, cred: MintedCredential): SecretUpsertRequest {
   return {
     name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
     namespace: targetNs,
     type: DOCKERCONFIG_TYPE,
     labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
-    data: { [DOCKERCONFIG_KEY]: dockerconfigjson },
+    annotations: { [FINGERPRINT_ANNOTATION]: cred.fingerprint },
+    data: { [DOCKERCONFIG_KEY]: cred.dockerconfigjson },
   }
 }
 
-async function mintAndBuild(orgName: string, host: string): Promise<string> {
-  const { key } = await mintOrgPullCredential(orgName)
-  return buildDockerconfigjson(host, key)
+interface MintedCredential {
+  dockerconfigjson: string
+  /** Short digest of the key, so copies in different namespaces can be compared. */
+  fingerprint: string
 }
 
-// Collapse concurrent ensures for the same (namespace, secret) WITHIN this replica so two
-// in-flight installs cannot both mint. Cross-replica races are bounded by the registry's
-// rotate-on-call (<=1 active pull key per org) plus the read-before-mint discipline below:
-// the loser of a create race re-reads and adopts the winner's Secret instead of minting.
-const inflight = new Map<string, Promise<EnsurePullSecretResult>>()
+/**
+ * Mint ONE credential. Call this at most once per ensure pass: the registry's mint is
+ * rotate-on-call, so a second mint revokes the first and would strand any namespace
+ * already written with it.
+ */
+async function mintCredential(orgName: string, host: string): Promise<MintedCredential> {
+  const { key } = await mintOrgPullCredential(orgName)
+  return {
+    dockerconfigjson: buildDockerconfigjson(host, key),
+    fingerprint: createHash('sha256').update(key).digest('hex').slice(0, 12),
+  }
+}
+
+// Collapse concurrent ensure passes WITHIN this replica so two in-flight installs cannot
+// both mint. Keyed on the whole target set, since a pass is atomic over its namespaces.
+const inflight = new Map<string, Promise<Map<string, EnsurePullSecretResult>>>()
+
+/** The platform workload namespaces a pull credential may legitimately be written into. */
+export function platformWorkloadNamespaces(): string[] {
+  return [
+    ...new Set([config.mcpServersNamespace, config.sandboxNamespace, config.sandboxUiNamespace]),
+  ]
+}
 
 /**
- * Ensure the `evenfire-registry-pull` Secret exists in `targetNs`, minting a fresh
- * pull-only credential only when it is absent or verifiably broken.
+ * Ensure the `evenfire-registry-pull` Secret exists, and is current, in EVERY given
+ * namespace — minting at most ONE credential for the whole pass.
  *
- * Returns `'skipped'` ONLY when provisioning is legitimately not our job (managed mode,
- * where the operator owns the Secret) or when no registry host is configured. Every other
- * "cannot provision" condition THROWS `PullSecretProvisionError` so the caller fails the
- * install loudly instead of attaching an unresolvable imagePullSecrets reference.
+ * The credential is per-ORG but the Secret is per-NAMESPACE, and the registry's mint is
+ * rotate-on-call (it revokes the org's previous key). Minting per namespace would
+ * therefore have each mint invalidate the namespaces already written. So: read all, mint
+ * once if any target needs it, then write that single credential to every target we own.
+ *
+ * Post-condition: every non-foreign target holds the same, current credential.
+ *
+ * Returns `'skipped'` for all targets ONLY when provisioning is legitimately not our job
+ * (managed mode, or no registry configured). Every other "cannot provision" condition
+ * THROWS `PullSecretProvisionError`, so a caller about to attach an imagePullSecrets
+ * reference fails the install loudly instead of persisting an unresolvable one.
  */
-export function ensureRegistryPullSecret(
+export function ensureRegistryPullSecrets(
   gateway: K8sGateway,
-  targetNs: string
-): Promise<EnsurePullSecretResult> {
-  const dedupeKey = `${targetNs}/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`
+  namespaces: string[]
+): Promise<Map<string, EnsurePullSecretResult>> {
+  const targets = [...new Set(namespaces)].sort()
+  const dedupeKey = targets.join(',')
   const existing = inflight.get(dedupeKey)
   if (existing) return existing
-  const run = ensureInner(gateway, targetNs).finally(() => inflight.delete(dedupeKey))
+  const run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
   inflight.set(dedupeKey, run)
   return run
 }
 
-async function ensureInner(gateway: K8sGateway, targetNs: string): Promise<EnsurePullSecretResult> {
+/**
+ * Single-namespace convenience wrapper, for the McpServer install/upgrade paths that
+ * provision exactly the namespace their workload lands in.
+ */
+export async function ensureRegistryPullSecret(
+  gateway: K8sGateway,
+  targetNs: string
+): Promise<EnsurePullSecretResult> {
+  const results = await ensureRegistryPullSecrets(gateway, [targetNs])
+  return results.get(targetNs) ?? 'skipped'
+}
+
+/** Classification of one namespace's current Secret, decided before anything is minted. */
+type TargetState =
+  | { kind: 'foreign' }
+  | { kind: 'valid'; fingerprint: string }
+  | { kind: 'absent' }
+  | { kind: 'broken'; wrongType: boolean }
+
+function classify(current: SecretView | null, host: string): TargetState {
+  if (!current) return { kind: 'absent' }
+  // INVARIANT 1: never write a Secret we do not own — even a broken one. Adopting it would
+  // seize an external operator's credential; repairing it in place would rotate the org
+  // key out from under them.
+  if (current.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) return { kind: 'foreign' }
+  const wrongType = current.type !== DOCKERCONFIG_TYPE
+  // Presence alone is not enough: a blob keyed on a previous registry host can never be
+  // selected by the kubelet, and a copy with no fingerprint cannot be compared across
+  // namespaces.
+  const fingerprint = current.annotations[FINGERPRINT_ANNOTATION]
+  if (wrongType || !dockerconfigMatchesHost(current.dockerconfig, host) || !fingerprint) {
+    return { kind: 'broken', wrongType }
+  }
+  return { kind: 'valid', fingerprint }
+}
+
+async function ensureInner(
+  gateway: K8sGateway,
+  targets: string[]
+): Promise<Map<string, EnsurePullSecretResult>> {
+  const out = new Map<string, EnsurePullSecretResult>()
+
   // ── Legitimate no-ops ─────────────────────────────────────────────────────
   // Managed clusters: the operator owns this Secret; never contend with it.
-  if (config.registryConnectionMode !== 'self-hosted') return 'skipped'
   const host = registryHostFromUrl(config.registryUrl)
-  if (!host) return 'skipped' // no registry configured; the attach predicate is false too
+  if (config.registryConnectionMode !== 'self-hosted' || !host) {
+    for (const ns of targets) out.set(ns, 'skipped')
+    return out
+  }
 
   // ── Hard preconditions: from here on we MUST provision or fail loudly ─────
-  // The pull Secret is a registry credential. Confine writes to the namespace this
-  // deployment actually serves so a caller-supplied `body.namespace` cannot plant it
-  // in an unrelated namespace (and cannot rotate the org key as a side effect).
-  if (targetNs !== config.mcpServersNamespace) {
+  // The pull Secret is a registry credential. Confine writes to the platform workload
+  // namespaces so a caller-supplied `body.namespace` can never plant it elsewhere (and
+  // can never rotate the org key as a side effect).
+  const allowed = new Set(platformWorkloadNamespaces())
+  const rogue = targets.filter(ns => !allowed.has(ns))
+  if (rogue.length > 0) {
     throw new PullSecretProvisionError(
-      `refusing to provision the registry pull secret outside the configured plugin namespace (got "${targetNs}", expected "${config.mcpServersNamespace}")`,
+      `refusing to provision the registry pull secret outside the platform workload namespaces (got ${rogue.map(n => `"${n}"`).join(', ')}, allowed ${[...allowed].map(n => `"${n}"`).join(', ')})`,
       'unsupported_namespace',
       400
     )
@@ -211,66 +288,107 @@ async function ensureInner(gateway: K8sGateway, targetNs: string): Promise<Ensur
     )
   }
 
-  // ── Read (getSecret re-throws 404; any other error aborts before minting) ──
-  const current = await readCurrent(gateway, targetNs)
+  // ── Read + classify every target BEFORE minting anything ──────────────────
+  const states = new Map<string, TargetState>()
+  for (const ns of targets) {
+    states.set(ns, classify(await readCurrent(gateway, ns), host))
+  }
 
-  if (current) {
-    const ours = current.labels[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
-    // INVARIANT 1: never write a Secret we do not own — even a broken one. Adopting it
-    // would seize an external operator's credential; repairing it in place would rotate
-    // the org key out from under them.
-    if (!ours) {
-      if (!dockerconfigMatchesHost(current.dockerconfig, host)) {
-        logger.warn(
-          { targetNs, host },
-          'externally-owned evenfire-registry-pull Secret is missing or mis-keyed; leaving it untouched (remove it to let control-api provision one)'
-        )
-      }
-      return 'exists-foreign'
+  const ours = targets.filter(ns => states.get(ns)!.kind !== 'foreign')
+  for (const ns of targets) {
+    if (states.get(ns)!.kind === 'foreign') {
+      logger.warn(
+        { namespace: ns },
+        'externally-owned evenfire-registry-pull Secret present; leaving it untouched (remove it to let control-api manage this namespace)'
+      )
+      out.set(ns, 'exists-foreign')
     }
-    // Ours and genuinely usable → reuse. Presence alone is not enough: a blob keyed on a
-    // previous registry host can never be selected by the kubelet.
-    if (current.type === DOCKERCONFIG_TYPE && dockerconfigMatchesHost(current.dockerconfig, host)) {
-      return 'exists-ours'
+  }
+  if (ours.length === 0) return out
+
+  // A mint is needed when any namespace we own lacks a usable credential, OR when the
+  // copies have diverged — divergence means an earlier pass wrote some namespaces and
+  // failed on others, and we cannot recover the live key from a fingerprint.
+  const valid = ours.filter(ns => states.get(ns)!.kind === 'valid')
+  const fingerprints = new Set(
+    valid.map(ns => (states.get(ns) as { fingerprint: string }).fingerprint)
+  )
+  const diverged = fingerprints.size > 1
+  const needsMint = valid.length !== ours.length || diverged
+
+  if (!needsMint) {
+    for (const ns of ours) out.set(ns, 'exists-ours')
+    return out
+  }
+  if (diverged) {
+    logger.warn(
+      { namespaces: ours },
+      'registry pull secret copies diverged across namespaces; re-minting to converge'
+    )
+  }
+
+  // `Secret.type` is immutable, so a wrong-typed Secret must be deleted and recreated.
+  // Do every delete BEFORE minting: a delete that fails must not leave us holding a
+  // freshly-minted key that has already revoked the credential the cluster was using.
+  const recreate = new Set<string>()
+  for (const ns of ours) {
+    const state = states.get(ns)!
+    if (state.kind === 'broken' && state.wrongType) {
+      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)
+      recreate.add(ns)
     }
-    // Ours but broken. `Secret.type` is immutable, so a wrong-typed Secret must be
-    // recreated. Delete FIRST so a failed delete cannot strand a freshly-minted key.
-    if (current.type !== DOCKERCONFIG_TYPE) {
-      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, targetNs)
-      await gateway.createSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
-    } else {
-      await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
-    }
-    logger.info({ targetNs, orgName }, 'registry pull secret repaired')
-    auditPullSecret('registry_pull_secret_provisioned', {
-      namespace: targetNs,
-      org: orgName,
-      outcome: 'repaired',
-    })
+  }
+
+  // ── Mint ONCE, then fan the same credential out to every namespace we own ──
+  // Namespaces that were already valid are rewritten too: the mint just revoked the key
+  // they were holding.
+  const cred = await mintCredential(orgName, host)
+  for (const ns of ours) {
+    const state = states.get(ns)!
+    const outcome = await writeCredential(gateway, ns, state, cred, recreate.has(ns))
+    out.set(ns, outcome)
+  }
+
+  auditPullSecret('registry_pull_secret_provisioned', {
+    namespaces: ours,
+    org: orgName,
+    fingerprint: cred.fingerprint,
+  })
+  logger.info({ namespaces: ours, orgName }, 'registry pull secret provisioned')
+  return out
+}
+
+/** Write `cred` into one namespace, choosing create/update/recreate from its prior state. */
+async function writeCredential(
+  gateway: K8sGateway,
+  ns: string,
+  state: TargetState,
+  cred: MintedCredential,
+  alreadyDeleted: boolean
+): Promise<EnsurePullSecretResult> {
+  // Wrong-typed Secrets were deleted before the mint (see ensureInner), so they are now
+  // absent and must be created, not updated.
+  if (alreadyDeleted) {
+    await gateway.createSecret(buildSecretReq(ns, cred))
     return 'repaired'
   }
-
-  // ── Absent → mint + create ────────────────────────────────────────────────
-  try {
-    await gateway.createSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
-  } catch (err) {
-    if (k8sStatus(err) !== 409) throw err
-    // Lost a concurrent create race. Do NOT mint again — a second mint would revoke the
-    // key the winner just stored. Re-read and adopt whatever is now there.
-    const winner = await readCurrent(gateway, targetNs)
-    if (!winner) throw err // vanished again; surface rather than loop
-    const winnerOurs = winner.labels[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
-    if (!winnerOurs) return 'exists-foreign'
-    logger.info({ targetNs, orgName }, 'registry pull secret already created concurrently')
-    return 'exists-ours'
+  if (state.kind === 'absent') {
+    try {
+      await gateway.createSecret(buildSecretReq(ns, cred))
+      return 'created'
+    } catch (err) {
+      if (k8sStatus(err) !== 409) throw err
+      // Lost a create race. The winner's Secret is authoritative for its own content, but
+      // OUR mint has already revoked whatever key it holds — so overwrite it with ours
+      // rather than adopting a now-dead credential. Skip if the winner is foreign.
+      const winner = await readCurrent(gateway, ns)
+      if (winner && winner.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) return 'exists-foreign'
+      await gateway.updateSecret(buildSecretReq(ns, cred))
+      return 'created'
+    }
   }
-  logger.info({ targetNs, orgName }, 'registry pull secret created')
-  auditPullSecret('registry_pull_secret_provisioned', {
-    namespace: targetNs,
-    org: orgName,
-    outcome: 'created',
-  })
-  return 'created'
+  await gateway.updateSecret(buildSecretReq(ns, cred))
+  return state.kind === 'valid' ? 'exists-ours' : 'repaired'
 }
 
 /** Read the Secret, mapping 404 to null. Any other error propagates (e.g. 403 = wrong ns). */

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -34,6 +34,22 @@
  *      registry's pull-credential mint is rotate-on-call — it revokes the org's previous
  *      key — so a mint that is followed by a failed write strands every other namespace's
  *      Secret on a revoked credential.
+ *
+ * Those two combine into an ALL-OR-NOTHING rule on external pre-provisioning, because the
+ * credential is per-ORG while the Secret is per-NAMESPACE. Minting for a namespace we own
+ * also revokes the key sealed inside a foreign Secret we deliberately refused to touch —
+ * silently: the foreign bytes never change, foreign copies are excluded from the
+ * fingerprint set so the divergence check can never see it, and invariant 1 forbids
+ * repairing it. So if ANY target in a pass holds a USABLE foreign Secret, the org's pull
+ * credential is externally managed and this service mints NOTHING, in any namespace. An
+ * operator therefore provisions ALL of `platformWorkloadNamespaces()` or none of them; a
+ * half-external cluster fails the installs that need a namespace we cannot fill
+ * (`foreign_secret_would_be_revoked`) instead of quietly breaking the ones that work.
+ *
+ * "Usable" is the gate, not "foreign": an unusable foreign Secret (wrong type, or keyed on
+ * another host) is not serving any pull for this registry, so rotating the org key cannot
+ * break a working path through it and it does not block the mint. It is still fatal to a
+ * caller that references its namespace — via `foreign_secret_unusable`, per invariant 1.
  */
 import { createHash } from 'node:crypto'
 import { config } from '../config.js'
@@ -192,18 +208,32 @@ async function mintCredential(orgName: string, host: string): Promise<MintedCred
 // would require an org-scoped distributed lock around the mint — control-api has Postgres
 // available for that. Not implemented: single-replica is the deployed shape today.
 //
-// The cached value carries the unusable-foreign REASONS alongside the results rather than
-// throwing for them inside the pass. Whether an unusable foreign Secret is fatal depends on
-// which namespaces the CALLER needs, and the dedupe key deliberately does not encode that —
+// The cached value carries the per-namespace FAILURE REASONS alongside the results rather
+// than throwing for them inside the pass. Whether an unusable foreign Secret — or a
+// namespace we could not fill without revoking a foreign key — is fatal depends on which
+// namespaces the CALLER needs, and the dedupe key deliberately does not encode that:
 // folding the required set into the key would stop an MCP install and a recipe install from
 // collapsing, which is the very race this map exists to prevent. So the pass records, and
 // each caller applies its own policy on the shared result.
 const inflight = new Map<string, Promise<EnsurePass>>()
 
-/** One pass's outcome: per-namespace results, plus why any foreign Secret is unusable. */
+/**
+ * One pass's outcome: per-namespace results, plus the two per-namespace reasons a caller
+ * may have to fail on.
+ *
+ * `unusable` — a FOREIGN Secret the kubelet cannot use (`foreign_secret_unusable`).
+ * `blocked`  — a namespace we OWN that needed a mint we refused to perform, because some
+ *              other target in the pass holds a USABLE foreign Secret and the mint would
+ *              revoke its key (`foreign_secret_would_be_revoked`). Full caller-facing
+ *              sentences, not fragments: the remedy names the foreign namespace, which only
+ *              the pass knows. A blocked namespace has NO entry in `results` — nothing
+ *              happened to it, and every caller that could observe the gap fails on it
+ *              first.
+ */
 type EnsurePass = {
   results: Map<string, EnsurePullSecretResult>
   unusable: Map<string, string>
+  blocked: Map<string, string>
 }
 
 /** The platform workload namespaces a pull credential may legitimately be written into. */
@@ -222,7 +252,10 @@ export function platformWorkloadNamespaces(): string[] {
  * therefore have each mint invalidate the namespaces already written. So: read all, mint
  * once if any target needs it, then write that single credential to every target we own.
  *
- * Post-condition: every non-foreign target holds the same, current credential.
+ * Post-condition: every non-foreign target holds the same, current credential — UNLESS some
+ * target holds a USABLE foreign Secret, in which case the pass mints and writes nothing at
+ * all (see the all-or-nothing rule in the file header) and every owned target that needed a
+ * mint is recorded as blocked instead.
  *
  * Returns `'skipped'` for all targets ONLY when provisioning is legitimately not our job
  * (managed mode, or no registry configured). Every other "cannot provision" condition
@@ -241,14 +274,21 @@ export async function ensureRegistryPullSecrets(
     run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
     inflight.set(dedupeKey, run)
   }
-  const { results, unusable } = await run
+  const { results, unusable, blocked } = await run
 
-  // An unusable foreign Secret is fatal only to a caller that needs THAT namespace. A pass
-  // covers the whole platform set (for the mint-once collapse), so an MCP install must not
-  // be failed by a squatter in a sandbox namespace it never references — while a recipe
+  // A recorded failure is fatal only to a caller that needs THAT namespace. A pass covers
+  // the whole platform set (for the mint-once collapse), so an MCP install must not be
+  // failed by a squatter in a sandbox namespace it never references — while a recipe
   // install, which does land there, still fails loudly. `required` defaults to every target,
   // so a caller that asks for a set is asserting it needs all of it.
-  for (const ns of opts.required ?? targets) {
+  const required = opts.required ?? targets
+
+  // `unusable` first, across the WHOLE required set, before any `blocked`. Both can apply
+  // at once (a malformed foreign copy in one namespace, a well-shaped one blocking the mint
+  // in another), and `unusable` names a concrete defect in a specific Secret that has to be
+  // fixed or removed either way — deleting the copy that blocked the mint would just
+  // surface it on the next install. Leading with the defect is the shorter path out.
+  for (const ns of required) {
     const why = unusable.get(ns)
     if (why) {
       throw new PullSecretProvisionError(
@@ -257,6 +297,10 @@ export async function ensureRegistryPullSecrets(
         409
       )
     }
+  }
+  for (const ns of required) {
+    const why = blocked.get(ns)
+    if (why) throw new PullSecretProvisionError(why, 'foreign_secret_would_be_revoked', 409)
   }
   return results
 }
@@ -284,8 +328,10 @@ export async function ensureRegistryPullSecret(
     gateway,
     [targetNs, ...platformWorkloadNamespaces()],
     // Only this caller's own namespace is load-bearing: the siblings are swept along for
-    // the mint-once collapse, so a foreign squatter in one of them must not fail an install
-    // that never references it.
+    // the mint-once collapse, so an unusable foreign squatter in one of them must not fail
+    // an install that never references it. A USABLE foreign copy in a sibling is different
+    // — it forbids the mint outright (see the all-or-nothing rule in the file header), so
+    // if `targetNs` needed one it comes back `foreign_secret_would_be_revoked`.
     { required: [targetNs] }
   )
   return results.get(targetNs) ?? 'skipped'
@@ -342,13 +388,14 @@ function classify(current: SecretView | null, host: string): TargetState {
 async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<EnsurePass> {
   const out = new Map<string, EnsurePullSecretResult>()
   const unusable = new Map<string, string>()
+  const blocked = new Map<string, string>()
 
   // ── Legitimate no-ops ─────────────────────────────────────────────────────
   // Managed clusters: the operator owns this Secret; never contend with it.
   const host = registryHostFromUrl(config.registryUrl)
   if (config.registryConnectionMode !== 'self-hosted' || !host) {
     for (const ns of targets) out.set(ns, 'skipped')
-    return { results: out, unusable }
+    return { results: out, unusable, blocked }
   }
 
   // ── Hard preconditions: from here on we MUST provision or fail loudly ─────
@@ -396,12 +443,11 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
   // throwing: the pass spans the whole platform set for the mint-once collapse, but only a
   // caller that actually references the namespace should be failed by it (see
   // `ensureRegistryPullSecrets`, which raises `foreign_secret_unusable` for its own
-  // required set). A well-shaped foreign Secret proceeds untouched either way: external
-  // pre-provisioning is a supported contract.
+  // required set). A well-shaped foreign Secret proceeds untouched either way.
+  const foreign = targets.filter(ns => states.get(ns)!.kind === 'foreign')
   const ours = targets.filter(ns => states.get(ns)!.kind !== 'foreign')
-  for (const ns of targets) {
-    const state = states.get(ns)!
-    if (state.kind !== 'foreign') continue
+  for (const ns of foreign) {
+    const state = states.get(ns) as { kind: 'foreign'; unusable: string | null }
     if (state.unusable) {
       unusable.set(ns, state.unusable)
       logger.warn(
@@ -416,7 +462,7 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
     }
     out.set(ns, 'exists-foreign')
   }
-  if (ours.length === 0) return { results: out, unusable }
+  if (ours.length === 0) return { results: out, unusable, blocked }
 
   // A mint is needed when any namespace we own lacks a usable credential, OR when the
   // copies have diverged — divergence means an earlier pass wrote some namespaces and
@@ -430,8 +476,54 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
 
   if (!needsMint) {
     for (const ns of ours) out.set(ns, 'exists-ours')
-    return { results: out, unusable }
+    return { results: out, unusable, blocked }
   }
+
+  // ── All-or-nothing: a USABLE foreign copy anywhere forbids the mint ───────
+  // The credential is per-ORG and the mint is rotate-on-call, so minting for a namespace we
+  // own would revoke the key inside the foreign Secret we just agreed not to touch. That
+  // damage is invisible — the foreign bytes are unchanged, the foreign fingerprint is not
+  // in the divergence set above, and invariant 1 forbids repairing it — so the only safe
+  // move is to mint nothing and report the namespaces we could not fill. Owned copies that
+  // are already current are untouched by this: they needed no mint, so `needsMint` above
+  // has already returned them as `exists-ours`.
+  //
+  // The gate is USABILITY, not foreignness. An UNUSABLE foreign Secret cannot be serving a
+  // pull for this registry by construction — the kubelet ignores a wrong `type` outright,
+  // and never selects a blob carrying no entry for our host — so rotating the org key
+  // cannot break a working path through it. Blocking on it would only fail installs that
+  // never reference its namespace, which is the scoping this service already decided
+  // against. It stays recorded in `unusable`, so the callers that DO reference it still
+  // fail on it (`foreign_secret_unusable`).
+  const blocking = foreign.filter(
+    ns => (states.get(ns) as { unusable: string | null }).unusable === null
+  )
+  if (blocking.length > 0) {
+    // Under divergence every owned copy needs the rewrite, not just the invalid ones.
+    const unfillable = diverged ? ours : ours.filter(ns => states.get(ns)!.kind !== 'valid')
+    const externals = blocking.map(n => `"${n}"`).join(', ')
+    const all = platformWorkloadNamespaces()
+      .map(n => `"${n}"`)
+      .join(', ')
+    for (const ns of unfillable) {
+      blocked.set(
+        ns,
+        `cannot provision the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}": an externally-owned copy of it exists in ${externals}, and this organization's pull credential is rotate-on-call — minting one for "${ns}" would revoke the key inside that external Secret and break every pod already pulling with it. Either provision ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} externally in ALL of ${all}, or delete the external copy in ${externals} so control-api can manage every namespace itself.`
+      )
+    }
+    // The owned copies we did NOT block are genuinely current — nothing rotated their key —
+    // so report them honestly. Leaving them out would fall through the wrapper's
+    // `?? 'skipped'` and claim provisioning was never our job.
+    for (const ns of ours) {
+      if (!blocked.has(ns)) out.set(ns, 'exists-ours')
+    }
+    logger.warn(
+      { external: blocking, unfillable },
+      'usable externally-owned evenfire-registry-pull Secret present; refusing to mint (the mint is org-wide and rotate-on-call, so it would revoke the external key) — installs that need the unfillable namespaces will fail'
+    )
+    return { results: out, unusable, blocked }
+  }
+
   if (diverged) {
     logger.warn(
       { namespaces: ours },
@@ -457,7 +549,10 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
   const cred = await mintCredential(orgName, host)
   for (const ns of ours) {
     const state = states.get(ns)!
-    const outcome = await writeCredential(gateway, ns, state, cred, recreate.has(ns))
+    const outcome = await writeCredential(gateway, ns, state, cred, recreate.has(ns), {
+      host,
+      unusable,
+    })
     out.set(ns, outcome)
   }
 
@@ -467,7 +562,7 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
     fingerprint: cred.fingerprint,
   })
   logger.info({ namespaces: ours, orgName }, 'registry pull secret provisioned')
-  return { results: out, unusable }
+  return { results: out, unusable, blocked }
 }
 
 /** Write `cred` into one namespace, choosing create/update/recreate from its prior state. */
@@ -476,7 +571,10 @@ async function writeCredential(
   ns: string,
   state: TargetState,
   cred: MintedCredential,
-  alreadyDeleted: boolean
+  alreadyDeleted: boolean,
+  // The pass's `unusable` map, so a foreign Secret discovered on the race path below is
+  // recorded exactly as one discovered by `classify` would be — see the comment there.
+  pass: { host: string; unusable: Map<string, string> }
 ): Promise<EnsurePullSecretResult> {
   // Wrong-typed Secrets were deleted before the mint (see ensureInner), so they are now
   // absent and must be created, not updated.
@@ -498,7 +596,28 @@ async function writeCredential(
       // adopting the winner's would split this namespace from the rest for a credential we
       // can verify no better. Skip if the winner is foreign — invariant 1 still holds.
       const winner = await readCurrent(gateway, ns)
-      if (winner && winner.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) return 'exists-foreign'
+      if (!winner) {
+        // Created and deleted again before this read. The Secret is absent, and an update
+        // against an absent Secret 404s — so create, do not fall through.
+        await gateway.createSecret(buildSecretReq(ns, cred))
+        return 'created'
+      }
+      if (winner.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) {
+        // The all-or-nothing scan in ensureInner ran before this Secret existed, so the
+        // mint has already happened and cannot be taken back. What we CAN still do is give
+        // this namespace the same verdict the classify path would: a foreign Secret the
+        // kubelet will ignore must fail the callers that reference it, not sail past them
+        // and leave a CRD pointing at a credential no pod can use.
+        const problem = foreignUsabilityProblem(winner, pass.host)
+        if (problem) {
+          pass.unusable.set(ns, problem)
+          logger.warn(
+            { namespace: ns, problem },
+            'lost the create race to an externally-owned evenfire-registry-pull Secret that cannot serve an image pull; leaving it untouched — installs that reference this namespace will fail until it is fixed or removed'
+          )
+        }
+        return 'exists-foreign'
+      }
       await gateway.updateSecret(buildSecretReq(ns, cred))
       return 'created'
     }

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -72,11 +72,11 @@
  * against each other, not against an operator, another controller or a `kubectl` replacing
  * the same NAME — and the reconcile cron reopens that window on every tick rather than once
  * per install. So every mutation re-proves ownership immediately before it acts, comparing
- * `metadata.uid` and the ownership marker against what was classified (`recheckOwnership`).
+ * `metadata.uid` and the ownership marker against what was classified (`recheckOwnership`),
+ * and then CARRIES that identity into the write itself as a precondition, so the apiserver
+ * refuses a replace or delete against an object that moved in the gap (`mutateOwned`).
  * A namespace that changed hands is recorded (`ownership_changed`) and left alone; one that
- * merely vanished is created, since the mint has already revoked whatever key it held. This
- * is a narrow compare-and-swap, not an atomic one — the proof read is a separate request —
- * and the residual is spelled out on `recheckOwnership`.
+ * merely vanished is created, since the mint has already revoked whatever key it held.
  */
 import { createHash } from 'node:crypto'
 import { config } from '../config.js'
@@ -87,7 +87,7 @@ import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   registryHostFromUrl,
 } from '../routes/admin/registryImagePullSecret.js'
-import type { SecretUpsertRequest } from '../types.js'
+import type { SecretPreconditions, SecretUpsertRequest } from '../types.js'
 import { mintOrgPullCredential, resolvePublishScope } from './registryClient.js'
 import { isRegistryAuthActive } from './registryConnectionDb.js'
 
@@ -493,9 +493,16 @@ function classify(current: SecretView | null, host: string): TargetState {
   return { kind: 'valid', fingerprint, observed }
 }
 
-/** What a pre-mutation re-read concluded about the object still sitting under that name. */
+/**
+ * What a pre-mutation re-read concluded about the object still sitting under that name.
+ *
+ * `same` carries the identity THAT READ saw, not the one `classify` saw: it is what the
+ * following mutation binds itself to, so the API server can reject the write if anything
+ * moves in between (see `mutateOwned`). Passing the older identity would pin the write to a
+ * version the object may legitimately have left behind.
+ */
 type OwnershipRecheck =
-  | { verdict: 'same' }
+  | { verdict: 'same'; current: SecretIdentity }
   | { verdict: 'gone' }
   | { verdict: 'taken'; why: string }
 
@@ -513,25 +520,29 @@ type OwnershipRecheck =
  * only holds for as long as nobody else moves — and the reconcile cron reopens the window
  * every tick rather than once per install.
  *
- * WHAT IT IS. A narrow compare-and-swap, NOT an atomic one: the proof read is a separate
- * API request from the mutation, so a takeover landing between the two still slips through.
- * What it buys is the size of the window — one round trip instead of the whole pass (read
- * all → mint → write all, with a registry call in the middle). Closing it completely means
- * an `If-Match`-style precondition on the write itself: `metadata.resourceVersion` on the
- * replace, and `preconditions.uid` on the delete. Both live in `SecretService`, which is
- * shared with the admin /secrets routes and inter-service token rotation, so changing their
- * semantics is out of scope here.
+ * WHAT IT IS — AND IS NOT. On its own this is only half a compare-and-swap: the proof read
+ * is a separate API request from the mutation, so a takeover landing between the two would
+ * still slip through. It is never called on its own for that reason. `mutateOwned` pairs it
+ * with an `If-Match`-style precondition on the write itself — the identity returned here is
+ * carried into `metadata.resourceVersion` on the replace and `preconditions.uid` on the
+ * delete — so the API server, not this function, is what finally refuses a write to an
+ * object that moved. This read still earns its place: it produces the fresh identity the
+ * write binds to, and it distinguishes `gone` (create instead) from `taken` (surrender),
+ * neither of which a bare 409 can tell apart.
  *
  * WHAT IT COMPARES. `uid` and the ownership label, per the two ways a name changes hands:
  *   - `uid` differs ⇒ deleted and recreated. Data, labels and annotations can all be
  *     reproduced by the new owner; the uid cannot.
  *   - the marker is gone ⇒ adopted in place by an external owner, and `classify` would now
  *     call it `foreign`.
- * `resourceVersion` is deliberately NOT a gate. It changes on any edit, including benign
- * ones by something that left our marker in place — and refusing there would be worse than
- * writing: the mint has already revoked the key that copy holds, so declining to overwrite
- * leaves the namespace on a dead credential. It is carried for the log line, which is where
- * "still ours, but someone edited it" is worth seeing.
+ * `resourceVersion` is deliberately NOT a gate HERE, though it is a precondition on the
+ * write. It changes on any edit, including benign ones by something that left our marker in
+ * place, and refusing on that basis would be worse than writing: the mint has already
+ * revoked the key that copy holds, so declining to overwrite leaves the namespace on a dead
+ * credential. That is why `mutateOwned` treats the resulting 409 as "re-read and try again",
+ * not as "surrender" — only this function's ownership verdict may end the attempt. Here the
+ * version difference is logged, which is where "still ours, but someone edited it" is worth
+ * seeing.
  *
  * `uid` is compared only when both reads surfaced one. The API server always sets it; a
  * caller that cannot see it (an older gateway, a fake) falls back to the ownership label,
@@ -567,7 +578,79 @@ async function recheckOwnership(
       'evenfire-registry-pull Secret was modified between classification and write; still ours, proceeding'
     )
   }
-  return { verdict: 'same' }
+  return { verdict: 'same', current: { uid: now.uid, resourceVersion: now.resourceVersion } }
+}
+
+/**
+ * How many times an ownership-bound mutation may lose a benign race before we stop.
+ *
+ * Each attempt is one read plus one write, and the only thing that makes an attempt fail
+ * without ending the loop is a 409 from something else writing the same Secret in that gap.
+ * Three is chosen to absorb a genuine race, not to wait out a controller that is fighting us
+ * for the name: with a persistent writer no number of retries converges, and the honest
+ * answer is to stop and report, which is what exhausting these does.
+ */
+const OWNERSHIP_CAS_ATTEMPTS = 3
+
+/** The outcome of an ownership-bound mutation. `done` means it landed. */
+type MutateOutcome = { verdict: 'done' } | { verdict: 'gone' } | { verdict: 'taken'; why: string }
+
+/**
+ * Mutate the Secret in `ns` ONLY IF it is still the object this pass classified and still
+ * ours — a real compare-and-swap, decided by the API server rather than by a read we hope
+ * nothing raced.
+ *
+ * `recheckOwnership` alone cannot do this: it proves ownership in one request and the
+ * mutation happens in the next, so a takeover in that gap is invisible to it. Here the
+ * identity it observed is carried INTO the mutation as a precondition (`resourceVersion` on
+ * a replace, `preconditions.uid` on a delete), so a write to an object that moved is
+ * refused with 409 by the apiserver — the check and the use become one operation.
+ *
+ * WHY 409 IS NOT AN ANSWER BY ITSELF. It says "this object is not what you thought", which
+ * conflates two very different situations: someone took the name over, and someone edited a
+ * Secret that is still ours. Surrendering on both would be wrong — the mint upstream has
+ * already revoked the key the existing copy holds, so refusing to write over a benign edit
+ * strands that namespace on a dead credential, an ImagePullBackOff we caused ourselves. So a
+ * 409 sends us back through `recheckOwnership`, which CAN tell the two apart, and only its
+ * `taken` verdict ends the loop. That is also why the retry drops the stale
+ * `resourceVersion` but keeps the `uid`: the version is expected to have moved, the identity
+ * is not.
+ *
+ * `gone` is returned rather than retried — the object is absent, and what to do about that
+ * differs per call site (create the credential, or accept that the delete is already done).
+ */
+async function mutateOwned(
+  gateway: K8sGateway,
+  ns: string,
+  observed: SecretIdentity,
+  mutate: (precondition: SecretPreconditions) => Promise<unknown>
+): Promise<MutateOutcome> {
+  let expected = observed
+  for (let attempt = 1; attempt <= OWNERSHIP_CAS_ATTEMPTS; attempt++) {
+    const recheck = await recheckOwnership(gateway, ns, expected)
+    if (recheck.verdict !== 'same') return recheck
+    try {
+      await mutate({
+        uid: recheck.current.uid,
+        resourceVersion: recheck.current.resourceVersion,
+      })
+      return { verdict: 'done' }
+    } catch (err) {
+      if (k8sStatus(err) !== 409) throw err
+      logger.info(
+        { namespace: ns, attempt },
+        'evenfire-registry-pull Secret changed under an ownership-bound write; re-proving ownership before retrying'
+      )
+      // Keep the identity, drop the version: the next `recheckOwnership` must still catch a
+      // delete-and-recreate, but the version it compares against is known to be stale and
+      // would only log noise.
+      expected = { uid: recheck.current.uid, resourceVersion: undefined }
+    }
+  }
+  return {
+    verdict: 'taken',
+    why: `something else rewrote it during each of ${OWNERSHIP_CAS_ATTEMPTS} ownership-bound write attempts, so this pass never managed to write it without risking somebody else's object`,
+  }
 }
 
 /**
@@ -847,18 +930,17 @@ async function ensureLocked(
   for (const ns of ours) {
     const state = states.get(ns)!
     if (state.kind !== 'broken' || !state.wrongType) continue
-    const recheck = await recheckOwnership(gateway, ns, state.observed)
-    if (recheck.verdict === 'taken') {
-      recordTakeover(pass, ns, recheck.why)
+    const outcome = await mutateOwned(gateway, ns, state.observed, precondition =>
+      gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, precondition)
+    )
+    if (outcome.verdict === 'taken') {
+      recordTakeover(pass, ns, outcome.why)
       surrendered.add(ns)
       continue
     }
     // 'gone': already deleted by someone else, so there is nothing to delete — but the
     // namespace still needs the credential, and `recreate` is exactly "create, do not
     // update" downstream. Falling through to the update path would 404.
-    if (recheck.verdict === 'same') {
-      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)
-    }
     recreate.add(ns)
   }
   // Namespaces that changed hands are no longer ours to write. Every caller that references
@@ -971,10 +1053,24 @@ async function writeCredential(
         }
         return 'exists-foreign'
       }
-      // Read-then-write with no gap: `winner` was read immediately above, and the ownership
-      // check on it is this path's compare-and-swap. Nothing more can be proved here — the
-      // object had no prior classification to compare against, it did not exist yet.
-      await gateway.updateSecret(buildSecretReq(ns, cred))
+      // The winner is ours, so adopt it — but bind the write to the object we just read.
+      // "Read `winner`, then update by name" is the same TOCTOU as everywhere else on this
+      // path: the ownership check and the replace are two requests, and `updateSecret`
+      // without a precondition re-reads and wins regardless of what landed in between. A
+      // create race is precisely when a third writer is known to be active on this name, so
+      // this is the LAST place to assume the gap is safe.
+      const adopted = await mutateOwned(gateway, ns, winner, precondition =>
+        gateway.updateSecret(buildSecretReq(ns, cred), precondition)
+      )
+      if (adopted.verdict === 'taken') {
+        recordTakeover(ctx.pass, ns, adopted.why)
+        return 'exists-foreign'
+      }
+      if (adopted.verdict === 'gone') {
+        // Deleted again in the gap. Nobody holds the name and the namespace still needs a
+        // credential, so create rather than leaving it empty.
+        await gateway.createSecret(buildSecretReq(ns, cred))
+      }
       return 'created'
     }
   }
@@ -984,16 +1080,18 @@ async function writeCredential(
     // turn invariant 1 into a runtime accident.
     return 'exists-foreign'
   }
-  // The update path. `SecretService.updateSecret` re-reads to pick up the latest
-  // `resourceVersion` and therefore ALWAYS wins the write — it proves the object is current,
-  // never that it is still ours — so ownership has to be re-proved here, against the object
-  // `classify` decided about. See `recheckOwnership` for what this does and does not buy.
-  const recheck = await recheckOwnership(gateway, ns, state.observed)
-  if (recheck.verdict === 'taken') {
-    recordTakeover(ctx.pass, ns, recheck.why)
+  // The update path. Left to itself `SecretService.updateSecret` re-reads to pick up the
+  // latest `resourceVersion` and therefore ALWAYS wins the write — it proves the object is
+  // current, never that it is still ours. `mutateOwned` binds the replace to the identity we
+  // classified instead, so the apiserver refuses it if the object moved.
+  const outcome = await mutateOwned(gateway, ns, state.observed, precondition =>
+    gateway.updateSecret(buildSecretReq(ns, cred), precondition)
+  )
+  if (outcome.verdict === 'taken') {
+    recordTakeover(ctx.pass, ns, outcome.why)
     return 'exists-foreign'
   }
-  if (recheck.verdict === 'gone') {
+  if (outcome.verdict === 'gone') {
     // Deleted under us. NOT a takeover — nobody else holds the name — and the mint above has
     // already revoked whatever key that copy carried, so leaving the namespace empty is the
     // one outcome guaranteed to ImagePullBackOff. Create, because an update against an
@@ -1001,7 +1099,6 @@ async function writeCredential(
     await gateway.createSecret(buildSecretReq(ns, cred))
     return 'created'
   }
-  await gateway.updateSecret(buildSecretReq(ns, cred))
   return state.kind === 'valid' ? 'exists-ours' : 'repaired'
 }
 

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -1,0 +1,175 @@
+/**
+ * Self-provisioning of the `evenfire-registry-pull` image-pull Secret.
+ *
+ * On a self-hosted cluster there is no managed operator to drop the dockerconfigjson
+ * Secret that local-mode plugins on the private registry need, so control-api
+ * provisions it itself. Design: docs/architecture/registry-pull-secret-self-provisioning.md.
+ *
+ * Contract (must match what the managed operator writes, so either satisfies the same
+ * McpServer.spec.imagePullSecrets reference):
+ *   name  = 'evenfire-registry-pull'         (EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+ *   ns    = the McpServer's own namespace    (imagePullSecrets are namespace-local)
+ *   type  = kubernetes.io/dockerconfigjson
+ *   data['.dockerconfigjson'] = base64 payload, keyed on OUR image host (registryUrl),
+ *                               NOT the registry's token-issuer (spec §7.9-2)
+ *   label clerum.io/managed-by = control-api  (ownership marker; absent ⇒ externally owned)
+ */
+import type { K8sGateway } from '../k8s.js'
+import type { SecretUpsertRequest } from '../types.js'
+import { rootLogger } from '../observability/logger.js'
+import { config } from '../config.js'
+import { isRegistryAuthActive } from './registryConnectionDb.js'
+import { resolvePublishScope, mintOrgPullCredential } from './registryClient.js'
+import {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  registryHostFromUrl,
+} from '../routes/admin/registryImagePullSecret.js'
+
+const logger = rootLogger.child({ module: 'registry-pull-secret' })
+
+const MANAGED_BY_LABEL = 'clerum.io/managed-by'
+const MANAGED_BY_VALUE = 'control-api'
+const DOCKERCONFIG_KEY = '.dockerconfigjson'
+
+export type EnsurePullSecretResult =
+  | 'created'
+  | 'repaired'
+  | 'exists-ours'
+  | 'exists-foreign'
+  | 'skipped'
+
+/** Extract an HTTP-ish status from a K8s client error (mirrors extractK8sError). */
+function k8sStatus(err: unknown): number | null {
+  if (err && typeof err === 'object') {
+    const e = err as { code?: number; statusCode?: number; httpStatus?: number }
+    const s = e.code ?? e.statusCode ?? e.httpStatus
+    if (typeof s === 'number') return s
+  }
+  return null
+}
+
+/**
+ * Build a kubernetes.io/dockerconfigjson payload (base64) for `key` against `host`.
+ * Keyed on OUR configured registry host (= the image host, per the attach invariant)
+ * so the kubelet selects this credential — the registry's server-built blob is keyed
+ * on its own token-issuer and cannot be trusted here (spec §7.9-2).
+ */
+function buildDockerconfigjson(host: string, key: string): string {
+  const auth = Buffer.from(`_:${key}`).toString('base64')
+  const cfg = { auths: { [host]: { username: '_', password: key, auth } } }
+  return Buffer.from(JSON.stringify(cfg)).toString('base64')
+}
+
+interface SecretView {
+  labels: Record<string, string>
+  dockerconfig: string | undefined
+}
+
+function readSecret(raw: unknown): SecretView {
+  const s = (raw ?? {}) as {
+    metadata?: { labels?: Record<string, string> }
+    data?: Record<string, string>
+  }
+  return {
+    labels: s.metadata?.labels ?? {},
+    dockerconfig: s.data?.[DOCKERCONFIG_KEY],
+  }
+}
+
+function buildSecretReq(targetNs: string, dockerconfigjson: string): SecretUpsertRequest {
+  return {
+    name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+    namespace: targetNs,
+    type: 'kubernetes.io/dockerconfigjson',
+    labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
+    data: { [DOCKERCONFIG_KEY]: dockerconfigjson },
+  }
+}
+
+async function mintAndBuild(orgName: string, host: string): Promise<string> {
+  const { key } = await mintOrgPullCredential(orgName)
+  return buildDockerconfigjson(host, key)
+}
+
+// Serialize concurrent ensures for the same (namespace, secret) WITHIN this replica so
+// two in-flight installs don't both mint. Cross-replica races are additionally bounded
+// by the registry's rotate-on-call (≤1 active pull key/org) plus reactive rotation.
+const inflight = new Map<string, Promise<EnsurePullSecretResult>>()
+
+/**
+ * Ensure the `evenfire-registry-pull` Secret exists in `targetNs`, minting a fresh
+ * pull-only credential only when it is absent or broken. Idempotent and coexistence-safe:
+ * a Secret we do not own (no managed-by=control-api label) is left untouched.
+ *
+ * No-ops (`'skipped'`) outside self-hosted mode, without active registry auth, without a
+ * configured registry host, or before the connect flow has resolved our org.
+ *
+ * THROWS on mint/write failure so the caller can fail the install loudly rather than
+ * attach an unresolvable imagePullSecrets reference.
+ */
+export function ensureRegistryPullSecret(
+  gateway: K8sGateway,
+  targetNs: string
+): Promise<EnsurePullSecretResult> {
+  const dedupeKey = `${targetNs}/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`
+  const existing = inflight.get(dedupeKey)
+  if (existing) return existing
+  const run = ensureInner(gateway, targetNs).finally(() => inflight.delete(dedupeKey))
+  inflight.set(dedupeKey, run)
+  return run
+}
+
+async function ensureInner(
+  gateway: K8sGateway,
+  targetNs: string
+): Promise<EnsurePullSecretResult> {
+  // ── Gate: only self-hosted, connected, with a resolvable org ──────────────
+  if (config.registryConnectionMode !== 'self-hosted') return 'skipped'
+  const host = registryHostFromUrl(config.registryUrl)
+  if (!host) return 'skipped'
+  if (!(await isRegistryAuthActive())) return 'skipped'
+  const { orgName } = await resolvePublishScope()
+  if (!orgName) {
+    logger.warn(
+      { targetNs },
+      'registry pull secret: org not resolved (connect flow incomplete); skipping'
+    )
+    return 'skipped'
+  }
+
+  // ── Read (getSecret re-throws 404; any other error aborts before minting) ──
+  let current: SecretView | null = null
+  try {
+    current = readSecret(await gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, targetNs))
+  } catch (err) {
+    if (k8sStatus(err) !== 404) throw err // e.g. 403 = ns outside our RBAC → abort
+    current = null // 404 → absent
+  }
+
+  if (current) {
+    const ours = current.labels[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
+    const hasCred = !!current.dockerconfig
+    if (hasCred && !ours) return 'exists-foreign' // external operator owns it — never touch
+    if (hasCred && ours) return 'exists-ours' // reuse; rotation handled reactively
+    // Present but missing/empty .dockerconfigjson → repair (mint + replace).
+    await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+    logger.info({ targetNs, orgName }, 'registry pull secret repaired')
+    return 'repaired'
+  }
+
+  // ── Absent → mint + create ────────────────────────────────────────────────
+  try {
+    await gateway.createSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+  } catch (err) {
+    if (k8sStatus(err) === 409) {
+      // Lost a concurrent create race. We hold a freshly-minted (now-active) key, so
+      // overwrite with it — rotate-on-call means the last minter's key is authoritative.
+      await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+      logger.info({ targetNs, orgName }, 'registry pull secret reconciled after create race')
+      return 'created'
+    }
+    throw err
+  }
+  logger.info({ targetNs, orgName }, 'registry pull secret created')
+  return 'created'
+}

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -20,10 +20,25 @@
  * split across all three platform workload namespaces by kind (transport → mcp-server,
  * spec.ui.workloadRef → sandbox-ui, everything else → sandbox-recipes). So the Secret must
  * exist in ALL of them — `platformWorkloadNamespaces()`, the one allowlist writes are
- * confined to. On a MANAGED cluster control-api writes none of them (provisioning
- * short-circuits to 'skipped'), which makes populating all three the external operator's
- * job: a managed cluster that provisions only mcp-server leaves recipe pods in
- * ImagePullBackOff with nothing in the API trail to explain it.
+ * confined to.
+ *
+ * MANAGED clusters: VERIFY, never write. control-api provisions nothing there — the
+ * platform operator owns the Secret — but WRC still injects the reference, so a namespace
+ * the operator has not populated yields a workload that can only ImagePullBackOff, behind
+ * a 201. Managed mode therefore runs a read-only presence check over the platform
+ * namespaces (`verifyOperatorProvisioned`) and fails the caller BEFORE the CRD is
+ * persisted when one it needs has no usable copy (`operator_secret_missing`). This asserts
+ * nothing about what any operator does; it only refuses to persist a reference that cannot
+ * resolve on THIS cluster right now. The check is scoped by `required` for the same reason
+ * everything else here is: today's managed operator populates mcp-server, so McpServer
+ * installs must keep working while recipe installs — which land in all three — do not
+ * silently half-work.
+ *
+ * A recipe caller passes the whole platform set and requires all of it, which is stricter
+ * than that recipe may strictly need: control-api does not model WRC's per-workload
+ * kind→namespace split, so it cannot tell which of the three a given recipe will land in.
+ * Requiring all three is the conservative side of that gap — it refuses an install that
+ * MIGHT have pulled rather than persisting one that might not.
  *
  * Two invariants make this safe to run repeatedly:
  *   1. NEVER write a Secret we do not own. An unlabeled Secret belongs to an external
@@ -230,11 +245,19 @@ const inflight = new Map<string, Promise<EnsurePass>>()
  *              the pass knows. A blocked namespace has NO entry in `results` — nothing
  *              happened to it, and every caller that could observe the gap fails on it
  *              first.
+ * `missing`   — MANAGED mode only: a platform namespace with no usable operator-provisioned
+ *              copy (`operator_secret_missing`). Fragments ("it does not exist", "it exists
+ *              but …"), because the caller-facing sentence names every missing namespace at
+ *              once and only `ensureRegistryPullSecrets` knows which ones the caller needs.
+ *
+ * The three are mutually exclusive by mode: `unusable`/`blocked` come from the
+ * provisioning pass, `missing` from the verification pass, and a pass is one or the other.
  */
 type EnsurePass = {
   results: Map<string, EnsurePullSecretResult>
   unusable: Map<string, string>
   blocked: Map<string, string>
+  missing: Map<string, string>
 }
 
 /** The platform workload namespaces a pull credential may legitimately be written into. */
@@ -261,7 +284,9 @@ export function platformWorkloadNamespaces(): string[] {
  * Returns `'skipped'` for all targets ONLY when provisioning is legitimately not our job
  * (managed mode, or no registry configured). Every other "cannot provision" condition
  * THROWS `PullSecretProvisionError`, so a caller about to attach an imagePullSecrets
- * reference fails the install loudly instead of persisting an unresolvable one.
+ * reference fails the install loudly instead of persisting an unresolvable one. In managed
+ * mode `'skipped'` is now a VERIFIED answer rather than an assumed one: the operator's
+ * copies are read first, and a required namespace without a usable one throws too.
  */
 export async function ensureRegistryPullSecrets(
   gateway: K8sGateway,
@@ -275,7 +300,7 @@ export async function ensureRegistryPullSecrets(
     run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
     inflight.set(dedupeKey, run)
   }
-  const { results, unusable, blocked } = await run
+  const { results, unusable, blocked, missing } = await run
 
   // A recorded failure is fatal only to a caller that needs THAT namespace. A pass covers
   // the whole platform set (for the mint-once collapse), so an MCP install must not be
@@ -283,6 +308,22 @@ export async function ensureRegistryPullSecrets(
   // install, which does land there, still fails loudly. `required` defaults to every target,
   // so a caller that asks for a set is asserting it needs all of it.
   const required = opts.required ?? targets
+
+  // MANAGED mode: the operator owns the Secret, so the only thing we can do for a caller
+  // is refuse to persist a reference that cannot resolve. Report every missing namespace
+  // at once — an operator fixing one at a time would otherwise walk the whole set through
+  // three failed installs. (Order against the two loops below is not load-bearing: this
+  // map and those are populated by different passes; see EnsurePass.)
+  const absent = required.filter(ns => missing.has(ns))
+  if (absent.length > 0) {
+    const host = registryHostFromUrl(config.registryUrl)
+    const detail = absent.map(ns => `"${ns}" (${missing.get(ns)})`).join(', ')
+    throw new PullSecretProvisionError(
+      `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret cannot serve an image pull in ${detail}. This cluster runs in "${config.registryConnectionMode}" registry mode, where the platform operator — not control-api — owns that Secret, so control-api will not create it here. Ask the operator to provision ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} (type ${DOCKERCONFIG_TYPE}, with a ${DOCKERCONFIG_KEY} entry for "${host}") in the namespace(s) above, then retry. Proceeding would persist a workload referencing a credential no pod can resolve.`,
+      'operator_secret_missing',
+      409
+    )
+  }
 
   // `unusable` first, across the WHOLE required set, before any `blocked`. Both can apply
   // at once (a malformed foreign copy in one namespace, a well-shaped one blocking the mint
@@ -417,13 +458,20 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
   const out = new Map<string, EnsurePullSecretResult>()
   const unusable = new Map<string, string>()
   const blocked = new Map<string, string>()
+  const missing = new Map<string, string>()
 
   // ── Legitimate no-ops ─────────────────────────────────────────────────────
-  // Managed clusters: the operator owns this Secret; never contend with it.
+  // No registry host: nothing references it, and there is no host to check a blob
+  // against either — the pull secret is not in play at all.
   const host = registryHostFromUrl(config.registryUrl)
-  if (config.registryConnectionMode !== 'self-hosted' || !host) {
+  if (!host) {
     for (const ns of targets) out.set(ns, 'skipped')
-    return { results: out, unusable, blocked }
+    return { results: out, unusable, blocked, missing }
+  }
+  // Managed clusters: the operator owns this Secret; never contend with it — but do check
+  // that what the caller is about to reference is actually there.
+  if (config.registryConnectionMode !== 'self-hosted') {
+    return verifyOperatorProvisioned(gateway, targets, host)
   }
 
   // ── Hard preconditions: from here on we MUST provision or fail loudly ─────
@@ -461,8 +509,59 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
   // Everything from here — read, classify, mint, write — must be serialized across
   // replicas, not just within this process (see withPullSecretLock).
   return withPullSecretLock(orgName, () =>
-    ensureLocked(gateway, targets, host, orgName as string, out, unusable, blocked)
+    ensureLocked(gateway, targets, host, orgName as string, out, unusable, blocked, missing)
   )
+}
+
+/**
+ * MANAGED clusters: read-only verification that the operator's Secret is where the caller
+ * is about to point a workload at it. Mints nothing, writes nothing, takes no lock, and
+ * touches neither Postgres nor the registry — invariant 1 admits no exception here, and
+ * "the operator owns it" is precisely why we may only look.
+ *
+ * Reuses `foreignUsabilityProblem`, the same shape-only test applied to externally-owned
+ * Secrets on the self-hosted path: correct type, and a dockerconfig entry for our host. A
+ * second notion of "usable" would drift from the one the kubelet actually acts on. Ownership
+ * is deliberately NOT consulted — whoever wrote it, all that matters is whether it can serve
+ * the pull — and neither is liveness of the sealed key, which would cost a registry
+ * round-trip per install.
+ *
+ * Scoped to `platformWorkloadNamespaces()`: that set is the operator contract. A target
+ * outside it stays `'skipped'` rather than becoming a failure, because control-api has no
+ * claim about namespaces no operator ever agreed to populate, and failing there would break
+ * managed installs that work today.
+ */
+async function verifyOperatorProvisioned(
+  gateway: K8sGateway,
+  targets: string[],
+  host: string
+): Promise<EnsurePass> {
+  const out = new Map<string, EnsurePullSecretResult>()
+  const missing = new Map<string, string>()
+  const platform = new Set(platformWorkloadNamespaces())
+  for (const ns of targets) {
+    // Provisioning is genuinely not our job on this cluster, so the result stays 'skipped'
+    // whichever way the check goes; the verdict travels in `missing`.
+    out.set(ns, 'skipped')
+    if (!platform.has(ns)) continue
+    const current = await readCurrent(gateway, ns)
+    if (!current) {
+      missing.set(ns, 'it does not exist')
+      continue
+    }
+    const problem = foreignUsabilityProblem(current, host)
+    if (problem) missing.set(ns, `it exists but ${problem}`)
+  }
+  // Deliberately not logged at warn: this runs on every reconcile tick as well as every
+  // install, and on a managed cluster an unpopulated namespace is a normal state until
+  // something actually asks for it. The caller that asks gets the loud failure.
+  if (missing.size > 0) {
+    logger.debug(
+      { namespaces: [...missing.keys()] },
+      'managed cluster: no usable operator-provisioned evenfire-registry-pull Secret in these namespaces'
+    )
+  }
+  return { results: out, unusable: new Map(), blocked: new Map(), missing }
 }
 
 /**
@@ -476,7 +575,10 @@ async function ensureLocked(
   orgName: string,
   out: Map<string, EnsurePullSecretResult>,
   unusable: Map<string, string>,
-  blocked: Map<string, string>
+  blocked: Map<string, string>,
+  // Always empty on this path: a namespace with nothing in it is one we PROVISION, not one
+  // we report as missing. It rides along so both passes return the same shape.
+  missing: Map<string, string>
 ): Promise<EnsurePass> {
   // ── Read + classify every target BEFORE minting anything ──────────────────
   const states = new Map<string, TargetState>()
@@ -510,7 +612,7 @@ async function ensureLocked(
     }
     out.set(ns, 'exists-foreign')
   }
-  if (ours.length === 0) return { results: out, unusable, blocked }
+  if (ours.length === 0) return { results: out, unusable, blocked, missing }
 
   // A mint is needed when any namespace we own lacks a usable credential, OR when the
   // copies have diverged — divergence means an earlier pass wrote some namespaces and
@@ -524,7 +626,7 @@ async function ensureLocked(
 
   if (!needsMint) {
     for (const ns of ours) out.set(ns, 'exists-ours')
-    return { results: out, unusable, blocked }
+    return { results: out, unusable, blocked, missing }
   }
 
   // ── All-or-nothing: a USABLE foreign copy anywhere forbids the mint ───────
@@ -569,7 +671,7 @@ async function ensureLocked(
       { external: blocking, unfillable },
       'usable externally-owned evenfire-registry-pull Secret present; refusing to mint (the mint is org-wide and rotate-on-call, so it would revoke the external key) — installs that need the unfillable namespaces will fail'
     )
-    return { results: out, unusable, blocked }
+    return { results: out, unusable, blocked, missing }
   }
 
   if (diverged) {
@@ -610,7 +712,7 @@ async function ensureLocked(
     fingerprint: cred.fingerprint,
   })
   logger.info({ namespaces: ours, orgName }, 'registry pull secret provisioned')
-  return { results: out, unusable, blocked }
+  return { results: out, unusable, blocked, missing }
 }
 
 /** Write `cred` into one namespace, choosing create/update/recreate from its prior state. */

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -11,25 +11,44 @@
  *   ns    = the McpServer's own namespace    (imagePullSecrets are namespace-local)
  *   type  = kubernetes.io/dockerconfigjson
  *   data['.dockerconfigjson'] = base64 payload, keyed on OUR image host (registryUrl),
- *                               NOT the registry's token-issuer (spec §7.9-2)
+ *                               NOT the registry's token-issuer
  *   label clerum.io/managed-by = control-api  (ownership marker; absent ⇒ externally owned)
+ *
+ * Two invariants make this safe to run repeatedly:
+ *   1. NEVER write a Secret we do not own. An unlabeled Secret belongs to an external
+ *      operator; we return `exists-foreign` and leave it alone even if it looks broken.
+ *   2. Mint ONLY when we are already committed to a write we know can succeed. The
+ *      registry's pull-credential mint is rotate-on-call — it revokes the org's previous
+ *      key — so a mint that is followed by a failed write strands every other namespace's
+ *      Secret on a revoked credential.
  */
-import type { K8sGateway } from '../k8s.js'
-import type { SecretUpsertRequest } from '../types.js'
-import { rootLogger } from '../observability/logger.js'
 import { config } from '../config.js'
-import { isRegistryAuthActive } from './registryConnectionDb.js'
-import { resolvePublishScope, mintOrgPullCredential } from './registryClient.js'
+import type { K8sGateway } from '../k8s.js'
+import { rootLogger } from '../observability/logger.js'
 import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   registryHostFromUrl,
 } from '../routes/admin/registryImagePullSecret.js'
+import type { SecretUpsertRequest } from '../types.js'
+import { mintOrgPullCredential, resolvePublishScope } from './registryClient.js'
+import { isRegistryAuthActive } from './registryConnectionDb.js'
 
 const logger = rootLogger.child({ module: 'registry-pull-secret' })
+
+/**
+ * Audit trail for minting + writing a registry credential, matching the `[AUDIT]` shape
+ * the admin registry routes emit. NEVER include the key or the dockerconfigjson payload.
+ */
+function auditPullSecret(action: string, details: Record<string, unknown>): void {
+  console.log(
+    `[AUDIT] ${JSON.stringify({ timestamp: new Date().toISOString(), action, ...details })}`
+  )
+}
 
 const MANAGED_BY_LABEL = 'clerum.io/managed-by'
 const MANAGED_BY_VALUE = 'control-api'
 const DOCKERCONFIG_KEY = '.dockerconfigjson'
+const DOCKERCONFIG_TYPE = 'kubernetes.io/dockerconfigjson'
 
 export type EnsurePullSecretResult =
   | 'created'
@@ -37,6 +56,23 @@ export type EnsurePullSecretResult =
   | 'exists-ours'
   | 'exists-foreign'
   | 'skipped'
+
+/**
+ * Raised when the pull Secret cannot be provisioned but the caller is about to attach a
+ * reference to it. The caller MUST fail the install rather than persist an McpServer
+ * whose imagePullSecrets can never resolve — that is the silent ImagePullBackOff this
+ * whole mechanism exists to remove.
+ */
+export class PullSecretProvisionError extends Error {
+  constructor(
+    message: string,
+    readonly reason: string,
+    readonly status: number = 500
+  ) {
+    super(message)
+    this.name = 'PullSecretProvisionError'
+  }
+}
 
 /** Extract an HTTP-ish status from a K8s client error (mirrors extractK8sError). */
 function k8sStatus(err: unknown): number | null {
@@ -52,7 +88,7 @@ function k8sStatus(err: unknown): number | null {
  * Build a kubernetes.io/dockerconfigjson payload (base64) for `key` against `host`.
  * Keyed on OUR configured registry host (= the image host, per the attach invariant)
  * so the kubelet selects this credential — the registry's server-built blob is keyed
- * on its own token-issuer and cannot be trusted here (spec §7.9-2).
+ * on its own token-issuer and cannot be trusted here.
  */
 function buildDockerconfigjson(host: string, key: string): string {
   const auth = Buffer.from(`_:${key}`).toString('base64')
@@ -60,18 +96,38 @@ function buildDockerconfigjson(host: string, key: string): string {
   return Buffer.from(JSON.stringify(cfg)).toString('base64')
 }
 
+/**
+ * True when the stored blob actually carries an entry for `host`. Presence alone is not
+ * enough: a Secret minted before CLERUM_REGISTRY_URL changed is keyed on the old host and
+ * the kubelet will never select it. Unparseable ⇒ false (treat as broken, repair it).
+ */
+function dockerconfigMatchesHost(blob: string | undefined, host: string): boolean {
+  if (!blob) return false
+  try {
+    const parsed = JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
+      auths?: Record<string, unknown>
+    }
+    return !!parsed?.auths && Object.prototype.hasOwnProperty.call(parsed.auths, host)
+  } catch {
+    return false
+  }
+}
+
 interface SecretView {
   labels: Record<string, string>
+  type: string | undefined
   dockerconfig: string | undefined
 }
 
 function readSecret(raw: unknown): SecretView {
   const s = (raw ?? {}) as {
     metadata?: { labels?: Record<string, string> }
+    type?: string
     data?: Record<string, string>
   }
   return {
     labels: s.metadata?.labels ?? {},
+    type: s.type,
     dockerconfig: s.data?.[DOCKERCONFIG_KEY],
   }
 }
@@ -80,7 +136,7 @@ function buildSecretReq(targetNs: string, dockerconfigjson: string): SecretUpser
   return {
     name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
     namespace: targetNs,
-    type: 'kubernetes.io/dockerconfigjson',
+    type: DOCKERCONFIG_TYPE,
     labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
     data: { [DOCKERCONFIG_KEY]: dockerconfigjson },
   }
@@ -91,21 +147,20 @@ async function mintAndBuild(orgName: string, host: string): Promise<string> {
   return buildDockerconfigjson(host, key)
 }
 
-// Serialize concurrent ensures for the same (namespace, secret) WITHIN this replica so
-// two in-flight installs don't both mint. Cross-replica races are additionally bounded
-// by the registry's rotate-on-call (≤1 active pull key/org) plus reactive rotation.
+// Collapse concurrent ensures for the same (namespace, secret) WITHIN this replica so two
+// in-flight installs cannot both mint. Cross-replica races are bounded by the registry's
+// rotate-on-call (<=1 active pull key per org) plus the read-before-mint discipline below:
+// the loser of a create race re-reads and adopts the winner's Secret instead of minting.
 const inflight = new Map<string, Promise<EnsurePullSecretResult>>()
 
 /**
  * Ensure the `evenfire-registry-pull` Secret exists in `targetNs`, minting a fresh
- * pull-only credential only when it is absent or broken. Idempotent and coexistence-safe:
- * a Secret we do not own (no managed-by=control-api label) is left untouched.
+ * pull-only credential only when it is absent or verifiably broken.
  *
- * No-ops (`'skipped'`) outside self-hosted mode, without active registry auth, without a
- * configured registry host, or before the connect flow has resolved our org.
- *
- * THROWS on mint/write failure so the caller can fail the install loudly rather than
- * attach an unresolvable imagePullSecrets reference.
+ * Returns `'skipped'` ONLY when provisioning is legitimately not our job (managed mode,
+ * where the operator owns the Secret) or when no registry host is configured. Every other
+ * "cannot provision" condition THROWS `PullSecretProvisionError` so the caller fails the
+ * install loudly instead of attaching an unresolvable imagePullSecrets reference.
  */
 export function ensureRegistryPullSecret(
   gateway: K8sGateway,
@@ -119,41 +174,79 @@ export function ensureRegistryPullSecret(
   return run
 }
 
-async function ensureInner(
-  gateway: K8sGateway,
-  targetNs: string
-): Promise<EnsurePullSecretResult> {
-  // ── Gate: only self-hosted, connected, with a resolvable org ──────────────
+async function ensureInner(gateway: K8sGateway, targetNs: string): Promise<EnsurePullSecretResult> {
+  // ── Legitimate no-ops ─────────────────────────────────────────────────────
+  // Managed clusters: the operator owns this Secret; never contend with it.
   if (config.registryConnectionMode !== 'self-hosted') return 'skipped'
   const host = registryHostFromUrl(config.registryUrl)
-  if (!host) return 'skipped'
-  if (!(await isRegistryAuthActive())) return 'skipped'
-  const { orgName } = await resolvePublishScope()
-  if (!orgName) {
-    logger.warn(
-      { targetNs },
-      'registry pull secret: org not resolved (connect flow incomplete); skipping'
+  if (!host) return 'skipped' // no registry configured; the attach predicate is false too
+
+  // ── Hard preconditions: from here on we MUST provision or fail loudly ─────
+  // The pull Secret is a registry credential. Confine writes to the namespace this
+  // deployment actually serves so a caller-supplied `body.namespace` cannot plant it
+  // in an unrelated namespace (and cannot rotate the org key as a side effect).
+  if (targetNs !== config.mcpServersNamespace) {
+    throw new PullSecretProvisionError(
+      `refusing to provision the registry pull secret outside the configured plugin namespace (got "${targetNs}", expected "${config.mcpServersNamespace}")`,
+      'unsupported_namespace',
+      400
     )
-    return 'skipped'
+  }
+  if (!(await isRegistryAuthActive())) {
+    throw new PullSecretProvisionError(
+      'registry connection is not active; complete the registry connect flow before installing a private plugin',
+      'registry_not_connected',
+      409
+    )
+  }
+  // A cold-started control-api can cache a null org from before the registry bound this
+  // client. Force one refresh before failing, mirroring the self-service key routes.
+  let { orgName } = await resolvePublishScope()
+  if (!orgName) ({ orgName } = await resolvePublishScope({ force: true }))
+  if (!orgName) {
+    throw new PullSecretProvisionError(
+      'registry has not bound this deployment to an organization yet; cannot mint an image-pull credential',
+      'org_unresolved',
+      409
+    )
   }
 
   // ── Read (getSecret re-throws 404; any other error aborts before minting) ──
-  let current: SecretView | null = null
-  try {
-    current = readSecret(await gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, targetNs))
-  } catch (err) {
-    if (k8sStatus(err) !== 404) throw err // e.g. 403 = ns outside our RBAC → abort
-    current = null // 404 → absent
-  }
+  const current = await readCurrent(gateway, targetNs)
 
   if (current) {
     const ours = current.labels[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
-    const hasCred = !!current.dockerconfig
-    if (hasCred && !ours) return 'exists-foreign' // external operator owns it — never touch
-    if (hasCred && ours) return 'exists-ours' // reuse; rotation handled reactively
-    // Present but missing/empty .dockerconfigjson → repair (mint + replace).
-    await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+    // INVARIANT 1: never write a Secret we do not own — even a broken one. Adopting it
+    // would seize an external operator's credential; repairing it in place would rotate
+    // the org key out from under them.
+    if (!ours) {
+      if (!dockerconfigMatchesHost(current.dockerconfig, host)) {
+        logger.warn(
+          { targetNs, host },
+          'externally-owned evenfire-registry-pull Secret is missing or mis-keyed; leaving it untouched (remove it to let control-api provision one)'
+        )
+      }
+      return 'exists-foreign'
+    }
+    // Ours and genuinely usable → reuse. Presence alone is not enough: a blob keyed on a
+    // previous registry host can never be selected by the kubelet.
+    if (current.type === DOCKERCONFIG_TYPE && dockerconfigMatchesHost(current.dockerconfig, host)) {
+      return 'exists-ours'
+    }
+    // Ours but broken. `Secret.type` is immutable, so a wrong-typed Secret must be
+    // recreated. Delete FIRST so a failed delete cannot strand a freshly-minted key.
+    if (current.type !== DOCKERCONFIG_TYPE) {
+      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, targetNs)
+      await gateway.createSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+    } else {
+      await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
+    }
     logger.info({ targetNs, orgName }, 'registry pull secret repaired')
+    auditPullSecret('registry_pull_secret_provisioned', {
+      namespace: targetNs,
+      org: orgName,
+      outcome: 'repaired',
+    })
     return 'repaired'
   }
 
@@ -161,15 +254,31 @@ async function ensureInner(
   try {
     await gateway.createSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
   } catch (err) {
-    if (k8sStatus(err) === 409) {
-      // Lost a concurrent create race. We hold a freshly-minted (now-active) key, so
-      // overwrite with it — rotate-on-call means the last minter's key is authoritative.
-      await gateway.updateSecret(buildSecretReq(targetNs, await mintAndBuild(orgName, host)))
-      logger.info({ targetNs, orgName }, 'registry pull secret reconciled after create race')
-      return 'created'
-    }
-    throw err
+    if (k8sStatus(err) !== 409) throw err
+    // Lost a concurrent create race. Do NOT mint again — a second mint would revoke the
+    // key the winner just stored. Re-read and adopt whatever is now there.
+    const winner = await readCurrent(gateway, targetNs)
+    if (!winner) throw err // vanished again; surface rather than loop
+    const winnerOurs = winner.labels[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
+    if (!winnerOurs) return 'exists-foreign'
+    logger.info({ targetNs, orgName }, 'registry pull secret already created concurrently')
+    return 'exists-ours'
   }
   logger.info({ targetNs, orgName }, 'registry pull secret created')
+  auditPullSecret('registry_pull_secret_provisioned', {
+    namespace: targetNs,
+    org: orgName,
+    outcome: 'created',
+  })
   return 'created'
+}
+
+/** Read the Secret, mapping 404 to null. Any other error propagates (e.g. 403 = wrong ns). */
+async function readCurrent(gateway: K8sGateway, targetNs: string): Promise<SecretView | null> {
+  try {
+    return readSecret(await gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, targetNs))
+  } catch (err) {
+    if (k8sStatus(err) === 404) return null
+    throw err
+  }
 }

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -65,6 +65,18 @@
  * another host) is not serving any pull for this registry, so rotating the org key cannot
  * break a working path through it and it does not block the mint. It is still fatal to a
  * caller that references its namespace — via `foreign_secret_unusable`, per invariant 1.
+ *
+ * Invariant 1 is about a moment, not a name. Ownership is classified once per pass, and the
+ * mutations that follow (the wrong-type delete, the credential write) happen later, with a
+ * mint in between. `withPullSecretLock` does not help: it serializes control-api replicas
+ * against each other, not against an operator, another controller or a `kubectl` replacing
+ * the same NAME — and the reconcile cron reopens that window on every tick rather than once
+ * per install. So every mutation re-proves ownership immediately before it acts, comparing
+ * `metadata.uid` and the ownership marker against what was classified (`recheckOwnership`).
+ * A namespace that changed hands is recorded (`ownership_changed`) and left alone; one that
+ * merely vanished is created, since the mint has already revoked whatever key it held. This
+ * is a narrow compare-and-swap, not an atomic one — the proof read is a separate request —
+ * and the residual is spelled out on `recheckOwnership`.
  */
 import { createHash } from 'node:crypto'
 import { config } from '../config.js'
@@ -160,7 +172,21 @@ function dockerconfigMatchesHost(blob: string | undefined, host: string): boolea
   }
 }
 
-interface SecretView {
+/**
+ * Which OBJECT a read saw, as opposed to what was in it.
+ *
+ * `uid` is the only thing that survives a delete-and-recreate of the same name: labels,
+ * annotations and data can all be reproduced by whoever took the name over, and
+ * `resourceVersion` only says "something changed", not "this is a different object". It is
+ * what lets a mutation prove it is acting on the thing `classify` decided about rather than
+ * on whatever now answers to that name (see `recheckOwnership`).
+ */
+interface SecretIdentity {
+  uid: string | undefined
+  resourceVersion: string | undefined
+}
+
+interface SecretView extends SecretIdentity {
   labels: Record<string, string>
   annotations: Record<string, string>
   type: string | undefined
@@ -169,13 +195,20 @@ interface SecretView {
 
 function readSecret(raw: unknown): SecretView {
   const s = (raw ?? {}) as {
-    metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> }
+    metadata?: {
+      labels?: Record<string, string>
+      annotations?: Record<string, string>
+      uid?: string
+      resourceVersion?: string
+    }
     type?: string
     data?: Record<string, string>
   }
   return {
     labels: s.metadata?.labels ?? {},
     annotations: s.metadata?.annotations ?? {},
+    uid: s.metadata?.uid,
+    resourceVersion: s.metadata?.resourceVersion,
     type: s.type,
     dockerconfig: s.data?.[DOCKERCONFIG_KEY],
   }
@@ -249,15 +282,19 @@ const inflight = new Map<string, Promise<EnsurePass>>()
  *              copy (`operator_secret_missing`). Fragments ("it does not exist", "it exists
  *              but …"), because the caller-facing sentence names every missing namespace at
  *              once and only `ensureRegistryPullSecrets` knows which ones the caller needs.
+ * `taken`    — a namespace we OWNED at classify time whose Secret changed hands before we
+ *              could mutate it (`ownership_changed`). Fragments, like `unusable`: the
+ *              caller-facing sentence is assembled by `ensureRegistryPullSecrets`.
  *
- * The three are mutually exclusive by mode: `unusable`/`blocked` come from the
- * provisioning pass, `missing` from the verification pass, and a pass is one or the other.
+ * `missing` is mutually exclusive with the rest by mode: it comes from the verification
+ * pass, the others from the provisioning pass, and a pass is one or the other.
  */
 type EnsurePass = {
   results: Map<string, EnsurePullSecretResult>
   unusable: Map<string, string>
   blocked: Map<string, string>
   missing: Map<string, string>
+  taken: Map<string, string>
 }
 
 /** The platform workload namespaces a pull credential may legitimately be written into. */
@@ -300,7 +337,7 @@ export async function ensureRegistryPullSecrets(
     run = ensureInner(gateway, targets).finally(() => inflight.delete(dedupeKey))
     inflight.set(dedupeKey, run)
   }
-  const { results, unusable, blocked, missing } = await run
+  const { results, unusable, blocked, missing, taken } = await run
 
   // A recorded failure is fatal only to a caller that needs THAT namespace. A pass covers
   // the whole platform set (for the mint-once collapse), so an MCP install must not be
@@ -336,6 +373,22 @@ export async function ensureRegistryPullSecrets(
       throw new PullSecretProvisionError(
         `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}" is externally owned and cannot serve an image pull: ${why}. Fix it in place, or delete it to let control-api manage that namespace. (A well-shaped foreign Secret is accepted even if its key has since been revoked — checking that would take a registry round-trip.)`,
         'foreign_secret_unusable',
+        409
+      )
+    }
+  }
+  // A namespace that changed hands mid-pass. Same scoping as `unusable` — the pass sweeps
+  // the whole platform set, so only a caller that references this namespace may be failed by
+  // it — and after `unusable`, which names a defect that is there to stay: a takeover is a
+  // race, and the retry this message asks for may well find a settled cluster.
+  // Order against `blocked` is not load-bearing: `blocked` is recorded on a path that
+  // returns before anything is mutated, so the two maps are never both populated.
+  for (const ns of required) {
+    const why = taken.get(ns)
+    if (why) {
+      throw new PullSecretProvisionError(
+        `the ${EVENFIRE_REGISTRY_PULL_SECRET_NAME} Secret in namespace "${ns}" changed hands while this pass was running: ${why}. control-api classified it as its own, then found a different object under that name before writing, so it wrote nothing — it never touches a Secret it does not own. Retry: the next pass classifies what is actually there, so a usable external copy settles into the normal externally-provisioned case and an unusable one comes back as foreign_secret_unusable, naming the concrete defect.`,
+        'ownership_changed',
         409
       )
     }
@@ -379,12 +432,21 @@ export async function ensureRegistryPullSecret(
   return results.get(targetNs) ?? 'skipped'
 }
 
-/** Classification of one namespace's current Secret, decided before anything is minted. */
+/**
+ * Classification of one namespace's current Secret, decided before anything is minted.
+ *
+ * The two states that lead to a MUTATION carry `observed`: the identity of the object the
+ * decision was made about. Everything downstream of `classify` acts on a snapshot — the
+ * mint sits between the read and the write — so a mutation has to be able to say which
+ * object it meant. `foreign` and `absent` carry none: nothing is ever mutated on a foreign
+ * target, and an absent one is created (a create is its own compare-and-swap — it 409s if
+ * the name is taken, which `writeCredential` already handles).
+ */
 type TargetState =
   | { kind: 'foreign'; unusable: string | null }
-  | { kind: 'valid'; fingerprint: string }
+  | { kind: 'valid'; fingerprint: string; observed: SecretIdentity }
   | { kind: 'absent' }
-  | { kind: 'broken'; wrongType: boolean }
+  | { kind: 'broken'; wrongType: boolean; observed: SecretIdentity }
 
 /**
  * Why a Secret we do NOT own cannot serve an image pull, or null when it can.
@@ -416,15 +478,96 @@ function classify(current: SecretView | null, host: string): TargetState {
   if (current.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) {
     return { kind: 'foreign', unusable: foreignUsabilityProblem(current, host) }
   }
+  const observed: SecretIdentity = {
+    uid: current.uid,
+    resourceVersion: current.resourceVersion,
+  }
   const wrongType = current.type !== DOCKERCONFIG_TYPE
   // Presence alone is not enough: a blob keyed on a previous registry host can never be
   // selected by the kubelet, and a copy with no fingerprint cannot be compared across
   // namespaces.
   const fingerprint = current.annotations[FINGERPRINT_ANNOTATION]
   if (wrongType || !dockerconfigMatchesHost(current.dockerconfig, host) || !fingerprint) {
-    return { kind: 'broken', wrongType }
+    return { kind: 'broken', wrongType, observed }
   }
-  return { kind: 'valid', fingerprint }
+  return { kind: 'valid', fingerprint, observed }
+}
+
+/** What a pre-mutation re-read concluded about the object still sitting under that name. */
+type OwnershipRecheck =
+  | { verdict: 'same' }
+  | { verdict: 'gone' }
+  | { verdict: 'taken'; why: string }
+
+/**
+ * Re-prove, immediately before mutating `ns`, that the Secret there is still the object
+ * `classify` decided about and still carries our ownership marker.
+ *
+ * WHY IT IS NEEDED. Everything after `classify` acts on a snapshot: the wrong-type delete
+ * and the credential write both happen later, with a mint in between. `withPullSecretLock`
+ * does not cover this — it serializes control-api replicas against each other, not against
+ * an operator, another controller or a `kubectl` replacing the same NAME. And
+ * `SecretService.updateSecret` cannot cover it either: it re-reads to pick up the latest
+ * `resourceVersion`, which makes it always WIN the write; it never asks whether it is still
+ * the same object. Without this check, invariant 1 ("never write a Secret we do not own")
+ * only holds for as long as nobody else moves — and the reconcile cron reopens the window
+ * every tick rather than once per install.
+ *
+ * WHAT IT IS. A narrow compare-and-swap, NOT an atomic one: the proof read is a separate
+ * API request from the mutation, so a takeover landing between the two still slips through.
+ * What it buys is the size of the window — one round trip instead of the whole pass (read
+ * all → mint → write all, with a registry call in the middle). Closing it completely means
+ * an `If-Match`-style precondition on the write itself: `metadata.resourceVersion` on the
+ * replace, and `preconditions.uid` on the delete. Both live in `SecretService`, which is
+ * shared with the admin /secrets routes and inter-service token rotation, so changing their
+ * semantics is out of scope here.
+ *
+ * WHAT IT COMPARES. `uid` and the ownership label, per the two ways a name changes hands:
+ *   - `uid` differs ⇒ deleted and recreated. Data, labels and annotations can all be
+ *     reproduced by the new owner; the uid cannot.
+ *   - the marker is gone ⇒ adopted in place by an external owner, and `classify` would now
+ *     call it `foreign`.
+ * `resourceVersion` is deliberately NOT a gate. It changes on any edit, including benign
+ * ones by something that left our marker in place — and refusing there would be worse than
+ * writing: the mint has already revoked the key that copy holds, so declining to overwrite
+ * leaves the namespace on a dead credential. It is carried for the log line, which is where
+ * "still ours, but someone edited it" is worth seeing.
+ *
+ * `uid` is compared only when both reads surfaced one. The API server always sets it; a
+ * caller that cannot see it (an older gateway, a fake) falls back to the ownership label,
+ * which is exactly the evidence `classify` itself used.
+ *
+ * A read failure other than 404 propagates, same as everywhere else here. Before the mint
+ * that aborts the pass having changed nothing; after it, it leaves the remaining namespaces
+ * unwritten — which is the pre-existing behaviour of any post-mint write failure, and the
+ * fingerprint divergence check converges it on the next pass.
+ */
+async function recheckOwnership(
+  gateway: K8sGateway,
+  ns: string,
+  observed: SecretIdentity
+): Promise<OwnershipRecheck> {
+  const now = await readCurrent(gateway, ns)
+  if (!now) return { verdict: 'gone' }
+  if (now.labels[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) {
+    return {
+      verdict: 'taken',
+      why: `its ${MANAGED_BY_LABEL} label is no longer "${MANAGED_BY_VALUE}", so an external owner has adopted that name`,
+    }
+  }
+  if (observed.uid && now.uid && observed.uid !== now.uid) {
+    return {
+      verdict: 'taken',
+      why: 'it was deleted and recreated by something else (metadata.uid changed), so it is no longer the Secret this pass classified',
+    }
+  }
+  if (observed.resourceVersion && now.resourceVersion !== observed.resourceVersion) {
+    logger.info(
+      { namespace: ns, from: observed.resourceVersion, to: now.resourceVersion },
+      'evenfire-registry-pull Secret was modified between classification and write; still ours, proceeding'
+    )
+  }
+  return { verdict: 'same' }
 }
 
 /**
@@ -454,19 +597,30 @@ async function withPullSecretLock<T>(orgName: string, work: () => Promise<T>): P
   })
 }
 
+/** An empty pass, ready to be recorded into. */
+function newPass(): EnsurePass {
+  return {
+    results: new Map(),
+    unusable: new Map(),
+    blocked: new Map(),
+    missing: new Map(),
+    taken: new Map(),
+  }
+}
+
 async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<EnsurePass> {
-  const out = new Map<string, EnsurePullSecretResult>()
-  const unusable = new Map<string, string>()
-  const blocked = new Map<string, string>()
-  const missing = new Map<string, string>()
+  // One record-and-decide accumulator threaded through the pass, rather than a growing list
+  // of positional Maps: which reason a namespace lands in is the whole output of this
+  // service, and every writer needs to reach more than one of them.
+  const pass = newPass()
 
   // ── Legitimate no-ops ─────────────────────────────────────────────────────
   // No registry host: nothing references it, and there is no host to check a blob
   // against either — the pull secret is not in play at all.
   const host = registryHostFromUrl(config.registryUrl)
   if (!host) {
-    for (const ns of targets) out.set(ns, 'skipped')
-    return { results: out, unusable, blocked, missing }
+    for (const ns of targets) pass.results.set(ns, 'skipped')
+    return pass
   }
   // Managed clusters: the operator owns this Secret; never contend with it — but do check
   // that what the caller is about to reference is actually there.
@@ -509,7 +663,7 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
   // Everything from here — read, classify, mint, write — must be serialized across
   // replicas, not just within this process (see withPullSecretLock).
   return withPullSecretLock(orgName, () =>
-    ensureLocked(gateway, targets, host, orgName as string, out, unusable, blocked, missing)
+    ensureLocked(gateway, targets, host, orgName as string, pass)
   )
 }
 
@@ -536,32 +690,31 @@ async function verifyOperatorProvisioned(
   targets: string[],
   host: string
 ): Promise<EnsurePass> {
-  const out = new Map<string, EnsurePullSecretResult>()
-  const missing = new Map<string, string>()
+  const pass = newPass()
   const platform = new Set(platformWorkloadNamespaces())
   for (const ns of targets) {
     // Provisioning is genuinely not our job on this cluster, so the result stays 'skipped'
     // whichever way the check goes; the verdict travels in `missing`.
-    out.set(ns, 'skipped')
+    pass.results.set(ns, 'skipped')
     if (!platform.has(ns)) continue
     const current = await readCurrent(gateway, ns)
     if (!current) {
-      missing.set(ns, 'it does not exist')
+      pass.missing.set(ns, 'it does not exist')
       continue
     }
     const problem = foreignUsabilityProblem(current, host)
-    if (problem) missing.set(ns, `it exists but ${problem}`)
+    if (problem) pass.missing.set(ns, `it exists but ${problem}`)
   }
   // Deliberately not logged at warn: this runs on every reconcile tick as well as every
   // install, and on a managed cluster an unpopulated namespace is a normal state until
   // something actually asks for it. The caller that asks gets the loud failure.
-  if (missing.size > 0) {
+  if (pass.missing.size > 0) {
     logger.debug(
-      { namespaces: [...missing.keys()] },
+      { namespaces: [...pass.missing.keys()] },
       'managed cluster: no usable operator-provisioned evenfire-registry-pull Secret in these namespaces'
     )
   }
-  return { results: out, unusable: new Map(), blocked: new Map(), missing }
+  return pass
 }
 
 /**
@@ -573,13 +726,12 @@ async function ensureLocked(
   targets: string[],
   host: string,
   orgName: string,
-  out: Map<string, EnsurePullSecretResult>,
-  unusable: Map<string, string>,
-  blocked: Map<string, string>,
-  // Always empty on this path: a namespace with nothing in it is one we PROVISION, not one
-  // we report as missing. It rides along so both passes return the same shape.
-  missing: Map<string, string>
+  // `pass.missing` is always empty on this path: a namespace with nothing in it is one we
+  // PROVISION, not one we report as missing. It rides along so both passes return the same
+  // shape.
+  pass: EnsurePass
 ): Promise<EnsurePass> {
+  const { results: out, unusable, blocked } = pass
   // ── Read + classify every target BEFORE minting anything ──────────────────
   const states = new Map<string, TargetState>()
   for (const ns of targets) {
@@ -612,7 +764,7 @@ async function ensureLocked(
     }
     out.set(ns, 'exists-foreign')
   }
-  if (ours.length === 0) return { results: out, unusable, blocked, missing }
+  if (ours.length === 0) return pass
 
   // A mint is needed when any namespace we own lacks a usable credential, OR when the
   // copies have diverged — divergence means an earlier pass wrote some namespaces and
@@ -626,7 +778,7 @@ async function ensureLocked(
 
   if (!needsMint) {
     for (const ns of ours) out.set(ns, 'exists-ours')
-    return { results: out, unusable, blocked, missing }
+    return pass
   }
 
   // ── All-or-nothing: a USABLE foreign copy anywhere forbids the mint ───────
@@ -671,7 +823,7 @@ async function ensureLocked(
       { external: blocking, unfillable },
       'usable externally-owned evenfire-registry-pull Secret present; refusing to mint (the mint is org-wide and rotate-on-call, so it would revoke the external key) — installs that need the unfillable namespaces will fail'
     )
-    return { results: out, unusable, blocked, missing }
+    return pass
   }
 
   if (diverged) {
@@ -684,35 +836,86 @@ async function ensureLocked(
   // `Secret.type` is immutable, so a wrong-typed Secret must be deleted and recreated.
   // Do every delete BEFORE minting: a delete that fails must not leave us holding a
   // freshly-minted key that has already revoked the credential the cluster was using.
+  //
+  // A delete acts on a name, not on the object we classified, so re-prove ownership first
+  // (`recheckOwnership`). This is the destructive half of the TOCTOU: without it, a Secret
+  // replaced between the classify read and here is deleted on the strength of a decision
+  // made about something that no longer exists — an external operator's credential removed
+  // by a reconcile tick.
   const recreate = new Set<string>()
+  const surrendered = new Set<string>()
   for (const ns of ours) {
     const state = states.get(ns)!
-    if (state.kind === 'broken' && state.wrongType) {
-      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)
-      recreate.add(ns)
+    if (state.kind !== 'broken' || !state.wrongType) continue
+    const recheck = await recheckOwnership(gateway, ns, state.observed)
+    if (recheck.verdict === 'taken') {
+      recordTakeover(pass, ns, recheck.why)
+      surrendered.add(ns)
+      continue
     }
+    // 'gone': already deleted by someone else, so there is nothing to delete — but the
+    // namespace still needs the credential, and `recreate` is exactly "create, do not
+    // update" downstream. Falling through to the update path would 404.
+    if (recheck.verdict === 'same') {
+      await gateway.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)
+    }
+    recreate.add(ns)
   }
+  // Namespaces that changed hands are no longer ours to write. Every caller that references
+  // one fails on `ownership_changed`; the rest of the pass proceeds for the namespaces we
+  // still own, because they need the credential regardless.
+  //
+  // KNOWN RESIDUAL: a copy that turns up here is NOT fed back into the all-or-nothing mint
+  // block above, so if it is a usable foreign Secret the mint below can still revoke the key
+  // sealed in it. Closing that would mean re-classifying the whole set and rebuilding the
+  // `blocked` messages mid-pass, for a window measured in one round trip — and the same
+  // residual already exists for a foreign Secret that appears any time after the classify
+  // read, including on the create-race path in `writeCredential`. What is fixed here is the
+  // part that is unrecoverable: we no longer DELETE or OVERWRITE somebody else's object.
+  const writable = ours.filter(ns => !surrendered.has(ns))
+  if (writable.length === 0) return pass
 
   // ── Mint ONCE, then fan the same credential out to every namespace we own ──
   // Namespaces that were already valid are rewritten too: the mint just revoked the key
   // they were holding.
   const cred = await mintCredential(orgName, host)
-  for (const ns of ours) {
+  for (const ns of writable) {
     const state = states.get(ns)!
     const outcome = await writeCredential(gateway, ns, state, cred, recreate.has(ns), {
       host,
-      unusable,
+      pass,
     })
     out.set(ns, outcome)
   }
 
   auditPullSecret('registry_pull_secret_provisioned', {
-    namespaces: ours,
+    namespaces: writable,
     org: orgName,
     fingerprint: cred.fingerprint,
   })
-  logger.info({ namespaces: ours, orgName }, 'registry pull secret provisioned')
-  return { results: out, unusable, blocked, missing }
+  logger.info({ namespaces: writable, orgName }, 'registry pull secret provisioned')
+  return pass
+}
+
+/**
+ * Record a namespace whose Secret changed hands between classification and mutation.
+ *
+ * Recorded, not thrown, for the same reason `unusable` is: the pass spans the whole platform
+ * set so the mint can be collapsed across callers, and only a caller that actually
+ * references this namespace should be failed by what happens in it.
+ *
+ * The result is `'exists-foreign'` because that is now literally true — someone else owns
+ * that name — and it keeps `results` complete, so a caller that does NOT require this
+ * namespace gets a truthful answer instead of falling through the single-namespace
+ * wrapper's `?? 'skipped'` (which would claim provisioning was never our job).
+ */
+function recordTakeover(pass: EnsurePass, ns: string, why: string): void {
+  pass.taken.set(ns, why)
+  pass.results.set(ns, 'exists-foreign')
+  logger.warn(
+    { namespace: ns, problem: why },
+    'evenfire-registry-pull Secret changed owner between classification and write; leaving it untouched — installs that reference this namespace will fail until the cluster settles'
+  )
 }
 
 /** Write `cred` into one namespace, choosing create/update/recreate from its prior state. */
@@ -722,9 +925,9 @@ async function writeCredential(
   state: TargetState,
   cred: MintedCredential,
   alreadyDeleted: boolean,
-  // The pass's `unusable` map, so a foreign Secret discovered on the race path below is
-  // recorded exactly as one discovered by `classify` would be — see the comment there.
-  pass: { host: string; unusable: Map<string, string> }
+  // The whole pass, so a foreign Secret discovered on either race path below is recorded
+  // exactly as one discovered by `classify` would be — see the comments there.
+  ctx: { host: string; pass: EnsurePass }
 ): Promise<EnsurePullSecretResult> {
   // Wrong-typed Secrets were deleted before the mint (see ensureInner), so they are now
   // absent and must be created, not updated.
@@ -758,9 +961,9 @@ async function writeCredential(
         // this namespace the same verdict the classify path would: a foreign Secret the
         // kubelet will ignore must fail the callers that reference it, not sail past them
         // and leave a CRD pointing at a credential no pod can use.
-        const problem = foreignUsabilityProblem(winner, pass.host)
+        const problem = foreignUsabilityProblem(winner, ctx.host)
         if (problem) {
-          pass.unusable.set(ns, problem)
+          ctx.pass.unusable.set(ns, problem)
           logger.warn(
             { namespace: ns, problem },
             'lost the create race to an externally-owned evenfire-registry-pull Secret that cannot serve an image pull; leaving it untouched — installs that reference this namespace will fail until it is fixed or removed'
@@ -768,9 +971,35 @@ async function writeCredential(
         }
         return 'exists-foreign'
       }
+      // Read-then-write with no gap: `winner` was read immediately above, and the ownership
+      // check on it is this path's compare-and-swap. Nothing more can be proved here — the
+      // object had no prior classification to compare against, it did not exist yet.
       await gateway.updateSecret(buildSecretReq(ns, cred))
       return 'created'
     }
+  }
+  if (state.kind === 'foreign') {
+    // Unreachable: foreign targets are filtered out of `ours` before the write loop. Kept as
+    // a typed dead end rather than a cast, so a future caller that forgets the filter cannot
+    // turn invariant 1 into a runtime accident.
+    return 'exists-foreign'
+  }
+  // The update path. `SecretService.updateSecret` re-reads to pick up the latest
+  // `resourceVersion` and therefore ALWAYS wins the write — it proves the object is current,
+  // never that it is still ours — so ownership has to be re-proved here, against the object
+  // `classify` decided about. See `recheckOwnership` for what this does and does not buy.
+  const recheck = await recheckOwnership(gateway, ns, state.observed)
+  if (recheck.verdict === 'taken') {
+    recordTakeover(ctx.pass, ns, recheck.why)
+    return 'exists-foreign'
+  }
+  if (recheck.verdict === 'gone') {
+    // Deleted under us. NOT a takeover — nobody else holds the name — and the mint above has
+    // already revoked whatever key that copy carried, so leaving the namespace empty is the
+    // one outcome guaranteed to ImagePullBackOff. Create, because an update against an
+    // absent Secret 404s.
+    await gateway.createSecret(buildSecretReq(ns, cred))
+    return 'created'
   }
   await gateway.updateSecret(buildSecretReq(ns, cred))
   return state.kind === 'valid' ? 'exists-ours' : 'repaired'

--- a/control-api/src/services/registryPullSecretService.ts
+++ b/control-api/src/services/registryPullSecretService.ts
@@ -53,6 +53,7 @@
  */
 import { createHash } from 'node:crypto'
 import { config } from '../config.js'
+import { withTransaction } from '../db.js'
 import type { K8sGateway } from '../k8s.js'
 import { rootLogger } from '../observability/logger.js'
 import {
@@ -385,6 +386,33 @@ function classify(current: SecretView | null, host: string): TargetState {
   return { kind: 'valid', fingerprint }
 }
 
+/**
+ * Serialize the read->mint->write pass ACROSS PROCESSES.
+ *
+ * The in-process dedupe map only covers one replica, and `replicas: 1` with the default
+ * RollingUpdate means two control-api pods coexist on every deploy. Without this, their
+ * mints interleave: A mints k1, B mints k2 (revoking k1), and whichever writes last leaves
+ * some namespaces holding a revoked key. The fingerprint check makes that self-healing,
+ * but only on the NEXT pass — pulls fail until then.
+ *
+ * `pg_advisory_xact_lock` blocks rather than failing, which is what we want: the second
+ * pod waits, then re-reads and finds a valid, agreeing credential, so it returns
+ * `exists-ours` without minting at all. The lock auto-releases on commit/rollback, so it
+ * cannot leak — the same mechanism the registry uses inside `mintPullKey`, and that
+ * `traceMaintenance` uses for cross-replica dedup.
+ *
+ * The transaction is held across the K8s and registry calls inside `work`. That is
+ * deliberate and bounded: the mint carries a timeout and the K8s calls are few.
+ */
+async function withPullSecretLock<T>(orgName: string, work: () => Promise<T>): Promise<T> {
+  return withTransaction(async db => {
+    await db.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+      `registry-pull-secret:${orgName}`,
+    ])
+    return work()
+  })
+}
+
 async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<EnsurePass> {
   const out = new Map<string, EnsurePullSecretResult>()
   const unusable = new Map<string, string>()
@@ -430,6 +458,26 @@ async function ensureInner(gateway: K8sGateway, targets: string[]): Promise<Ensu
     )
   }
 
+  // Everything from here — read, classify, mint, write — must be serialized across
+  // replicas, not just within this process (see withPullSecretLock).
+  return withPullSecretLock(orgName, () =>
+    ensureLocked(gateway, targets, host, orgName as string, out, unusable, blocked)
+  )
+}
+
+/**
+ * The read -> classify -> mint -> write pass. Runs while holding the cross-process lock,
+ * so it may assume no other replica is minting for this org concurrently.
+ */
+async function ensureLocked(
+  gateway: K8sGateway,
+  targets: string[],
+  host: string,
+  orgName: string,
+  out: Map<string, EnsurePullSecretResult>,
+  unusable: Map<string, string>,
+  blocked: Map<string, string>
+): Promise<EnsurePass> {
   // ── Read + classify every target BEFORE minting anything ──────────────────
   const states = new Map<string, TargetState>()
   for (const ns of targets) {

--- a/control-api/src/services/secretService.ts
+++ b/control-api/src/services/secretService.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node'
-import { SecretUpsertRequest } from '../types.js'
+import { SecretPreconditions, SecretUpsertRequest } from '../types.js'
 import { assertValidSecretDataKey, assertValidSecretWriteKeys } from './secretKeys.js'
 
 export class SecretService {
@@ -62,11 +62,27 @@ export class SecretService {
    * truth for the whole Secret body — admin /secrets, registry credentials,
    * inter-service token rotation. For multi-owner Secrets where individual
    * keys must survive a partial update, use `mergeSecret` instead.
+   *
+   * Pass `precondition` to make the replace ownership-bound rather than
+   * last-writer-wins (see `SecretPreconditions`). When it carries a
+   * `resourceVersion` the pre-read is SKIPPED and that version is sent as-is,
+   * so the API server rejects the write with 409 if anything touched the
+   * object since the caller read it. Re-reading here would defeat the entire
+   * point, by refreshing away the staleness we are trying to detect.
+   *
+   * Because that read is skipped, a precondition caller must supply everything
+   * it wants persisted: the `labels`/`annotations`/`type` fallbacks to the
+   * existing object are not available on this path.
    */
-  async updateSecret(req: SecretUpsertRequest): Promise<unknown> {
+  async updateSecret(
+    req: SecretUpsertRequest,
+    precondition?: SecretPreconditions
+  ): Promise<unknown> {
     assertValidSecretWriteKeys(req)
     const ns = req.namespace || this.defaultNamespace
-    const existing = await this.coreApi.readNamespacedSecret({ namespace: ns, name: req.name })
+    const existing = precondition?.resourceVersion
+      ? undefined
+      : await this.coreApi.readNamespacedSecret({ namespace: ns, name: req.name })
 
     const body: k8s.V1Secret = {
       apiVersion: 'v1',
@@ -74,11 +90,14 @@ export class SecretService {
       metadata: {
         name: req.name,
         namespace: ns,
-        resourceVersion: existing.metadata?.resourceVersion,
-        labels: req.labels || existing.metadata?.labels,
-        annotations: req.annotations || existing.metadata?.annotations,
+        resourceVersion: precondition?.resourceVersion ?? existing?.metadata?.resourceVersion,
+        // Enforced by the API server when set: a replace naming a different uid than the
+        // stored object is refused. Free when the caller does not set it.
+        ...(precondition?.uid ? { uid: precondition.uid } : {}),
+        labels: req.labels || existing?.metadata?.labels,
+        annotations: req.annotations || existing?.metadata?.annotations,
       },
-      type: req.type || existing.type || 'Opaque',
+      type: req.type || existing?.type || 'Opaque',
       data: req.data,
       stringData: req.stringData,
     }
@@ -148,10 +167,36 @@ export class SecretService {
     )
   }
 
-  async deleteSecret(name: string, namespace?: string): Promise<unknown> {
+  /**
+   * Delete a Secret by name.
+   *
+   * Pass `precondition` to bind the delete to a specific object rather than to
+   * whatever currently answers to that name (see `SecretPreconditions`). A
+   * name-addressed delete is the more dangerous of the two mutations: an
+   * ownership check followed by a bare delete will remove a REPLACEMENT object
+   * — including one an external owner created in the gap — on the strength of
+   * a decision made about something that no longer exists. With `uid` set the
+   * API server refuses that with 409 instead.
+   */
+  async deleteSecret(
+    name: string,
+    namespace?: string,
+    precondition?: SecretPreconditions
+  ): Promise<unknown> {
+    const hasPrecondition = Boolean(precondition?.uid || precondition?.resourceVersion)
     return this.coreApi.deleteNamespacedSecret({
       namespace: namespace || this.defaultNamespace,
       name,
+      ...(hasPrecondition && {
+        body: {
+          preconditions: {
+            ...(precondition?.uid && { uid: precondition.uid }),
+            ...(precondition?.resourceVersion && {
+              resourceVersion: precondition.resourceVersion,
+            }),
+          },
+        },
+      }),
     })
   }
 }

--- a/control-api/src/types.ts
+++ b/control-api/src/types.ts
@@ -49,3 +49,33 @@ export interface SecretUpsertRequest {
   data?: Record<string, string>
   stringData?: Record<string, string>
 }
+
+/**
+ * Optimistic-concurrency preconditions for a Secret mutation: "act on THIS object, or
+ * fail". Both fields come from a read the caller has already performed.
+ *
+ * WHY THIS EXISTS. `updateSecret` and `deleteSecret` are name-addressed by default — the
+ * update re-reads to pick up the current `resourceVersion` (so it always wins the write)
+ * and the delete carries no preconditions at all. That is the right default for a
+ * single-owner Secret, where the caller IS the source of truth. It is wrong for one whose
+ * ownership can change hands, because a caller that checked ownership and then mutated by
+ * name will happily overwrite or delete whatever answers to that name now.
+ *
+ * Supplying these turns the mutation itself into the compare-and-swap: the API server
+ * rejects it with 409 rather than the caller trying to prove freshness with a second
+ * request it can never fuse to the write. Callers are expected to handle 409 — re-read,
+ * decide whether the object is still theirs, and retry or surrender.
+ *
+ * `uid` is the identity check that survives a delete-and-recreate of the same name: data,
+ * labels and annotations can all be reproduced by a new owner, the uid cannot.
+ * `resourceVersion` is the change check — it says "something edited this", not "this is a
+ * different object".
+ *
+ * OPTIONAL BY DESIGN. Omit them and both methods behave exactly as they always have; the
+ * admin `/secrets` routes and inter-service token rotation are single-owner writers and
+ * want the last-writer-wins default.
+ */
+export interface SecretPreconditions {
+  uid?: string
+  resourceVersion?: string
+}

--- a/control-api/test/config.registryPullSecretReconcile.test.ts
+++ b/control-api/test/config.registryPullSecretReconcile.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The reconcile interval feeds `setInterval` directly, so an unvalidated value is not a
+ * cosmetic problem: `0` and any sub-millisecond fraction turn a coarse background loop into
+ * a hot one (each tick is three Secret reads plus a Postgres advisory-lock transaction), a
+ * negative or `NaN` value produces a timer Node cannot honour, and both are silent.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const KEY = 'REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS'
+
+async function loadConfigWith(value?: string) {
+  const original = process.env[KEY]
+  delete process.env[KEY]
+  if (value !== undefined) process.env[KEY] = value
+  vi.resetModules()
+  try {
+    const mod = await import('../src/config.js')
+    return mod.config
+  } finally {
+    if (original === undefined) delete process.env[KEY]
+    else process.env[KEY] = original
+  }
+}
+
+describe('control-api registry pull secret reconcile interval config', () => {
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  it('defaults to 10 minutes when unset', async () => {
+    const config = await loadConfigWith()
+    expect(config.registryPullSecretReconcileIntervalMs).toBe(600_000)
+  })
+
+  it('accepts a positive integer override at or above the floor', async () => {
+    const config = await loadConfigWith('60000')
+    expect(config.registryPullSecretReconcileIntervalMs).toBe(60_000)
+  })
+
+  it.each(['0', '-1', '1.5', 'abc'])('rejects %s', async value => {
+    await expect(loadConfigWith(value)).rejects.toThrow(new RegExp(KEY))
+  })
+
+  // A positive integer is not sufficient on its own: `1` parses fine and still reconciles a
+  // thousand times a second. The floor is what actually rules out the hot loop.
+  it('rejects a positive value below the floor', async () => {
+    await expect(loadConfigWith('1')).rejects.toThrow(new RegExp(KEY))
+  })
+})

--- a/control-api/test/config.sharedFilesystemsNamespace.test.ts
+++ b/control-api/test/config.sharedFilesystemsNamespace.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * SharedFileSystem CRDs live with the Hosts that mount their PVCs (the v1
- * invariant: "always in the mcp-host namespace"). On a per-tenant MCC cluster
+ * invariant: "always in the mcp-host namespace"). On a per-tenant managed cluster
  * the Hosts namespace is `mcp-host-<slug>`, set via CONTROL_API_HOSTS_NAMESPACE.
  *
  * The SharedFilesystems admin route must therefore resolve to the SAME

--- a/control-api/test/k8s.recipePods.test.ts
+++ b/control-api/test/k8s.recipePods.test.ts
@@ -3,7 +3,7 @@ import type * as k8s from '@kubernetes/client-node'
 import { listRecipePodsAcrossNamespaces } from '../src/k8s.js'
 
 // listPodsForRecipe used to call listPodForAllNamespaces (cluster-scoped).
-// On MCC shared tenants control-api only has namespaced RBAC, so the K8s API
+// On managed shared tenants control-api only has namespaced RBAC, so the K8s API
 // returned 403 and the Workloads tab showed "500" + "no pod" for everything.
 // The helper must list per-namespace and tolerate per-namespace 403/404 so a
 // missing grant degrades to "fewer pods" instead of failing the whole call.

--- a/control-api/test/mockGateway.ts
+++ b/control-api/test/mockGateway.ts
@@ -48,6 +48,11 @@ export class MockGateway {
       type?: string
       labels?: Record<string, string>
       annotations?: Record<string, string>
+      // Server-assigned identity. Real Secrets always carry both; seeding them is optional
+      // so existing tests are unaffected, and only a test that cares about object identity
+      // (e.g. a takeover between two reads of the same name) has to set them.
+      uid?: string
+      resourceVersion?: string
       data?: Record<string, string>
       stringData?: Record<string, string>
     }
@@ -98,6 +103,8 @@ export class MockGateway {
       type?: string
       labels?: Record<string, string>
       annotations?: Record<string, string>
+      uid?: string
+      resourceVersion?: string
       data?: Record<string, string>
       stringData?: Record<string, string>
     }
@@ -109,6 +116,8 @@ export class MockGateway {
       type: options?.type,
       labels: options?.labels,
       annotations: options?.annotations,
+      uid: options?.uid,
+      resourceVersion: options?.resourceVersion,
       data: options?.data,
       stringData: options?.stringData,
     })
@@ -263,6 +272,9 @@ export class MockGateway {
         namespace: entry.namespace,
         labels: entry.labels,
         annotations: entry.annotations,
+        // Only surfaced when seeded, so no existing assertion on this object changes shape.
+        ...(entry.uid !== undefined && { uid: entry.uid }),
+        ...(entry.resourceVersion !== undefined && { resourceVersion: entry.resourceVersion }),
       },
       type: entry.type || 'Opaque',
       data: entry.data,

--- a/control-api/test/mockGateway.ts
+++ b/control-api/test/mockGateway.ts
@@ -1,4 +1,5 @@
 import { K8sNotFoundError } from '../src/services/resourceService.js'
+import type { SecretPreconditions } from '../src/types.js'
 
 type ResourceType =
   | 'hosts'
@@ -304,7 +305,17 @@ export class MockGateway {
     return req
   }
 
-  async updateSecret(req: unknown): Promise<unknown> {
+  /**
+   * Mock Secret replace. Honours `precondition` the way the API server does: a `uid` or
+   * `resourceVersion` that disagrees with the stored object is a 409, not a silent
+   * overwrite. Without this a test could not tell an ownership-bound write from a
+   * name-addressed one — both would "pass" — which is the exact defect the preconditions
+   * exist to prevent.
+   *
+   * A successful write bumps `resourceVersion`, so a caller replaying a stale version is
+   * rejected on the second attempt just as it would be against a real cluster.
+   */
+  async updateSecret(req: unknown, precondition?: SecretPreconditions): Promise<unknown> {
     const body = req as {
       name: string
       namespace?: string
@@ -314,16 +325,52 @@ export class MockGateway {
       data?: Record<string, string>
       stringData?: Record<string, string>
     }
-    this.secretStore.set(this.key(body.name, body.namespace), {
+    const key = this.key(body.name, body.namespace)
+    const existing = this.secretStore.get(key)
+    this.assertPrecondition(body.name, existing, precondition)
+    this.secretStore.set(key, {
       name: body.name,
       namespace: body.namespace || this.ns,
       type: body.type,
       labels: body.labels,
       annotations: body.annotations,
+      uid: existing?.uid,
+      resourceVersion: MockGateway.nextResourceVersion(existing?.resourceVersion),
       data: body.data,
       stringData: body.stringData,
     })
     return req
+  }
+
+  /**
+   * Reject a mutation whose preconditions do not match the stored object, with the same
+   * 409 the API server returns. `undefined` fields are not constraints — a caller that
+   * supplies neither gets the historical last-writer-wins behaviour.
+   */
+  private assertPrecondition(
+    name: string,
+    existing: { uid?: string; resourceVersion?: string } | undefined,
+    precondition?: SecretPreconditions
+  ): void {
+    if (!precondition) return
+    const mismatch =
+      (precondition.uid !== undefined && existing?.uid !== precondition.uid) ||
+      (precondition.resourceVersion !== undefined &&
+        existing?.resourceVersion !== precondition.resourceVersion)
+    if (!mismatch) return
+    const err = new Error(
+      `Operation cannot be fulfilled on secrets "${name}": the object has been modified; please apply your changes to the latest version and try again`
+    ) as Error & { statusCode: number; code: number }
+    err.statusCode = 409
+    err.code = 409
+    throw err
+  }
+
+  /** Monotonic, and only meaningful relative to itself — exactly like the real one. */
+  private static nextResourceVersion(current?: string): string | undefined {
+    if (current === undefined) return undefined
+    const n = Number(current)
+    return Number.isFinite(n) ? String(n + 1) : `${current}-1`
   }
 
   async removeSecretKey(req: { name: string; namespace?: string; key: string }): Promise<unknown> {
@@ -339,9 +386,16 @@ export class MockGateway {
     return { name: req.name, namespace: ns, deletedKey: req.key }
   }
 
-  async deleteSecret(name: string, namespace?: string): Promise<unknown> {
+  /** Mock Secret delete. Honours `precondition` exactly as `updateSecret` does. */
+  async deleteSecret(
+    name: string,
+    namespace?: string,
+    precondition?: SecretPreconditions
+  ): Promise<unknown> {
     const ns = namespace || this.ns
-    const deleted = this.secretStore.delete(this.key(name, ns))
+    const key = this.key(name, ns)
+    this.assertPrecondition(name, this.secretStore.get(key), precondition)
+    const deleted = this.secretStore.delete(key)
     return { deleted, name, namespace: ns }
   }
 

--- a/control-api/test/registryImagePullSecret.test.ts
+++ b/control-api/test/registryImagePullSecret.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/routes/admin/registryImagePullSecret.js'
 
 describe('EVENFIRE_REGISTRY_PULL_SECRET_NAME', () => {
-  it('is the exact secret name MCC provisions', () => {
+  it('is the frozen pull-secret name', () => {
     expect(EVENFIRE_REGISTRY_PULL_SECRET_NAME).toBe('evenfire-registry-pull')
   })
 })

--- a/control-api/test/registryPullSecretReconcileCron.test.ts
+++ b/control-api/test/registryPullSecretReconcileCron.test.ts
@@ -42,11 +42,15 @@ describe('reconcileRegistryPullSecret', () => {
       ])
     )
     await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(true)
-    expect(ensureRegistryPullSecrets).toHaveBeenCalledWith(gateway, [
-      'mcp-server',
-      'sandbox-recipes',
-      'sandbox-ui',
-    ])
+    // `required: []` is load-bearing, not decoration: this loop is not a caller about to
+    // persist a CRD, so it must never fail on a namespace nobody has asked for. It is what
+    // keeps a managed cluster — where control-api provisions nothing and the operator may
+    // not have populated every namespace — from reporting a failed pass on every tick.
+    expect(ensureRegistryPullSecrets).toHaveBeenCalledWith(
+      gateway,
+      ['mcp-server', 'sandbox-recipes', 'sandbox-ui'],
+      { required: [] }
+    )
   })
 
   it('does NOT throw when the cluster is not connected yet — it retries next tick', async () => {

--- a/control-api/test/registryPullSecretReconcileCron.test.ts
+++ b/control-api/test/registryPullSecretReconcileCron.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The reconcile loop that makes the platform pull credential a standing invariant.
+ *
+ * The property under test is the one that differs from the install path: a precondition
+ * failure here must be LOGGED AND RETRIED, never thrown. An install throws because a user
+ * asked for something we cannot deliver; this loop runs unprompted on every cluster,
+ * including ones that have not finished the registry connect flow, and must not turn that
+ * normal state into recurring errors or a crash loop.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { K8sGateway } from '../src/k8s.js'
+import {
+  reconcileRegistryPullSecret,
+  startRegistryPullSecretReconcileCron,
+  stopRegistryPullSecretReconcileCron,
+} from '../src/services/registryPullSecretReconcileCron.js'
+
+const ensureRegistryPullSecrets = vi.hoisted(() => vi.fn())
+vi.mock('../src/services/registryPullSecretService.js', () => ({
+  ensureRegistryPullSecrets,
+  platformWorkloadNamespaces: () => ['mcp-server', 'sandbox-recipes', 'sandbox-ui'],
+}))
+
+const gateway = {} as K8sGateway
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  stopRegistryPullSecretReconcileCron()
+  vi.useRealTimers()
+})
+
+describe('reconcileRegistryPullSecret', () => {
+  it('provisions across every platform namespace', async () => {
+    ensureRegistryPullSecrets.mockResolvedValue(
+      new Map([
+        ['mcp-server', 'created'],
+        ['sandbox-recipes', 'created'],
+        ['sandbox-ui', 'created'],
+      ])
+    )
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(true)
+    expect(ensureRegistryPullSecrets).toHaveBeenCalledWith(gateway, [
+      'mcp-server',
+      'sandbox-recipes',
+      'sandbox-ui',
+    ])
+  })
+
+  it('does NOT throw when the cluster is not connected yet — it retries next tick', async () => {
+    // The exact state a freshly-deployed, unconnected cluster is in. Throwing here would
+    // crash-loop the process or spam an error every interval.
+    const err = Object.assign(new Error('registry connection is not active'), {
+      reason: 'registry_not_connected',
+    })
+    ensureRegistryPullSecrets.mockRejectedValue(err)
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(false)
+  })
+
+  it('does NOT throw when no org is bound yet', async () => {
+    ensureRegistryPullSecrets.mockRejectedValue(
+      Object.assign(new Error('no org'), { reason: 'org_unresolved' })
+    )
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(false)
+  })
+
+  it('swallows an unexpected error rather than escaping the timer callback', async () => {
+    ensureRegistryPullSecrets.mockRejectedValue(new Error('boom'))
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(false)
+  })
+
+  it('reports success without provisioning when everything is already in place', async () => {
+    ensureRegistryPullSecrets.mockResolvedValue(new Map([['mcp-server', 'exists-ours']]))
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(true)
+  })
+})
+
+describe('startRegistryPullSecretReconcileCron', () => {
+  it('runs on the interval and is idempotent to start', async () => {
+    vi.useFakeTimers()
+    ensureRegistryPullSecrets.mockResolvedValue(new Map())
+
+    startRegistryPullSecretReconcileCron(gateway, 1000)
+    // A second start must not install a second timer (which would double the mint rate).
+    startRegistryPullSecretReconcileCron(gateway, 1000)
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(ensureRegistryPullSecrets).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops cleanly', async () => {
+    vi.useFakeTimers()
+    ensureRegistryPullSecrets.mockResolvedValue(new Map())
+    startRegistryPullSecretReconcileCron(gateway, 1000)
+    await vi.advanceTimersByTimeAsync(1000)
+    stopRegistryPullSecretReconcileCron()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(ensureRegistryPullSecrets).toHaveBeenCalledTimes(1)
+  })
+})

--- a/control-api/test/registryPullSecretReconcileCron.test.ts
+++ b/control-api/test/registryPullSecretReconcileCron.test.ts
@@ -21,6 +21,17 @@ vi.mock('../src/services/registryPullSecretService.js', () => ({
   platformWorkloadNamespaces: () => ['mcp-server', 'sandbox-recipes', 'sandbox-ui'],
 }))
 
+// The log LEVEL is part of this loop's contract, not decoration: it runs unprompted on every
+// cluster, so a level chosen per-state is what keeps a normal pre-connect cluster from
+// looking broken while a genuinely stuck one stays findable.
+const log = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+vi.mock('../src/observability/logger.js', () => ({ rootLogger: { child: () => log } }))
+
 const gateway = {} as K8sGateway
 
 beforeEach(() => {
@@ -78,6 +89,67 @@ describe('reconcileRegistryPullSecret', () => {
   it('reports success without provisioning when everything is already in place', async () => {
     ensureRegistryPullSecrets.mockResolvedValue(new Map([['mcp-server', 'exists-ours']]))
     await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(true)
+  })
+})
+
+/**
+ * Level selection. `registry_not_connected` and `org_unresolved` are states this loop's own
+ * comment calls expected — a cluster that has not finished the connect flow is not
+ * misconfigured, it is early — and at the default interval a warn per tick is 144 warnings a
+ * day that mean nothing. But "expected" stops being true if it never resolves, so the signal
+ * has to survive somewhere an operator will look.
+ */
+describe('reconcileRegistryPullSecret — log level', () => {
+  const notConnected = () =>
+    Object.assign(new Error('registry connection is not active'), {
+      reason: 'registry_not_connected',
+    })
+
+  it.each(['registry_not_connected', 'org_unresolved'])(
+    'logs %s below warn while it is still a plausible startup state',
+    async reason => {
+      ensureRegistryPullSecrets.mockRejectedValue(Object.assign(new Error('nope'), { reason }))
+      await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(false)
+      expect(log.warn).not.toHaveBeenCalled()
+      expect(log.debug).toHaveBeenCalled()
+    }
+  )
+
+  // Not "quiet forever": a precondition that has held for this many consecutive ticks is a
+  // cluster somebody has to look at, and the operator debugging it greps for warnings.
+  it('escalates to warn once a known precondition persists', async () => {
+    ensureRegistryPullSecrets.mockRejectedValue(notConnected())
+    for (let i = 0; i < 5; i += 1) {
+      await reconcileRegistryPullSecret(gateway)
+    }
+    expect(log.warn).not.toHaveBeenCalled()
+
+    await reconcileRegistryPullSecret(gateway)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+    expect(log.warn.mock.calls[0][0]).toMatchObject({ reason: 'registry_not_connected' })
+  })
+
+  // An unexpected failure has no "this is normal at first" story, so it warns on tick one.
+  it('warns immediately on an unexpected failure', async () => {
+    ensureRegistryPullSecrets.mockRejectedValue(new Error('boom'))
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(false)
+    expect(log.warn).toHaveBeenCalledTimes(1)
+  })
+
+  // A cluster that connects mid-run is back to normal, and the count that would escalate the
+  // NEXT transient precondition has to go with it — otherwise one bad hour makes every later
+  // blip look persistent.
+  it('resets the escalation count after a pass succeeds', async () => {
+    ensureRegistryPullSecrets.mockRejectedValue(notConnected())
+    for (let i = 0; i < 5; i += 1) {
+      await reconcileRegistryPullSecret(gateway)
+    }
+    ensureRegistryPullSecrets.mockResolvedValue(new Map())
+    await reconcileRegistryPullSecret(gateway)
+
+    ensureRegistryPullSecrets.mockRejectedValue(notConnected())
+    await reconcileRegistryPullSecret(gateway)
+    expect(log.warn).not.toHaveBeenCalled()
   })
 })
 

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -90,12 +90,13 @@ async function readStored(
  * delegates to it), so a test aimed at one namespace's state must settle the others too —
  * an absent sibling alone forces a mint and swamps what the test is about.
  */
-function seedValid(mock: MockGateway, namespaces: string[], key: string): void {
+function seedValid(mock: MockGateway, namespaces: string[], key: string, uid?: string): void {
   for (const ns of namespaces) {
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
       type: 'kubernetes.io/dockerconfigjson',
       labels: OURS,
       annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf(key) },
+      ...(uid && { uid }),
       data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, key) },
     })
   }
@@ -677,6 +678,215 @@ describe('ensureRegistryPullSecret — concurrent create race', () => {
       false
     )
     expect((await readStored(mock)).blob).toBeTruthy()
+  })
+})
+
+/**
+ * TOCTOU: the pass classifies every namespace ONCE, then acts on that decision later — the
+ * wrong-type delete and the credential write both happen after the classify read.
+ *
+ * The advisory lock does not close this. It serializes control-api replicas against each
+ * other; it says nothing about an operator, another controller, or a `kubectl` replacing the
+ * same name in between. And the reconcile cron re-opens the window on every tick, so it is
+ * not a once-per-install race but a standing one. Invariant 1 ("never write a Secret we do
+ * not own") therefore has to be re-proved immediately before each mutation, against the
+ * OBJECT the pass classified — identity (`metadata.uid`), not just the name.
+ */
+describe('ensureRegistryPullSecrets — ownership taken over between classify and mutate', () => {
+  /**
+   * Simulate an EXTERNAL actor mutating one namespace's Secret in the window that opens the
+   * instant the pass has classified it. The classify read is served from the real store,
+   * and `mutate` runs immediately after — so the takeover lands at the same point in the
+   * sequence whether or not the service re-reads later. (Arming it on a LATER read would
+   * make the test describe the fix instead of the race: with no re-read, the mutation would
+   * slide onto whatever read came next, including the assertions'.)
+   */
+  function takeoverAfterClassify(
+    mock: MockGateway,
+    ns: string,
+    mutate: (mock: MockGateway) => void
+  ): void {
+    const real = mock.getSecret.bind(mock)
+    let fired = false
+    vi.spyOn(mock, 'getSecret').mockImplementation(async (name: string, namespace?: string) => {
+      const result = await real(name, namespace)
+      if (namespace === ns && !fired) {
+        fired = true
+        mutate(mock)
+      }
+      return result
+    })
+  }
+
+  /** What a stranger's Secret looks like: usable, and NOT carrying our ownership marker. */
+  function seedStranger(mock: MockGateway, ns: string, uid: string): void {
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+      type: 'kubernetes.io/dockerconfigjson',
+      uid,
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'stranger-key') },
+    })
+  }
+
+  // The wrong-type path is the destructive one: `Secret.type` is immutable, so a broken copy
+  // is DELETED and recreated. Deleting on a stale classification means deleting whatever now
+  // holds that name — here, an external operator's freshly-installed credential.
+  it('does not delete a wrong-typed Secret that a foreign owner replaced after classification', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'Opaque',
+      labels: OURS,
+      uid: 'uid-ours',
+      data: {},
+    })
+    const deleteSpy = vi.spyOn(mock, 'deleteSecret')
+    takeoverAfterClassify(mock, NS, m => seedStranger(m, NS, 'uid-theirs'))
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    expect(deleteSpy).not.toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
+    const squatter = await readStored(mock, NS)
+    expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+    expect(squatter.blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
+  })
+
+  // Same window, other mutation. `SecretService.updateSecret` re-reads to pick up the latest
+  // `resourceVersion`, which makes it ALWAYS win the write — it proves nothing about the
+  // object still being the one we classified, so the guard has to live here.
+  it('does not overwrite an owned Secret whose UID changed after classification', async () => {
+    const { gateway, mock } = gw()
+    // mcp-server + sandbox-recipes are ours and current; sandbox-ui is absent, so the pass
+    // must mint and rewrite EVERY namespace it owns — including the one changing hands.
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    seedValid(mock, [SANDBOX], 'efrk_live', 'uid-sandbox')
+    takeoverAfterClassify(mock, SANDBOX, m => {
+      // The marker is copied, so only the uid can prove this is a different object.
+      m.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        uid: 'uid-stranger',
+        annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'stranger-key') },
+      })
+    })
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    expect((await readStored(mock, SANDBOX)).blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
+  })
+
+  it('does not overwrite an owned Secret whose ownership label was removed after classification', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    seedValid(mock, [SANDBOX], 'efrk_live', 'uid-sandbox')
+    // Same object (same uid), but the marker is gone: an external owner adopted the name.
+    takeoverAfterClassify(mock, SANDBOX, m => seedStranger(m, SANDBOX, 'uid-sandbox'))
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    expect((await readStored(mock, SANDBOX)).blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
+  })
+
+  // The benign half of the same race, and the reason the guard cannot just be "refuse if
+  // anything changed": a Secret that vanished under us is not a takeover. The mint has
+  // already revoked whatever key it held, so leaving the namespace empty is the one outcome
+  // that guarantees an ImagePullBackOff.
+  it('creates the Secret when it was deleted externally between classify and write', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    seedValid(mock, [SANDBOX], 'efrk_live', 'uid-sandbox')
+    // The mock's deleteSecret has no await before its Map.delete, so the effect lands before
+    // the read it precedes.
+    takeoverAfterClassify(mock, NS, m => {
+      void m.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
+    })
+
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(res.get(NS)).toBe('created')
+    const stored = await readStored(mock, NS)
+    expect(stored.labels['clerum.io/managed-by']).toBe('control-api')
+    expect(stored.annotations[FINGERPRINT_ANNOTATION]).toBe(fingerprintOf('efrk_test_key'))
+  })
+
+  it('skips the delete and still recreates when the wrong-typed Secret is already gone', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'Opaque',
+      labels: OURS,
+      uid: 'uid-ours',
+      data: {},
+    })
+    const deleteSpy = vi.spyOn(mock, 'deleteSecret')
+    takeoverAfterClassify(mock, NS, m => {
+      void m.deleteSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
+    })
+
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(res.get(NS)).toBe('repaired')
+    // Exactly one delete of this name: the external one the test performed. A second would
+    // be the service deleting on a stale classification.
+    expect(deleteSpy.mock.calls.filter(c => c[1] === NS)).toHaveLength(1)
+    expect((await readStored(mock, NS)).type).toBe('kubernetes.io/dockerconfigjson')
+  })
+
+  // Scoped like every other recorded failure in this service: the pass sweeps the whole
+  // platform set for the mint-once collapse, so a takeover in a namespace this caller never
+  // references must not fail its install — while the Secret still goes untouched.
+  it('fails only the callers that need the taken-over namespace', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    seedValid(mock, [UI], 'efrk_live', 'uid-ui')
+    const updateSpy = vi.spyOn(mock, 'updateSecret')
+    // sandbox-recipes is absent, so the pass mints and rewrites what it owns.
+    takeoverAfterClassify(mock, UI, m => seedStranger(m, UI, 'uid-theirs'))
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
+    // Asserted on the WRITE, not on the stored bytes: a post-pass read would itself be the
+    // read the takeover is armed on, and would make this pass for the wrong reason.
+    expect(updateSpy.mock.calls.some(c => (c[0] as { namespace?: string }).namespace === UI)).toBe(
+      false
+    )
+  })
+
+  // This is a narrow compare-and-swap, not an atomic one — the proof read is a separate
+  // request from the mutation. What keeps it worth having is that NOTHING happens between
+  // them, so the window is one round trip rather than the whole pass (read all, mint, write
+  // all). Pin both halves: one extra read per mutating namespace, and it is the last thing
+  // before the mutation.
+  it('re-reads immediately before each mutation, and only then', async () => {
+    const { gateway, mock } = gw()
+    // One of each mutating shape: wrong-typed (delete + create), valid (update), absent
+    // (create — a create is already its own compare-and-swap, it 409s if the name is taken).
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'Opaque',
+      labels: OURS,
+      uid: 'uid-ns',
+      data: {},
+    })
+    seedValid(mock, [SANDBOX], 'efrk_live', 'uid-sandbox')
+    const getSpy = vi.spyOn(mock, 'getSecret')
+    const deleteSpy = vi.spyOn(mock, 'deleteSecret')
+    const updateSpy = vi.spyOn(mock, 'updateSecret')
+
+    await ensureRegistryPullSecrets(gateway, ALL)
+
+    const readsOf = (ns: string) => getSpy.mock.calls.filter(c => c[1] === ns).length
+    expect(readsOf(NS)).toBe(2)
+    expect(readsOf(SANDBOX)).toBe(2)
+    expect(readsOf(UI)).toBe(1)
+    const lastReadOrder = (ns: string) =>
+      Math.max(...getSpy.mock.invocationCallOrder.filter((_, i) => getSpy.mock.calls[i][1] === ns))
+    expect(lastReadOrder(NS)).toBeLessThan(deleteSpy.mock.invocationCallOrder[0])
+    expect(lastReadOrder(SANDBOX)).toBeLessThan(updateSpy.mock.invocationCallOrder[0])
   })
 })
 

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -5,6 +5,7 @@ import type { K8sGateway } from '../src/k8s.js'
 import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
 import { mintOrgPullCredential, resolvePublishScope } from '../src/services/registryClient.js'
 import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
+import { reconcileRegistryPullSecret } from '../src/services/registryPullSecretReconcileCron.js'
 import {
   PullSecretProvisionError,
   ensureRegistryPullSecret,
@@ -132,10 +133,21 @@ afterEach(() => {
   config.registryUrl = savedUrl
 })
 
+/** What a managed operator's copy looks like: correctly shaped, and NOT labelled as ours. */
+function seedOperator(mock: MockGateway, namespaces: string[], key = 'operator-key'): void {
+  for (const ns of namespaces) {
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, key) },
+    })
+  }
+}
+
 describe('ensureRegistryPullSecret — legitimate no-ops', () => {
   it('skips (no mint) in managed mode — the operator owns the Secret', async () => {
     config.registryConnectionMode = 'managed'
-    const { gateway } = gw()
+    const { gateway, mock } = gw()
+    seedOperator(mock, [NS])
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
@@ -145,6 +157,125 @@ describe('ensureRegistryPullSecret — legitimate no-ops', () => {
     const { gateway } = gw()
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Managed clusters: VERIFY what the operator provisioned, write nothing.
+ *
+ * Skipping the write is right — the operator owns this Secret — but it is not the same as
+ * having nothing to say. WRC still injects the `imagePullSecrets` reference into every
+ * workload whose image is ours, and recipe workloads land in all three platform
+ * namespaces, so an install into a namespace the operator has not populated persists a CRD
+ * that can only ImagePullBackOff. Presence is therefore checked read-only, and a caller
+ * that needs a namespace without a usable copy is failed BEFORE the CRD is written.
+ */
+describe('ensureRegistryPullSecrets — managed mode verifies the operator provisioned it', () => {
+  beforeEach(() => {
+    config.registryConnectionMode = 'managed'
+  })
+
+  it('passes without minting or writing when every required namespace is populated', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, ALL)
+    const getSpy = vi.spyOn(mock, 'getSecret')
+    const createSpy = vi.spyOn(mock, 'createSecret')
+    const updateSpy = vi.spyOn(mock, 'updateSecret')
+    const deleteSpy = vi.spyOn(mock, 'deleteSecret')
+
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    // 'skipped' still means "provisioning was not our job", which is true on a managed
+    // cluster — but it is now an answer we checked rather than assumed.
+    expect([...res.values()]).toEqual(['skipped', 'skipped', 'skipped'])
+    for (const ns of ALL) {
+      expect(getSpy).toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)
+    }
+    // Invariant 1 is absolute here: managed mode is read-only, all the way down.
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(deleteSpy).not.toHaveBeenCalled()
+    expect(dbCalls.queries).toHaveLength(0)
+  })
+
+  // The shape of a real managed cluster today: MCC provisions `mcp-server`, so transport
+  // installs pull fine, and the two sandbox namespaces recipes land in are empty. That is
+  // exactly the gap that used to surface only as an ImagePullBackOff.
+  it('fails a recipe install for the namespaces the operator never populated', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, [NS])
+
+    const err = await ensureRegistryPullSecrets(gateway, ALL).catch((e: Error) => e)
+
+    expect(err).toBeInstanceOf(PullSecretProvisionError)
+    expect(err).toMatchObject({ reason: 'operator_secret_missing', status: 409 })
+    const message = (err as Error).message
+    // Actionable means naming the namespaces that are actually missing — and only those.
+    expect(message).toContain(`"${SANDBOX}"`)
+    expect(message).toContain(`"${UI}"`)
+    expect(message).not.toContain(`"${NS}"`)
+    expect(message).toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+    expect(message).toMatch(/operator/i) // whose job it is on this cluster
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('fails when the operator copy exists but is the wrong type (kubelet ignores it)', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, [SANDBOX, UI])
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, { type: 'Opaque', data: {} })
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'operator_secret_missing',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('fails when the operator copy is keyed on a different registry host', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, [SANDBOX, UI])
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg('old-registry.example.com', 'operator-key') },
+    })
+
+    const err = await ensureRegistryPullSecrets(gateway, ALL).catch((e: Error) => e)
+    expect(err).toMatchObject({ reason: 'operator_secret_missing', status: 409 })
+    // The kubelet never selects a blob with no entry for our host, so say so rather than
+    // reporting a Secret that is plainly sitting right there as "missing".
+    expect((err as Error).message).toContain(HOST)
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // `required` scoping is what keeps this from being the blanket reject it must not be:
+  // MCC does provision `mcp-server`, so an McpServer install lands somewhere that works
+  // and must not be failed by the sandbox namespaces it never touches.
+  it('does not fail an McpServer install over a sandbox namespace it never lands in', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, [NS])
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('does fail an McpServer install when ITS OWN namespace is the empty one', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, [SANDBOX, UI])
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'operator_secret_missing',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // The verification covers the operator's contract, which is defined over the platform
+  // workload namespaces. A namespace outside that set is not part of it — and failing on
+  // one would break a managed install that works today, which is the opposite of the point.
+  it('says nothing about a namespace outside the platform set', async () => {
+    const { gateway, mock } = gw()
+    seedOperator(mock, ALL)
+    const res = await ensureRegistryPullSecrets(gateway, [...ALL, 'channels'])
+    expect(res.get('channels')).toBe('skipped')
   })
 })
 
@@ -727,9 +858,31 @@ describe('ensureRegistryPullSecrets — cross-process serialization', () => {
 
   it('does not reach the lock when the pass is a legitimate no-op', async () => {
     config.registryConnectionMode = 'managed'
-    const { gateway } = gw()
+    const { gateway, mock } = gw()
+    seedOperator(mock, ALL)
     await ensureRegistryPullSecrets(gateway, ALL)
-    // Managed clusters must not touch Postgres (or anything else) on this path.
+    // Managed clusters must not touch Postgres on this path: the lock exists to serialize
+    // a mint, and the managed pass only reads.
     expect(dbCalls.queries).toHaveLength(0)
+  })
+})
+
+/**
+ * The reconcile loop against the REAL service — its own suite mocks this module out, so
+ * this is the only place the managed interaction can be observed.
+ *
+ * A managed cluster genuinely has nothing for control-api to do here, and the loop runs on
+ * a timer: it must stay a quiet no-op rather than reporting a failed pass every tick just
+ * because the operator has not populated a namespace no install has asked for yet.
+ */
+describe('reconcileRegistryPullSecret — managed cluster', () => {
+  it('stays a quiet no-op when the operator has provisioned nothing', async () => {
+    config.registryConnectionMode = 'managed'
+    const { gateway, mock } = gw()
+    const createSpy = vi.spyOn(mock, 'createSecret')
+
+    await expect(reconcileRegistryPullSecret(gateway)).resolves.toBe(true)
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect(createSpy).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -21,6 +21,9 @@ vi.mock('../src/services/registryClient.js', () => ({
 }))
 
 const NS = 'mcp-server'
+const SANDBOX = 'sandbox-recipes'
+const UI = 'sandbox-ui'
+const ALL = [NS, SANDBOX, UI]
 const HOST = 'registry.evenfire.ai'
 const DOCKERCONFIG_KEY = '.dockerconfigjson'
 const OURS = { 'clerum.io/managed-by': 'control-api' }
@@ -60,6 +63,24 @@ async function readStored(mock: MockGateway): Promise<{
     labels: raw.metadata?.labels ?? {},
     annotations: raw.metadata?.annotations ?? {},
     blob: raw.data?.[DOCKERCONFIG_KEY],
+  }
+}
+
+/**
+ * Seed an already-provisioned, agreeing credential in `namespaces`.
+ *
+ * Every entry point provisions the WHOLE platform set (the single-namespace wrapper
+ * delegates to it), so a test aimed at one namespace's state must settle the others too —
+ * an absent sibling alone forces a mint and swamps what the test is about.
+ */
+function seedValid(mock: MockGateway, namespaces: string[], key: string): void {
+  for (const ns of namespaces) {
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf(key) },
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, key) },
+    })
   }
 }
 
@@ -180,12 +201,7 @@ describe('ensureRegistryPullSecret — provisioning', () => {
 
   it('reuses our existing, correctly-keyed Secret without minting', async () => {
     const { gateway, mock } = gw()
-    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
-      type: 'kubernetes.io/dockerconfigjson',
-      labels: OURS,
-      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
-      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
-    })
+    seedValid(mock, ALL, 'efrk_live')
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
@@ -233,33 +249,64 @@ describe('ensureRegistryPullSecret — provisioning', () => {
 })
 
 describe('ensureRegistryPullSecret — never touches a Secret we do not own', () => {
-  it('leaves a foreign Secret WITH data untouched', async () => {
+  it('leaves a well-shaped foreign Secret untouched and proceeds', async () => {
     const { gateway, mock } = gw()
+    // The siblings are settled, so nothing but the foreign namespace is in play.
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
       type: 'kubernetes.io/dockerconfigjson',
-      data: { [DOCKERCONFIG_KEY]: 'operator-provisioned' },
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
     })
+    // External pre-provisioning is a supported contract: usable + not ours ⇒ hands off.
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
-    expect((await readStored(mock)).blob).toBe('operator-provisioned')
+    expect((await readStored(mock)).blob).toBe(encodeDockercfg(HOST, 'operator-key'))
   })
 
-  it('leaves a foreign EMPTY Secret untouched (never seizes ownership)', async () => {
+  // Foreign is a reason not to WRITE, not a reason to wave the caller through: every
+  // caller attaches an imagePullSecrets reference to this exact name and then persists a
+  // CRD. A foreign Secret the kubelet cannot use makes that reference unresolvable, which
+  // is the silent ImagePullBackOff this service exists to prevent.
+  it('fails loudly when a foreign Secret is the wrong type (kubelet ignores it)', async () => {
     const { gateway, mock } = gw()
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, { type: 'Opaque', data: {} })
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'foreign_secret_unusable',
+      status: 409,
+    })
+    // Still never written, and never minted for: invariant 1 is unchanged.
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
     const stored = await readStored(mock)
     expect(stored.type).toBe('Opaque')
     expect(stored.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  it('fails loudly when a foreign Secret is keyed on a different registry host', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg('old-registry.example.com', 'operator-key') },
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'foreign_secret_unusable',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 })
 
 describe('ensureRegistryPullSecret — concurrent create race', () => {
   it('adopts the winner without minting a second key', async () => {
     const { gateway, mock } = gw()
-    // The winner's Secret appears between our 404 read and our create.
-    vi.spyOn(mock, 'createSecret').mockImplementation(async () => {
+    // The winner's Secret appears between our 404 read and our create — in ONE namespace;
+    // the pass's other namespaces are created normally.
+    const create = mock.createSecret.bind(mock)
+    vi.spyOn(mock, 'createSecret').mockImplementation(async req => {
+      if ((req as { namespace?: string }).namespace !== NS) return create(req)
       mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
         type: 'kubernetes.io/dockerconfigjson',
         labels: OURS,
@@ -268,8 +315,8 @@ describe('ensureRegistryPullSecret — concurrent create race', () => {
       throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
     })
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
-    // Exactly ONE mint. Our mint already revoked whatever the winner stored, so we
-    // overwrite with ours rather than adopting a now-dead credential.
+    // Exactly ONE mint, and the pass converges its own namespaces on that one key rather
+    // than adopting a winner's credential it cannot verify.
     expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
     const stored = await readStored(mock)
     expect(decodeHosts(stored.blob)).toEqual([HOST])
@@ -278,10 +325,6 @@ describe('ensureRegistryPullSecret — concurrent create race', () => {
 })
 
 describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () => {
-  const SANDBOX = 'sandbox-recipes'
-  const UI = 'sandbox-ui'
-  const ALL = [NS, SANDBOX, UI]
-
   async function blobIn(mock: MockGateway, ns: string) {
     const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
       metadata?: { annotations?: Record<string, string> }
@@ -370,9 +413,10 @@ describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () 
 
   it('skips a foreign namespace but still provisions the others', async () => {
     const { gateway, mock } = gw()
+    const operatorBlob = encodeDockercfg(HOST, 'operator-key')
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
       type: 'kubernetes.io/dockerconfigjson',
-      data: { [DOCKERCONFIG_KEY]: 'operator-provisioned' },
+      data: { [DOCKERCONFIG_KEY]: operatorBlob },
     })
     const res = await ensureRegistryPullSecrets(gateway, ALL)
 
@@ -380,7 +424,7 @@ describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () 
     expect(res.get(NS)).toBe('created')
     expect(res.get(UI)).toBe('created')
     // Untouched, byte for byte.
-    expect((await blobIn(mock, SANDBOX)).blob).toBe('operator-provisioned')
+    expect((await blobIn(mock, SANDBOX)).blob).toBe(operatorBlob)
   })
 
   it('refuses a namespace outside the platform set, before minting', async () => {
@@ -390,5 +434,40 @@ describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () 
       status: 400,
     })
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // The inflight dedupe is keyed on the target SET, so concurrent passes only collapse if
+  // they agree on that set. An MCP install (one namespace) and a recipe install (all
+  // three) overlap on mcp-server, and two mints against a rotate-on-call registry leave
+  // the loser's namespaces holding a revoked key — with matching fingerprints, so the
+  // divergence detector cannot see it and no later pass ever re-mints. Hence: the
+  // single-namespace wrapper must run the SAME full-set pass.
+  it('collapses a single-namespace pass and a full-set pass into ONE mint', async () => {
+    const { gateway, mock } = gw()
+
+    const [single, fanOut] = await Promise.all([
+      ensureRegistryPullSecret(gateway, NS),
+      ensureRegistryPullSecrets(gateway, ALL),
+    ])
+
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect(single).toBe('created')
+    expect([...fanOut.values()]).toEqual(['created', 'created', 'created'])
+    // Every namespace holds the one live credential — including the two the
+    // single-namespace caller did not name.
+    const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
+    expect(new Set(seen.map(s => s.fingerprint))).toEqual(new Set([fingerprintOf('efrk_test_key')]))
+  })
+
+  it('provisions the whole platform set from a single-namespace caller', async () => {
+    const { gateway, mock } = gw()
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+
+    // A full-set pass every time is also what lets a diverged cluster self-heal on the
+    // next install, whichever route triggers it.
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
+    expect(new Set(seen.map(s => s.fingerprint))).toEqual(new Set([fingerprintOf('efrk_test_key')]))
   })
 })

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { config } from '../src/config.js'
-import { MockGateway } from './mockGateway.js'
 import type { K8sGateway } from '../src/k8s.js'
 import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
+import { mintOrgPullCredential, resolvePublishScope } from '../src/services/registryClient.js'
+import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
+import {
+  PullSecretProvisionError,
+  ensureRegistryPullSecret,
+} from '../src/services/registryPullSecretService.js'
+import { MockGateway } from './mockGateway.js'
 
 vi.mock('../src/services/registryConnectionDb.js', () => ({
   isRegistryAuthActive: vi.fn(),
@@ -12,33 +18,41 @@ vi.mock('../src/services/registryClient.js', () => ({
   mintOrgPullCredential: vi.fn(),
 }))
 
-import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
-import { resolvePublishScope, mintOrgPullCredential } from '../src/services/registryClient.js'
-import { ensureRegistryPullSecret } from '../src/services/registryPullSecretService.js'
-
 const NS = 'mcp-server'
+const HOST = 'registry.evenfire.ai'
+const DOCKERCONFIG_KEY = '.dockerconfigjson'
+const OURS = { 'clerum.io/managed-by': 'control-api' }
 
 function gw(): { gateway: K8sGateway; mock: MockGateway } {
   const mock = new MockGateway(NS)
   return { gateway: mock as unknown as K8sGateway, mock }
 }
 
-/** Decode the `.dockerconfigjson` a seeded/created Secret carries. */
-async function decodeDockercfg(
+/** Encode a dockerconfigjson blob keyed on `host`, matching what the realm expects. */
+function encodeDockercfg(host: string, key: string): string {
+  const auth = Buffer.from(`_:${key}`).toString('base64')
+  return Buffer.from(
+    JSON.stringify({ auths: { [host]: { username: '_', password: key, auth } } })
+  ).toString('base64')
+}
+
+async function readStored(
   mock: MockGateway
-): Promise<{ host: string; username: string; password: string }> {
+): Promise<{ type?: string; labels: Record<string, string>; blob?: string }> {
   const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+    metadata?: { labels?: Record<string, string> }
     type?: string
     data?: Record<string, string>
   }
-  expect(raw.type).toBe('kubernetes.io/dockerconfigjson')
-  const blob = raw.data?.['.dockerconfigjson']
-  expect(blob).toBeTruthy()
-  const parsed = JSON.parse(Buffer.from(blob as string, 'base64').toString('utf8')) as {
-    auths: Record<string, { username: string; password: string }>
+  return { type: raw.type, labels: raw.metadata?.labels ?? {}, blob: raw.data?.[DOCKERCONFIG_KEY] }
+}
+
+function decodeHosts(blob: string | undefined): string[] {
+  if (!blob) return []
+  const parsed = JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
+    auths: Record<string, unknown>
   }
-  const host = Object.keys(parsed.auths)[0]!
-  return { host, username: parsed.auths[host]!.username, password: parsed.auths[host]!.password }
+  return Object.keys(parsed.auths)
 }
 
 let savedMode: typeof config.registryConnectionMode
@@ -49,9 +63,13 @@ beforeEach(() => {
   savedMode = config.registryConnectionMode
   savedUrl = config.registryUrl
   config.registryConnectionMode = 'self-hosted'
-  config.registryUrl = 'https://registry.evenfire.ai'
+  config.registryUrl = `https://${HOST}`
   vi.mocked(isRegistryAuthActive).mockResolvedValue(true)
-  vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: 'acme', scope: '@acme' })
+  vi.mocked(resolvePublishScope).mockResolvedValue({
+    curator: false,
+    orgName: 'acme',
+    scope: '@acme',
+  })
   vi.mocked(mintOrgPullCredential).mockResolvedValue({ key: 'efrk_test_key' })
 })
 
@@ -60,77 +78,58 @@ afterEach(() => {
   config.registryUrl = savedUrl
 })
 
-describe('ensureRegistryPullSecret', () => {
-  it('skips (no mint) in managed mode', async () => {
+describe('ensureRegistryPullSecret — legitimate no-ops', () => {
+  it('skips (no mint) in managed mode — the operator owns the Secret', async () => {
     config.registryConnectionMode = 'managed'
     const { gateway } = gw()
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
-  it('skips when registry auth is inactive', async () => {
+  it('skips when no registry host is configured', async () => {
+    config.registryUrl = ''
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensureRegistryPullSecret — fails loudly instead of silently skipping', () => {
+  it('throws (not skips) when the registry connection is inactive', async () => {
     vi.mocked(isRegistryAuthActive).mockResolvedValue(false)
     const { gateway } = gw()
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toBeInstanceOf(
+      PullSecretProvisionError
+    )
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
-  it('skips when the org is not yet resolved (connect flow incomplete)', async () => {
+  it('throws when the org cannot be resolved even after a forced refresh', async () => {
     vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: null, scope: null })
     const { gateway } = gw()
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'org_unresolved',
+    })
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
-  it('mints and creates the Secret when absent, keyed on the registryUrl host', async () => {
-    const { gateway, mock } = gw()
+  it('recovers from a stale cached null org by forcing one refresh', async () => {
+    vi.mocked(resolvePublishScope)
+      .mockResolvedValueOnce({ curator: false, orgName: null, scope: null })
+      .mockResolvedValueOnce({ curator: false, orgName: 'acme', scope: '@acme' })
+    const { gateway } = gw()
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    expect(resolvePublishScope).toHaveBeenNthCalledWith(2, { force: true })
     expect(mintOrgPullCredential).toHaveBeenCalledWith('acme')
-    const { host, username, password } = await decodeDockercfg(mock)
-    expect(host).toBe('registry.evenfire.ai') // image host, NOT the registry token-issuer
-    expect(username).toBe('_')
-    expect(password).toBe('efrk_test_key')
-    const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
-      metadata: { labels: Record<string, string> }
-    }
-    expect(raw.metadata.labels['clerum.io/managed-by']).toBe('control-api')
   })
 
-  it('reuses our existing Secret without minting', async () => {
-    const { gateway, mock } = gw()
-    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
-      type: 'kubernetes.io/dockerconfigjson',
-      labels: { 'clerum.io/managed-by': 'control-api' },
-      data: { '.dockerconfigjson': 'existing' },
+  it('refuses to write the credential outside the configured plugin namespace', async () => {
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecret(gateway, 'channels')).rejects.toMatchObject({
+      reason: 'unsupported_namespace',
+      status: 400,
     })
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
-  })
-
-  it('leaves a foreign (unlabeled) Secret untouched', async () => {
-    const { gateway, mock } = gw()
-    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
-      type: 'kubernetes.io/dockerconfigjson',
-      data: { '.dockerconfigjson': 'operator-provisioned' },
-    })
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
-    expect(mintOrgPullCredential).not.toHaveBeenCalled()
-    const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
-      data: Record<string, string>
-    }
-    expect(raw.data['.dockerconfigjson']).toBe('operator-provisioned') // unchanged
-  })
-
-  it('repairs a present-but-empty Secret via update', async () => {
-    const { gateway, mock } = gw()
-    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
-      type: 'kubernetes.io/dockerconfigjson',
-      labels: { 'clerum.io/managed-by': 'control-api' },
-      data: {},
-    })
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
-    expect(mintOrgPullCredential).toHaveBeenCalledOnce()
-    expect((await decodeDockercfg(mock)).password).toBe('efrk_test_key')
   })
 
   it('aborts without minting when the read fails with a non-404 (e.g. 403)', async () => {
@@ -140,5 +139,119 @@ describe('ensureRegistryPullSecret', () => {
     )
     await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({ statusCode: 403 })
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('propagates a mint failure and writes nothing', async () => {
+    vi.mocked(mintOrgPullCredential).mockRejectedValue(new Error('registry returned no pull key'))
+    const { gateway, mock } = gw()
+    const createSpy = vi.spyOn(mock, 'createSecret')
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toThrow(/no pull key/)
+    expect(createSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('ensureRegistryPullSecret — provisioning', () => {
+  it('mints and creates the Secret when absent, keyed on the image host', async () => {
+    const { gateway, mock } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    expect(mintOrgPullCredential).toHaveBeenCalledWith('acme')
+    const stored = await readStored(mock)
+    expect(stored.type).toBe('kubernetes.io/dockerconfigjson')
+    expect(stored.labels['clerum.io/managed-by']).toBe('control-api')
+    // Keyed on OUR image host, never the registry's token issuer.
+    expect(decodeHosts(stored.blob)).toEqual([HOST])
+  })
+
+  it('reuses our existing, correctly-keyed Secret without minting', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('repairs our Secret when the blob is keyed on a STALE host (registry URL changed)', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg('old-registry.example.com', 'efrk_stale') },
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
+    expect(decodeHosts((await readStored(mock)).blob)).toEqual([HOST])
+  })
+
+  it('repairs our Secret when the payload is missing', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      data: {},
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
+    expect(decodeHosts((await readStored(mock)).blob)).toEqual([HOST])
+  })
+
+  it('recreates our Secret when the type is wrong (Secret.type is immutable)', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'Opaque',
+      labels: OURS,
+      data: {},
+    })
+    const deleteSpy = vi.spyOn(mock, 'deleteSecret')
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
+    // An in-place update of `type` would 422, so it must delete first — and the delete
+    // must precede the mint so a failed delete cannot strand a freshly-rotated key.
+    expect(deleteSpy).toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
+    expect(deleteSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]
+    )
+    expect((await readStored(mock)).type).toBe('kubernetes.io/dockerconfigjson')
+  })
+})
+
+describe('ensureRegistryPullSecret — never touches a Secret we do not own', () => {
+  it('leaves a foreign Secret WITH data untouched', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: 'operator-provisioned' },
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect((await readStored(mock)).blob).toBe('operator-provisioned')
+  })
+
+  it('leaves a foreign EMPTY Secret untouched (never seizes ownership)', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, { type: 'Opaque', data: {} })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    const stored = await readStored(mock)
+    expect(stored.type).toBe('Opaque')
+    expect(stored.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+})
+
+describe('ensureRegistryPullSecret — concurrent create race', () => {
+  it('adopts the winner without minting a second key', async () => {
+    const { gateway, mock } = gw()
+    // The winner's Secret appears between our 404 read and our create.
+    vi.spyOn(mock, 'createSecret').mockImplementation(async () => {
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_winner') },
+      })
+      throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
+    // Exactly ONE mint — a second would revoke the key the winner just stored.
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect(decodeHosts((await readStored(mock)).blob)).toEqual([HOST])
   })
 })

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -47,13 +47,16 @@ function encodeDockercfg(host: string, key: string): string {
   ).toString('base64')
 }
 
-async function readStored(mock: MockGateway): Promise<{
+async function readStored(
+  mock: MockGateway,
+  ns: string = NS
+): Promise<{
   type?: string
   labels: Record<string, string>
   annotations: Record<string, string>
   blob?: string
 }> {
-  const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+  const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
     metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> }
     type?: string
     data?: Record<string, string>
@@ -296,6 +299,38 @@ describe('ensureRegistryPullSecret — never touches a Secret we do not own', ()
       status: 409,
     })
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // The pass covers the whole platform set so the mint can be collapsed across callers —
+  // but that must not turn a squatter in one namespace into an outage for installs that
+  // never land there. The failure is scoped to the caller's OWN required namespaces.
+  it('does not fail a single-namespace install over an unusable foreign Secret elsewhere', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, { type: 'Opaque', data: {} })
+
+    // The MCP install references mcp-server only; sandbox-ui is swept along for the mint
+    // collapse, so its broken squatter is not this caller's problem.
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+
+    // The namespaces we own were still provisioned from the one mint...
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect((await readStored(mock, NS)).blob).toBeTruthy()
+    // ...and the foreign Secret is still never written, usable or not.
+    const squatter = await readStored(mock, UI)
+    expect(squatter.type).toBe('Opaque')
+    expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  it('still fails the recipe path, which does reference that namespace', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, { type: 'Opaque', data: {} })
+
+    // Same broken squatter, but a full-set caller lands workloads in sandbox-ui, so for it
+    // the reference really is unresolvable.
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'foreign_secret_unusable',
+      status: 409,
+    })
   })
 })
 

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { config } from '../src/config.js'
+import { MockGateway } from './mockGateway.js'
+import type { K8sGateway } from '../src/k8s.js'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
+
+vi.mock('../src/services/registryConnectionDb.js', () => ({
+  isRegistryAuthActive: vi.fn(),
+}))
+vi.mock('../src/services/registryClient.js', () => ({
+  resolvePublishScope: vi.fn(),
+  mintOrgPullCredential: vi.fn(),
+}))
+
+import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
+import { resolvePublishScope, mintOrgPullCredential } from '../src/services/registryClient.js'
+import { ensureRegistryPullSecret } from '../src/services/registryPullSecretService.js'
+
+const NS = 'mcp-server'
+
+function gw(): { gateway: K8sGateway; mock: MockGateway } {
+  const mock = new MockGateway(NS)
+  return { gateway: mock as unknown as K8sGateway, mock }
+}
+
+/** Decode the `.dockerconfigjson` a seeded/created Secret carries. */
+async function decodeDockercfg(
+  mock: MockGateway
+): Promise<{ host: string; username: string; password: string }> {
+  const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+    type?: string
+    data?: Record<string, string>
+  }
+  expect(raw.type).toBe('kubernetes.io/dockerconfigjson')
+  const blob = raw.data?.['.dockerconfigjson']
+  expect(blob).toBeTruthy()
+  const parsed = JSON.parse(Buffer.from(blob as string, 'base64').toString('utf8')) as {
+    auths: Record<string, { username: string; password: string }>
+  }
+  const host = Object.keys(parsed.auths)[0]!
+  return { host, username: parsed.auths[host]!.username, password: parsed.auths[host]!.password }
+}
+
+let savedMode: typeof config.registryConnectionMode
+let savedUrl: string
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  savedMode = config.registryConnectionMode
+  savedUrl = config.registryUrl
+  config.registryConnectionMode = 'self-hosted'
+  config.registryUrl = 'https://registry.evenfire.ai'
+  vi.mocked(isRegistryAuthActive).mockResolvedValue(true)
+  vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: 'acme', scope: '@acme' })
+  vi.mocked(mintOrgPullCredential).mockResolvedValue({ key: 'efrk_test_key' })
+})
+
+afterEach(() => {
+  config.registryConnectionMode = savedMode
+  config.registryUrl = savedUrl
+})
+
+describe('ensureRegistryPullSecret', () => {
+  it('skips (no mint) in managed mode', async () => {
+    config.registryConnectionMode = 'managed'
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('skips when registry auth is inactive', async () => {
+    vi.mocked(isRegistryAuthActive).mockResolvedValue(false)
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('skips when the org is not yet resolved (connect flow incomplete)', async () => {
+    vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: null, scope: null })
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('skipped')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('mints and creates the Secret when absent, keyed on the registryUrl host', async () => {
+    const { gateway, mock } = gw()
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    expect(mintOrgPullCredential).toHaveBeenCalledWith('acme')
+    const { host, username, password } = await decodeDockercfg(mock)
+    expect(host).toBe('registry.evenfire.ai') // image host, NOT the registry token-issuer
+    expect(username).toBe('_')
+    expect(password).toBe('efrk_test_key')
+    const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+      metadata: { labels: Record<string, string> }
+    }
+    expect(raw.metadata.labels['clerum.io/managed-by']).toBe('control-api')
+  })
+
+  it('reuses our existing Secret without minting', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: { 'clerum.io/managed-by': 'control-api' },
+      data: { '.dockerconfigjson': 'existing' },
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('leaves a foreign (unlabeled) Secret untouched', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { '.dockerconfigjson': 'operator-provisioned' },
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-foreign')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+      data: Record<string, string>
+    }
+    expect(raw.data['.dockerconfigjson']).toBe('operator-provisioned') // unchanged
+  })
+
+  it('repairs a present-but-empty Secret via update', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: { 'clerum.io/managed-by': 'control-api' },
+      data: {},
+    })
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
+    expect(mintOrgPullCredential).toHaveBeenCalledOnce()
+    expect((await decodeDockercfg(mock)).password).toBe('efrk_test_key')
+  })
+
+  it('aborts without minting when the read fails with a non-404 (e.g. 403)', async () => {
+    const { gateway, mock } = gw()
+    vi.spyOn(mock, 'getSecret').mockRejectedValue(
+      Object.assign(new Error('forbidden'), { statusCode: 403, code: 403 })
+    )
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({ statusCode: 403 })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { config } from '../src/config.js'
 import type { K8sGateway } from '../src/k8s.js'
 import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
@@ -7,6 +8,7 @@ import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
 import {
   PullSecretProvisionError,
   ensureRegistryPullSecret,
+  ensureRegistryPullSecrets,
 } from '../src/services/registryPullSecretService.js'
 import { MockGateway } from './mockGateway.js'
 
@@ -22,6 +24,12 @@ const NS = 'mcp-server'
 const HOST = 'registry.evenfire.ai'
 const DOCKERCONFIG_KEY = '.dockerconfigjson'
 const OURS = { 'clerum.io/managed-by': 'control-api' }
+const FINGERPRINT_ANNOTATION = 'clerum.io/pull-key-fingerprint'
+
+/** Mirrors the service's fingerprint derivation so seeds can look already-provisioned. */
+function fingerprintOf(key: string): string {
+  return createHash('sha256').update(key).digest('hex').slice(0, 12)
+}
 
 function gw(): { gateway: K8sGateway; mock: MockGateway } {
   const mock = new MockGateway(NS)
@@ -36,15 +44,23 @@ function encodeDockercfg(host: string, key: string): string {
   ).toString('base64')
 }
 
-async function readStored(
-  mock: MockGateway
-): Promise<{ type?: string; labels: Record<string, string>; blob?: string }> {
+async function readStored(mock: MockGateway): Promise<{
+  type?: string
+  labels: Record<string, string>
+  annotations: Record<string, string>
+  blob?: string
+}> {
   const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
-    metadata?: { labels?: Record<string, string> }
+    metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> }
     type?: string
     data?: Record<string, string>
   }
-  return { type: raw.type, labels: raw.metadata?.labels ?? {}, blob: raw.data?.[DOCKERCONFIG_KEY] }
+  return {
+    type: raw.type,
+    labels: raw.metadata?.labels ?? {},
+    annotations: raw.metadata?.annotations ?? {},
+    blob: raw.data?.[DOCKERCONFIG_KEY],
+  }
 }
 
 function decodeHosts(blob: string | undefined): string[] {
@@ -167,6 +183,7 @@ describe('ensureRegistryPullSecret — provisioning', () => {
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
       type: 'kubernetes.io/dockerconfigjson',
       labels: OURS,
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
       data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
     })
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
@@ -205,7 +222,8 @@ describe('ensureRegistryPullSecret — provisioning', () => {
     const deleteSpy = vi.spyOn(mock, 'deleteSecret')
     await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
     // An in-place update of `type` would 422, so it must delete first — and the delete
-    // must precede the mint so a failed delete cannot strand a freshly-rotated key.
+    // must still precede the (now single, up-front) mint, so a failed delete cannot
+    // strand a freshly-rotated key that has already revoked the cluster's credential.
     expect(deleteSpy).toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
     expect(deleteSpy.mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]
@@ -249,9 +267,128 @@ describe('ensureRegistryPullSecret — concurrent create race', () => {
       })
       throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
     })
-    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('exists-ours')
-    // Exactly ONE mint — a second would revoke the key the winner just stored.
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    // Exactly ONE mint. Our mint already revoked whatever the winner stored, so we
+    // overwrite with ours rather than adopting a now-dead credential.
     expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
-    expect(decodeHosts((await readStored(mock)).blob)).toEqual([HOST])
+    const stored = await readStored(mock)
+    expect(decodeHosts(stored.blob)).toEqual([HOST])
+    expect(stored.annotations[FINGERPRINT_ANNOTATION]).toBe(fingerprintOf('efrk_test_key'))
+  })
+})
+
+describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () => {
+  const SANDBOX = 'sandbox-recipes'
+  const UI = 'sandbox-ui'
+  const ALL = [NS, SANDBOX, UI]
+
+  async function blobIn(mock: MockGateway, ns: string) {
+    const raw = (await mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
+      metadata?: { annotations?: Record<string, string> }
+      data?: Record<string, string>
+    }
+    return {
+      blob: raw.data?.[DOCKERCONFIG_KEY],
+      fingerprint: raw.metadata?.annotations?.[FINGERPRINT_ANNOTATION],
+    }
+  }
+
+  it('mints EXACTLY ONCE and writes the same credential to every namespace', async () => {
+    const { gateway, mock } = gw()
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    // The registry mint is rotate-on-call: a second mint would revoke the key the first
+    // namespaces were just given. One mint, N copies, is the whole invariant.
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect([...res.values()]).toEqual(['created', 'created', 'created'])
+
+    const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
+    expect(new Set(seen.map(s => s.blob)).size).toBe(1)
+    expect(new Set(seen.map(s => s.fingerprint)).size).toBe(1)
+    expect(seen[0].fingerprint).toBe(fingerprintOf('efrk_test_key'))
+  })
+
+  it('re-mints once and rewrites ALL namespaces when only one is missing', async () => {
+    const { gateway, mock } = gw()
+    // Two namespaces already hold a valid, matching credential; the third is absent.
+    for (const ns of [NS, SANDBOX]) {
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_old') },
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_old') },
+      })
+    }
+    await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    // The already-valid namespaces MUST be rewritten: minting for the third revoked the
+    // key they were holding. Leaving them alone is the cross-namespace corruption bug.
+    const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
+    expect(new Set(seen.map(s => s.fingerprint))).toEqual(new Set([fingerprintOf('efrk_test_key')]))
+  })
+
+  it('does not mint when every namespace already agrees', async () => {
+    const { gateway, mock } = gw()
+    for (const ns of ALL) {
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
+      })
+    }
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect([...res.values()]).toEqual(['exists-ours', 'exists-ours', 'exists-ours'])
+  })
+
+  it('re-mints to converge when copies have DIVERGED', async () => {
+    const { gateway, mock } = gw()
+    // A previous pass minted and then failed partway: two namespaces carry one key, the
+    // third a different one. Only one can still be active registry-side.
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_a') },
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_a') },
+    })
+    for (const ns of [SANDBOX, UI]) {
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_b') },
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_b') },
+      })
+    }
+    await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
+    expect(new Set(seen.map(s => s.fingerprint)).size).toBe(1)
+  })
+
+  it('skips a foreign namespace but still provisions the others', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: 'operator-provisioned' },
+    })
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(res.get(SANDBOX)).toBe('exists-foreign')
+    expect(res.get(NS)).toBe('created')
+    expect(res.get(UI)).toBe('created')
+    // Untouched, byte for byte.
+    expect((await blobIn(mock, SANDBOX)).blob).toBe('operator-provisioned')
+  })
+
+  it('refuses a namespace outside the platform set, before minting', async () => {
+    const { gateway } = gw()
+    await expect(ensureRegistryPullSecrets(gateway, [NS, 'channels'])).rejects.toMatchObject({
+      reason: 'unsupported_namespace',
+      status: 400,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -12,6 +12,19 @@ import {
 } from '../src/services/registryPullSecretService.js'
 import { MockGateway } from './mockGateway.js'
 
+// Records every SQL the service issues, so the cross-process advisory lock is asserted
+// rather than mocked into invisibility. Passthrough otherwise, to stay Postgres-free.
+const dbCalls = vi.hoisted(() => ({ queries: [] as Array<{ text: string; values?: unknown[] }> }))
+vi.mock('../src/db.js', () => ({
+  withTransaction: (work: (db: unknown) => unknown) =>
+    work({
+      query: async (text: string, values?: unknown[]) => {
+        dbCalls.queries.push({ text, values })
+        return { rows: [], rowCount: 0 }
+      },
+    }),
+}))
+
 vi.mock('../src/services/registryConnectionDb.js', () => ({
   isRegistryAuthActive: vi.fn(),
 }))
@@ -100,6 +113,7 @@ let savedUrl: string
 
 beforeEach(() => {
   vi.clearAllMocks()
+  dbCalls.queries.length = 0
   savedMode = config.registryConnectionMode
   savedUrl = config.registryUrl
   config.registryConnectionMode = 'self-hosted'
@@ -694,5 +708,28 @@ describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () 
     expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
     const seen = await Promise.all(ALL.map(ns => blobIn(mock, ns)))
     expect(new Set(seen.map(s => s.fingerprint))).toEqual(new Set([fingerprintOf('efrk_test_key')]))
+  })
+})
+
+describe('ensureRegistryPullSecrets — cross-process serialization', () => {
+  it('takes a per-org advisory lock BEFORE minting', async () => {
+    const { gateway } = gw()
+    await ensureRegistryPullSecrets(gateway, ALL)
+
+    // Two replicas coexist on every RollingUpdate; without this lock their mints
+    // interleave and some namespaces end up holding a revoked key.
+    const lock = dbCalls.queries.find(q => q.text.includes('pg_advisory_xact_lock'))
+    expect(lock).toBeDefined()
+    expect(lock?.values?.[0]).toBe('registry-pull-secret:acme')
+    // An xact lock auto-releases on commit, so there is no explicit unlock to leak.
+    expect(dbCalls.queries.some(q => q.text.includes('pg_advisory_unlock'))).toBe(false)
+  })
+
+  it('does not reach the lock when the pass is a legitimate no-op', async () => {
+    config.registryConnectionMode = 'managed'
+    const { gateway } = gw()
+    await ensureRegistryPullSecrets(gateway, ALL)
+    // Managed clusters must not touch Postgres (or anything else) on this path.
+    expect(dbCalls.queries).toHaveLength(0)
   })
 })

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -302,8 +302,36 @@ describe('ensureRegistryPullSecret — never touches a Secret we do not own', ()
   })
 
   // The pass covers the whole platform set so the mint can be collapsed across callers —
-  // but that must not turn a squatter in one namespace into an outage for installs that
-  // never land there. The failure is scoped to the caller's OWN required namespaces.
+  // and that sweep is exactly why a USABLE foreign copy anywhere has to stop the mint. The
+  // credential is per-ORG and the registry's mint is rotate-on-call, so provisioning
+  // mcp-server revokes whatever key the external owner sealed into the sandbox-ui Secret,
+  // which we may not repair (invariant 1) and cannot even detect (a foreign copy is not in
+  // the fingerprint set). A well-shaped foreign copy therefore means the org credential is
+  // externally managed: mint nothing, and fail the caller that needed a namespace we could
+  // not fill.
+  it('refuses to provision around a usable foreign Secret in a namespace the caller never references', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'foreign_secret_would_be_revoked',
+      status: 409,
+    })
+    // Nothing minted, so the operator's key is still live...
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    // ...and nothing written, in the foreign namespace or the ones we own.
+    await expect(mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)).rejects.toThrow()
+    expect((await readStored(mock, UI)).labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  // ...but that sweep must not turn a BROKEN squatter into an outage for installs that
+  // never land there. An unusable foreign Secret is by definition not serving any pull —
+  // the kubelet ignores a wrong type outright, and never selects a blob keyed on another
+  // host — so rotating the org key cannot break a working path through it. The failure
+  // stays scoped to the caller's OWN required namespaces.
   it('does not fail a single-namespace install over an unusable foreign Secret elsewhere', async () => {
     const { gateway, mock } = gw()
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, { type: 'Opaque', data: {} })
@@ -319,6 +347,106 @@ describe('ensureRegistryPullSecret — never touches a Secret we do not own', ()
     const squatter = await readStored(mock, UI)
     expect(squatter.type).toBe('Opaque')
     expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  // The boundary itself, pinned in one place. The gate is USABILITY, not foreignness: only
+  // a foreign Secret that could plausibly be serving pulls right now (correct type AND
+  // keyed on our host) can be holding the org's live key, and only that one is worth
+  // blocking a mint for. Collapsing the two cases in either direction breaks this test —
+  // treating every foreign copy as blocking reverses the deliberate scoping fix above;
+  // treating none as blocking reinstates the silent cross-namespace revocation.
+  it('blocks the mint for a USABLE foreign sibling but not for an unusable one', async () => {
+    // (a) unusable squatter — nothing to revoke through it, so the mint proceeds.
+    const broken = gw()
+    broken.mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, { type: 'Opaque', data: {} })
+    await expect(ensureRegistryPullSecret(broken.gateway, NS)).resolves.toBe('created')
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+
+    // (b) same shape, same caller, but the squatter is well-formed — it may be the live
+    // credential for this org, so the mint is refused instead.
+    vi.mocked(mintOrgPullCredential).mockClear()
+    const wellShaped = gw()
+    wellShaped.mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+    await expect(ensureRegistryPullSecret(wellShaped.gateway, NS)).rejects.toMatchObject({
+      reason: 'foreign_secret_would_be_revoked',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // The remedy is not obvious from a bare 409 — the namespace that fails is not the one
+  // holding the external Secret — so the message has to name both and say what to do.
+  it('names the external namespace, the unfillable one, and both remedies', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+
+    const err = await ensureRegistryPullSecrets(gateway, ALL).catch((e: Error) => e)
+    expect(err).toBeInstanceOf(PullSecretProvisionError)
+    const message = (err as Error).message
+    expect(message).toContain(`"${SANDBOX}"`) // the namespace we cannot provision
+    expect(message).toContain(`"${NS}"`) // the externally-owned one that blocks it
+    expect(message).toMatch(/revoke/i) // why we refuse
+    expect(message).toMatch(/delete/i) // remedy B: hand the namespaces back to control-api
+    expect(message).toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  })
+
+  // A pass that has nothing to mint for is untouched by the rule: no mint, no revocation,
+  // no block. This is the shape a fully externally-provisioned cluster settles into.
+  it('accepts a foreign Secret alongside already-current owned copies (nothing to mint)', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS, UI], 'efrk_live')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+    expect(res.get(SANDBOX)).toBe('exists-foreign')
+    expect(res.get(NS)).toBe('exists-ours')
+    expect(res.get(UI)).toBe('exists-ours')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // A blocked pass is not a blanket failure: the namespaces it leaves alone are genuinely
+  // fine, and a caller that only needs one of those must still get a truthful answer. It
+  // must NOT come back `'skipped'`, which means "provisioning is not our job" (managed
+  // cluster) and would tell an operator to look in entirely the wrong place.
+  it('reports an untouched, already-current copy as exists-ours even when the mint is blocked', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+    seedValid(mock, [SANDBOX], 'efrk_live')
+    // sandbox-ui is absent, so the pass wants a mint — and the foreign mcp-server copy
+    // forbids it. sandbox-recipes is unaffected: nothing rotated the key it holds.
+    await expect(ensureRegistryPullSecret(gateway, SANDBOX)).resolves.toBe('exists-ours')
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  // Divergence is normally the trigger for a corrective re-mint. It is not a licence to
+  // rotate a key we do not fully own: converging our copies would still kill the external
+  // one. Stay diverged and say so.
+  it('does not re-mint to converge diverged owned copies while a foreign copy exists', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'operator-key') },
+    })
+    seedValid(mock, [SANDBOX], 'efrk_a')
+    seedValid(mock, [UI], 'efrk_b')
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'foreign_secret_would_be_revoked',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
   it('still fails the recipe path, which does reference that namespace', async () => {
@@ -356,6 +484,54 @@ describe('ensureRegistryPullSecret — concurrent create race', () => {
     const stored = await readStored(mock)
     expect(decodeHosts(stored.blob)).toEqual([HOST])
     expect(stored.annotations[FINGERPRINT_ANNOTATION]).toBe(fingerprintOf('efrk_test_key'))
+  })
+
+  // The winner appeared after classification, so the up-front foreign scan never saw it.
+  // Bowing out with 'exists-foreign' is right (invariant 1) but is not the whole job: the
+  // caller is still about to attach an imagePullSecrets reference to a Secret the kubelet
+  // will ignore. The race path has to record the same unusability the classify path does,
+  // or the install persists a CRD that can never pull.
+  it('records an unusable foreign race winner, so a caller that needs it still fails', async () => {
+    const { gateway, mock } = gw()
+    const create = mock.createSecret.bind(mock)
+    vi.spyOn(mock, 'createSecret').mockImplementation(async req => {
+      if ((req as { namespace?: string }).namespace !== NS) return create(req)
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, { type: 'Opaque', data: {} })
+      throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).rejects.toMatchObject({
+      reason: 'foreign_secret_unusable',
+      status: 409,
+    })
+    // Still never written: invariant 1 holds on the race path too.
+    const stored = await readStored(mock)
+    expect(stored.type).toBe('Opaque')
+    expect(stored.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  it('creates again when the race winner is already gone by the time we re-read', async () => {
+    const { gateway, mock } = gw()
+    const create = mock.createSecret.bind(mock)
+    const updateSpy = vi.spyOn(mock, 'updateSecret')
+    let raced = false
+    vi.spyOn(mock, 'createSecret').mockImplementation(async req => {
+      if ((req as { namespace?: string }).namespace === NS && !raced) {
+        raced = true
+        // Created and deleted again before our re-read, so the re-read finds nothing.
+        throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
+      }
+      return create(req)
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    // The real API 404s an update against an absent Secret, so this path must CREATE. The
+    // mock's updateSecret happily upserts, which is precisely why the assertion is on the
+    // call and not on the stored bytes.
+    expect(updateSpy.mock.calls.some(c => (c[0] as { namespace?: string }).namespace === NS)).toBe(
+      false
+    )
+    expect((await readStored(mock)).blob).toBeTruthy()
   })
 })
 
@@ -446,20 +622,34 @@ describe('ensureRegistryPullSecrets — fan-out across platform namespaces', () 
     expect(new Set(seen.map(s => s.fingerprint)).size).toBe(1)
   })
 
-  it('skips a foreign namespace but still provisions the others', async () => {
+  // This used to assert that a foreign namespace is skipped while the others are
+  // provisioned, and that the foreign blob survives "byte for byte". Byte-identity is NOT
+  // the property that matters here, and asserting it is what let the bug through: the mint
+  // is per-ORG and rotate-on-call, so provisioning the two namespaces we own revokes the
+  // key sealed INSIDE those untouched bytes. The Secret then looks perfect and is dead —
+  // its fingerprint is not in the divergence set (foreign copies are excluded), invariant 1
+  // forbids repairing it, and every pod already pulling with it breaks on its next restart.
+  // The property that actually keeps the credential alive is that no mint happens at all.
+  it('mints nothing at all when one namespace is foreign, and says which one it cannot fill', async () => {
     const { gateway, mock } = gw()
     const operatorBlob = encodeDockercfg(HOST, 'operator-key')
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
       type: 'kubernetes.io/dockerconfigjson',
       data: { [DOCKERCONFIG_KEY]: operatorBlob },
     })
-    const res = await ensureRegistryPullSecrets(gateway, ALL)
 
-    expect(res.get(SANDBOX)).toBe('exists-foreign')
-    expect(res.get(NS)).toBe('created')
-    expect(res.get(UI)).toBe('created')
-    // Untouched, byte for byte.
+    // A full-set caller lands workloads in the namespaces we cannot fill without that
+    // mint, so it must fail loudly instead of getting a 201 over a cluster we just broke.
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'foreign_secret_would_be_revoked',
+      status: 409,
+    })
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    // The bytes are unchanged — but only as a consequence of the key still being live.
     expect((await blobIn(mock, SANDBOX)).blob).toBe(operatorBlob)
+    // And the namespaces we own stay absent rather than half-provisioned.
+    await expect(mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)).rejects.toThrow()
+    await expect(mock.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI)).rejects.toThrow()
   })
 
   it('refuses a namespace outside the platform set, before minting', async () => {

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -382,6 +382,8 @@ describe('ensureRegistryPullSecret — provisioning', () => {
     mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
       type: 'Opaque',
       labels: OURS,
+      uid: 'uid-wrong-type',
+      resourceVersion: '100',
       data: {},
     })
     const deleteSpy = vi.spyOn(mock, 'deleteSecret')
@@ -389,7 +391,14 @@ describe('ensureRegistryPullSecret — provisioning', () => {
     // An in-place update of `type` would 422, so it must delete first — and the delete
     // must still precede the (now single, up-front) mint, so a failed delete cannot
     // strand a freshly-rotated key that has already revoked the cluster's credential.
-    expect(deleteSpy).toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)
+    //
+    // The delete must also be OWNERSHIP-BOUND. A bare name-addressed delete removes
+    // whatever answers to that name at the moment it lands — including a replacement an
+    // external owner created after we classified this one.
+    expect(deleteSpy).toHaveBeenCalledWith(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      uid: 'uid-wrong-type',
+      resourceVersion: '100',
+    })
     expect(deleteSpy.mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]
     )
@@ -857,11 +866,10 @@ describe('ensureRegistryPullSecrets — ownership taken over between classify an
     )
   })
 
-  // This is a narrow compare-and-swap, not an atomic one — the proof read is a separate
-  // request from the mutation. What keeps it worth having is that NOTHING happens between
-  // them, so the window is one round trip rather than the whole pass (read all, mint, write
-  // all). Pin both halves: one extra read per mutating namespace, and it is the last thing
-  // before the mutation.
+  // The re-proof read is what produces the identity the write then binds itself to, so it
+  // has to be the LAST thing before the mutation — a read with anything in between would
+  // pin the write to an identity that is already one step stale. Pin both halves: one extra
+  // read per mutating namespace, and it is the last thing before the mutation.
   it('re-reads immediately before each mutation, and only then', async () => {
     const { gateway, mock } = gw()
     // One of each mutating shape: wrong-typed (delete + create), valid (update), absent
@@ -887,6 +895,169 @@ describe('ensureRegistryPullSecrets — ownership taken over between classify an
       Math.max(...getSpy.mock.invocationCallOrder.filter((_, i) => getSpy.mock.calls[i][1] === ns))
     expect(lastReadOrder(NS)).toBeLessThan(deleteSpy.mock.invocationCallOrder[0])
     expect(lastReadOrder(SANDBOX)).toBeLessThan(updateSpy.mock.invocationCallOrder[0])
+  })
+})
+
+/**
+ * The half of the TOCTOU that a re-read CANNOT close: a takeover landing AFTER the ownership
+ * re-proof and BEFORE the mutation it authorises. No amount of checking beforehand helps —
+ * the check and the write are two requests, and the gap between them is exactly where this
+ * lands.
+ *
+ * What closes it is carrying the identity the re-proof observed INTO the write, as a
+ * precondition the apiserver enforces: `metadata.resourceVersion` on a replace,
+ * `preconditions.uid` on a delete. The write to a moved object is then refused with 409
+ * rather than silently winning.
+ *
+ * Every test here arms the takeover on the RE-PROOF read specifically (the classify read is
+ * #1, the re-proof is #2), so the re-proof itself succeeds. That is what makes them
+ * regression tests rather than restatements of the block above: against a name-addressed
+ * mutation they fail, because the check passes and the write lands anyway.
+ */
+describe('ensureRegistryPullSecrets — ownership taken over between the re-proof and the write', () => {
+  /**
+   * Fire `mutate` immediately after the `nth` read of `ns`, placing a takeover in a chosen
+   * gap. Counted in `finally` so a 404 advances the clock too — an absent Secret is still a
+   * read, and without this "the Nth read" would quietly mean "the Nth read that found
+   * something", which is a different position in the sequence on the create path.
+   */
+  function takeoverAfterRead(
+    mock: MockGateway,
+    ns: string,
+    nth: number,
+    mutate: (mock: MockGateway) => void
+  ): void {
+    const real = mock.getSecret.bind(mock)
+    let seen = 0
+    vi.spyOn(mock, 'getSecret').mockImplementation(async (name: string, namespace?: string) => {
+      try {
+        return await real(name, namespace)
+      } finally {
+        if (namespace === ns && ++seen === nth) mutate(mock)
+      }
+    })
+  }
+
+  /** A stranger's Secret: usable, and NOT carrying our ownership marker. */
+  function seedStranger(mock: MockGateway, ns: string, uid: string): void {
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+      type: 'kubernetes.io/dockerconfigjson',
+      uid,
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'stranger-key') },
+    })
+  }
+
+  it('refuses the replace when a stranger takes the name after the re-proof', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      uid: 'uid-sandbox',
+      resourceVersion: '42',
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
+    })
+    // sandbox-ui is absent, so the pass mints and rewrites every namespace it owns.
+    takeoverAfterRead(mock, SANDBOX, 2, m => seedStranger(m, SANDBOX, 'uid-stranger'))
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    const squatter = await readStored(mock, SANDBOX)
+    expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+    expect(squatter.blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
+  })
+
+  // The destructive half. A name-addressed delete does not just lose a race, it REMOVES the
+  // object that won it — here an external owner's credential, which no later pass restores.
+  it('refuses the delete when a stranger takes the name after the re-proof', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [SANDBOX, UI], 'efrk_live')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      // Wrong type ⇒ the immutable-field path, which deletes and recreates.
+      type: 'Opaque',
+      labels: OURS,
+      uid: 'uid-ours',
+      resourceVersion: '7',
+      data: {},
+    })
+    takeoverAfterRead(mock, NS, 2, m => seedStranger(m, NS, 'uid-theirs'))
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    // Still there, and still theirs.
+    const squatter = await readStored(mock, NS)
+    expect(squatter.type).toBe('kubernetes.io/dockerconfigjson')
+    expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+    expect(squatter.blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
+  })
+
+  // The other direction, and the reason a 409 cannot simply mean "give up": a benign edit
+  // that leaves the object ours produces the SAME 409 as a takeover. Surrendering there would
+  // strand this namespace on the key the mint has already revoked — an ImagePullBackOff we
+  // caused ourselves, in the name of safety.
+  it('retries the write when the 409 came from a benign edit, not a takeover', async () => {
+    const { gateway, mock } = gw()
+    seedValid(mock, [NS], 'efrk_live', 'uid-ns')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      uid: 'uid-sandbox',
+      resourceVersion: '42',
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+      data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
+    })
+    // Same object (same uid), still marked ours — somebody just edited it. Only the version
+    // moved, which is enough to make our precondition fail.
+    takeoverAfterRead(mock, SANDBOX, 2, m =>
+      m.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: { ...OURS, 'example.com/touched-by': 'something-else' },
+        uid: 'uid-sandbox',
+        resourceVersion: '43',
+        annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_live') },
+      })
+    )
+
+    const res = await ensureRegistryPullSecrets(gateway, ALL)
+
+    expect(res.get(SANDBOX)).toBe('exists-ours')
+    // The retry wrote OUR freshly minted key, not the one the mint just revoked.
+    const stored = await readStored(mock, SANDBOX)
+    expect(stored.annotations[FINGERPRINT_ANNOTATION]).toBe(fingerprintOf('efrk_test_key'))
+  })
+
+  // The create-race path adopts a winner it read a moment earlier. A create race is the one
+  // situation where a third writer is KNOWN to be active on this name, so it is the last
+  // place to assume the gap between that read and the write is safe.
+  it('binds the adopt-the-winner write to the winner it just read', async () => {
+    const { gateway, mock } = gw()
+    const create = mock.createSecret.bind(mock)
+    vi.spyOn(mock, 'createSecret').mockImplementation(async req => {
+      if ((req as { namespace?: string }).namespace !== NS) return create(req)
+      mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+        type: 'kubernetes.io/dockerconfigjson',
+        labels: OURS,
+        uid: 'uid-winner',
+        resourceVersion: '5',
+        data: { [DOCKERCONFIG_KEY]: encodeDockercfg(HOST, 'efrk_winner') },
+      })
+      throw Object.assign(new Error('already exists'), { statusCode: 409, code: 409 })
+    })
+    // Reads of mcp-server: #1 classify (404), #2 read the race winner, #3 re-prove it. The
+    // takeover lands after #3, so only the precondition on the write can still catch it.
+    takeoverAfterRead(mock, NS, 3, m => seedStranger(m, NS, 'uid-stranger'))
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'ownership_changed',
+      status: 409,
+    })
+    expect((await readStored(mock, NS)).blob).toBe(encodeDockercfg(HOST, 'stranger-key'))
   })
 })
 

--- a/control-api/test/registryPullSecretService.test.ts
+++ b/control-api/test/registryPullSecretService.test.ts
@@ -532,6 +532,67 @@ describe('ensureRegistryPullSecret — never touches a Secret we do not own', ()
     expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
+  // The sharp edge of that boundary: `auths[host]` PRESENT but carrying nothing. It parses,
+  // it names our host, and it is completely unusable — the kubelet finds no credential to
+  // send and pulls anonymously. Reading host-presence alone as "usable" put this on the
+  // BLOCKING side, so an empty or template-generated Secret in any platform namespace
+  // fail-closed every private install in the org, permanently, over a copy that could never
+  // have served a pull. It is unusable, so it must not block.
+  it('does not block the mint for a foreign entry that names our host but carries no credential', async () => {
+    const { gateway, mock } = gw()
+    const emptyEntry = Buffer.from(JSON.stringify({ auths: { [HOST]: {} } })).toString('base64')
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { [DOCKERCONFIG_KEY]: emptyEntry },
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('created')
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    // Unusable does not mean ours: invariant 1 still forbids touching it.
+    const squatter = await readStored(mock, UI)
+    expect(squatter.blob).toBe(emptyEntry)
+    expect(squatter.labels['clerum.io/managed-by']).toBeUndefined()
+  })
+
+  // A caller that actually needs that namespace must still fail — unusable is not "fine",
+  // it is "fatal to whoever references it". Otherwise we would persist a CRD pointing at a
+  // Secret the kubelet cannot use, which is the silent ImagePullBackOff this exists to stop.
+  it('still fails a caller that requires the namespace holding the empty foreign entry', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, UI, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: {
+        [DOCKERCONFIG_KEY]: Buffer.from(JSON.stringify({ auths: { [HOST]: {} } })).toString(
+          'base64'
+        ),
+      },
+    })
+
+    await expect(ensureRegistryPullSecrets(gateway, ALL)).rejects.toMatchObject({
+      reason: 'foreign_secret_unusable',
+      status: 409,
+    })
+  })
+
+  // Same tightening, our side of the fence: an empty entry in a Secret WE own is broken, not
+  // healthy. Left as "valid" it would survive every pass while pulling anonymously.
+  it('repairs a Secret we own whose entry names our host but carries no credential', async () => {
+    const { gateway, mock } = gw()
+    mock.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS, {
+      type: 'kubernetes.io/dockerconfigjson',
+      labels: OURS,
+      annotations: { [FINGERPRINT_ANNOTATION]: fingerprintOf('efrk_live') },
+      data: {
+        [DOCKERCONFIG_KEY]: Buffer.from(JSON.stringify({ auths: { [HOST]: {} } })).toString(
+          'base64'
+        ),
+      },
+    })
+
+    await expect(ensureRegistryPullSecret(gateway, NS)).resolves.toBe('repaired')
+    expect(decodeHosts((await readStored(mock, NS)).blob)).toEqual([HOST])
+  })
+
   // The remedy is not obvious from a bare 409 — the namespace that fails is not the one
   // holding the external Secret — so the message has to name both and say what to do.
   it('names the external namespace, the unfillable one, and both remedies', async () => {

--- a/control-api/test/routes.adminRecipes.pullSecret.test.ts
+++ b/control-api/test/routes.adminRecipes.pullSecret.test.ts
@@ -17,7 +17,11 @@ import request from 'supertest'
 import { config } from '../src/config.js'
 import { createAdminRecipesRouter } from '../src/routes/admin/recipes.js'
 import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
-import { mintOrgPullCredential, resolvePublishScope } from '../src/services/registryClient.js'
+import {
+  RegistryProxyError,
+  mintOrgPullCredential,
+  resolvePublishScope,
+} from '../src/services/registryClient.js'
 import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
 import { MockGateway } from './mockGateway.js'
 
@@ -134,6 +138,28 @@ describe('POST /admin/recipes — pull-secret provisioning (self-hosted)', () =>
     })
     await expect(gateway.getResource('workflowrecipes', 'plat', SANDBOX_NS)).rejects.toBeTruthy()
   })
+
+  it('maps a registry rejection to 502 registry_rejected, not a bare 500', async () => {
+    // The mint endpoint 403s when the registry has not been upgraded to support tenant
+    // pull-credential minting, or this deployment lacks `registry:manage-keys`. That is a
+    // deploy-ordering problem the operator can act on — collapsing it into a generic 500
+    // (which is what a plain K8s-error mapping does, since it cannot read
+    // RegistryProxyError.status) makes it look like a control-api bug.
+    vi.mocked(mintOrgPullCredential).mockRejectedValue(
+      new RegistryProxyError(403, { error: 'forbidden' })
+    )
+    const gateway = new MockGateway(MCP_NS)
+
+    const res = await request(makeApp(gateway)).post('/admin/recipes').send(platformRecipe('plat'))
+
+    expect(res.status).toBe(502)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'registry_rejected',
+      upstreamStatus: 403,
+    })
+    await expect(gateway.getResource('workflowrecipes', 'plat', SANDBOX_NS)).rejects.toBeTruthy()
+  })
 })
 
 describe('PUT /admin/recipes/:name — pull-secret provisioning (self-hosted)', () => {
@@ -163,6 +189,20 @@ describe('PUT /admin/recipes/:name — pull-secret provisioning (self-hosted)', 
       }
       expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
     }
+  })
+
+  it('mints NOTHING for a PUT naming a recipe that does not exist', async () => {
+    const gateway = new MockGateway(MCP_NS)
+
+    const res = await request(makeApp(gateway))
+      .put('/admin/recipes/ghost')
+      .send({ spec: platformRecipe('ghost').spec })
+
+    // The mint is rotate-on-call — it revokes the org's previous key. A request that was
+    // always going to 404 must not spend one, or it strands every namespace already
+    // holding a Secret built from the key it just replaced.
+    expect(res.status).toBe(404)
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
   })
 
   it('provisions nothing when the update keeps a third-party image', async () => {

--- a/control-api/test/routes.adminRecipes.pullSecret.test.ts
+++ b/control-api/test/routes.adminRecipes.pullSecret.test.ts
@@ -248,3 +248,38 @@ describe('PUT /admin/recipes/:name — pull-secret provisioning (self-hosted)', 
     expect(stored.spec.workloads[0].image).toBe('ghcr.io/acme/plugin:1.0')
   })
 })
+
+/**
+ * Managed mode reaches the generic recipe routes too. A hand-authored recipe is
+ * indistinguishable at reconcile time from an installed one — WRC injects the reference
+ * from the image host either way — so the same verification has to gate this path, or the
+ * narrowing is only as good as the route the author happened to use.
+ */
+describe('POST /admin/recipes — managed mode verifies instead of provisioning', () => {
+  beforeEach(() => {
+    config.registryConnectionMode = 'managed'
+  })
+
+  it('refuses the recipe and persists nothing when the operator Secret is absent', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    const createSecret = vi.spyOn(gateway, 'createSecret')
+
+    const res = await request(makeApp(gateway)).post('/admin/recipes').send(platformRecipe('plat'))
+
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'operator_secret_missing',
+    })
+    await expect(gateway.getResource('workflowrecipes', 'plat', SANDBOX_NS)).rejects.toBeTruthy()
+    // Managed mode is read-only: no mint, and no Secret written on the way to the refusal.
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect(createSecret).not.toHaveBeenCalled()
+  })
+
+  it('accepts a recipe with no platform-registry image, unchecked', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    await request(makeApp(gateway)).post('/admin/recipes').send(foreignRecipe('ext')).expect(201)
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/routes.adminRecipes.pullSecret.test.ts
+++ b/control-api/test/routes.adminRecipes.pullSecret.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Route-level coverage for image-pull-secret provisioning on the GENERIC recipe routes.
+ *
+ * `POST /admin/recipes` and `PUT /admin/recipes/:name` persist the same WorkflowRecipe CRD
+ * the registry install path does, and WRC injects the platform pull-secret reference for
+ * any workload whose image is ours — it does not care which route wrote the recipe. So a
+ * recipe authored or edited here must provision too, or the pod references a Secret that
+ * was never minted: ImagePullBackOff behind a green 201.
+ *
+ * The main `routes.adminRecipes` suite runs in the default `managed` connection mode,
+ * where provisioning short-circuits to `'skipped'`; these force `self-hosted`, the only
+ * mode where the hook does anything.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { config } from '../src/config.js'
+import { createAdminRecipesRouter } from '../src/routes/admin/recipes.js'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
+import { mintOrgPullCredential, resolvePublishScope } from '../src/services/registryClient.js'
+import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
+import { MockGateway } from './mockGateway.js'
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => [{ address: '93.184.216.34' }]),
+}))
+vi.mock('../src/services/registryClient.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryClient.js')>()),
+  resolvePublishScope: vi.fn(),
+  mintOrgPullCredential: vi.fn(),
+}))
+vi.mock('../src/services/registryConnectionDb.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryConnectionDb.js')>()),
+  isRegistryAuthActive: vi.fn(),
+}))
+
+const REGISTRY_HOST = 'registry.evenfire.ai'
+const MCP_NS = 'mcp-server'
+const SANDBOX_NS = 'sandbox-recipes'
+const PLATFORM_NAMESPACES = [MCP_NS, SANDBOX_NS, 'sandbox-ui']
+
+/** A workload image on the configured platform registry — needs the pull credential. */
+function platformRecipe(name: string) {
+  return {
+    metadata: { name },
+    spec: {
+      workloads: [{ id: 'svc', type: 'deployment', image: `${REGISTRY_HOST}/acme/plugin:1.0` }],
+    },
+  }
+}
+
+/** Same shape, third-party image — the platform credential is none of its business. */
+function foreignRecipe(name: string) {
+  return {
+    metadata: { name },
+    spec: {
+      workloads: [{ id: 'svc', type: 'deployment', image: 'ghcr.io/acme/plugin:1.0' }],
+    },
+  }
+}
+
+function makeApp(gateway: MockGateway) {
+  const app = express()
+  app.use(express.json())
+  app.use(createAdminRecipesRouter(gateway as never))
+  return app
+}
+
+let savedMode: typeof config.registryConnectionMode
+let savedUrl: string
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  savedMode = config.registryConnectionMode
+  savedUrl = config.registryUrl
+  config.registryConnectionMode = 'self-hosted'
+  config.registryUrl = `https://${REGISTRY_HOST}`
+  vi.mocked(isRegistryAuthActive).mockResolvedValue(true)
+  vi.mocked(resolvePublishScope).mockResolvedValue({
+    curator: false,
+    orgName: 'acme',
+    scope: '@acme',
+  })
+  vi.mocked(mintOrgPullCredential).mockResolvedValue({ key: 'efrk_recipe_route_key' })
+})
+
+afterEach(() => {
+  config.registryConnectionMode = savedMode
+  config.registryUrl = savedUrl
+})
+
+describe('POST /admin/recipes — pull-secret provisioning (self-hosted)', () => {
+  it('provisions every platform namespace BEFORE persisting the CRD', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    const createResource = vi.spyOn(gateway, 'createResource')
+
+    await request(makeApp(gateway)).post('/admin/recipes').send(platformRecipe('plat')).expect(201)
+
+    // Ordering is the point: a CRD persisted first would reference a Secret that does not
+    // exist yet, and a provisioning failure after the write leaves it stranded.
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]).toBeLessThan(
+      createResource.mock.invocationCallOrder[0]
+    )
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = (await gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
+        type?: string
+      }
+      expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
+    }
+  })
+
+  it('provisions nothing for a recipe with no platform-registry image', async () => {
+    const gateway = new MockGateway(MCP_NS)
+
+    await request(makeApp(gateway)).post('/admin/recipes').send(foreignRecipe('ext')).expect(201)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    await expect(
+      gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX_NS)
+    ).rejects.toBeTruthy()
+  })
+
+  it('maps a provisioning failure to its own status and persists NO recipe', async () => {
+    vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: null, scope: null })
+    const gateway = new MockGateway(MCP_NS)
+
+    const res = await request(makeApp(gateway)).post('/admin/recipes').send(platformRecipe('plat'))
+
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'org_unresolved',
+    })
+    await expect(gateway.getResource('workflowrecipes', 'plat', SANDBOX_NS)).rejects.toBeTruthy()
+  })
+})
+
+describe('PUT /admin/recipes/:name — pull-secret provisioning (self-hosted)', () => {
+  /** Seed a third-party-image recipe, so the update is what first pulls ours into play. */
+  async function seedForeignRecipe(gateway: MockGateway, name: string) {
+    await request(makeApp(gateway)).post('/admin/recipes').send(foreignRecipe(name)).expect(201)
+    vi.mocked(mintOrgPullCredential).mockClear()
+  }
+
+  it('provisions every platform namespace BEFORE persisting the update', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    await seedForeignRecipe(gateway, 'plat')
+    const updateResource = vi.spyOn(gateway, 'updateResource')
+
+    await request(makeApp(gateway))
+      .put('/admin/recipes/plat')
+      .send({ spec: platformRecipe('plat').spec })
+      .expect(200)
+
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]).toBeLessThan(
+      updateResource.mock.invocationCallOrder[0]
+    )
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = (await gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
+        type?: string
+      }
+      expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
+    }
+  })
+
+  it('provisions nothing when the update keeps a third-party image', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    await seedForeignRecipe(gateway, 'ext')
+
+    await request(makeApp(gateway))
+      .put('/admin/recipes/ext')
+      .send({ spec: foreignRecipe('ext').spec })
+      .expect(200)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    await expect(
+      gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX_NS)
+    ).rejects.toBeTruthy()
+  })
+
+  it('maps a provisioning failure to its own status and does NOT persist the update', async () => {
+    const gateway = new MockGateway(MCP_NS)
+    await seedForeignRecipe(gateway, 'plat')
+    vi.mocked(resolvePublishScope).mockResolvedValue({ curator: false, orgName: null, scope: null })
+
+    const res = await request(makeApp(gateway))
+      .put('/admin/recipes/plat')
+      .send({ spec: platformRecipe('plat').spec })
+
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'org_unresolved',
+    })
+    const stored = (await gateway.getResource('workflowrecipes', 'plat', SANDBOX_NS)) as {
+      spec: { workloads: Array<{ image: string }> }
+    }
+    expect(stored.spec.workloads[0].image).toBe('ghcr.io/acme/plugin:1.0')
+  })
+})

--- a/control-api/test/routes.adminRecipes.pullSecret.test.ts
+++ b/control-api/test/routes.adminRecipes.pullSecret.test.ts
@@ -25,6 +25,14 @@ import {
 import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
 import { MockGateway } from './mockGateway.js'
 
+vi.mock('../src/db.js', () => ({
+  // The provisioner takes a cross-process advisory lock; without this the suite reaches a
+  // real Postgres and every test times out. The lock itself is asserted in
+  // registryPullSecretService.test.ts.
+  withTransaction: (work: (db: unknown) => unknown) =>
+    work({ query: async () => ({ rows: [], rowCount: 0 }) }),
+}))
+
 vi.mock('node:dns/promises', () => ({
   lookup: vi.fn(async () => [{ address: '93.184.216.34' }]),
 }))

--- a/control-api/test/routes.adminRecipes.test.ts
+++ b/control-api/test/routes.adminRecipes.test.ts
@@ -5,6 +5,7 @@ import http from 'node:http'
 import request from 'supertest'
 import { config } from '../src/config.js'
 import { createAdminRecipesRouter } from '../src/routes/admin/recipes.js'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
 import { MockGateway } from './mockGateway.js'
 
 vi.mock('node:dns/promises', () => ({
@@ -1631,6 +1632,28 @@ describe.sequential('routes/admin/recipes', () => {
     await expect(gateway.getSecret('wf-example-coordinator-token', SANDBOX_NS)).rejects.toThrow()
   })
 
+  it('POST /admin/recipes/secrets — rejects the platform registry pull Secret name', async () => {
+    // This endpoint writes Opaque + WORKFLOW_SECRET_LABELS, which carry the same
+    // `clerum.io/managed-by: control-api` marker the pull-secret service reads as its own
+    // ownership. Left unreserved, a request here would relabel (or shadow) the live
+    // credential; today only K8s type immutability stands in the way.
+    // Ownership is supplied so the ONLY thing that can reject this is the reserved name.
+    const res = await request(app)
+      .post('/admin/recipes/secrets')
+      .send({
+        name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+        ownership: { kind: 'owner-recipe', recipeName: 'my-recipe' },
+        stringData: { token: 'not-a-pull-key' },
+      })
+      .expect(400)
+
+    expect(res.body.error).toMatch(/platform-managed/)
+
+    await expect(
+      gateway.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, SANDBOX_NS)
+    ).rejects.toThrow()
+  })
+
   it('POST /admin/recipes/secrets — rejects invalid keys and non-string values', async () => {
     await request(app)
       .post('/admin/recipes/secrets')
@@ -2078,6 +2101,98 @@ describe.sequential('routes/admin/recipes', () => {
       rule: 'workflowWorkloadSecretRefReserved',
       field: 'spec.workloads[0].envSecret.name',
     })
+  })
+
+  // ── The platform registry pull Secret is reserved, like the wf- prefix ────
+  //
+  // control-api writes `evenfire-registry-pull` into the platform workload namespaces and
+  // WRC injects the reference itself, after the #637 ownership filter. A recipe that names
+  // it is asking for something it will never legitimately get: a declared imagePullSecret
+  // is stripped as unowned (and re-injected anyway), while the same name in `envSecret` is
+  // an attempt to read the org's registry credential into a container's environment.
+  // Reject at the door — a declaration we silently ignore is worse than a 422.
+  const PLATFORM_PULL_SECRET_ENV_RECIPE = {
+    metadata: { name: 'pull-secret-env-recipe' },
+    spec: {
+      workloads: [
+        {
+          id: 'api',
+          type: 'deployment',
+          image: 'my-api:latest',
+          envSecret: {
+            name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+            keys: [{ secretKey: '.dockerconfigjson', envVar: 'DOCKER_CONFIG' }],
+          },
+        },
+      ],
+    },
+  }
+
+  const PLATFORM_PULL_SECRET_IMAGE_RECIPE = {
+    metadata: { name: 'pull-secret-image-recipe' },
+    spec: {
+      workloads: [
+        {
+          id: 'api',
+          type: 'deployment',
+          image: 'my-api:latest',
+          imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME],
+        },
+      ],
+    },
+  }
+
+  it('POST /admin/recipes/validate — rejects workload envSecret naming the platform pull Secret', async () => {
+    const res = await request(app)
+      .post('/admin/recipes/validate')
+      .send(PLATFORM_PULL_SECRET_ENV_RECIPE)
+      .expect(422)
+
+    expect(res.body.valid).toBe(false)
+    expect(res.body.errors[0]).toMatchObject({
+      rule: 'workflowWorkloadSecretRefReserved',
+      field: 'spec.workloads[0].envSecret.name',
+    })
+  })
+
+  it('POST /admin/recipes/validate — rejects imagePullSecrets naming the platform pull Secret', async () => {
+    const res = await request(app)
+      .post('/admin/recipes/validate')
+      .send(PLATFORM_PULL_SECRET_IMAGE_RECIPE)
+      .expect(422)
+
+    expect(res.body.valid).toBe(false)
+    expect(res.body.errors[0]).toMatchObject({
+      rule: 'workflowWorkloadSecretRefReserved',
+      field: 'spec.workloads[0].imagePullSecrets[0]',
+    })
+  })
+
+  it('POST /admin/recipes — refuses to persist a recipe naming the platform pull Secret', async () => {
+    const res = await request(app)
+      .post('/admin/recipes')
+      .send(PLATFORM_PULL_SECRET_IMAGE_RECIPE)
+      .expect(422)
+
+    expect(res.body.errors[0]).toMatchObject({ rule: 'workflowWorkloadSecretRefReserved' })
+    await expect(
+      gateway.getResource('workflowrecipes', 'pull-secret-image-recipe', SANDBOX_NS)
+    ).rejects.toThrow()
+  })
+
+  it('PUT /admin/recipes/:name — refuses an update naming the platform pull Secret', async () => {
+    await request(app).post('/admin/recipes').send(VALID_RECIPE).expect(201)
+
+    const res = await request(app)
+      .put('/admin/recipes/my-recipe')
+      .send({ spec: PLATFORM_PULL_SECRET_ENV_RECIPE.spec })
+      .expect(422)
+
+    expect(res.body.errors[0]).toMatchObject({ rule: 'workflowWorkloadSecretRefReserved' })
+    const stored = (await gateway.getResource('workflowrecipes', 'my-recipe', SANDBOX_NS)) as {
+      spec: { workloads: Array<{ envSecret?: unknown }> }
+    }
+    expect(stored.spec.workloads[0].envSecret).toBeUndefined()
   })
 
   it('POST /admin/recipes/validate — accepts workload envSecret when Secret and keys exist', async () => {

--- a/control-api/test/routes.adminRecipes.test.ts
+++ b/control-api/test/routes.adminRecipes.test.ts
@@ -1654,6 +1654,26 @@ describe.sequential('routes/admin/recipes', () => {
     ).rejects.toThrow()
   })
 
+  it('POST /admin/recipes/secrets — refuses a pull-secret-shaped payload', async () => {
+    // This route writes `type: Opaque`, and the kubelet honors ONLY
+    // kubernetes.io/dockerconfigjson (or .dockercfg) for image pulls. Storing the key on an
+    // Opaque Secret would be accepted here and then SILENTLY ignored at pull time — an
+    // unexplained ImagePullBackOff long after the 201 that caused it.
+    for (const key of ['.dockerconfigjson', '.dockercfg']) {
+      const res = await request(app)
+        .post('/admin/recipes/secrets')
+        .send({
+          name: 'third-party-pull',
+          ownership: { kind: 'owner-recipe', recipeName: 'snippet-secret-recipe' },
+          stringData: { [key]: '{"auths":{}}' },
+        })
+        .expect(400)
+
+      expect(res.body.error).toMatch(/Kubernetes ignores for image pulls/)
+      await expect(gateway.getSecret('third-party-pull', SANDBOX_NS)).rejects.toThrow()
+    }
+  })
+
   it('POST /admin/recipes/secrets — rejects invalid keys and non-string values', async () => {
     await request(app)
       .post('/admin/recipes/secrets')

--- a/control-api/test/routes.registryInstall.pullSecret.test.ts
+++ b/control-api/test/routes.registryInstall.pullSecret.test.ts
@@ -28,6 +28,13 @@ import {
 import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
 import { MockGateway } from './mockGateway.js'
 
+vi.mock('../src/db.js', () => ({
+  // The cross-process advisory lock is exercised for real in the integration suite; here
+  // it is a passthrough so the unit tests stay Postgres-free.
+  withTransaction: (work: (db: unknown) => unknown) =>
+    work({ query: async () => ({ rows: [], rowCount: 0 }) }),
+}))
+
 vi.mock('node:dns/promises', () => ({
   lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
 }))
@@ -325,5 +332,100 @@ describe('POST /admin/registry/install-recipe — pull-secret provisioning (self
       metadata: { name: string }
     }>
     expect(persisted.map(r => r.metadata.name)).toEqual([])
+  })
+})
+
+describe('POST /admin/registry/upgrade-recipe — pull-secret provisioning (self-hosted)', () => {
+  const PLATFORM_NAMESPACES = ['mcp-server', 'sandbox-recipes', 'sandbox-ui']
+
+  /** An upgrade target whose NEW spec runs `image`. */
+  function upgradeEntry(image: string) {
+    return {
+      id: 'r2',
+      name: 'workflow-template',
+      version: '2.0.0',
+      entry_type: 'recipe',
+      description: 'Workflow template',
+      author: 'acme',
+      recipe_meta: {
+        recipeYaml: JSON.stringify({
+          spec: {
+            description: 'Workflow template',
+            steps: [{ id: 's1', instruction: 'Run step' }],
+            workloads: [{ id: 'w1', type: 'deployment', image }],
+          },
+        }),
+      },
+    }
+  }
+
+  function makeUpgradeApp() {
+    const gw = new MockGateway(NS)
+    gw.createResource(
+      'workflowrecipes',
+      {
+        metadata: { name: 'existing-recipe' },
+        spec: { steps: [{ id: 's1', instruction: 'Run step' }] },
+      },
+      'sandbox-recipes'
+    )
+    return { app: makeApp(gw), gw }
+  }
+
+  function upgradeBody() {
+    return {
+      recipeName: 'existing-recipe',
+      registryEntryName: 'workflow-template',
+      registryEntryVersion: '2.0.0',
+    }
+  }
+
+  it('provisions when an upgrade moves a recipe from a PUBLIC to a PRIVATE image', async () => {
+    // The regression this guards: the pre-existing CRD is public, so nothing was ever
+    // provisioned; the upgrade introduces a platform image. Without a hook here the new
+    // CRD persists, returns 200, and then fails at pull time.
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      upgradeEntry(`${REGISTRY_HOST}/acme/plugin:2.0`) as never
+    )
+    const { app, gw } = makeUpgradeApp()
+
+    await request(app).post('/admin/registry/upgrade-recipe').send(upgradeBody()).expect(200)
+
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = (await gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
+        type?: string
+      }
+      expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
+    }
+  })
+
+  it('does not provision when the upgraded recipe stays on a public image', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      upgradeEntry('ghcr.io/acme/plugin:2.0') as never
+    )
+    const { app, gw } = makeUpgradeApp()
+
+    await request(app).post('/admin/registry/upgrade-recipe').send(upgradeBody()).expect(200)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    await expect(
+      gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, 'sandbox-recipes')
+    ).rejects.toBeTruthy()
+  })
+
+  it('fails the upgrade loudly when provisioning fails', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      upgradeEntry(`${REGISTRY_HOST}/acme/plugin:2.0`) as never
+    )
+    vi.mocked(mintOrgPullCredential).mockRejectedValueOnce(new Error('registry unavailable'))
+    const { app, gw } = makeUpgradeApp()
+    const updateSpy = vi.spyOn(gw, 'updateResource')
+
+    const res = await request(app).post('/admin/registry/upgrade-recipe').send(upgradeBody())
+    expect(res.status).toBeGreaterThanOrEqual(500)
+    expect(res.body.error).toBe('registry_pull_secret_provision_failed')
+    // The CRD must not be updated to reference a credential that does not exist.
+    expect(updateSpy).not.toHaveBeenCalled()
   })
 })

--- a/control-api/test/routes.registryInstall.pullSecret.test.ts
+++ b/control-api/test/routes.registryInstall.pullSecret.test.ts
@@ -218,3 +218,85 @@ describe('POST /admin/registry/install — pull-secret provisioning (self-hosted
     expect(mcp.spec.imagePullSecrets).toBeUndefined()
   })
 })
+
+describe('POST /admin/registry/install-recipe — pull-secret provisioning (self-hosted)', () => {
+  const PLATFORM_NAMESPACES = ['mcp-server', 'sandbox-recipes', 'sandbox-ui']
+
+  function recipeEntry(image: string) {
+    return {
+      id: 'r1',
+      name: 'intel-report',
+      version: '1.0.0',
+      entry_type: 'recipe',
+      description: 'Research + PDF report',
+      author: 'acme',
+      server_mode: null,
+      transport: null,
+      recipe_type: 'workflow',
+      mcp_server_meta: null,
+      recipe_meta: {
+        recipeYaml: JSON.stringify({
+          spec: {
+            description: 'Intel',
+            steps: [{ id: 'research', description: 'Research step' }],
+            workloads: [{ id: 'w1', type: 'deployment', image }],
+          },
+        }),
+        stepCount: 1,
+        hasAgent: true,
+      },
+    }
+  }
+
+  function recipeBody() {
+    return { registryEntryName: 'intel-report', registryEntryVersion: '1.0.0' }
+  }
+
+  it('provisions the credential in EVERY platform namespace, minting once', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
+    )
+    const { app, gw } = makeInstallApp()
+
+    await request(app).post('/admin/registry/install-recipe').send(recipeBody()).expect(201)
+
+    // Recipe workloads split across namespaces by kind, and WRC injects the reference at
+    // reconcile time — so all three must hold the credential, from ONE mint (the registry
+    // mint is rotate-on-call; a second would revoke the first).
+    expect(mintOrgPullCredential).toHaveBeenCalledTimes(1)
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = (await gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns)) as {
+        type?: string
+      }
+      expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
+    }
+  })
+
+  it('does not provision for a recipe with no platform-registry image', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry('ghcr.io/acme/plugin:1.0') as never
+    )
+    const { app, gw } = makeInstallApp()
+
+    await request(app).post('/admin/registry/install-recipe').send(recipeBody()).expect(201)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    await expect(
+      gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, 'sandbox-recipes')
+    ).rejects.toBeTruthy()
+  })
+
+  it('fails the recipe install loudly when provisioning fails', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
+    )
+    vi.mocked(mintOrgPullCredential).mockRejectedValueOnce(new Error('registry unavailable'))
+    const { app, gw } = makeInstallApp()
+
+    const res = await request(app).post('/admin/registry/install-recipe').send(recipeBody())
+    expect(res.status).toBeGreaterThanOrEqual(500)
+    expect(res.body.error).toBe('registry_pull_secret_provision_failed')
+    // No WorkflowRecipe may be persisted referencing a credential that does not exist.
+    await expect(gw.getResource('workflowrecipes', 'intel-report', NS)).rejects.toBeTruthy()
+  })
+})

--- a/control-api/test/routes.registryInstall.pullSecret.test.ts
+++ b/control-api/test/routes.registryInstall.pullSecret.test.ts
@@ -1,15 +1,17 @@
 /**
- * Route-level coverage for image-pull-secret self-provisioning on the install path.
+ * Route-level coverage for the image-pull-secret hook on the install path, in BOTH
+ * connection modes — the hook behaves differently in each, and the difference is the point.
  *
- * The main `routes.registryInstall` suite runs in the default `managed` connection mode,
- * where `ensureRegistryPullSecret` short-circuits to `'skipped'` before doing anything —
- * so none of it can catch a regression in the wiring. These tests force `self-hosted`,
- * which is the only mode where the hook actually runs, and pin the properties the wiring
- * is supposed to guarantee:
+ * self-hosted: control-api provisions the Secret itself, so these pin
  *   - it provisions even when the plugin needs NO credentials (outside `credRequired`)
  *   - it provisions BEFORE the McpServer CRD that references the Secret
  *   - a provisioning failure fails the install loudly and persists NOTHING
  *   - it does not run at all for images that are not evenfire-hosted
+ *
+ * managed: control-api provisions nothing — the operator owns the Secret — but WRC injects
+ * the reference regardless, so the install VERIFIES the operator's copy is present and
+ * usable and refuses before persisting when it is not. Same guarantee, opposite mechanism:
+ * no CRD is written that references a credential no pod can resolve.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
@@ -115,6 +117,55 @@ function installBody() {
     contextRef: 'default-context',
     registryEntryName: 'forecast',
     registryEntryVersion: '1.0.0',
+  }
+}
+
+/** A recipe entry whose single workload runs `image`. */
+function recipeEntry(image: string) {
+  return {
+    id: 'r1',
+    name: 'intel-report',
+    version: '1.0.0',
+    entry_type: 'recipe',
+    description: 'Research + PDF report',
+    author: 'acme',
+    server_mode: null,
+    transport: null,
+    recipe_type: 'workflow',
+    mcp_server_meta: null,
+    recipe_meta: {
+      recipeYaml: JSON.stringify({
+        spec: {
+          description: 'Intel',
+          steps: [{ id: 'research', description: 'Research step' }],
+          workloads: [{ id: 'w1', type: 'deployment', image }],
+        },
+      }),
+      stepCount: 1,
+      hasAgent: true,
+    },
+  }
+}
+
+function recipeBody() {
+  return { registryEntryName: 'intel-report', registryEntryVersion: '1.0.0' }
+}
+
+const PLATFORM_NAMESPACES = ['mcp-server', 'sandbox-recipes', 'sandbox-ui']
+
+/** Seed the Secret a managed cluster's operator is contracted to provision. */
+function seedOperatorSecret(gw: MockGateway, namespaces: string[]): void {
+  const auth = Buffer.from('_:operator-key').toString('base64')
+  const blob = Buffer.from(
+    JSON.stringify({
+      auths: { [REGISTRY_HOST]: { username: '_', password: 'operator-key', auth } },
+    })
+  ).toString('base64')
+  for (const ns of namespaces) {
+    gw.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, ns, {
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { '.dockerconfigjson': blob },
+    })
   }
 }
 
@@ -227,38 +278,6 @@ describe('POST /admin/registry/install — pull-secret provisioning (self-hosted
 })
 
 describe('POST /admin/registry/install-recipe — pull-secret provisioning (self-hosted)', () => {
-  const PLATFORM_NAMESPACES = ['mcp-server', 'sandbox-recipes', 'sandbox-ui']
-
-  function recipeEntry(image: string) {
-    return {
-      id: 'r1',
-      name: 'intel-report',
-      version: '1.0.0',
-      entry_type: 'recipe',
-      description: 'Research + PDF report',
-      author: 'acme',
-      server_mode: null,
-      transport: null,
-      recipe_type: 'workflow',
-      mcp_server_meta: null,
-      recipe_meta: {
-        recipeYaml: JSON.stringify({
-          spec: {
-            description: 'Intel',
-            steps: [{ id: 'research', description: 'Research step' }],
-            workloads: [{ id: 'w1', type: 'deployment', image }],
-          },
-        }),
-        stepCount: 1,
-        hasAgent: true,
-      },
-    }
-  }
-
-  function recipeBody() {
-    return { registryEntryName: 'intel-report', registryEntryVersion: '1.0.0' }
-  }
-
   it('provisions the credential in EVERY platform namespace, minting once', async () => {
     vi.mocked(getEntryVersion).mockResolvedValueOnce(
       recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
@@ -336,8 +355,6 @@ describe('POST /admin/registry/install-recipe — pull-secret provisioning (self
 })
 
 describe('POST /admin/registry/upgrade-recipe — pull-secret provisioning (self-hosted)', () => {
-  const PLATFORM_NAMESPACES = ['mcp-server', 'sandbox-recipes', 'sandbox-ui']
-
   /** An upgrade target whose NEW spec runs `image`. */
   function upgradeEntry(image: string) {
     return {
@@ -427,5 +444,107 @@ describe('POST /admin/registry/upgrade-recipe — pull-secret provisioning (self
     expect(res.body.error).toBe('registry_pull_secret_provision_failed')
     // The CRD must not be updated to reference a credential that does not exist.
     expect(updateSpy).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * MANAGED mode: control-api provisions nothing, so the routes verify instead.
+ *
+ * The reference is injected either way — by WRC, from the image host — so a managed
+ * cluster whose operator has not populated a namespace produces a CRD that can only
+ * ImagePullBackOff, with a 201 in the API trail. These pin the narrowing: the install is
+ * refused BEFORE anything is persisted, and only for the namespaces it actually lands in.
+ */
+describe('managed mode — installs verify the operator-owned Secret, and never mint', () => {
+  beforeEach(() => {
+    ;(config as { registryConnectionMode: string }).registryConnectionMode = 'managed'
+  })
+
+  it('installs an McpServer when the operator populated the plugin namespace', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(evenfireEntry() as never)
+    const { app, gw } = makeInstallApp()
+    // MCC provisions mcp-server today, which is why this path must keep working.
+    seedOperatorSecret(gw, [NS])
+    const createSecret = vi.spyOn(gw, 'createSecret')
+
+    await request(app).post('/admin/registry/install').send(installBody()).expect(201)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect(createSecret).not.toHaveBeenCalled()
+    const mcp = (await gw.getResource('mcpservers', 'forecast', NS)) as {
+      spec: { imagePullSecrets?: Array<{ name: string }> }
+    }
+    expect(mcp.spec.imagePullSecrets).toEqual([{ name: EVENFIRE_REGISTRY_PULL_SECRET_NAME }])
+  })
+
+  it('refuses the McpServer install, persisting nothing, when the Secret is absent', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(evenfireEntry() as never)
+    const { app, gw } = makeInstallApp()
+
+    const res = await request(app).post('/admin/registry/install').send(installBody())
+
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'operator_secret_missing',
+    })
+    // The whole point: fail before persisting, not at pull time.
+    await expect(gw.getResource('mcpservers', 'forecast', NS)).rejects.toBeTruthy()
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('installs a recipe when the operator populated every platform namespace', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
+    )
+    const { app, gw } = makeInstallApp()
+    seedOperatorSecret(gw, PLATFORM_NAMESPACES)
+    const createSecret = vi.spyOn(gw, 'createSecret')
+
+    await request(app).post('/admin/registry/install-recipe').send(recipeBody()).expect(201)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    expect(createSecret).not.toHaveBeenCalled()
+  })
+
+  it('refuses the recipe install when only the mcp-server namespace is populated', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
+    )
+    const { app, gw } = makeInstallApp()
+    // The real managed shape: transport workloads pull, recipe workloads do not.
+    seedOperatorSecret(gw, [NS])
+
+    const res = await request(app).post('/admin/registry/install-recipe').send(recipeBody())
+
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'operator_secret_missing',
+    })
+    expect(res.body.detail).toContain('sandbox-recipes')
+    const persisted = (await gw.listResource('workflowrecipes', '*')) as Array<{
+      metadata: { name: string }
+    }>
+    expect(persisted.map(r => r.metadata.name)).toEqual([])
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+  })
+
+  it('leaves an install with a NON-platform image untouched', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      evenfireEntry({
+        mcp_server_meta: { imageRef: 'ghcr.io/acme/forecast:1.2.3', port: 3000 },
+      }) as never
+    )
+    const { app, gw } = makeInstallApp()
+    // Nothing seeded anywhere: a public image needs no pull credential, so the check must
+    // not run at all. Narrowing that fails installs it has no claim on is not a narrowing.
+    const getSecret = vi.spyOn(gw, 'getSecret')
+
+    await request(app).post('/admin/registry/install').send(installBody()).expect(201)
+
+    expect(getSecret.mock.calls.some(([name]) => name === EVENFIRE_REGISTRY_PULL_SECRET_NAME)).toBe(
+      false
+    )
   })
 })

--- a/control-api/test/routes.registryInstall.pullSecret.test.ts
+++ b/control-api/test/routes.registryInstall.pullSecret.test.ts
@@ -272,6 +272,27 @@ describe('POST /admin/registry/install-recipe — pull-secret provisioning (self
     }
   })
 
+  it('provisions BEFORE persisting the WorkflowRecipe CRD', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      recipeEntry(`${REGISTRY_HOST}/acme/plugin:1.0`) as never
+    )
+    const { app, gw } = makeInstallApp()
+    // Spy AFTER the fixture context is seeded, so only route writes are recorded.
+    const createResource = vi.spyOn(gw, 'createResource')
+
+    await request(app).post('/admin/registry/install-recipe').send(recipeBody()).expect(201)
+
+    // Ordering is the point: a CRD persisted first would reference a Secret that does not
+    // exist yet, and a provisioning failure after the write leaves it stranded.
+    const recipeWrite = createResource.mock.calls.findIndex(
+      ([plural]) => plural === 'workflowrecipes'
+    )
+    expect(recipeWrite).toBeGreaterThanOrEqual(0)
+    expect(vi.mocked(mintOrgPullCredential).mock.invocationCallOrder[0]).toBeLessThan(
+      createResource.mock.invocationCallOrder[recipeWrite]
+    )
+  })
+
   it('does not provision for a recipe with no platform-registry image', async () => {
     vi.mocked(getEntryVersion).mockResolvedValueOnce(
       recipeEntry('ghcr.io/acme/plugin:1.0') as never
@@ -297,6 +318,12 @@ describe('POST /admin/registry/install-recipe — pull-secret provisioning (self
     expect(res.status).toBeGreaterThanOrEqual(500)
     expect(res.body.error).toBe('registry_pull_secret_provision_failed')
     // No WorkflowRecipe may be persisted referencing a credential that does not exist.
-    await expect(gw.getResource('workflowrecipes', 'intel-report', NS)).rejects.toBeTruthy()
+    // Assert on the persisted SET, not on a guessed name: the route derives the CRD name
+    // (`recipe-<entry>-v<version>-<hash>`), so a by-name lookup 404s whether the route
+    // wrote something or nothing — an assertion that cannot fail.
+    const persisted = (await gw.listResource('workflowrecipes', '*')) as Array<{
+      metadata: { name: string }
+    }>
+    expect(persisted.map(r => r.metadata.name)).toEqual([])
   })
 })

--- a/control-api/test/routes.registryInstall.pullSecret.test.ts
+++ b/control-api/test/routes.registryInstall.pullSecret.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Route-level coverage for image-pull-secret self-provisioning on the install path.
+ *
+ * The main `routes.registryInstall` suite runs in the default `managed` connection mode,
+ * where `ensureRegistryPullSecret` short-circuits to `'skipped'` before doing anything —
+ * so none of it can catch a regression in the wiring. These tests force `self-hosted`,
+ * which is the only mode where the hook actually runs, and pin the properties the wiring
+ * is supposed to guarantee:
+ *   - it provisions even when the plugin needs NO credentials (outside `credRequired`)
+ *   - it provisions BEFORE the McpServer CRD that references the Secret
+ *   - a provisioning failure fails the install loudly and persists NOTHING
+ *   - it does not run at all for images that are not evenfire-hosted
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { config } from '../src/config.js'
+import { createAdminRegistryRouter } from '../src/routes/admin/registry.js'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '../src/routes/admin/registryImagePullSecret.js'
+import {
+  getCredentialSchema,
+  getDigest,
+  getEntryVersion,
+  mintOrgPullCredential,
+  reportInstall,
+  resolvePublishScope,
+} from '../src/services/registryClient.js'
+import { isRegistryAuthActive } from '../src/services/registryConnectionDb.js'
+import { MockGateway } from './mockGateway.js'
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }]),
+}))
+vi.mock('../src/services/registryClient.js', () => ({
+  searchEntries: vi.fn(),
+  getEntry: vi.fn(),
+  getEntryVersion: vi.fn(),
+  getCredentialSchema: vi.fn(),
+  getCategories: vi.fn(),
+  reportInstall: vi.fn(),
+  downloadBundle: vi.fn(),
+  getDigest: vi.fn(),
+  uploadArtifacts: vi.fn(),
+  updateVersionMetadata: vi.fn(),
+  deleteVersion: vi.fn(),
+  publishEntry: vi.fn(),
+  resolvePublishScope: vi.fn(),
+  applyPublishScope: vi.fn((name?: string) => name),
+  mintOrgPullCredential: vi.fn(),
+  RegistryProxyError: class RegistryProxyError extends Error {
+    constructor(
+      readonly status: number,
+      readonly body: unknown
+    ) {
+      super(`Registry ${status}`)
+      this.name = 'RegistryProxyError'
+    }
+  },
+}))
+vi.mock('../src/services/registryConnectionDb.js', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/services/registryConnectionDb.js')>()),
+  isRegistryAuthActive: vi.fn(),
+}))
+
+const REGISTRY_HOST = 'registry.evenfire.ai'
+const NS = 'mcp-server'
+
+function makeApp(gateway: MockGateway) {
+  const app = express()
+  app.use(express.json())
+  app.use(createAdminRegistryRouter(gateway as unknown as import('../src/k8s.js').K8sGateway))
+  app.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' })
+    }
+  )
+  return app
+}
+
+function makeInstallApp() {
+  const gw = new MockGateway(NS)
+  gw.createResource('contexts', {
+    metadata: { name: 'default-context' },
+    spec: { contextId: 'default-context', mcpServers: [] },
+  })
+  return { app: makeApp(gw), gw }
+}
+
+/** A local-mode entry whose image lives on the configured evenfire registry. */
+function evenfireEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '1',
+    name: 'forecast',
+    version: '1.0.0',
+    entry_type: 'mcp-server',
+    description: 'Forecast MCP',
+    author: 'acme',
+    server_mode: 'local' as const,
+    transport: 'streamableHttp',
+    mcp_server_meta: { imageRef: `${REGISTRY_HOST}/acme/forecast:1.2.3`, port: 3000 },
+    ...overrides,
+  }
+}
+
+function installBody() {
+  return {
+    serverName: 'forecast',
+    contextRef: 'default-context',
+    registryEntryName: 'forecast',
+    registryEntryVersion: '1.0.0',
+  }
+}
+
+let savedMode: typeof config.registryConnectionMode
+let savedUrl: string
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  savedMode = config.registryConnectionMode
+  savedUrl = config.registryUrl
+  ;(config as { registryConnectionMode: string }).registryConnectionMode = 'self-hosted'
+  ;(config as { registryUrl: string }).registryUrl = `https://${REGISTRY_HOST}`
+
+  vi.mocked(getDigest).mockResolvedValue({ digest: null })
+  // No credentials required — proves provisioning is NOT gated on `credRequired`.
+  vi.mocked(getCredentialSchema).mockResolvedValue({
+    required: false,
+    authType: 'none',
+    keys: [],
+  } as never)
+  vi.mocked(reportInstall).mockResolvedValue({ acknowledged: true, stored: true } as never)
+  vi.mocked(isRegistryAuthActive).mockResolvedValue(true)
+  vi.mocked(resolvePublishScope).mockResolvedValue({
+    curator: false,
+    orgName: 'acme',
+    scope: '@acme',
+  } as never)
+  vi.mocked(mintOrgPullCredential).mockResolvedValue({ key: 'efrk_route_key' } as never)
+})
+
+afterEach(() => {
+  ;(config as { registryConnectionMode: string }).registryConnectionMode = savedMode
+  ;(config as { registryUrl: string }).registryUrl = savedUrl
+})
+
+describe('POST /admin/registry/install — pull-secret provisioning (self-hosted)', () => {
+  it('provisions the pull Secret for a credential-less private plugin', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(evenfireEntry() as never)
+    const { app, gw } = makeInstallApp()
+
+    await request(app).post('/admin/registry/install').send(installBody()).expect(201)
+
+    // The Secret must exist in the plugin namespace, keyed on the image host.
+    const secret = (await gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)) as {
+      type?: string
+      data?: Record<string, string>
+    }
+    expect(secret.type).toBe('kubernetes.io/dockerconfigjson')
+    const blob = JSON.parse(
+      Buffer.from(secret.data?.['.dockerconfigjson'] as string, 'base64').toString('utf8')
+    ) as { auths: Record<string, unknown> }
+    expect(Object.keys(blob.auths)).toEqual([REGISTRY_HOST])
+
+    // ...and the CRD must reference it.
+    const mcp = (await gw.getResource('mcpservers', 'forecast', NS)) as {
+      spec: { imagePullSecrets?: Array<{ name: string }> }
+    }
+    expect(mcp.spec.imagePullSecrets).toEqual([{ name: EVENFIRE_REGISTRY_PULL_SECRET_NAME }])
+  })
+
+  it('fails the install loudly and persists NO McpServer when minting fails', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(evenfireEntry() as never)
+    vi.mocked(mintOrgPullCredential).mockRejectedValueOnce(new Error('registry unavailable'))
+    const { app, gw } = makeInstallApp()
+
+    const res = await request(app).post('/admin/registry/install').send(installBody())
+    expect(res.status).toBeGreaterThanOrEqual(500)
+    expect(res.body.error).toBe('registry_pull_secret_provision_failed')
+
+    // Nothing may be persisted — an McpServer referencing an absent Secret is exactly the
+    // silent ImagePullBackOff this mechanism exists to prevent.
+    await expect(gw.getResource('mcpservers', 'forecast', NS)).rejects.toBeTruthy()
+  })
+
+  it('surfaces an actionable error when the deployment has no org bound yet', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(evenfireEntry() as never)
+    vi.mocked(resolvePublishScope).mockResolvedValue({
+      curator: false,
+      orgName: null,
+      scope: null,
+    } as never)
+    const { app, gw } = makeInstallApp()
+
+    const res = await request(app).post('/admin/registry/install').send(installBody())
+    expect(res.status).toBe(409)
+    expect(res.body).toMatchObject({
+      error: 'registry_pull_secret_provision_failed',
+      reason: 'org_unresolved',
+    })
+    await expect(gw.getResource('mcpservers', 'forecast', NS)).rejects.toBeTruthy()
+  })
+
+  it('does not provision for an image that is not evenfire-hosted', async () => {
+    vi.mocked(getEntryVersion).mockResolvedValueOnce(
+      evenfireEntry({
+        mcp_server_meta: { imageRef: 'ghcr.io/acme/forecast:1.2.3', port: 3000 },
+      }) as never
+    )
+    const { app, gw } = makeInstallApp()
+
+    await request(app).post('/admin/registry/install').send(installBody()).expect(201)
+
+    expect(mintOrgPullCredential).not.toHaveBeenCalled()
+    await expect(gw.getSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, NS)).rejects.toBeTruthy()
+    const mcp = (await gw.getResource('mcpservers', 'forecast', NS)) as {
+      spec: { imagePullSecrets?: unknown }
+    }
+    expect(mcp.spec.imagePullSecrets).toBeUndefined()
+  })
+})

--- a/control-api/test/routes.registryInstall.test.ts
+++ b/control-api/test/routes.registryInstall.test.ts
@@ -68,6 +68,27 @@ function makeApp(gateway?: MockGateway) {
   return app
 }
 
+/**
+ * Seed the `evenfire-registry-pull` Secret an operator provisions on a managed cluster.
+ *
+ * This file runs in the default `managed` connection mode, where control-api writes that
+ * Secret for nobody — but a platform-registry image still makes the install VERIFY that
+ * the operator's copy is present and usable, and refuse before persisting when it is not
+ * (registryPullSecretService). Without this seed those installs 409, and the suites below
+ * stop being about what they are about: which images get an imagePullSecrets reference.
+ */
+function seedOperatorPullSecret(gw: MockGateway, host: string, namespace = 'mcp-server'): void {
+  const auth = Buffer.from('_:operator-key').toString('base64')
+  gw.seedSecret(EVENFIRE_REGISTRY_PULL_SECRET_NAME, namespace, {
+    type: 'kubernetes.io/dockerconfigjson',
+    data: {
+      '.dockerconfigjson': Buffer.from(
+        JSON.stringify({ auths: { [host]: { username: '_', password: 'operator-key', auth } } })
+      ).toString('base64'),
+    },
+  })
+}
+
 function internalSiblingRecipeYaml(dns = 'db.sandbox-recipes.svc.cluster.local'): string {
   return JSON.stringify({
     spec: {
@@ -1436,6 +1457,7 @@ describe('POST /admin/registry/install — evenfire imagePullSecrets attach', ()
       metadata: { name: 'default-context' },
       spec: { contextId: 'default-context', mcpServers: [] },
     })
+    seedOperatorPullSecret(gw, 'example.com')
     return { app: makeApp(gw), gw }
   }
 
@@ -1560,6 +1582,7 @@ describe('POST /admin/registry/install — evenfire imageRef identity (2.5)', ()
       metadata: { name: 'default-context' },
       spec: { contextId: 'default-context', mcpServers: [] },
     })
+    seedOperatorPullSecret(gw, 'example.com')
     return { app: makeApp(gw), gw }
   }
 
@@ -3199,6 +3222,7 @@ describe('POST /admin/registry/upgrade — evenfire imagePullSecrets recompute',
         ...existingSpecPatch,
       },
     })
+    seedOperatorPullSecret(gw, 'example.com')
     return { app: makeApp(gw), gw }
   }
 
@@ -3319,6 +3343,7 @@ describe('POST /admin/registry/upgrade — evenfire imageRef identity (2.5)', ()
         },
       },
     })
+    seedOperatorPullSecret(gw, 'example.com')
     return { app: makeApp(gw), gw }
   }
 

--- a/control-api/test/routes.secrets.platformPullSecretName.test.ts
+++ b/control-api/test/routes.secrets.platformPullSecretName.test.ts
@@ -1,0 +1,96 @@
+/**
+ * The reserved platform Secret name, on the mcp-secret / recipe-secret surfaces.
+ *
+ * `evenfire-registry-pull` is control-api's own image-pull credential, self-provisioned
+ * into every platform workload namespace. These routes write into that SAME set of
+ * namespaces (`RECIPE_SECRET_NAMESPACES` is set-identical to `platformWorkloadNamespaces()`),
+ * so the name is reachable from here — and squatting it is unrepairable: the provisioner
+ * refuses to overwrite a Secret it does not own, so a foreign `Opaque` object under the
+ * reserved name makes every private-image install into that namespace 409 permanently.
+ *
+ * The recipe routes in `routes/admin/recipes.ts` already reserve the name; these three did
+ * not. The DELETE is the sharp one — it deletes by name with no ownership guard at all.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
+import { createAdminSecretsRouter } from '../src/routes/admin/secrets.js'
+
+function createGateway() {
+  return {
+    listSecrets: vi.fn(async () => []),
+    listResource: vi.fn(async () => [] as unknown[]),
+    getSecret: vi.fn(async () => null),
+    createSecret: vi.fn(async (body: unknown) => body),
+    updateSecret: vi.fn(async (body: unknown) => body),
+    deleteSecret: vi.fn(async (_name: string, _namespace?: string) => ({ deleted: true })),
+  }
+}
+
+function makeApp(gateway: ReturnType<typeof createGateway>) {
+  const app = express()
+  app.use(express.json())
+  app.use(createAdminSecretsRouter(gateway as never))
+  app.use(
+    (err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+      res.status(500).json({ error: err instanceof Error ? err.message : 'unknown' })
+    }
+  )
+  return app
+}
+
+describe('platform-managed Secret name is reserved', () => {
+  it('POST /admin/recipe-secrets refuses the reserved name and writes nothing', async () => {
+    const gateway = createGateway()
+
+    const res = await request(makeApp(gateway))
+      .post('/admin/recipe-secrets')
+      .send({
+        name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+        data: { token: 'squat' },
+        ownership: { kind: 'shared' },
+        targetNamespace: 'mcp-server',
+      })
+      .expect(400)
+
+    expect(res.body.error).toMatch(/platform-managed/)
+    expect(gateway.createSecret).not.toHaveBeenCalled()
+  })
+
+  it('POST /admin/mcp-secrets refuses the reserved name and writes nothing', async () => {
+    const gateway = createGateway()
+
+    const res = await request(makeApp(gateway))
+      .post('/admin/mcp-secrets')
+      .send({ name: EVENFIRE_REGISTRY_PULL_SECRET_NAME, data: { token: 'squat' } })
+      .expect(400)
+
+    expect(res.body.error).toMatch(/platform-managed/)
+    expect(gateway.createSecret).not.toHaveBeenCalled()
+  })
+
+  it('DELETE /admin/mcp-secrets/:name refuses the reserved name and deletes nothing', async () => {
+    const gateway = createGateway()
+
+    const res = await request(makeApp(gateway))
+      .delete(`/admin/mcp-secrets/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`)
+      .expect(400)
+
+    expect(res.body.error).toMatch(/platform-managed/)
+    expect(gateway.deleteSecret).not.toHaveBeenCalled()
+  })
+
+  it('still deletes an ordinary connector Secret whose name merely resembles it', async () => {
+    const gateway = createGateway()
+
+    await request(makeApp(gateway))
+      .delete(`/admin/mcp-secrets/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}-backup`)
+      .expect(200)
+
+    expect(gateway.deleteSecret).toHaveBeenCalledWith(
+      `${EVENFIRE_REGISTRY_PULL_SECRET_NAME}-backup`,
+      'mcp-server'
+    )
+  })
+})

--- a/control-api/test/routes.secrets.platformPullSecretName.test.ts
+++ b/control-api/test/routes.secrets.platformPullSecretName.test.ts
@@ -81,6 +81,54 @@ describe('platform-managed Secret name is reserved', () => {
     expect(gateway.deleteSecret).not.toHaveBeenCalled()
   })
 
+  // The gap this file's own header missed. POST and DELETE were reserved; the MERGE path
+  // was not, and it is the one that can quietly replace `.dockerconfigjson` with anything —
+  // every private image pull in `mcp-server`, broken through a route whose stated job is to
+  // refuse this name. The recipe-secret label check inside the handler does NOT cover it:
+  // the platform Secret carries `clerum.io/managed-by`, not the recipe label, so it passes.
+  it('PUT /admin/mcp-secrets/:name refuses the reserved name and merges nothing', async () => {
+    const gateway = createGateway()
+    // Shaped like the real platform Secret: present, and NOT a recipe secret — the exact
+    // state in which every other guard in the handler waves it through.
+    gateway.getSecret = vi.fn(async () => ({
+      metadata: {
+        name: EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+        namespace: 'mcp-server',
+        labels: { 'clerum.io/managed-by': 'control-api' },
+      },
+      type: 'kubernetes.io/dockerconfigjson',
+      data: { '.dockerconfigjson': 'e30=' },
+    })) as never
+    const mergeSecret = vi.fn(async (body: unknown) => body)
+    ;(gateway as unknown as { mergeSecret: unknown }).mergeSecret = mergeSecret
+
+    const res = await request(makeApp(gateway))
+      .put(`/admin/mcp-secrets/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`)
+      .send({ data: { '.dockerconfigjson': 'bm90LWEtY3JlZGVudGlhbA==' } })
+      .expect(400)
+
+    expect(res.body.error).toMatch(/platform-managed/)
+    expect(mergeSecret).not.toHaveBeenCalled()
+  })
+
+  it('still merges into an ordinary connector Secret whose name merely resembles it', async () => {
+    const gateway = createGateway()
+    gateway.getSecret = vi.fn(async () => ({
+      metadata: { name: `${EVENFIRE_REGISTRY_PULL_SECRET_NAME}-backup`, namespace: 'mcp-server' },
+      type: 'Opaque',
+      data: {},
+    })) as never
+    const mergeSecret = vi.fn(async (body: unknown) => body)
+    ;(gateway as unknown as { mergeSecret: unknown }).mergeSecret = mergeSecret
+
+    await request(makeApp(gateway))
+      .put(`/admin/mcp-secrets/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}-backup`)
+      .send({ data: { token: 'fine' } })
+      .expect(200)
+
+    expect(mergeSecret).toHaveBeenCalled()
+  })
+
   it('still deletes an ordinary connector Secret whose name merely resembles it', async () => {
     const gateway = createGateway()
 

--- a/control-api/test/services.memberRegistrationEnrollment.test.ts
+++ b/control-api/test/services.memberRegistrationEnrollment.test.ts
@@ -365,7 +365,7 @@ describe('memberRegistrationEnrollment', () => {
     fetchMock.mockClear()
     // Assert at the STORE boundary: with a stored credential lingering from the
     // hosted half, a dropped mode gate would still show fetch=0 while running
-    // enrollment DB reads on every remote (incl. managed/MCC) boot.
+    // enrollment DB reads on every remote (incl. managed) boot.
     store.getActiveMemberRegistrationCredential.mockClear()
     cfg.memberRegistrationMode = 'remote'
     await runBootEnrollment()

--- a/control-api/test/services.secretService.test.ts
+++ b/control-api/test/services.secretService.test.ts
@@ -161,6 +161,75 @@ describe('SecretService — invalid Secret keys never reach the apiserver', () =
   })
 })
 
+/**
+ * The preconditions are only worth anything if they reach the apiserver in the shape it
+ * enforces. Every other test of this feature asserts that the CALLER passes a precondition;
+ * these assert that passing one changes the actual request. Get the translation wrong —
+ * resourceVersion on the wrong field, delete preconditions omitted — and the whole
+ * ownership-bound write silently degrades to last-writer-wins with every test still green.
+ */
+describe('SecretService — ownership-bound mutations', () => {
+  let coreApi: CoreApiMock
+  let svc: SecretService
+
+  beforeEach(() => {
+    coreApi = createCoreApiMock()
+    svc = new SecretService(coreApi as unknown as k8s.CoreV1Api, 'test-ns')
+  })
+
+  it('sends the CALLER’s resourceVersion on a replace, without re-reading', async () => {
+    coreApi.readNamespacedSecret.mockResolvedValue({
+      metadata: { resourceVersion: '999' },
+      type: 'Opaque',
+      data: {},
+    })
+
+    await svc.updateSecret(
+      { name: 's', namespace: 'ns', type: 'Opaque', data: { k: 'dg==' } },
+      { resourceVersion: '42', uid: 'uid-1' }
+    )
+
+    // The re-read is the bug, not an optimization: it would replace the stale version we
+    // are trying to detect with the current one, and the write would win regardless.
+    expect(coreApi.readNamespacedSecret).not.toHaveBeenCalled()
+    const body = coreApi.replaceNamespacedSecret.mock.calls[0][0].body
+    expect(body.metadata.resourceVersion).toBe('42')
+    expect(body.metadata.uid).toBe('uid-1')
+  })
+
+  it('keeps last-writer-wins when no precondition is given', async () => {
+    coreApi.readNamespacedSecret.mockResolvedValue({
+      metadata: { resourceVersion: '999' },
+      type: 'Opaque',
+      data: {},
+    })
+
+    await svc.updateSecret({ name: 's', namespace: 'ns', data: { k: 'dg==' } })
+
+    // Unchanged for the admin /secrets routes and token rotation, which are single-owner
+    // writers and want the current version.
+    expect(coreApi.readNamespacedSecret).toHaveBeenCalled()
+    const body = coreApi.replaceNamespacedSecret.mock.calls[0][0].body
+    expect(body.metadata.resourceVersion).toBe('999')
+    expect(body.metadata.uid).toBeUndefined()
+  })
+
+  it('sends delete preconditions so the apiserver refuses to delete a replacement', async () => {
+    await svc.deleteSecret('s', 'ns', { uid: 'uid-1', resourceVersion: '42' })
+
+    const req = coreApi.deleteNamespacedSecret.mock.calls[0][0]
+    expect(req.body.preconditions).toEqual({ uid: 'uid-1', resourceVersion: '42' })
+  })
+
+  it('sends no delete body at all when no precondition is given', async () => {
+    await svc.deleteSecret('s', 'ns')
+
+    // An empty `preconditions: {}` is not the same as none — keep the historical request
+    // shape for callers that never opted in.
+    expect(coreApi.deleteNamespacedSecret.mock.calls[0][0].body).toBeUndefined()
+  })
+})
+
 describe('invalidSecretDataKeyReason — the shared rule', () => {
   it('accepts every legitimate key', () => {
     for (const key of VALID_KEYS) {

--- a/deploy/base/control-plane/workflow-recipes.yaml
+++ b/deploy/base/control-plane/workflow-recipes.yaml
@@ -84,6 +84,33 @@ spec:
             configMapKeyRef:
               name: control-api-config
               key: CLERUM_WORKFLOW_UI_EGRESS_INTERNAL_MAX_ITEMS
+        # Registry URL — read from the ONE key that defines it
+        # (`control-api-config.CLERUM_REGISTRY_URL`, which control-api itself consumes via
+        # envFrom) rather than a second copy here. Dual-purpose in WRC: API base URL for
+        # the catalog client, and image host for the platform pull-credential predicate.
+        #
+        # The pairing is load-bearing, not tidiness. WRC decides whether to attach the
+        # platform pull credential with `isPlatformRegistryImage(workload.image,
+        # registryUrl)`, comparing the IMAGE host against this URL's host; control-api
+        # provisions that credential from its own copy. When the two disagree — or when
+        # this is left unset, which the predicate treats as "no platform registry" —
+        # control-api still mints and writes the Secret and returns 201, but WRC never
+        # emits `imagePullSecrets`, so recipe pods get `ImagePullBackOff`
+        # (`unauthorized: authentication required`) with an empty pod-level
+        # `imagePullSecrets` while McpServers — whose reference control-api writes itself
+        # — keep working. That asymmetry is risk R3 in
+        # docs/architecture/registry-pull-secret-recipe-workloads.md.
+        #
+        # `optional: true` because the base ConfigMap ships no CLERUM_REGISTRY_URL — only
+        # overlays set it. A hard reference would put a plain `deploy/base` install into
+        # CreateContainerConfigError. Unset stays a valid configuration (no platform
+        # registry); WRC logs a startup WARN so the disabled state is visible.
+        - name: CLERUM_REGISTRY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: control-api-config
+              key: CLERUM_REGISTRY_URL
+              optional: true
         # Step output stored in WorkflowRecipe status is only a bounded preview.
         # Keep max_steps * preview_chars under the Kubernetes object budget
         # (etcd default ~1.5MiB; GKE API server request body commonly ~3MiB).

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -66,6 +66,13 @@ data:
   # allowlist applies to any explicitly self-hosted deployment with a registry
   # URL configured, regardless of whether auth is active, and control-api
   # refuses to start if the configured URL is not allowlisted.
+  #
+  # This key is the SINGLE definition of the registry URL for the whole
+  # control plane: workflow-recipes projects it via configMapKeyRef
+  # (deploy/overlays/minikube/patches/registry-env.yaml) instead of keeping a
+  # second copy. Both services must agree, because WRC decides which images
+  # are ours — and therefore get the platform pull credential — by comparing
+  # the image host against this URL's host. Change it here and WRC follows.
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
   # The Publisher UI (Sidebar entry + /publisher route) defaults ON for every

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -68,11 +68,12 @@ data:
   # refuses to start if the configured URL is not allowlisted.
   #
   # This key is the SINGLE definition of the registry URL for the whole
-  # control plane: workflow-recipes projects it via configMapKeyRef
-  # (deploy/overlays/minikube/patches/registry-env.yaml) instead of keeping a
-  # second copy. Both services must agree, because WRC decides which images
-  # are ours — and therefore get the platform pull credential — by comparing
-  # the image host against this URL's host. Change it here and WRC follows.
+  # control plane: workflow-recipes projects it via configMapKeyRef in the BASE
+  # Deployment (deploy/base/control-plane/workflow-recipes.yaml) instead of
+  # keeping a second copy, so this overlay only supplies the value. Both
+  # services must agree, because WRC decides which images are ours — and
+  # therefore get the platform pull credential — by comparing the image host
+  # against this URL's host. Change it here and WRC follows.
   CLERUM_REGISTRY_URL: 'https://registry.evenfire.ai'
   REGISTRY_CONNECTION_MODE: 'self-hosted'
   # The Publisher UI (Sidebar entry + /publisher route) defaults ON for every

--- a/deploy/overlays/minikube/kustomization.yaml
+++ b/deploy/overlays/minikube/kustomization.yaml
@@ -82,8 +82,9 @@ patchesStrategicMerge:
   - patches/image-pull-policy.yaml
   - patches/service-tokens.yaml
   - patches/nginx-workflow-approval-gateway.yaml
-  # Registry env vars for workflow-recipes (in-cluster URL, auth off).
-  # control-api gets registry env via configmaps/control-api-config.yaml.
+  # Registry auth off for workflow-recipes. The registry URL is NOT patched here:
+  # the base Deployment projects it from configmaps/control-api-config.yaml, the
+  # one key that also feeds control-api.
   - patches/registry-env.yaml
   # Multi-document YAML must use patchesStrategicMerge — kubectl's embedded
   # kustomize (e.g. v4.5.x) rejects the same files under `patches:` with:

--- a/deploy/overlays/minikube/patches/registry-env.yaml
+++ b/deploy/overlays/minikube/patches/registry-env.yaml
@@ -1,22 +1,13 @@
 ---
-# Minikube: workflow-recipes reads the SAME registry URL as control-api, sourced from the
-# one key that defines it (`control-api-config.CLERUM_REGISTRY_URL`) rather than a second
-# hardcoded copy here.
+# Minikube: registry auth off for workflow-recipes.
 #
-# This pairing is load-bearing, not tidiness. WRC decides whether to attach the platform
-# pull credential with `isPlatformRegistryImage(workload.image, registryUrl)`, which
-# compares the IMAGE host against this URL's host. control-api provisions that credential
-# using its own copy. When the two disagree, control-api mints and writes the Secret but
-# WRC never references it, so recipe pods get `ImagePullBackOff`
-# (`unauthorized: authentication required`) with an empty pod-level `imagePullSecrets`
-# while McpServers — whose reference control-api writes itself — keep working. That is
-# risk R3 in docs/architecture/registry-pull-secret-recipe-workloads.md, and it is exactly
-# what this file used to cause: it pinned WRC to the in-cluster registry while
-# control-api pointed at https://registry.evenfire.ai.
-#
-# Sourcing both from one key makes the divergence unrepresentable. Point
-# control-api-config at a different registry (e.g. your own in-cluster deploy) and WRC
-# follows automatically.
+# CLERUM_REGISTRY_URL is deliberately NOT here. The base Deployment projects it from the
+# one key that defines it (`control-api-config.CLERUM_REGISTRY_URL`), and this overlay
+# supplies that key's value in configmaps/control-api-config.yaml — so WRC and control-api
+# read the same URL by construction. Re-declaring the env var here would only add a second
+# place to keep in sync; point the ConfigMap at a different registry (e.g. your own
+# in-cluster deploy) and WRC follows automatically. See the comment on that env entry in
+# deploy/base/control-plane/workflow-recipes.yaml for why divergence is risk R3.
 #
 # Auth stays disabled here: WRC's catalog client has no machine credentials wired, and
 # with auth off it reads anonymously instead of throwing.
@@ -31,10 +22,5 @@ spec:
       containers:
         - name: workflow-recipes
           env:
-            - name: CLERUM_REGISTRY_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: control-api-config
-                  key: CLERUM_REGISTRY_URL
             - name: CLERUM_REGISTRY_AUTH_ENABLED
               value: "false"

--- a/deploy/overlays/minikube/patches/registry-env.yaml
+++ b/deploy/overlays/minikube/patches/registry-env.yaml
@@ -1,6 +1,25 @@
 ---
-# Minikube: workflow-recipes points at the local evenfire-registry deploy.
-# Auth is disabled in minikube — no registry-client-credentials Secret needed.
+# Minikube: workflow-recipes reads the SAME registry URL as control-api, sourced from the
+# one key that defines it (`control-api-config.CLERUM_REGISTRY_URL`) rather than a second
+# hardcoded copy here.
+#
+# This pairing is load-bearing, not tidiness. WRC decides whether to attach the platform
+# pull credential with `isPlatformRegistryImage(workload.image, registryUrl)`, which
+# compares the IMAGE host against this URL's host. control-api provisions that credential
+# using its own copy. When the two disagree, control-api mints and writes the Secret but
+# WRC never references it, so recipe pods get `ImagePullBackOff`
+# (`unauthorized: authentication required`) with an empty pod-level `imagePullSecrets`
+# while McpServers — whose reference control-api writes itself — keep working. That is
+# risk R3 in docs/architecture/registry-pull-secret-recipe-workloads.md, and it is exactly
+# what this file used to cause: it pinned WRC to the in-cluster registry while
+# control-api pointed at https://registry.evenfire.ai.
+#
+# Sourcing both from one key makes the divergence unrepresentable. Point
+# control-api-config at a different registry (e.g. your own in-cluster deploy) and WRC
+# follows automatically.
+#
+# Auth stays disabled here: WRC's catalog client has no machine credentials wired, and
+# with auth off it reads anonymously instead of throwing.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,6 +32,9 @@ spec:
         - name: workflow-recipes
           env:
             - name: CLERUM_REGISTRY_URL
-              value: "http://registry-api.registry.svc.cluster.local:8085"
+              valueFrom:
+                configMapKeyRef:
+                  name: control-api-config
+                  key: CLERUM_REGISTRY_URL
             - name: CLERUM_REGISTRY_AUTH_ENABLED
               value: "false"

--- a/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
+++ b/docs/agents/CLERUM_WORKFLOW_RECIPE_GUIDE.md
@@ -1440,6 +1440,48 @@ Enforced by the WRC reconciler (not CEL, so the rejection arrives as a status co
 
 Plus field-level patterns: `metadata.name` DNS-1123 ≤ 63, `workloadRef` DNS-1123 ≤ 63, `port` ∈ [1, 65535], `icon` data URI regex, `defaultPath` regex.
 
+### 11.5 Platform-managed Secret names (S*)
+
+| Code | Rule |
+|---|---|
+| S1 | No `secretRef` may name a platform-managed Secret. Today that is `evenfire-registry-pull`, the image-pull credential for the evenfire registry. It applies to every reference kind: `workloads[].imagePullSecrets`, `workloads[].envSecret`, snippet secrets, and `oauthClients[]` refs. Rejected with `422`, rule `workflowWorkloadSecretRefReserved` (or the `workflowSnippetSecret…` / `workflowOauthClientSecret…` variant for those kinds). |
+
+**Why you never declare it.** Images on the evenfire registry are private to the
+publishing org, so every install is an authenticated pull. The installing
+deployment mints its own pull credential from its own registry identity and
+writes it as `evenfire-registry-pull` into `mcp-server`, `sandbox-recipes` and
+`sandbox-ui`. The reference is then attached for you: control-api writes it onto
+the `McpServer` for connectors, and workflow-recipes injects it into the rendered
+pod template for recipe workloads. Injection is keyed on the image host matching
+the deployment's `CLERUM_REGISTRY_URL`, so it covers evenfire-registry images
+only.
+
+The reference has to be injected rather than declared. A recipe-declared Secret
+name is classified by the ownership filter (issue #637) and stripped, because the
+recipe does not own that Secret. Declaring the name would therefore fail even if
+it were allowed, which is why it is rejected outright instead.
+
+Consequences for a recipe author:
+
+- Publishing a private image on the evenfire registry needs **no** credential
+  field in the recipe. The entry stays portable.
+- `imagePullSecrets` remains available for a **third-party** private registry
+  (GHCR, Docker Hub). Name your own Secret there as usual.
+- The Secret is deliberately not labelled `clerum.io/shared` or
+  `clerum.io/owner-recipe`, so no recipe's `envSecret` can read it. It is a
+  pull-only credential and is not reachable as an environment variable.
+
+If a pod on an evenfire-registry image lands in `ImagePullBackOff`, check whether
+the reference was attached at all:
+
+```bash
+kubectl get pod <pod> -n sandbox-recipes -o jsonpath='{.spec.imagePullSecrets}'
+```
+
+Empty on a recipe workload means injection did not fire, which in practice means
+control-api and workflow-recipes disagree on `CLERUM_REGISTRY_URL`. Both read the
+same `control-api-config` key by default.
+
 ---
 
 ## 12. Common pitfalls
@@ -1693,7 +1735,7 @@ Failure modes that surface ONLY at the pod layer (not in WRC status):
 
 | Pod-level failure | Likely cause | Where it surfaces |
 |---|---|---|
-| `ImagePullBackOff` / `ErrImagePull` | Image not publicly pullable; missing `imagePullSecrets`; image truly doesn't exist. | Pod events, container `state.waiting.message`. |
+| `ImagePullBackOff` / `ErrImagePull` | Image not publicly pullable; missing `imagePullSecrets`; image truly doesn't exist. For an image on the **evenfire registry**, the platform credential was not attached — check `kubectl get pod <p> -o jsonpath='{.spec.imagePullSecrets}'` (§11.5). | Pod events, container `state.waiting.message`. |
 | `CreateContainerConfigError` | A **required** `envSecret` key references a missing Secret or missing key. (Keys marked `optional: true` are skipped at reconcile time — see §4.1.1 — so they never reach this state.) | Pod events: `secret "X" not found` / `couldn't find key K in Secret X`. |
 | `CrashLoopBackOff` | App crashes on startup — usually unresolved env vars, bad config, DB unreachable. | Pod logs. |
 | Stuck in `ContainerCreating` past sandbox setup | CNI plugin failure, missing PVC, fsGroup mismatch, missing mount target. | Pod events. |
@@ -1771,7 +1813,7 @@ The image must satisfy all of:
 
 | Requirement | Why | How to verify |
 |---|---|---|
-| **Publicly pullable** (no auth). | `imagePullSecrets` defeats portability. | `docker logout && docker pull <image>` from a fresh shell. If it fails with `repository does not exist or may require 'docker login'`, your registry repo is **private**, not nonexistent — Docker Hub creates new repos as private by default. Flip to Public in the repo's *Settings → Visibility* (Docker Hub) or *Package settings → Change visibility* (GHCR). Your push succeeding tells you nothing about visibility. |
+| **Publicly pullable** (no auth) **unless it is on the evenfire registry**. | A pull credential the installer has to create by hand defeats portability. Images on the evenfire registry are exempt: the installing deployment provisions its own credential and attaches it automatically (see §11.5), so a private evenfire-registry image stays portable. | `docker logout && docker pull <image>` from a fresh shell. If it fails with `repository does not exist or may require 'docker login'`, your registry repo is **private**, not nonexistent — Docker Hub creates new repos as private by default. For a third-party registry, flip to Public in the repo's *Settings → Visibility* (Docker Hub) or *Package settings → Change visibility* (GHCR). Your push succeeding tells you nothing about visibility. |
 | **Immutable semver tag** (`1.0.0`, not `:latest` / `:dev`). | `latest` floats; installers can't reproduce builds; K8s won't re-pull on restart without `imagePullPolicy: Always` (which slows every restart). | `docker buildx imagetools inspect <image>` shows a content digest. |
 | **Multi-arch: `linux/amd64` + `linux/arm64`.** | Prod clusters amd64; dev laptops Apple Silicon. Single-arch → `exec format error` on the wrong arch. | `docker buildx imagetools inspect <image>` lists both platforms. |
 | **Non-root.** | All three namespaces (`sandbox-ui`, `sandbox-recipes`, `mcp-server`) enforce PodSecurity baseline; root pods are rejected. UI workloads have additional CSP / sandbox constraints — see §6.4. | `docker run --rm <image> id` → UID ≠ 0. |
@@ -1826,7 +1868,7 @@ Before writing `spec.description`, enumerate every Secret reference in your YAML
 | `webhooks[].verification.secretRef` | HMAC signing secret OR static bearer. | All schemes except `jwt-bearer-jwks`. Webhooks with `optional: true` (§8.6) keep the field but tolerate a missing Secret — the webhook stays dormant (`410 integration_not_configured`) until the Secret is created. |
 | `webhooks[].verification.setupHandshake.secretRef` | Provider verify token (e.g. Meta `hub.verify_token`). | Only with `meta-hub-challenge`. |
 | `workloads[].envSecret` | Env-var-shaped runtime credentials (one Secret, N keys). Keys with `optional: true` (§4.1.1) may be deferred to post-install setup. | Required keys: when the workload needs them. Optional keys: only when the operator wants to enable that integration. |
-| `workloads[].imagePullSecrets` | Private-registry pull credentials. | Discouraged for published recipes — document loudly if used. |
+| `workloads[].imagePullSecrets` | Pull credentials for a **third-party** private registry (GHCR, Docker Hub). | Discouraged for published recipes — document loudly if used. Do **not** use it for images on the evenfire registry: `evenfire-registry-pull` is a reserved name and declaring it fails the install with `422 workflowWorkloadSecretRefReserved` (§11.5). |
 
 For each Secret in the inventory, your description MUST answer these five questions:
 

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,13 +1,15 @@
 # Platform image-pull credentials for recipe workloads
 
 **Status:** Implemented in PR #243. Five blocking review findings were raised against it
-(§13); **the four P1s are fixed** — including §13.1, which reversed this document's
-install-time trigger decision (provisioning is now a standing invariant, because a
-`WorkflowRecipe` can be created without control-api while WRC injects the pull-secret
-reference regardless). **§13.5 — end-to-end runtime evidence — remains open and is the
-last acceptance gate.** Two earlier carve-outs also remain recorded in place: WRC injection
-is deliberately **not** mode-gated, so the operator contract changes on managed clusters
-too (§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship.
+(§13); **all five are now closed** — the four P1s in code, including §13.1, which reversed
+this document's install-time trigger decision (provisioning is now a standing invariant,
+because a `WorkflowRecipe` can be created without control-api while WRC injects the
+pull-secret reference regardless); and **§13.5, the runtime acceptance gate, by a live
+cluster E2E: `tests/e2e/integration/registry-pull-secret-runtime.test.ts`** (§11, §13.5).
+Two earlier carve-outs remain recorded in place and are still true: WRC injection is
+deliberately **not** mode-gated, so the operator contract changes on managed clusters too
+(§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship — the
+third-party BYO-registry path is still the silent failure described there.
 **Date:** 2026-08-04
 **Area:** control-api · workflow-recipes (WRC) · workflow-runtime-core · image pull · self-hosted
 **Follows:** [`registry-pull-secret-self-provisioning.md`](registry-pull-secret-self-provisioning.md)
@@ -165,7 +167,7 @@ platform removes the reference to it.
   the managed operator keeps owning provisioning on its clusters. Note this is a non-goal
   for the *write* side only — WRC's **injection** is not mode-gated and therefore does
   change what the managed operator must provision (§9).
-- Reactive rotation of an out-of-band-revoked key (still open from #243 §12-2), though
+- Reactive rotation of an out-of-band-revoked key (still open — `registry-pull-secret-self-provisioning.md` §12-1), though
   §6.3's fingerprint makes cross-namespace divergence detectable.
 
 ---
@@ -229,19 +231,28 @@ Both enforcement points get the injection, since both produce runnable specs:
 | Pod template | `resourceBuilder.ts` (after the `allowedPullSecrets` filter) | recipe workloads in any namespace |
 | McpServer delegation | `mcpDelegation.ts` (after `projectableImagePullSecrets`) | transport workloads → `McpServer` → HCC |
 
-**Reserved-name handling — NOT shipped in #243** (still §12-2). The intent: if a recipe
-explicitly declares the platform name, injection makes it redundant, so recipe validation
-should **reject** the reserved name with a message saying it is platform-managed — fail
-loudly rather than appear to honor a declaration we ignore.
+**Reserved-name handling — SHIPPED in #243** (§12-2, resolved; R5). If a recipe explicitly
+declares the platform name, injection makes it redundant, so recipe validation **rejects**
+the reserved name with a message saying it is platform-managed — failing loudly rather than
+appearing to honor a declaration we ignore. As built:
+`isPlatformManagedWorkflowSecretName` (`control-api/src/routes/admin/recipes.ts`) reserves
+`EVENFIRE_REGISTRY_PULL_SECRET_NAME` alongside the `wf-` prefix, and `/validate`, POST, PUT
+and `POST /admin/recipes/secrets` all reject the declaration at admission with a
+`RefReserved` rule.
 
-What actually happens today, absent that validation, is *louder* than the "silent no-op"
-this paragraph feared: the #637 gate classifies the declared name `denied`, which makes the
-whole **workload** denied (`workflowRecipeReconciler.ts`, `collectSecretOwnership` counts
-`imagePullSecrets` refs alongside `envSecret`), so the workload is **not rendered at all** —
-it is torn down and reported `EnvSecretOwnershipDenied`. A recipe must therefore *not* name
-the reserved Secret. The injection sites still normalize the name defensively (§11), because
-the builders are re-entered with a denied access map on the StatefulSet revocation
-re-render path.
+> An earlier revision of this section recorded the validation as *not shipped* while §12-2
+> and R5 recorded it as shipped. That contradiction was flagged in review (P2) and is
+> resolved here in favour of the source: the reservation is live.
+
+The #637 gate stays behind that validation as defense-in-depth for anything already
+persisted, and its behavior is *louder* than the "silent no-op" the validation was meant to
+prevent: the gate classifies the declared name `denied`, which makes the whole **workload**
+denied (`workflowRecipeReconciler.ts`, `collectSecretOwnership` counts `imagePullSecrets`
+refs alongside `envSecret`), so the workload is **not rendered at all** — it is torn down and
+reported `EnvSecretOwnershipDenied`. A recipe must therefore not name the reserved Secret by
+either route. The injection sites still normalize the name defensively (§11), because the
+builders are re-entered with a denied access map on the StatefulSet revocation re-render
+path.
 
 ### 6.2 One source of truth, in `@clerum/workflow-runtime-core`
 
@@ -541,10 +552,10 @@ working immediately.
 
 | # | Risk | Mitigation |
 | --- | --- | --- |
-| R1 | Per-namespace minting revokes other namespaces' keys → partial cluster-wide `ImagePullBackOff`. | Single mint + fan-out write (§6.3); post-condition asserted in tests. |
-| R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). |
+| R1 | Per-namespace minting revokes other namespaces' keys → partial cluster-wide `ImagePullBackOff`. | Single mint + fan-out write (§6.3); post-condition asserted in unit tests, and on a live cluster by the E2E's one-fingerprint-across-all-copies assertion (§11) — divergent fingerprints are the only symptom this failure has. |
+| R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). **Observed working live** — an induced divergence was detected and converged on the next ensure pass; timestamps and fingerprints in §11. |
 | R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | **Was live, not hypothetical** — the shipped minikube overlay pinned WRC to the in-cluster registry while control-api used the shared one, so every recipe install hit it (found in live testing 2026-08-04). Closed in-repo: the **base** WRC Deployment now projects `control-api-config.CLERUM_REGISTRY_URL` via an `optional: true` `configMapKeyRef`, so every deployment built from `deploy/base` — including OSS self-hosted, the only mode where control-api provisioning actually runs — reads the same definition control-api does, and the minikube overlay no longer redeclares it (§6.2). Pinned by `workflow-recipes/tests/unit/workflow/deployManifest.test.ts`. Shared predicate alone was insufficient. **Residual:** the GCP dev/prod overlays and MCC tenant rendering live outside this repo and still set the value for both services independently (they agree today); and an overlay may still leave the key unset, which disables injection — WRC now emits a startup WARN naming that consequence instead of failing silently. Surfacing both values on a status/health endpoint is still worth doing. |
-| R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; add a test asserting the Secret is NOT `shared`/`owner-recipe` labeled. |
+| R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; the live-cluster E2E asserts the Secret carries neither `clerum.io/shared` nor `clerum.io/owner-recipe` in any platform namespace (§11), so a "fix" of this shape fails the acceptance gate. |
 | R5 | A recipe declares the reserved name and expects it honored. | **Closed.** Validation rejection (§6.1) shipped: `isPlatformManagedWorkflowSecretName` now reserves `EVENFIRE_REGISTRY_PULL_SECRET_NAME`, so `/validate`, POST, PUT and `POST /admin/recipes/secrets` reject the declaration at admission with a reserved-name rule. The #637 gate stays behind it as defense-in-depth for anything already persisted. |
 | R6 | Two extra copies of the credential. | Pull-only, org-scoped, no push; §8.2. |
 
@@ -564,8 +575,45 @@ working immediately.
 - **Anti-exfiltration** — a recipe declaring the platform Secret as `envSecret` is `denied`
   (regression guard for §5.1); a test asserts the Secret carries neither `shared` nor
   `owner-recipe`.
-- **e2e (minikube, self-hosted)** — install a recipe plugin with a private image; assert the
-  pod pulls; assert a mixed recipe (transport + non-transport) works in both namespaces.
+- **e2e (minikube, self-hosted)** — **SHIPPED:**
+  `tests/e2e/integration/registry-pull-secret-runtime.test.ts`, the §13.5 acceptance gate.
+  Four blocks against a live cluster and the live registry:
+
+  | Block | Asserts | Why a MockGateway cannot |
+  | --- | --- | --- |
+  | Secret placement | present in all three platform namespaces; `kubernetes.io/dockerconfigjson`; `managed-by=control-api`; `auths` keyed on the configured registry host; **one fingerprint across all copies**; neither `shared` nor `owner-recipe` | namespace + RBAC are real; the fingerprint check is the only cluster-visible symptom of R1 (three mints against a rotate-on-call registry) |
+  | Materialization | WRC renders the recipe workload's PodTemplate with `imagePullSecrets: [evenfire-registry-pull]` while the CRD does **not** declare it (proving injection, not declaration); control-api writes the reference onto the `McpServer` CRD and HCC materializes it verbatim onto the Deployment it owns | the WRC and HCC reconcile hops, and the rollout, are outside any route test |
+  | Pod readiness + real pull | image evicted from the node's docker cache first (`imagePullPolicy: IfNotPresent` would otherwise serve it from cache and exercise no credential); Pod Ready; the `Pulled` event says `Successfully pulled image … Image size: N bytes` and **not** `already present on machine` | proves the kubelet accepts the blob and the registry honors the minted key — both previously assumed from docs |
+  | Pre-persistence failure | a foreign, unusable Secret planted in one namespace makes `install-recipe` return `409 foreign_secret_unusable` **and** leaves no `WorkflowRecipe` behind | the ordering of provision-then-persist only matters against a real API server |
+
+  Guarded to **skip** (not fail) when the cluster, the port-forward, the admin credential,
+  self-hosted mode, or the private fixtures are unavailable; everything it creates is
+  prefixed `e2e-pullsecret-` and removed in `afterAll`, including an unconditional restore
+  of the temporary foreign Secret.
+
+  Two gaps it deliberately does not close. **The periodic reconcile (§13.1)** is not in the
+  suite: `REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS` defaults to 600 000 ms and shortening
+  it needs a redeploy, so a committed E2E cannot wait for a tick. It was verified
+  out-of-band on `clerum-test` instead — the `sandbox-ui` copy was deleted at 11:30:18Z and
+  restored by the cron at 11:32:33Z with a fresh fingerprint and a
+  `registry_pull_secret_reconciled` log line naming all three namespaces. **The
+  `kubectl apply` creation path** is covered only indirectly: the suite proves the standing
+  invariant is what makes it work (the Secret is present in every namespace before any
+  particular install), not the apply itself.
+
+  **R2's divergence repair was observed live during this work**, which is worth recording
+  because it is otherwise only argued. A regression rehearsal left `sandbox-ui` holding a
+  fingerprint (`dab2bc929d3d`) that disagreed with `mcp-server` / `sandbox-recipes`
+  (`f64af065ebe4`). The next install's ensure pass detected it —
+  `registry pull secret copies diverged across namespaces; re-minting to converge`
+  (2026-08-04T12:37:38Z) — re-minted once and rewrote all three onto `f3170a6e0585`. The
+  following run then took the no-mint path (`exists-ours`, fingerprint unchanged),
+  confirming both halves of §6.3: converge when diverged, do nothing when already current.
+
+  The suite is not in `DEFAULT_VITEST_SUITES` in `scripts/e2e/run-vitest-e2e.sh`, so it does
+  not run in the default gate; invoke it by path. Adding it there is safe — it skips
+  cleanly without the fixtures — and is worth doing when the fixtures become part of the
+  seeded environment.
 
 ---
 
@@ -703,6 +751,16 @@ control-api already has Postgres, so `pg_advisory_lock` is the natural mechanism
 no dependency — mirroring what the registry itself does inside `mintPullKey`. The
 in-process map stays as a cheap first-level dedupe.
 
+**The overlap is observed, not argued.** During #243's live testing on `clerum-test`
+(2026-08-04) a control-api rollout put two pods in `Running` simultaneously —
+ReplicaSets `786f7dcb9` and `7b7746fdf9`, both serving, before the older was killed.
+The finding was originally derived from the manifest (`replicas: 1` + default
+`RollingUpdate` ⇒ transient two-pod overlap); this is the same shape happening in an
+ordinary deploy on the deployed configuration. It is worth recording because the
+counter-argument to §13.3 was that a single-replica Deployment makes the in-process
+`inflight` map sufficient — which is true only between rollouts, and a rollout is
+exactly when a boot-time provisioning pass runs.
+
 ### 13.4 [P1] ✅ SHIPPED — `upgrade-recipe` has no provisioning hook
 
 `POST /admin/registry/upgrade-recipe` (`control-api/src/routes/admin/registry.ts:2001`)
@@ -717,22 +775,43 @@ fails at pull time, with a `200` on the API call.
 install-recipe placement. Fix it explicitly even once §13.1 lands: the reconcile is a
 safety net, not a substitute for failing the request that introduced the problem.
 
-### 13.5 [Acceptance] ⏳ OPEN — No end-to-end runtime evidence
+### 13.5 [Acceptance] ✅ SHIPPED — End-to-end runtime evidence
 
-Coverage is unit- and route-level against `MockGateway`. Nothing exercises
-`Secret → WRC → McpServer/HCC → Pod Ready → private image pull`.
-
-Mutation testing sharpens this rather than substituting for it: it proves the tests fail
-when the code breaks. It cannot prove the kubelet accepts the blob, that the type and data
-key are what Kubernetes wants, that RBAC permits the write in `sandbox-ui`, or that the
-registry honors the minted key at pull time. Those are assumptions verified only against
+**The finding.** Coverage was unit- and route-level against `MockGateway`. Nothing
+exercised `Secret → WRC → McpServer/HCC → Pod Ready → private image pull`. Mutation
+testing sharpened that rather than substituting for it: it proves the tests fail when the
+code breaks, but it cannot prove the kubelet accepts the blob, that the type and data key
+are what Kubernetes wants, that RBAC permits the write in `sandbox-ui`, or that the
+registry honors the minted key at pull time. Those were assumptions verified only against
 docs and source.
 
-The dependency that made this untestable is gone: `evenfire-registry` #64 is merged and
-deployed. **Remediation:** a minikube e2e against the live registry covering (a) an
-MCP-server plugin, (b) a recipe plugin with a non-transport workload, (c) a recipe created
-by `kubectl apply` (the §13.1 path), each asserting `Pod Ready` rather than just Secret
-contents.
+**Closed by** `tests/e2e/integration/registry-pull-secret-runtime.test.ts` — a live-cluster
+suite against `clerum-test` and the live `registry.evenfire.ai`, run in
+`REGISTRY_CONNECTION_MODE=self-hosted` against a connected org. Contents and per-block
+rationale are in §11; the short version is the four things a mock could not reach:
+
+| Assumption previously unverified | How the suite verifies it |
+| --- | --- |
+| the kubelet accepts the blob we write | a Pod pulls a private image with only this Secret referenced, after the image is evicted from the node |
+| the type and data key are what Kubernetes wants | the Secret is read back as `kubernetes.io/dockerconfigjson` with `.dockerconfigjson`, and a pull actually succeeds through it |
+| RBAC permits the write in `sandbox-ui` | the Secret is asserted present in all three platform namespaces, `sandbox-ui` included |
+| the registry honors the minted key at pull time | the `Pulled` event must read `Successfully pulled image … Image size: N bytes`, never `already present on machine` |
+
+Two additional properties the suite pins that no unit test can: **one mint fanned out**
+(all copies must carry the same `clerum.io/pull-key-fingerprint` — the only cluster-visible
+symptom of R1), and **injection rather than declaration** (the rendered PodTemplate carries
+the reference while the `WorkflowRecipe` CRD does not).
+
+**Coverage against the remediation as originally written.** (a) MCP-server plugin — covered.
+(b) recipe plugin with a non-transport workload — covered. (c) recipe created by
+`kubectl apply` — covered only *indirectly*: §13.1 turned provisioning into a standing
+invariant, so what makes that path work is the Secret already being present in every
+namespace, which the suite asserts directly. The apply itself is not exercised.
+
+**Deliberately still out of the suite:** the periodic reconcile tick (interval is 10 min by
+default and shortening it needs a redeploy — verified out-of-band instead; timestamps in
+§11) and managed-cluster behaviour (control-api writes nothing there by design, so there is
+no runtime outcome to observe — §9.1).
 
 ### 13.7 As-built
 
@@ -742,7 +821,7 @@ contents.
 | 13.2 | ✅ | `registryPullSecretService.ts` — `foreign_secret_would_be_revoked`, all-or-nothing refusal |
 | 13.3 | ✅ | `withPullSecretLock` — `pg_advisory_xact_lock(hashtext('registry-pull-secret:<org>'))` around read→mint→write |
 | 13.4 | ✅ | `registry.ts` — hook on `upgrade-recipe`, keyed on the INCOMING spec |
-| 13.5 | ⏳ | still open — the only remaining acceptance gate |
+| 13.5 | ✅ | `tests/e2e/integration/registry-pull-secret-runtime.test.ts` — live-cluster acceptance (§11, §13.5) |
 
 Notes worth carrying forward:
 

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,6 +1,6 @@
 # Platform image-pull credentials for recipe workloads
 
-**Status:** Draft / proposed
+**Status:** Implemented (see PR #243)
 **Date:** 2026-08-04
 **Area:** control-api · workflow-recipes (WRC) · workflow-runtime-core · image pull · self-hosted
 **Follows:** [`registry-pull-secret-self-provisioning.md`](registry-pull-secret-self-provisioning.md)
@@ -343,6 +343,21 @@ kubelet ignores is the one outcome that must not remain.
 ---
 
 ## 7. Implementation
+
+> **As-built note.** Shipped in PR #243 alongside the MCP-server slice. Two deviations
+> from the plan below, both deliberate:
+> - **`buildSecretReq` carries a key fingerprint annotation**
+>   (`clerum.io/pull-key-fingerprint`), and a copy *without* one is treated as broken. This
+>   is what makes cross-namespace divergence detectable — and it means Secrets written by
+>   the pre-fan-out code are re-minted once on upgrade, converging the cluster onto the
+>   annotated form.
+> - **Wrong-typed Secrets are deleted BEFORE the single mint**, not during the per-namespace
+>   write. A delete that fails must not leave us holding a freshly-minted key that has
+>   already revoked the credential the cluster was using.
+>
+> WRC reads the registry URL via `loadConfig().registryUrl` at the point of use, matching
+> the existing pattern in `restEndpoints.ts` rather than threading a new parameter through
+> every builder call site.
 
 **`packages/workflow-runtime-core`**
 - Add `registry-image.ts`: the name constant + `registryHostFromUrl` / `imageRefHost` /

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,0 +1,412 @@
+# Platform image-pull credentials for recipe workloads
+
+**Status:** Draft / proposed
+**Date:** 2026-08-04
+**Area:** control-api · workflow-recipes (WRC) · workflow-runtime-core · image pull · self-hosted
+**Follows:** [`registry-pull-secret-self-provisioning.md`](registry-pull-secret-self-provisioning.md)
+(the MCP-server slice, PR #243) — read that first; this spec extends its model to
+`WorkflowRecipe` workloads and deliberately reuses its decisions rather than inventing a
+parallel mechanism.
+
+---
+
+## 1. Summary
+
+PR #243 made control-api self-provision the `evenfire-registry-pull` dockerconfigjson
+Secret so **MCP-server** plugins on a self-hosted cluster can pull private images. That
+slice stops at the `mcp-server` namespace.
+
+**Recipe plugins are not covered, and cannot be made to work by configuration.** A
+`WorkflowRecipe` whose workload runs a private evenfire-registry image fails today, in one
+of two ways depending on the recipe's shape — and the platform has no supported path to
+fix it, because *nothing in the repo creates a usable pull Secret for recipe namespaces*.
+
+This spec closes that with the same shape as #243: **control-api owns the credential, the
+platform injects the reference, the recipe never names it.** The two changes of substance
+are (a) provisioning fans out to every platform workload namespace from a **single** mint,
+and (b) WRC injects the reference itself instead of trusting a recipe-declared name.
+
+---
+
+## 2. What exists today
+
+### 2.1 WRC projects and gates pull secrets — it never creates them
+
+The CRD supports declaration: `workloads[].imagePullSecrets: string[]`
+(`charts/clerum-crds/crds/workflowrecipe.yaml:1100`, `workflow-recipes/src/types.ts:129`
+— *"Docker registry secrets for private images"*). WRC consumes it at two enforcement
+points, both **fail-closed** under Issue #637:
+
+- `workflow-recipes/src/reconciler/resourceBuilder.ts:872-882` — builds the pod's
+  `imagePullSecrets`, dropping `denied`/`error` names.
+- `workflow-recipes/src/reconciler/mcpDelegation.ts:231` — filters to
+  `projectableImagePullSecrets` **before** writing the `McpServer` CRD, because HCC
+  materializes that spec verbatim and re-checks nothing
+  (`host-context-controller/src/reconciler.ts:994-1002`).
+
+The access states (`workflow-recipes/src/reconciler/secretOwnership.ts:54-102`):
+
+| State | Meaning | Outcome |
+| --- | --- | --- |
+| `accessible` | `clerum.io/owner-recipe` matches, or `clerum.io/shared=true` | projected |
+| `denied` | exists but **unlabeled**, or owned by another recipe | **stripped** |
+| `error` | ownership unverifiable | stripped, requeue |
+| `missing` | 404 | projected anyway → `ImagePullBackOff` |
+
+`combineSecretAccess` is cross-namespace and fail-closed: **a name `denied` in ANY
+classified namespace is denied everywhere.**
+
+This is live, not latent: the access map is threaded through the reconciler
+(`workflowRecipeReconciler.ts:2006-2032`) and denied workloads are actively torn down
+(`:2082`).
+
+### 2.2 Nothing provisions a recipe pull Secret
+
+The only `kubernetes.io/dockerconfigjson` writer in the repo is
+`control-api/src/services/registryPullSecretService.ts` (from #243), and it targets
+`config.mcpServersNamespace` only.
+
+The endpoint that *does* create recipe-owned Secrets — `POST /admin/recipes/secrets` —
+**hardcodes `type: 'Opaque'`** (`control-api/src/routes/admin/recipes.ts:1654`). The
+kubelet honors only `kubernetes.io/dockerconfigjson` / `kubernetes.io/dockercfg` for image
+pulls, so that endpoint **structurally cannot** produce a working pull Secret. An operator
+who follows the documented recipe-secret flow to create one gets a silently unusable
+object — no error, just `ImagePullBackOff` later.
+
+So the only path that works today is entirely out-of-band:
+
+```bash
+kubectl create secret docker-registry my-pull -n sandbox-recipes ...
+kubectl label secret my-pull -n sandbox-recipes clerum.io/owner-recipe=<recipe>
+```
+
+### 2.3 Recipe workloads do not run in `mcp-server`
+
+`resolveWorkloadSecretNamespace` (`control-api/src/routes/admin/recipes.ts:66-80`,
+mirrored in WRC) splits three ways:
+
+| Workload | Namespace |
+| --- | --- |
+| has `transport` | `config.mcpServersNamespace` (`mcp-server`) |
+| is `spec.ui.workloadRef` | `config.sandboxUiNamespace` (`sandbox-ui`) |
+| everything else | `config.sandboxNamespace` (`sandbox-recipes`) |
+
+---
+
+## 3. The failure, precisely
+
+For a recipe workload running `registry.evenfire.ai/<org>/<img>`:
+
+1. **`install-recipe` provisions nothing** — the pull-secret hook exists only on the
+   MCP-server install/upgrade paths (`registry.ts:1278`, `:1904`).
+2. **No Secret exists** in `sandbox-recipes` / `sandbox-ui`. #243's service actively
+   *refuses* to write outside `mcpServersNamespace` (its namespace guard), so it cannot
+   even be pointed there.
+3. **If the recipe declares the name anyway**, #637 classifies it. In a recipe with only
+   non-transport workloads it is `missing` → projected → `ImagePullBackOff`. In a **mixed**
+   recipe it is also classified in `mcp-server`, where #243's Secret exists carrying only
+   `clerum.io/managed-by=control-api` — *unlabeled* to the #637 model → **`denied`** →
+   denied in every namespace → the reference is **silently stripped**.
+
+The second case is the nastier one: the credential is present and correct, and the
+platform removes the reference to it.
+
+---
+
+## 4. Goals / Non-goals
+
+### Goals
+
+- **G1.** A recipe plugin whose workload image lives on the configured evenfire registry
+  pulls successfully on a self-hosted cluster, with no operator action.
+- **G2.** One credential per org, materialized consistently across every platform workload
+  namespace — never one mint per namespace (§6.3).
+- **G3.** The platform credential is **never** reachable by recipe-authored `envSecret`
+  references. Closing G1 must not open an exfiltration path.
+- **G4.** No second source of truth. The "is this image ours?" predicate and the Secret
+  name are defined **once** and consumed by both services (§6.2).
+- **G5.** Recipes stay portable: a recipe manifest carries no evenfire-specific pull-secret
+  plumbing, so the same manifest works on managed and self-hosted.
+
+### Non-goals
+
+- **Third-party private registries.** A recipe pulling from a non-evenfire registry keeps
+  using recipe-declared `imagePullSecrets` + the #637 owner-recipe model. That separation
+  is deliberate: *platform credential for the platform registry, recipe-owned credential
+  for everything else* (§8.3).
+- Changing the #637 ownership model, or exempting names from it (§6.1, rejected).
+- Managed-cluster behavior. As in #243, everything here is gated to `self-hosted`; the
+  managed operator keeps owning provisioning on its clusters.
+- Reactive rotation of an out-of-band-revoked key (still open from #243 §12-2), though
+  §6.3's fingerprint makes cross-namespace divergence detectable.
+
+---
+
+## 5. Why not the obvious approaches
+
+Recording these because each looks reasonable and two are actively unsafe.
+
+### 5.1 Label the Secret `clerum.io/shared=true` — **rejected, unsafe**
+
+The natural way to satisfy #637. But `isSecretAccessibleByRecipe`
+(`packages/workflow-runtime-core/src/secret-ownership.ts:36-44`) is the **same predicate**
+for `envSecret` and `imagePullSecrets`. `shared=true` would let any third-party recipe on
+the cluster declare:
+
+```yaml
+envSecret: { name: evenfire-registry-pull, keys: [{ secretKey: .dockerconfigjson, envVar: X }] }
+```
+
+and read the org's registry credential out of its own environment. This converts a
+pull-only credential into a cluster-wide exfiltration primitive. **Never label it shared.**
+
+### 5.2 control-api writes `imagePullSecrets` into the recipe CRD at install — **rejected, does not work**
+
+Appealing because it needs no WRC change. But a name in the CRD *is* a recipe-declared
+reference, so #637 classifies it — and our Secret is unlabeled to that model → `denied` →
+stripped. It fails for exactly the reason in §3.3.
+
+It is also brittle long-term: the reference would be frozen into every stored CRD, so a
+later `CLERUM_REGISTRY_URL` change leaves stale references behind. Injection at reconcile
+time self-corrects (same reasoning as validating the Secret's `auths` host in #243 §7.6).
+
+### 5.3 Exempt the reserved name inside the #637 pull-secret filter — **rejected, erodes the gate**
+
+Workable (exempt only in the `imagePullSecrets` filter, never `envSecret`), and it would
+let §5.2 proceed. Rejected because it puts a name-based exemption inside a security gate
+whose entire value is that it is uniform and fail-closed — precisely the kind of
+special-case that rots. It also still requires WRC to know the reserved name, so it saves
+nothing over injection.
+
+---
+
+## 6. Design
+
+### 6.1 The platform injects; recipes never name it
+
+WRC attaches the platform pull secret **after** the #637 ownership filter, to any workload
+whose image host equals the configured registry host — mirroring what control-api already
+does for `McpServer` (`shouldAttachEvenfirePullSecret`).
+
+Because the recipe never *references* the Secret, it is **never classified**, so:
+
+- no ownership label is needed → no `shared` → **no `envSecret` exfiltration path** (G3)
+- a recipe cannot opt in, opt out, or rename the credential
+- recipe manifests stay portable across managed/self-hosted (G5)
+
+Both enforcement points get the injection, since both produce runnable specs:
+
+| Point | File | Effect |
+| --- | --- | --- |
+| Pod template | `resourceBuilder.ts` (after the `allowedPullSecrets` filter) | recipe workloads in any namespace |
+| McpServer delegation | `mcpDelegation.ts` (after `projectableImagePullSecrets`) | transport workloads → `McpServer` → HCC |
+
+**Reserved-name handling.** If a recipe explicitly declares the platform name, injection
+makes it redundant; the declared copy would be `denied` and stripped, and we would inject
+it anyway. To avoid that confusing silent no-op, recipe validation should **reject** the
+reserved name with a message saying it is platform-managed. Fail loudly rather than
+appear to honor a declaration we ignore.
+
+### 6.2 One source of truth, in `@clerum/workflow-runtime-core`
+
+Issue #637 was *caused* by the same rule living in two services and drifting; the fix put
+the predicate in the shared package "precisely so the rule cannot drift between the two
+enforcement points" (`secret-ownership.ts:9-12`). Both control-api and workflow-recipes
+already depend on `@clerum/workflow-runtime-core`.
+
+Move there, and have both services import:
+
+```ts
+export const EVENFIRE_REGISTRY_PULL_SECRET_NAME = 'evenfire-registry-pull'
+export function registryHostFromUrl(registryUrl: string): string | null
+export function imageRefHost(image: string): string | null
+/** True when `image` is hosted on the configured evenfire registry. */
+export function isPlatformRegistryImage(image: unknown, registryUrl: string): boolean
+```
+
+control-api's `shouldAttachEvenfirePullSecret` becomes
+`isLocal && isPlatformRegistryImage(...)`, preserving its current semantics exactly. WRC
+calls `isPlatformRegistryImage` directly (recipe workloads have no `isLocal` notion).
+
+**New WRC config:** `CONTEXT_*`-style registry URL (WRC has none today). It must be the
+same value control-api uses; document that a mismatch means recipe pods get no credential
+while MCP servers do.
+
+### 6.3 One mint, fanned out — the core correctness rule
+
+The credential is per-**org**; the Secret is per-**namespace**. The registry's
+`mintPullKey` is **rotate-on-call** with ≤1 active pull key per org, so minting per
+namespace would have each mint **revoke the previous namespace's key** — leaving the first
+namespaces holding dead credentials while the last one works. This is the single easiest
+way to get this feature badly wrong.
+
+Generalize #243's service:
+
+```ts
+ensureRegistryPullSecrets(gateway, namespaces: string[]): Promise<Map<string, EnsurePullSecretResult>>
+```
+
+1. **Read all** target namespaces.
+2. **Classify each** with #243's existing rules (ours-and-valid / foreign / absent-or-broken).
+   Foreign namespaces are dropped from the write set and never touched.
+3. **Mint at most once**, and only if ≥1 non-foreign target is absent or broken.
+4. **Write the new blob to every non-foreign target** — *including ones that were valid*,
+   because the mint just revoked their key.
+
+Post-condition (the invariant worth testing): *after a successful ensure, every
+non-foreign target namespace holds the same, current credential.*
+
+**Fingerprint annotation.** Write `clerum.io/pull-key-fingerprint: <sha256(key)[0:12]>`
+alongside the payload. This makes cross-namespace divergence **detectable**: if targets
+disagree, a partial write happened (mint succeeded, one write failed) and the stale ones
+must be repaired. #243 dropped the "key id" annotation because the registry returns no id
+— a fingerprint of the key we wrote needs no registry support and is strictly more useful.
+
+**Namespace allowlist.** #243 restricts writes to `config.mcpServersNamespace`. Widen to
+the three **platform** workload namespaces (`mcpServersNamespace`, `sandboxNamespace`,
+`sandboxUiNamespace`) — still a fixed allowlist derived from config, never from
+`body.namespace`. control-api already holds `secrets:create` in all three.
+
+### 6.4 Provisioning trigger
+
+Provision into **all three** platform workload namespaces whenever provisioning runs at
+all, rather than computing per-recipe which namespaces a given manifest touches.
+
+Rationale: the invariant becomes global ("the platform credential is present everywhere it
+could be needed") instead of per-install, so a recipe *upgraded* into a new workload shape
+cannot outrun provisioning. The cost is two extra Secret copies of a credential the cluster
+already holds — no extra mint (§6.3), and no extra registry calls.
+
+Triggered from both `install` and `install-recipe`, on the same lazy principle as #243: only
+when the entry actually references a platform-registry image.
+
+### 6.5 Fix the `Opaque` trap
+
+`POST /admin/recipes/secrets` hardcodes `type: 'Opaque'` (`recipes.ts:1654`), so an
+operator creating a *third-party* registry pull secret through the documented flow gets a
+silently unusable object. Either:
+
+- **(a)** accept an optional `type`, allowing `kubernetes.io/dockerconfigjson` with the
+  matching `.dockerconfigjson` key — makes §4's non-goal (BYO registries) a first-class
+  supported path; or
+- **(b)** keep it Opaque-only but **reject** a request whose payload looks like a docker
+  config, pointing at the right mechanism.
+
+Recommend **(a)**: it completes the BYO story that the #637 owner-recipe model already
+implies, and it removes the only silent-failure mode in that endpoint.
+
+---
+
+## 7. Implementation
+
+**`packages/workflow-runtime-core`**
+- Add `registry-image.ts`: the name constant + `registryHostFromUrl` / `imageRefHost` /
+  `isPlatformRegistryImage`, moved (not copied) from
+  `control-api/src/routes/admin/registryImagePullSecret.ts`. Re-export from the package
+  index.
+
+**`control-api`**
+- `registryImagePullSecret.ts` re-exports from the shared package (keeps existing imports
+  working); `shouldAttachEvenfirePullSecret` delegates to `isPlatformRegistryImage`.
+- `registryPullSecretService.ts`: `ensureRegistryPullSecrets(namespaces[])` per §6.3 —
+  single mint, fan-out write, fingerprint annotation, three-namespace allowlist.
+- `registry.ts`: install + upgrade pass the platform namespace set; **`install-recipe`
+  gains the same hook**, gated on the entry carrying a platform-registry image.
+- `recipes.ts:1654`: §6.5.
+
+**`workflow-recipes` (WRC)**
+- New config: registry URL (+ document that it must match control-api's).
+- `resourceBuilder.ts`: after `allowedPullSecrets`, append the platform pull secret when
+  `isPlatformRegistryImage(workload.image, config.registryUrl)`.
+- `mcpDelegation.ts`: same, after `projectableImagePullSecrets`.
+- Recipe validation: reject a recipe declaring the reserved name (§6.1).
+
+**Docs**
+- `docs/how-to/publish-plugin-to-registry.md` — private-image recipes need no pull-secret
+  declaration; the platform handles it.
+- Update #243's spec §8/§12 to point here.
+
+---
+
+## 8. Security analysis
+
+**8.1 The credential is not reachable by recipes.** It stays labeled `managed-by=control-api`
+only — *unlabeled* to the #637 model — so any recipe-authored `envSecret` **or**
+`imagePullSecrets` reference to it is `denied` and stripped. Injection happens after that
+filter and is not recipe-authored. Workload pods run on the `default` ServiceAccount with
+no `secrets` RBAC, so a pod cannot read it from the API either.
+
+**8.2 Blast radius of two extra copies.** The same org-scoped, pull-only credential now
+sits in `sandbox-recipes` and `sandbox-ui` as well as `mcp-server`. It grants pull on the
+org's own/granted/public repos and **never push** (`kind='pull'`, empty scopes). Anyone
+who could read it in the new namespaces could already read it in `mcp-server` given the
+same RBAC class, so this widens exposure by namespace count, not by capability.
+
+**8.3 Third-party registries are unaffected.** Recipe-declared `imagePullSecrets` keep
+their existing owner-recipe/shared semantics. Injection only ever *appends* the platform
+name for platform-registry images; it never removes or rewrites a recipe's own entries.
+
+**8.4 Host confusion.** Injection keys on the image host matching the configured registry
+host — the same invariant as #243 §7.9-2, and the reason the Secret's `auths` map is built
+locally rather than trusting the registry's `registryTokenIssuer`-keyed blob.
+
+---
+
+## 9. Rollout
+
+1. Ship `workflow-runtime-core` first (additive; no behavior change).
+2. control-api: fan-out provisioning + the `install-recipe` hook. Safe alone — it only
+   creates Secrets nothing references yet.
+3. WRC: config + injection. This is the step that changes pod specs; a WRC rollout with a
+   *missing* registry URL simply injects nothing (degrades to today's behavior).
+4. `recipes.ts` `Opaque` fix — independent, can land any time.
+
+Managed clusters are inert throughout (the `self-hosted` gate from #243 is unchanged).
+Existing recipes that already declare their own third-party pull secrets are unaffected.
+
+---
+
+## 10. Risks
+
+| # | Risk | Mitigation |
+| --- | --- | --- |
+| R1 | Per-namespace minting revokes other namespaces' keys → partial cluster-wide `ImagePullBackOff`. | Single mint + fan-out write (§6.3); post-condition asserted in tests. |
+| R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). |
+| R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | Shared predicate (§6.2) + documented config pairing; consider surfacing both values on a status/health endpoint. |
+| R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; add a test asserting the Secret is NOT `shared`/`owner-recipe` labeled. |
+| R5 | A recipe declares the reserved name and expects it honored. | Validation rejects it with an explanatory message (§6.1). |
+| R6 | Two extra copies of the credential. | Pull-only, org-scoped, no push; §8.2. |
+
+---
+
+## 11. Test plan
+
+- **Shared predicate** — `isPlatformRegistryImage` table: platform host, other registry,
+  no host, empty `registryUrl`; control-api's `shouldAttachEvenfirePullSecret` keeps its
+  exact current truth table after delegating.
+- **Fan-out** — absent in one of three namespaces → **exactly one** mint, three writes, all
+  three carrying the same fingerprint; a foreign Secret in one namespace → untouched, other
+  two still provisioned; all-valid-and-same-fingerprint → **no** mint.
+- **WRC injection** — platform-registry image gets the reference appended; non-platform
+  image does not; a recipe's own third-party pull secrets are preserved alongside;
+  injection survives the #637 filter (i.e. is not classified).
+- **Anti-exfiltration** — a recipe declaring the platform Secret as `envSecret` is `denied`
+  (regression guard for §5.1); a test asserts the Secret carries neither `shared` nor
+  `owner-recipe`.
+- **e2e (minikube, self-hosted)** — install a recipe plugin with a private image; assert the
+  pod pulls; assert a mixed recipe (transport + non-transport) works in both namespaces.
+
+---
+
+## 12. Open questions
+
+1. **Config plumbing for WRC** — reuse `CLERUM_REGISTRY_URL` verbatim, or a WRC-prefixed
+   variable? Reusing the same name reduces drift risk (R3) but couples the deployments.
+2. **Eager vs per-recipe namespaces (§6.4)** — is provisioning all three acceptable, or
+   should it be computed from the manifest's actual workloads?
+3. **`recipes.ts` `Opaque` fix (§6.5)** — accept `dockerconfigjson` (a), or reject with
+   guidance (b)?
+4. **Reserved-name declaration (§6.1)** — hard-reject at validation, or accept-and-ignore
+   with a warning for backwards compatibility?
+5. Should HCC gain the presence-validation from #243 §7.7 now that more namespaces
+   reference the same Secret name?

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -277,11 +277,24 @@ service feeds it a different value.
 
 What actually makes it safe is a single *definition*, not a single name:
 `control-api-config.CLERUM_REGISTRY_URL` is the only place the URL is written, and WRC
-projects that key via `configMapKeyRef` (`deploy/overlays/minikube/patches/registry-env.yaml`).
-Divergence is then unrepresentable in the overlay rather than merely discouraged. Any other
-overlay (notably the GCP/prod overlay, which lives in `evenfire-infra`) must establish the
-same pairing; WRC's base Deployment sets no `CLERUM_REGISTRY_URL`, so an overlay that
-neither patches it nor projects the key leaves it empty, which disables injection silently.
+projects that key via `configMapKeyRef`. That projection lives in the **base** Deployment
+(`deploy/base/control-plane/workflow-recipes.yaml`), alongside the two workflow limits
+already sourced from the same ConfigMap, so anything built from `deploy/base` inherits the
+pairing and no overlay has to remember it. The reference is `optional: true` because base
+ships no `CLERUM_REGISTRY_URL` key — only overlays set the value — and a hard reference
+would put a plain `deploy/base` install into `CreateContainerConfigError`. The minikube
+overlay consequently no longer redeclares the env var; it only supplies the ConfigMap value
+(`deploy/overlays/minikube/configmaps/control-api-config.yaml`).
+
+Two caveats remain. Overlays that live outside this repo — the GCP dev/prod overlays in
+`evenfire-infra`, and MCC tenant rendering — still set `CLERUM_REGISTRY_URL` for both
+services independently; they agree today, but base cannot enforce that from here. And an
+overlay is still free to leave the key unset, which leaves WRC's value empty and disables
+injection; WRC now logs a startup WARN naming the consequence
+(`registryUrlStartupWarning` in `workflow-recipes/src/config.ts`, printed from `main.ts`)
+rather than failing silently. The base projection is pinned by
+`workflow-recipes/tests/unit/workflow/deployManifest.test.ts` so a later edit cannot quietly
+revert it to a literal or drop it.
 
 ### 6.3 One mint, fanned out — the core correctness rule
 
@@ -519,7 +532,7 @@ working immediately.
 | --- | --- | --- |
 | R1 | Per-namespace minting revokes other namespaces' keys → partial cluster-wide `ImagePullBackOff`. | Single mint + fan-out write (§6.3); post-condition asserted in tests. |
 | R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). |
-| R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | **Was live, not hypothetical** — the shipped minikube overlay pinned WRC to the in-cluster registry while control-api used the shared one, so every recipe install hit it (found in live testing 2026-08-04). Closed for this overlay by making `control-api-config.CLERUM_REGISTRY_URL` the single definition and projecting it into WRC via `configMapKeyRef` (§6.2). Shared predicate alone was insufficient. **Still open elsewhere:** WRC's base Deployment sets no default, so any other overlay (GCP/prod in `evenfire-infra`) must repeat the pairing or injection silently disables; surfacing both values on a status/health endpoint is still worth doing. |
+| R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | **Was live, not hypothetical** — the shipped minikube overlay pinned WRC to the in-cluster registry while control-api used the shared one, so every recipe install hit it (found in live testing 2026-08-04). Closed in-repo: the **base** WRC Deployment now projects `control-api-config.CLERUM_REGISTRY_URL` via an `optional: true` `configMapKeyRef`, so every deployment built from `deploy/base` — including OSS self-hosted, the only mode where control-api provisioning actually runs — reads the same definition control-api does, and the minikube overlay no longer redeclares it (§6.2). Pinned by `workflow-recipes/tests/unit/workflow/deployManifest.test.ts`. Shared predicate alone was insufficient. **Residual:** the GCP dev/prod overlays and MCC tenant rendering live outside this repo and still set the value for both services independently (they agree today); and an overlay may still leave the key unset, which disables injection — WRC now emits a startup WARN naming that consequence instead of failing silently. Surfacing both values on a status/health endpoint is still worth doing. |
 | R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; add a test asserting the Secret is NOT `shared`/`owner-recipe` labeled. |
 | R5 | A recipe declares the reserved name and expects it honored. | **Closed.** Validation rejection (§6.1) shipped: `isPlatformManagedWorkflowSecretName` now reserves `EVENFIRE_REGISTRY_PULL_SECRET_NAME`, so `/validate`, POST, PUT and `POST /admin/recipes/secrets` reject the declaration at admission with a reserved-name rule. The #637 gate stays behind it as defense-in-depth for anything already persisted. |
 | R6 | Two extra copies of the credential. | Pull-only, org-scoped, no push; §8.2. |

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,6 +1,8 @@
 # Platform image-pull credentials for recipe workloads
 
-**Status:** Implemented (see PR #243)
+**Status:** Implemented in PR #243, with two carve-outs recorded in place: WRC injection is
+deliberately **not** mode-gated, so the operator contract changes on managed clusters too
+(§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship with it.
 **Date:** 2026-08-04
 **Area:** control-api · workflow-recipes (WRC) · workflow-runtime-core · image pull · self-hosted
 **Follows:** [`registry-pull-secret-self-provisioning.md`](registry-pull-secret-self-provisioning.md)
@@ -8,29 +10,41 @@
 `WorkflowRecipe` workloads and deliberately reuses its decisions rather than inventing a
 parallel mechanism.
 
+> **Reading note.** §2 and §3 describe the **pre-#243 baseline** this spec was written
+> against — design history, kept because §5-§6 only make sense against it. They are not a
+> description of current behavior. §6-§8 describe the shipped design; §7 carries the
+> as-built deviations from the plan.
+
 ---
 
 ## 1. Summary
 
-PR #243 made control-api self-provision the `evenfire-registry-pull` dockerconfigjson
-Secret so **MCP-server** plugins on a self-hosted cluster can pull private images. That
-slice stops at the `mcp-server` namespace.
+The MCP-server slice of #243 made control-api self-provision the `evenfire-registry-pull`
+dockerconfigjson Secret so **MCP-server** plugins on a self-hosted cluster can pull private
+images. As first written, that slice stopped at the `mcp-server` namespace.
 
-**Recipe plugins are not covered, and cannot be made to work by configuration.** A
-`WorkflowRecipe` whose workload runs a private evenfire-registry image fails today, in one
-of two ways depending on the recipe's shape — and the platform has no supported path to
-fix it, because *nothing in the repo creates a usable pull Secret for recipe namespaces*.
+**Recipe plugins were not covered, and could not be made to work by configuration.** A
+`WorkflowRecipe` whose workload ran a private evenfire-registry image failed in one of two
+ways depending on the recipe's shape (§3), with no supported path to fix it, because
+*nothing in the repo created a usable pull Secret for recipe namespaces*.
 
-This spec closes that with the same shape as #243: **control-api owns the credential, the
-platform injects the reference, the recipe never names it.** The two changes of substance
-are (a) provisioning fans out to every platform workload namespace from a **single** mint,
-and (b) WRC injects the reference itself instead of trusting a recipe-declared name.
+This spec closes that with the same shape as the MCP-server slice: **control-api owns the
+credential, the platform injects the reference, the recipe never names it.** The two
+changes of substance, both shipped in #243, are (a) provisioning fans out to every platform
+workload namespace from a **single** mint, and (b) WRC injects the reference itself instead
+of trusting a recipe-declared name.
 
 ---
 
-## 2. What exists today
+## 2. What existed before this change (pre-#243 baseline)
+
+*Design history. §2.2's "nothing provisions" and §3's failure modes are what #243 removed;
+read them as the problem statement, not as current behavior.*
 
 ### 2.1 WRC projects and gates pull secrets — it never creates them
+
+*(Still accurate: WRC creates no Secret. What changed is that it now also **injects** the
+platform reference after the filter — §6.1.)*
 
 The CRD supports declaration: `workloads[].imagePullSecrets: string[]`
 (`charts/clerum-crds/crds/workflowrecipe.yaml:1100`, `workflow-recipes/src/types.ts:129`
@@ -62,8 +76,10 @@ This is live, not latent: the access map is threaded through the reconciler
 
 ### 2.2 Nothing provisions a recipe pull Secret
 
+*Closed by §6.3: the same service now fans out to all three platform workload namespaces.*
+
 The only `kubernetes.io/dockerconfigjson` writer in the repo is
-`control-api/src/services/registryPullSecretService.ts` (from #243), and it targets
+`control-api/src/services/registryPullSecretService.ts` (from #243), and it targeted
 `config.mcpServersNamespace` only.
 
 The endpoint that *does* create recipe-owned Secrets — `POST /admin/recipes/secrets` —
@@ -93,7 +109,12 @@ mirrored in WRC) splits three ways:
 
 ---
 
-## 3. The failure, precisely
+## 3. The failure, precisely (pre-#243)
+
+*Design history — §6 removes this on self-hosted clusters. On a **managed** cluster the
+platform still creates nothing (control-api's provisioner stays mode-gated), so the
+injected reference resolves only where the external operator has provisioned the Secret —
+see §9.*
 
 For a recipe workload running `registry.evenfire.ai/<org>/<img>`:
 
@@ -135,8 +156,10 @@ platform removes the reference to it.
   is deliberate: *platform credential for the platform registry, recipe-owned credential
   for everything else* (§8.3).
 - Changing the #637 ownership model, or exempting names from it (§6.1, rejected).
-- Managed-cluster behavior. As in #243, everything here is gated to `self-hosted`; the
-  managed operator keeps owning provisioning on its clusters.
+- Managed-cluster **provisioning**. control-api's writer keeps #243's `self-hosted` gate;
+  the managed operator keeps owning provisioning on its clusters. Note this is a non-goal
+  for the *write* side only — WRC's **injection** is not mode-gated and therefore does
+  change what the managed operator must provision (§9).
 - Reactive rotation of an out-of-band-revoked key (still open from #243 §12-2), though
   §6.3's fingerprint makes cross-namespace divergence detectable.
 
@@ -201,11 +224,19 @@ Both enforcement points get the injection, since both produce runnable specs:
 | Pod template | `resourceBuilder.ts` (after the `allowedPullSecrets` filter) | recipe workloads in any namespace |
 | McpServer delegation | `mcpDelegation.ts` (after `projectableImagePullSecrets`) | transport workloads → `McpServer` → HCC |
 
-**Reserved-name handling.** If a recipe explicitly declares the platform name, injection
-makes it redundant; the declared copy would be `denied` and stripped, and we would inject
-it anyway. To avoid that confusing silent no-op, recipe validation should **reject** the
-reserved name with a message saying it is platform-managed. Fail loudly rather than
-appear to honor a declaration we ignore.
+**Reserved-name handling — NOT shipped in #243** (still §12-2). The intent: if a recipe
+explicitly declares the platform name, injection makes it redundant, so recipe validation
+should **reject** the reserved name with a message saying it is platform-managed — fail
+loudly rather than appear to honor a declaration we ignore.
+
+What actually happens today, absent that validation, is *louder* than the "silent no-op"
+this paragraph feared: the #637 gate classifies the declared name `denied`, which makes the
+whole **workload** denied (`workflowRecipeReconciler.ts`, `collectSecretOwnership` counts
+`imagePullSecrets` refs alongside `envSecret`), so the workload is **not rendered at all** —
+it is torn down and reported `EnvSecretOwnershipDenied`. A recipe must therefore *not* name
+the reserved Secret. The injection sites still normalize the name defensively (§11), because
+the builders are re-entered with a denied access map on the StatefulSet revocation
+re-render path.
 
 ### 6.2 One source of truth, in `@clerum/workflow-runtime-core`
 
@@ -414,15 +445,54 @@ locally rather than trusting the registry's `registryTokenIssuer`-keyed blob.
 
 ## 9. Rollout
 
-1. Ship `workflow-runtime-core` first (additive; no behavior change).
-2. control-api: fan-out provisioning + the `install-recipe` hook. Safe alone — it only
-   creates Secrets nothing references yet.
-3. WRC: config + injection. This is the step that changes pod specs; a WRC rollout with a
-   *missing* registry URL simply injects nothing (degrades to today's behavior).
-4. `recipes.ts` `Opaque` fix — independent, can land any time.
+1. **Shipped** — `workflow-runtime-core` first (additive; no behavior change).
+2. **Shipped** — control-api: fan-out provisioning + the `install-recipe` hook. Safe alone —
+   it only creates Secrets nothing references yet.
+3. **Shipped** — WRC: config + injection. This is the step that changes pod specs; a WRC
+   rollout with a *missing* registry URL simply injects nothing (degrades to the prior
+   behavior).
+4. **Not shipped** — `recipes.ts` `Opaque` fix (§6.5). Independent of the above and still
+   open (§12); `POST /admin/recipes/secrets` continues to write `type: 'Opaque'`, so the
+   third-party BYO-registry path is still the silent failure described there.
 
-Managed clusters are inert throughout (the `self-hosted` gate from #243 is unchanged).
-Existing recipes that already declare their own third-party pull secrets are unaffected.
+Existing recipes that already declare their own third-party pull secrets are unaffected
+(§8.3).
+
+### 9.1 Managed clusters — only the control-api half is inert
+
+**Do not read this as "managed is unaffected".** Only the *write* side carries the
+`self-hosted` gate:
+
+- **control-api never writes on a managed cluster.** `ensureRegistryPullSecrets` returns
+  `skipped` for every target when `registryConnectionMode !== 'self-hosted'`
+  (`control-api/src/services/registryPullSecretService.ts`), exactly as in #243.
+- **WRC injection has no mode gate at all.** It keys solely on
+  `isPlatformRegistryImage(workload.image, loadConfig().registryUrl)`
+  (`workflow-recipes/src/reconciler/resourceBuilder.ts`, `.../mcpDelegation.ts`), and WRC's
+  `registryUrl` is `CLERUM_REGISTRY_URL` (`workflow-recipes/src/config.ts`) — which managed
+  clusters **do** set. So on a managed cluster WRC still appends
+  `imagePullSecrets: [evenfire-registry-pull]` to every recipe workload pulling a
+  platform-registry image, in whichever namespace that workload lands.
+
+This asymmetry is deliberate and must stay. Gating injection on the mode flag would break
+managed private recipes *even after* the operator provisions the credential — the whole
+point of injection is that the recipe never names the Secret, so there is no other way for
+the reference to appear. The correct resolution is on the operator side, not in the gate.
+
+**Consequent operator contract (this is the part that changed).** An external operator on a
+managed cluster must provision `evenfire-registry-pull` in **all three** platform workload
+namespaces — `mcp-server`, `sandbox-recipes`, `sandbox-ui` (the `resolveWorkloadSecretNamespace`
+split, §2.3) — not just the McpServer's own namespace, which was the pre-existing contract.
+The credential is per-org and the mint is rotate-on-call, so the operator must fan out from a
+**single** mint for the same reason control-api does (§6.3); minting once per namespace
+revokes the previous namespace's key.
+
+Until the operator does that, a managed recipe workload on a private platform image behaves
+as it did before this change: the injected name is *never classified* (the recipe does not
+declare it), so it is projected verbatim and a missing Secret surfaces as
+`ImagePullBackOff` — the same symptom as the pre-#243 baseline (§3), not a new failure mode.
+Transport workloads delegated into the operator-provisioned `mcp-server` namespace start
+working immediately.
 
 ---
 
@@ -434,7 +504,7 @@ Existing recipes that already declare their own third-party pull secrets are una
 | R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). |
 | R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | Shared predicate (§6.2) + documented config pairing; consider surfacing both values on a status/health endpoint. |
 | R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; add a test asserting the Secret is NOT `shared`/`owner-recipe` labeled. |
-| R5 | A recipe declares the reserved name and expects it honored. | Validation rejects it with an explanatory message (§6.1). |
+| R5 | A recipe declares the reserved name and expects it honored. | **Closed.** Validation rejection (§6.1) shipped: `isPlatformManagedWorkflowSecretName` now reserves `EVENFIRE_REGISTRY_PULL_SECRET_NAME`, so `/validate`, POST, PUT and `POST /admin/recipes/secrets` reject the declaration at admission with a reserved-name rule. The #637 gate stays behind it as defense-in-depth for anything already persisted. |
 | R6 | Two extra copies of the credential. | Pull-only, org-scoped, no push; §8.2. |
 
 ---
@@ -474,7 +544,7 @@ Existing recipes that already declare their own third-party pull secrets are una
 1. **Scope of the third-party path (§6.5)** — ship the structured `kind: 'imagePull'`
    endpoint in this slice, or ship only the hard rejection now and the endpoint when a
    real BYO-registry recipe appears?
-2. **Reserved-name declaration (§6.1)** — hard-reject at validation, or accept-and-ignore
-   with a warning for backwards compatibility?
+2. ~~**Reserved-name declaration (§6.1)** — hard-reject at validation, or keep the #637
+   gate's ownership-worded denial?~~ **Resolved: hard-reject at validation shipped.**
 3. Should HCC gain the presence-validation from #243 §7.7 now that more namespaces
    reference the same Secret name?

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,10 +1,11 @@
 # Platform image-pull credentials for recipe workloads
 
-**Status:** Implemented in PR #243 — **not approved; five blocking review findings open**
-(§13), four of them P1. The most consequential (§13.1) reverses this document's
-install-time trigger decision: provisioning must become a standing invariant, because a
+**Status:** Implemented in PR #243. Five blocking review findings were raised against it
+(§13); **the four P1s are fixed** — including §13.1, which reversed this document's
+install-time trigger decision (provisioning is now a standing invariant, because a
 `WorkflowRecipe` can be created without control-api while WRC injects the pull-secret
-reference regardless. Two earlier carve-outs also remain recorded in place: WRC injection
+reference regardless). **§13.5 — end-to-end runtime evidence — remains open and is the
+last acceptance gate.** Two earlier carve-outs also remain recorded in place: WRC injection
 is deliberately **not** mode-gated, so the operator contract changes on managed clusters
 too (§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship.
 **Date:** 2026-08-04
@@ -598,7 +599,7 @@ accepted; none is dismissed. **§13.1 is the important one** — it invalidates 
 recorded in §12 and changes the shape of the feature from an install-time side effect into
 a standing cluster invariant.
 
-### 13.1 [P1] Provisioning must be a standing invariant, not an install-time hook
+### 13.1 [P1] ✅ SHIPPED — Provisioning is a standing invariant, not an install-time hook
 
 **The mismatch.** As shipped, the two halves of this feature are triggered by different
 things:
@@ -664,7 +665,7 @@ a credential that does not exist, but the pod still cannot pull, so it trades on
 failure for another. The presence-*surfacing* idea (§12-3 / #243 §7.7 — emit a condition
 instead of a bare `ImagePullBackOff`) is complementary and still worth doing.
 
-### 13.2 [P1] Minting can revoke a valid foreign copy
+### 13.2 [P1] ✅ SHIPPED — Minting can revoke a valid foreign copy
 
 The "never touch a foreign Secret" rule protects the **Secret object**; it does not protect
 the **credential inside it**. `mintPullKey` revokes `WHERE org_id = $1 AND kind = 'pull'`
@@ -685,7 +686,7 @@ actionable error (`foreign_secret_present`: remove it, or provision every namesp
 same way) rather than silently invalidating it. Reading the credential out of a foreign
 Secret and reusing it is explicitly rejected — that is someone else's credential.
 
-### 13.3 [P1] Serialization is per-process only
+### 13.3 [P1] ✅ SHIPPED — Serialization is per-process only
 
 `replicas: 1` in `deploy/base/control-plane/control-api.yaml:15` with no explicit
 `strategy` takes the default `RollingUpdate`, so two pods coexist on every deploy. The
@@ -702,7 +703,7 @@ control-api already has Postgres, so `pg_advisory_lock` is the natural mechanism
 no dependency — mirroring what the registry itself does inside `mintPullKey`. The
 in-process map stays as a cheap first-level dedupe.
 
-### 13.4 [P1] `upgrade-recipe` has no provisioning hook
+### 13.4 [P1] ✅ SHIPPED — `upgrade-recipe` has no provisioning hook
 
 `POST /admin/registry/upgrade-recipe` (`control-api/src/routes/admin/registry.ts:2001`)
 never calls `ensureRegistryPullSecret(s)`. The three existing hooks are at `:1206`
@@ -716,7 +717,7 @@ fails at pull time, with a `200` on the API call.
 install-recipe placement. Fix it explicitly even once §13.1 lands: the reconcile is a
 safety net, not a substitute for failing the request that introduced the problem.
 
-### 13.5 [Acceptance] No end-to-end runtime evidence
+### 13.5 [Acceptance] ⏳ OPEN — No end-to-end runtime evidence
 
 Coverage is unit- and route-level against `MockGateway`. Nothing exercises
 `Secret → WRC → McpServer/HCC → Pod Ready → private image pull`.
@@ -733,7 +734,31 @@ MCP-server plugin, (b) a recipe plugin with a non-transport workload, (c) a reci
 by `kubectl apply` (the §13.1 path), each asserting `Pod Ready` rather than just Secret
 contents.
 
-### 13.6 Sequencing
+### 13.7 As-built
+
+| # | Status | Where |
+| --- | --- | --- |
+| 13.1 | ✅ | `services/registryPullSecretReconcileCron.ts` (boot pass + timer, wired in `main.ts`); interval via `REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS` (default 10 min) |
+| 13.2 | ✅ | `registryPullSecretService.ts` — `foreign_secret_would_be_revoked`, all-or-nothing refusal |
+| 13.3 | ✅ | `withPullSecretLock` — `pg_advisory_xact_lock(hashtext('registry-pull-secret:<org>'))` around read→mint→write |
+| 13.4 | ✅ | `registry.ts` — hook on `upgrade-recipe`, keyed on the INCOMING spec |
+| 13.5 | ⏳ | still open — the only remaining acceptance gate |
+
+Notes worth carrying forward:
+
+- **The reconcile is why 13.3 was not optional.** A periodic loop without the lock does not
+  race occasionally, it fights continuously. The lock blocks rather than fails, so the
+  second replica waits, re-reads, finds an agreeing credential, and returns `exists-ours`
+  without minting — which is the convergence property the whole design wants.
+- **Failure semantics are split as specified**: `ensureRegistryPullSecrets` throws, the
+  install path surfaces that as a 4xx/5xx, and the cron swallows it into a warning and
+  retries. Both directions are mutation-tested (letting the error escape the cron fails 3
+  tests; removing the install-path throw fails the route tests).
+- **The unit suites now mock `../src/db.js`.** The advisory lock made them reach Postgres
+  and hang. The lock itself is still asserted — the mock records the SQL, so a test checks
+  the lock is taken, is keyed on the org, and is taken *before* the mint.
+
+### 13.6 Sequencing (as planned)
 
 ```
 §13.3 lock ──┬──> §13.1 periodic reconcile ──> §13.5 e2e

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -228,9 +228,12 @@ control-api's `shouldAttachEvenfirePullSecret` becomes
 `isLocal && isPlatformRegistryImage(...)`, preserving its current semantics exactly. WRC
 calls `isPlatformRegistryImage` directly (recipe workloads have no `isLocal` notion).
 
-**New WRC config:** `CONTEXT_*`-style registry URL (WRC has none today). It must be the
-same value control-api uses; document that a mismatch means recipe pods get no credential
-while MCP servers do.
+**New WRC config: reuse `CLERUM_REGISTRY_URL` verbatim** (WRC has no registry config
+today). Deliberately the *same* variable name control-api reads, not a WRC-prefixed alias:
+the two values must agree, and a shared name makes a mismatch a deployment error rather
+than a silent divergence. If they ever drift, recipe pods get no credential while MCP
+servers do — the hardest failure in this design to diagnose (R3), so the config is kept
+impossible to set inconsistently by accident.
 
 ### 6.3 One mint, fanned out — the core correctness rule
 
@@ -267,33 +270,75 @@ the three **platform** workload namespaces (`mcpServersNamespace`, `sandboxNames
 `sandboxUiNamespace`) — still a fixed allowlist derived from config, never from
 `body.namespace`. control-api already holds `secrets:create` in all three.
 
-### 6.4 Provisioning trigger
+### 6.4 Provisioning trigger — eager across all platform namespaces
 
-Provision into **all three** platform workload namespaces whenever provisioning runs at
-all, rather than computing per-recipe which namespaces a given manifest touches.
+**Decision: provision into all three platform workload namespaces** whenever provisioning
+runs, rather than computing per-recipe which namespaces a manifest touches. Triggered from
+both `install` and `install-recipe`, and only when the entry actually references a
+platform-registry image (same lazy principle as #243).
 
-Rationale: the invariant becomes global ("the platform credential is present everywhere it
-could be needed") instead of per-install, so a recipe *upgraded* into a new workload shape
-cannot outrun provisioning. The cost is two extra Secret copies of a credential the cluster
-already holds — no extra mint (§6.3), and no extra registry calls.
+The alternatives, and why they lose:
 
-Triggered from both `install` and `install-recipe`, on the same lazy principle as #243: only
-when the entry actually references a platform-registry image.
+| Option | Verdict |
+| --- | --- |
+| **Eager — all three** | **Chosen.** One fan-out, one global invariant. |
+| Per-recipe — namespaces computed from the manifest | Rejected — see below. |
+| Hybrid — `mcp-server` always, sandboxes once recipes exist | Rejected: saves two Secret copies, adds deployment-state tracking. |
+| Reconcile-driven — WRC requests the credential when it needs one | Rejected: WRC holds no registry credentials (the same argument that ruled out HCC in #243 §5); adds a control-plane callback. |
 
-### 6.5 Fix the `Opaque` trap
+**Rotate-on-call is what actually decides this.** Because every mint revokes the org's
+previous key, provisioning a *new* namespace later forces a re-mint — which invalidates
+the namespaces already provisioned, so all of them must be rewritten anyway (§6.3 step 4).
+Per-recipe provisioning therefore does **not** reduce mints; it multiplies cluster-wide
+credential churn, once per recipe that introduces a workload class the cluster has not seen.
 
-`POST /admin/recipes/secrets` hardcodes `type: 'Opaque'` (`recipes.ts:1654`), so an
-operator creating a *third-party* registry pull secret through the documented flow gets a
-silently unusable object. Either:
+It is also fragile across the control-api/WRC seam: control-api provisions at **install**,
+WRC reconciles **continuously**. A recipe later edited to add a `spec.ui.workloadRef` needs
+`sandbox-ui`, which was never provisioned and which nothing re-triggers — a silent
+`ImagePullBackOff` with no failing request to attribute it to. Eager provisioning removes
+that class of gap entirely.
 
-- **(a)** accept an optional `type`, allowing `kubernetes.io/dockerconfigjson` with the
-  matching `.dockerconfigjson` key — makes §4's non-goal (BYO registries) a first-class
-  supported path; or
-- **(b)** keep it Opaque-only but **reject** a request whose payload looks like a docker
-  config, pointing at the right mechanism.
+Cost: two extra copies of a pull-only, org-scoped credential in namespaces the operator
+already controls. **No extra mint, no extra registry calls** (§8.2).
 
-Recommend **(a)**: it completes the BYO story that the #637 owner-recipe model already
-implies, and it removes the only silent-failure mode in that endpoint.
+### 6.5 Fix the silent `Opaque` failure
+
+`POST /admin/recipes/secrets` hardcodes `type: 'Opaque'` (`recipes.ts:1654`). The kubelet
+honors only `kubernetes.io/dockerconfigjson` / `dockercfg` for image pulls, so a request
+that intends to create a pull Secret is accepted, written, returns `201` — and is then
+**silently ignored at pull time**. The user sees `ImagePullBackOff` with nothing pointing
+at the cause.
+
+**The silent failure is the bug**, and it must not survive regardless of how much of the
+third-party story we choose to support.
+
+Two cases must stay separate:
+
+- **Platform-registry images** — fully automatic, zero user input. That is this entire
+  spec; the recipe-secrets endpoint is not involved at all.
+- **Third-party registries** (ghcr.io, private Docker Hub, …) — the platform cannot invent
+  these credentials; someone must supply them once.
+
+For the third-party case, **do not ask anyone to paste a base64 `dockerconfigjson`.**
+Nobody will, and it is not a credential format humans should handle. Instead accept
+**structured input** and let the server assemble it:
+
+```
+POST /admin/recipes/secrets   { kind: 'imagePull', registry, username, password, ownership }
+  → type: kubernetes.io/dockerconfigjson
+  → data['.dockerconfigjson'] = buildDockerconfigjson(registry, username, password)
+  → labels: clerum.io/owner-recipe=<recipe>   (so #637 admits it for THAT recipe only)
+```
+
+This reuses the same blob builder the platform path already has
+(`registryPullSecretService.buildDockerconfigjson`), generalized from the fixed
+`username: '_'` form to an arbitrary username. The user supplies a registry, a username and
+a token — never base64.
+
+**Minimum bar if the structured endpoint is deferred:** reject a request that is evidently
+trying to create a pull Secret (a `.dockerconfigjson` key, or a docker-config-shaped
+payload) with an error naming the supported path. Accepting it and writing an object the
+kubelet ignores is the one outcome that must not remain.
 
 ---
 
@@ -400,13 +445,21 @@ Existing recipes that already declare their own third-party pull secrets are una
 
 ## 12. Open questions
 
-1. **Config plumbing for WRC** — reuse `CLERUM_REGISTRY_URL` verbatim, or a WRC-prefixed
-   variable? Reusing the same name reduces drift risk (R3) but couples the deployments.
-2. **Eager vs per-recipe namespaces (§6.4)** — is provisioning all three acceptable, or
-   should it be computed from the manifest's actual workloads?
-3. **`recipes.ts` `Opaque` fix (§6.5)** — accept `dockerconfigjson` (a), or reject with
-   guidance (b)?
-4. **Reserved-name declaration (§6.1)** — hard-reject at validation, or accept-and-ignore
+**Resolved**
+
+- ~~WRC config plumbing~~ — **reuse `CLERUM_REGISTRY_URL` verbatim** (§6.2).
+- ~~Eager vs per-recipe namespaces~~ — **eager, all three** (§6.4). Rotate-on-call means
+  per-recipe provisioning increases credential churn rather than reducing it.
+- ~~How much of the third-party story to support~~ — **structured input, server builds the
+  blob** (§6.5). Never ask a human for base64. Silent acceptance of an unusable Secret is
+  the bug being fixed, independent of scope.
+
+**Still open**
+
+1. **Scope of the third-party path (§6.5)** — ship the structured `kind: 'imagePull'`
+   endpoint in this slice, or ship only the hard rejection now and the endpoint when a
+   real BYO-registry recipe appears?
+2. **Reserved-name declaration (§6.1)** — hard-reject at validation, or accept-and-ignore
    with a warning for backwards compatibility?
-5. Should HCC gain the presence-validation from #243 §7.7 now that more namespaces
+3. Should HCC gain the presence-validation from #243 §7.7 now that more namespaces
    reference the same Secret name?

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -1,8 +1,12 @@
 # Platform image-pull credentials for recipe workloads
 
-**Status:** Implemented in PR #243, with two carve-outs recorded in place: WRC injection is
-deliberately **not** mode-gated, so the operator contract changes on managed clusters too
-(§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship with it.
+**Status:** Implemented in PR #243 — **not approved; five blocking review findings open**
+(§13), four of them P1. The most consequential (§13.1) reverses this document's
+install-time trigger decision: provisioning must become a standing invariant, because a
+`WorkflowRecipe` can be created without control-api while WRC injects the pull-secret
+reference regardless. Two earlier carve-outs also remain recorded in place: WRC injection
+is deliberately **not** mode-gated, so the operator contract changes on managed clusters
+too (§9), and the `POST /admin/recipes/secrets` `Opaque` fix (§6.5) did **not** ship.
 **Date:** 2026-08-04
 **Area:** control-api · workflow-recipes (WRC) · workflow-runtime-core · image pull · self-hosted
 **Follows:** [`registry-pull-secret-self-provisioning.md`](registry-pull-secret-self-provisioning.md)
@@ -333,6 +337,12 @@ the three **platform** workload namespaces (`mcpServersNamespace`, `sandboxNames
 
 ### 6.4 Provisioning trigger — eager across all platform namespaces
 
+> **SUPERSEDED IN PART by §13.1.** The *namespace* decision below stands (eager across all
+> three). The *trigger* decision does not: install-time hooks alone leave the `kubectl
+> apply` and `deploy_recipe` creation paths unprovisioned, because WRC injects the
+> reference for CRDs control-api never sees. Provisioning becomes a standing invariant
+> (boot + periodic + the lazy hooks). Read §13.1 before implementing this section.
+
 **Decision: provision into all three platform workload namespaces** whenever provisioning
 runs, rather than computing per-recipe which namespaces a manifest touches. Triggered from
 both `install` and `install-recipe`, and only when the entry actually references a
@@ -578,3 +588,159 @@ working immediately.
    gate's ownership-worded denial?~~ **Resolved: hard-reject at validation shipped.**
 3. Should HCC gain the presence-validation from #243 §7.7 now that more namespaces
    reference the same Secret name?
+
+---
+
+## 13. Review findings — remediation plan
+
+Five blocking findings from PR review. All five were verified against source before being
+accepted; none is dismissed. **§13.1 is the important one** — it invalidates a decision
+recorded in §12 and changes the shape of the feature from an install-time side effect into
+a standing cluster invariant.
+
+### 13.1 [P1] Provisioning must be a standing invariant, not an install-time hook
+
+**The mismatch.** As shipped, the two halves of this feature are triggered by different
+things:
+
+| Half | Trigger | Covers |
+| --- | --- | --- |
+| WRC **injects** the reference | every reconcile, for **any** `WorkflowRecipe` CRD | all creation paths |
+| control-api **provisions** the Secret | its own install/upgrade routes | one creation path |
+
+A `WorkflowRecipe` does not only come from control-api. `docs/crds/workflowrecipe.md:339`
+documents three supported paths:
+
+1. control-api (`POST /admin/registry/install-recipe`) — the only one hooked;
+2. **`kubectl apply`** of a CRD;
+3. the **WRC MCP `deploy_recipe` tool** (`workflow-recipes/src/mcp/tools.ts:62`,
+   `server.ts:128`), callable by an agent and authorized only by a `contextRef` match.
+
+For paths 2 and 3, WRC injects a reference to a Secret nobody created →
+`ImagePullBackOff`.
+
+**Why this is worse than the pre-existing gap.** Before this feature those paths produced a
+pod with *no* pull secret and the same failure. After it, the pod asserts a credential the
+platform never provisioned. Same symptom, but the platform is now making a claim it has
+not backed — which is exactly the class of silent precondition §2 exists to eliminate.
+
+**Decision — reverses §12's "lazy only".** control-api ensures the platform pull Secret as
+a **standing invariant**:
+
+- **At boot**, non-fatal, alongside the existing boot reconcilers in `main.ts`.
+- **Periodically**, on a configurable interval (default ~10 min), so a CRD created by any
+  path finds the credential already present.
+- **Plus the existing lazy hooks**, retained deliberately — an install must not wait up to
+  a full interval, and the lazy path is the only one that can fail the request with an
+  actionable error.
+
+**Two different failure semantics — specify both.** This is the part most likely to be got
+wrong:
+
+| Context | On a precondition failure (no org, not connected) |
+| --- | --- |
+| **Install/upgrade (lazy)** | **THROW** → fail the request with `registry_pull_secret_provision_failed` and a reason. The user asked for something we cannot deliver. |
+| **Boot / periodic reconcile** | **LOG and retry next tick.** A cluster mid-connect-flow must not crash-loop or emit an error every interval. |
+
+Reusing the install path's fail-loud behavior in the reconcile would turn a normal
+pre-connect state into recurring noise; reusing the reconcile's log-and-continue in the
+install would restore the silent `ImagePullBackOff`.
+
+**Hard dependency: the periodic loop makes §13.3 mandatory, not optional.** Two replicas
+reconciling on a timer, without a cross-process lock, do not merely race occasionally —
+they fight *continuously*: each pod's mint revokes the other's key, the fingerprint check
+then sees divergence, and both re-mint on the next tick. A lazy-only design races only
+during concurrent installs; a periodic design races forever. **§13.3 must land with, or
+before, the periodic reconcile.**
+
+**Second-order effect on §13.2.** With a periodic loop, a mint can happen at an arbitrary
+time rather than only during an install — so the possibility of revoking an
+externally-managed copy's credential (§13.2) stops being install-scoped and becomes
+continuous. That raises §13.2's priority from "handle it" to "handle it before enabling
+the timer."
+
+**Not chosen: have WRC skip injection when the Secret is absent.** It would avoid asserting
+a credential that does not exist, but the pod still cannot pull, so it trades one silent
+failure for another. The presence-*surfacing* idea (§12-3 / #243 §7.7 — emit a condition
+instead of a bare `ImagePullBackOff`) is complementary and still worth doing.
+
+### 13.2 [P1] Minting can revoke a valid foreign copy
+
+The "never touch a foreign Secret" rule protects the **Secret object**; it does not protect
+the **credential inside it**. `mintPullKey` revokes `WHERE org_id = $1 AND kind = 'pull'`
+(`evenfire-registry/src/services/orgApiKeyService.ts:130-131`) — every prior pull key for
+the org, whoever minted it.
+
+So: an operator-managed Secret in one namespace holds a working key; a plugin installs into
+another namespace with no Secret; we mint; the operator's key is revoked; we correctly do
+not touch their Secret — which now contains a dead credential. Their workloads break, we
+report success.
+
+Conditional on the foreign copy having been built from a `kind='pull'` key for the same
+org. A user token or publish-scoped `efrk_` key is unaffected.
+
+**Remediation:** treat a foreign copy as a **refusal to mint**, not something to work
+around. If any target namespace holds an externally-managed Secret, fail with an
+actionable error (`foreign_secret_present`: remove it, or provision every namespace the
+same way) rather than silently invalidating it. Reading the credential out of a foreign
+Secret and reusing it is explicitly rejected — that is someone else's credential.
+
+### 13.3 [P1] Serialization is per-process only
+
+`replicas: 1` in `deploy/base/control-plane/control-api.yaml:15` with no explicit
+`strategy` takes the default `RollingUpdate`, so two pods coexist on every deploy. The
+`inflight` map is per-process and does not span them.
+
+Interleaving is the problem, not key accumulation (which rotate-on-call already bounds):
+pod A mints `k1`; pod B mints `k2` (revoking `k1`); writes interleave; some namespaces end
+up holding the revoked key. The fingerprint annotation makes this **detectable and
+self-healing on the next pass** — but "the next pass" is the next install, so pulls fail
+until then.
+
+**Remediation:** a cross-process lock around read→mint→write, keyed on the org.
+control-api already has Postgres, so `pg_advisory_lock` is the natural mechanism and adds
+no dependency — mirroring what the registry itself does inside `mintPullKey`. The
+in-process map stays as a cheap first-level dedupe.
+
+### 13.4 [P1] `upgrade-recipe` has no provisioning hook
+
+`POST /admin/registry/upgrade-recipe` (`control-api/src/routes/admin/registry.ts:2001`)
+never calls `ensureRegistryPullSecret(s)`. The three existing hooks are at `:1206`
+(McpServer install), `:1522` (install-recipe) and `:1850` (McpServer upgrade).
+
+Upgrading a recipe from a public image to a private one therefore persists the CRD and then
+fails at pull time, with a `200` on the API call.
+
+**Remediation:** add the same hook, gated on `recipeReferencesPlatformImage` of the
+**incoming** spec, positioned after validation and before the CRD write — matching the
+install-recipe placement. Fix it explicitly even once §13.1 lands: the reconcile is a
+safety net, not a substitute for failing the request that introduced the problem.
+
+### 13.5 [Acceptance] No end-to-end runtime evidence
+
+Coverage is unit- and route-level against `MockGateway`. Nothing exercises
+`Secret → WRC → McpServer/HCC → Pod Ready → private image pull`.
+
+Mutation testing sharpens this rather than substituting for it: it proves the tests fail
+when the code breaks. It cannot prove the kubelet accepts the blob, that the type and data
+key are what Kubernetes wants, that RBAC permits the write in `sandbox-ui`, or that the
+registry honors the minted key at pull time. Those are assumptions verified only against
+docs and source.
+
+The dependency that made this untestable is gone: `evenfire-registry` #64 is merged and
+deployed. **Remediation:** a minikube e2e against the live registry covering (a) an
+MCP-server plugin, (b) a recipe plugin with a non-transport workload, (c) a recipe created
+by `kubectl apply` (the §13.1 path), each asserting `Pod Ready` rather than just Secret
+contents.
+
+### 13.6 Sequencing
+
+```
+§13.3 lock ──┬──> §13.1 periodic reconcile ──> §13.5 e2e
+§13.2 foreign┘
+§13.4 upgrade-recipe hook  (independent, land immediately)
+```
+
+§13.4 is independent and should land first as the smallest correct fix. §13.3 and §13.2
+gate the periodic half of §13.1 — the boot-only half is safe without them, so §13.1 may be
+split (boot now, timer after the lock) if that shortens the path to a mergeable state.

--- a/docs/architecture/registry-pull-secret-recipe-workloads.md
+++ b/docs/architecture/registry-pull-secret-recipe-workloads.md
@@ -259,12 +259,29 @@ control-api's `shouldAttachEvenfirePullSecret` becomes
 `isLocal && isPlatformRegistryImage(...)`, preserving its current semantics exactly. WRC
 calls `isPlatformRegistryImage` directly (recipe workloads have no `isLocal` notion).
 
-**New WRC config: reuse `CLERUM_REGISTRY_URL` verbatim** (WRC has no registry config
-today). Deliberately the *same* variable name control-api reads, not a WRC-prefixed alias:
-the two values must agree, and a shared name makes a mismatch a deployment error rather
-than a silent divergence. If they ever drift, recipe pods get no credential while MCP
-servers do — the hardest failure in this design to diagnose (R3), so the config is kept
-impossible to set inconsistently by accident.
+**New WRC config: reuse `CLERUM_REGISTRY_URL` verbatim.** Deliberately the *same* variable
+name control-api reads, not a WRC-prefixed alias: the two values must agree. If they drift,
+recipe pods get no credential while MCP servers do — the hardest failure in this design to
+diagnose (R3).
+
+A shared variable *name* is not by itself sufficient, and the original form of this section
+claimed more than it delivered on two counts. First, WRC did already have registry config:
+`registry/clerumRegistryClient.ts` reads `CLERUM_REGISTRY_URL` for catalog search (live via
+`mcp/handlers.ts`), so the variable is dual-purpose — API base URL for that client, image
+host for this predicate. Second, the values were not merely *possible* to set
+inconsistently, they were inconsistent **by default**: the shipped minikube overlay pinned
+WRC to `http://registry-api.registry.svc.cluster.local:8085` while control-api used
+`https://registry.evenfire.ai`, so R3 was the out-of-the-box behaviour and recipe installs
+reliably produced `ImagePullBackOff`. A shared predicate cannot prevent drift when each
+service feeds it a different value.
+
+What actually makes it safe is a single *definition*, not a single name:
+`control-api-config.CLERUM_REGISTRY_URL` is the only place the URL is written, and WRC
+projects that key via `configMapKeyRef` (`deploy/overlays/minikube/patches/registry-env.yaml`).
+Divergence is then unrepresentable in the overlay rather than merely discouraged. Any other
+overlay (notably the GCP/prod overlay, which lives in `evenfire-infra`) must establish the
+same pairing; WRC's base Deployment sets no `CLERUM_REGISTRY_URL`, so an overlay that
+neither patches it nor projects the key leaves it empty, which disables injection silently.
 
 ### 6.3 One mint, fanned out — the core correctness rule
 
@@ -502,7 +519,7 @@ working immediately.
 | --- | --- | --- |
 | R1 | Per-namespace minting revokes other namespaces' keys → partial cluster-wide `ImagePullBackOff`. | Single mint + fan-out write (§6.3); post-condition asserted in tests. |
 | R2 | Partial write (mint OK, one namespace fails) leaves a stale, undetectable key. | Fingerprint annotation makes divergence detectable and repairable (§6.3). |
-| R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | Shared predicate (§6.2) + documented config pairing; consider surfacing both values on a status/health endpoint. |
+| R3 | WRC/control-api registry URL drift → recipe pods get no credential while MCP servers do. | **Was live, not hypothetical** — the shipped minikube overlay pinned WRC to the in-cluster registry while control-api used the shared one, so every recipe install hit it (found in live testing 2026-08-04). Closed for this overlay by making `control-api-config.CLERUM_REGISTRY_URL` the single definition and projecting it into WRC via `configMapKeyRef` (§6.2). Shared predicate alone was insufficient. **Still open elsewhere:** WRC's base Deployment sets no default, so any other overlay (GCP/prod in `evenfire-infra`) must repeat the pairing or injection silently disables; surfacing both values on a status/health endpoint is still worth doing. |
 | R4 | Someone "fixes" #637 denial by labelling the Secret `shared`. | §5.1 recorded as an explicit, permanent non-goal; add a test asserting the Secret is NOT `shared`/`owner-recipe` labeled. |
 | R5 | A recipe declares the reserved name and expects it honored. | **Closed.** Validation rejection (§6.1) shipped: `isPlatformManagedWorkflowSecretName` now reserves `EVENFIRE_REGISTRY_PULL_SECRET_NAME`, so `/validate`, POST, PUT and `POST /admin/recipes/secrets` reject the declaration at admission with a reserved-name rule. The #637 gate stays behind it as defense-in-depth for anything already persisted. |
 | R6 | Two extra copies of the credential. | Pull-only, org-scoped, no push; §8.2. |

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -465,7 +465,11 @@ failure contract) — mirroring the existing fail-loud credentials write at
 `registry.ts:1226-1240`. When `gateway` is absent (dev/no-cluster), provisioning
 no-ops and the attach behaves as today.
 
-**Optional: boot-time reconcile.** A non-fatal pass in `main.ts` alongside
+**Boot + periodic reconcile — now REQUIRED, not optional (see the recipe spec §13.1).**
+For `McpServer` installs the lazy hook alone is sufficient, since that CRD is only ever
+created here. It is *not* sufficient once WRC injects the same reference into
+`WorkflowRecipe` workloads, because those CRDs can be created without control-api. A
+non-fatal pass in `main.ts` alongside
 `reconcileAllowedModelsConfigMapOnBoot` (`main.ts:~61`) can pre-create the Secret so
 it exists before any pod schedules. Deferred unless install-time latency is a
 concern; the lazy path suffices because HCC re-pulls once the Secret appears.
@@ -803,8 +807,14 @@ nothing. Mutation-verified: gating the hook on `credRequired` fails 3 of these 4
 
 - ~~MCC-word scrub breadth (§7.8)~~ — **done**: scrubbed repo-wide in comments, behavior
   unchanged. `grep -rn '\bMCC\b' control-api/src control-api/test` returns nothing.
-- ~~Trigger (§7.3)~~ — **lazy**, at the install/upgrade Secret-write phase; no boot
-  reconcile (it would provision on clusters that never install a private plugin).
+- ~~Trigger (§7.3)~~ — **REVERSED.** Originally resolved as lazy-only (no boot reconcile,
+  to avoid provisioning on clusters that never install a private plugin). That reasoning
+  holds for `McpServer` installs, which only ever originate here — but not for
+  `WorkflowRecipe`, which can be created by `kubectl apply` or the WRC `deploy_recipe`
+  tool without control-api being involved, while WRC injects the pull-secret reference
+  regardless. Provisioning therefore has to be a standing invariant. See
+  [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md)
+  §13.1.
 
 **Still open**
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -636,12 +636,27 @@ cluster" is the **self-hosted/dedicated** truth; the managed operator's own mode
 shared multi-tenant with per-`mcp-server-<slug>` isolation. This spec targets the
 self-hosted single-tenant slice and does not regress the managed per-namespace model.
 
-**Generality note:** the auto-attach only fires for registry-built `McpServer`s,
-which land in `mcp-server[-slug]`. A *non-transport* recipe workload pulling a
-private evenfire image would resolve its imagePullSecrets to `sandbox-recipes[-slug]`
-(`control-api/src/routes/admin/recipes.ts:66-80`) — not covered here. For now,
-private-image plugins are transport workloads; broadening to `sandbox-recipes` is
-future scope.
+> **KNOWN LIMITATION — recipe plugins are NOT covered by this spec.**
+>
+> The auto-attach fires only for registry-built `McpServer`s, which land in
+> `mcp-server[-slug]`. A `WorkflowRecipe` workload pulling a private evenfire image
+> resolves to `sandbox-recipes[-slug]` or `sandbox-ui[-slug]`
+> (`control-api/src/routes/admin/recipes.ts:66-80`), where this spec provisions nothing —
+> and `install-recipe` has no pull-secret hook at all. Worse, a *mixed* recipe (transport
+> + non-transport) that declares the Secret by name gets it **silently stripped**: the
+> Issue-#637 gate classifies our `managed-by`-only Secret as unlabeled → `denied`, and
+> `combineSecretAccess` makes a denial in one namespace denial everywhere.
+>
+> This is a design gap, not a configuration one — nothing in the platform can currently
+> create a usable pull Secret for a recipe namespace (`POST /admin/recipes/secrets`
+> hardcodes `type: 'Opaque'`, which the kubelet ignores for image pulls).
+>
+> Closing it is specified in
+> [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md),
+> which extends this model with a single-mint fan-out and platform-side injection. **Do
+> not** close it by labelling this Secret `clerum.io/shared=true` — the #637 predicate is
+> shared between `envSecret` and `imagePullSecrets`, so that would let any recipe read the
+> credential out of its own environment (see that spec, §5.1).
 
 ---
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -790,14 +790,24 @@ is outside `credRequired`); a mint failure fails the install and persists **no**
 McpServer; an unresolved org returns `409 org_unresolved`; a non-evenfire image provisions
 nothing. Mutation-verified: gating the hook on `credRequired` fails 3 of these 4.
 
-**Not shipped (deliberate)**
+**Shipped since — `tests/e2e/integration/registry-pull-secret-runtime.test.ts`**
 
 - **Integration / e2e (minikube, self-hosted)** — install a private plugin end-to-end and
-  assert the pod actually pulls. Requires the Workstream-A registry change deployed to a
-  reachable registry; worth adding once that lands.
+  assert the pod actually pulls. This was blocked on the Workstream-A registry change
+  reaching a live registry; `evenfire-registry` #64 is merged and deployed, so it now
+  exists. It covers this spec's `McpServer` path — control-api → `McpServer` CRD → HCC →
+  Deployment → Pod Ready → a real authenticated pull, with the image evicted from the
+  node's docker cache first so `imagePullPolicy: IfNotPresent` cannot serve it from cache
+  and leave the credential unexercised — alongside the recipe-workload extension. See
+  [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md)
+  §11 and §13.5.
+
+**Not shipped (deliberate)**
+
 - **A `mintOrgPullCredential` transport test** (endpoint path, POST, timeout, key
-  validation). It is mocked in both suites above; its behavior is asserted only
-  indirectly.
+  validation). It is mocked in both suites above; its behavior is still asserted only
+  indirectly at the unit level — though the e2e above now exercises the real transport end
+  to end, since a pull that succeeds proves the minted key reached the registry intact.
 
 ---
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -753,3 +753,86 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 
 **evenfire-managed-cluster-control (out of repo; sequenced retirement)**
 - `packages/backend/src/operations/handlers/tenant-install-shared.ts:476-496`, `evenfire-install.ts:356-378`, `install/secrets.ts:110-121,181-212`, `install/registry.ts:48-95` — the `install_registry_pull_secret` behavior being superseded.
+
+---
+
+## 14. Implementation plan
+
+Two phases. **Phase 1** unblocks self-hosted with **no registry change** (publish-scoped
+key). **Phase 2** swaps in a least-privilege pull-only credential and requires a small
+`evenfire-registry` change. control-api reads the *same* Secret in both; only the mint
+call and the key's scope/lifecycle change.
+
+### Phase 1 — control-api self-provisioning (evenfire repo)
+
+Ordered so each task is independently reviewable; **P1.1–P1.3** are the functional core,
+**P1.4–P1.7** are decoupling/quality.
+
+- **P1.1 — `registryClient.mintOrgMachineKey(orgName)`** (`control-api/src/services/registryClient.ts`).
+  New exported fn built on the private `orgRegistryFetch` (machine Bearer, prefixes
+  `/api/v1`), mirroring `createOrgGrant`. `POST /org/${orgName}/keys` with a **fixed
+  description marker** (e.g. `evenfire-registry-pull (auto)`); returns
+  `{ keyId, key }`. Do **not** consume the response's `dockerconfigjson` (wrong host,
+  §7.9-2). Add `revokeOrgMachineKey(orgName, keyId)` (`DELETE /org/:org/keys/:id`) and a
+  `listOrgMachineKeys(orgName)` filtered to the marker (for revoke-prior + repair).
+  *Accept:* unit test hits a mocked registry, asserts machine-Bearer + marker.
+- **P1.2 — `registryPullSecretService.ensureRegistryPullSecret(targetNs)`**
+  (`control-api/src/services/registryPullSecretService.ts`, **new**). The §7.1 state
+  machine: gate (mode/auth/url/non-null `orgName`) → read (404→absent, 403→abort,
+  classify ours/foreign/repair) → revoke-prior (marker-scoped) → mint (P1.1) → **build
+  dockerconfigjson locally** keyed on `registryHostFromUrl(config.registryUrl)` →
+  `createSecret`/`updateSecret` with `managed-by:control-api` + key-id annotation. In-process
+  mutex on the Secret name. Deps injected: `K8sGateway`, the P1.1 mint fns, `config`.
+  *Accept:* the §11 unit matrix (absent/ours/foreign/repair/409/gate-off) green.
+- **P1.3 — Wire into install + upgrade** (`control-api/src/routes/admin/registry.ts`).
+  Call `ensureRegistryPullSecret(targetNs)` when `shouldAttachEvenfirePullSecret` is true,
+  **outside the `if (credRequired)` block** (§7.9-1), in the Step-3 window **before** the
+  Step-4 CRD create, and **outside** the per-plugin `secretCreated`/rollback bookkeeping
+  (§7.3). Fail-loud (`registry_pull_secret_provision_failed`, `5xx`) — do not attach an
+  unresolvable ref. Same in the upgrade handler's credentials phase.
+  *Accept:* e2e (minikube, self-hosted) — a private plugin pulls; a credential-less
+  private plugin pulls; re-install idempotent; a pre-seeded foreign Secret is preserved.
+- **P1.4 — Revise existing tests** (`control-api/test/routes.registryInstall.test.ts`).
+  Update the `createSecret` call-count assertions (`:864`, `:1148`, `:1204`) and extend the
+  `evenfire imagePullSecrets attach` block (`:1424`) to assert the pull-Secret create,
+  shape, namespace (`targetNs`), and host-keying.
+- **P1.5 — Remove MCC knowledge** (§7.8). Rewrite comments at
+  `registryImagePullSecret.ts:6,12-13` and `registry.ts:1114-1116`; reword the test name at
+  `registryImagePullSecret.test.ts:10`; scrub the adjacent managed-mode "MCC" wording
+  (keep the `registryConnectionMode` behavior). *Gate:* `grep -rn '\bMCC\b' control-api/src
+  control-api/test` returns only intentional, neutral phrasings.
+- **P1.6 — Docs** — fix `docs/how-to/connect-to-registry.md:59,70` to describe
+  self-provisioning; add the node-level registry-egress note for remote-registry
+  self-hosters (§7.8).
+- **P1.7 — (optional) HCC presence-validation** (§7.7) — separate PR; read-validate the
+  pull Secret and emit a `SecretResolved`-style condition instead of silent
+  `ImagePullBackOff`.
+
+### Phase 2 — least-privilege pull-only mint (evenfire-registry + control-api)
+
+- **P2.1 — Registry: relax the pull-credential gate** (`evenfire-registry/src/routes/org.ts`).
+  In `POST /:org/registry-pull-credential`, replace the `*`-admin gate (`:376`) with
+  `authorizeMachineForOrg(auth, orgName, 'registry:manage-keys')` (option §6.2(a)) so an
+  org-bound machine can mint a pull-only key for its **own** org. Keep `mintPullKey`
+  (rotate-on-call, `kind:'pull'`) and the audit log; no change to `buildDockerconfigjson`.
+  *Accept:* an org-bound `manage-keys` machine gets `201`; a foreign org still `403`s;
+  `*`-admin still works (MCC unaffected).
+- **P2.2 — control-api: switch the mint call** (`registryClient.ts` + `registryPullSecretService.ts`).
+  Point the mint at the pull-only endpoint, extract `key`, build the dockerconfigjson
+  locally keyed on the `registryUrl` host (unchanged from P1). Since the pull endpoint is
+  **rotate-on-call** (revokes the org's prior pull key), the explicit revoke-prior (P1.1)
+  becomes redundant — but keep the **read-before-mint** discipline strict (a blind re-mint
+  now *orphans* the on-cluster key). This flips the key-lifecycle tradeoff: accumulation
+  (R3) disappears, the rotate-on-call footgun returns and is handled by read-before-mint.
+  *Accept:* the minted key carries only pull scope (`kind:'pull'`); re-provision with the
+  Secret present does not rotate.
+- **P2.3 — Security sign-off** on retiring the interim publish-scoped key (§6.3, §12-1);
+  once P2 ships, existing Phase-1 Secrets are replaced on next ensure/rotation.
+
+### Sequencing (see §9)
+
+`P1.1 → P1.2 → P1.3` land the fix; `P1.4–P1.6` land with them. `P2.*` is a fast follow.
+Retiring the managed operator's `install_registry_pull_secret` step (§9.3) is a separate,
+later change in that repo — **not** part of this plan, and only once managed-mode
+provisioning is guaranteed by another actor; until then the `registryConnectionMode` gate
+keeps managed and self-hosted cleanly partitioned.

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -312,72 +312,74 @@ same namespace as the plugin pod (`server.namespace = targetNs`,
 `host-context-controller/src/reconciler.ts:946-948`) or the ref silently fails to
 resolve. It does **not** invent its own namespace — co-location with the McpServer is
 a correctness requirement, not a policy choice. The guardrail against writing into an
-arbitrary namespace is the RBAC check in step 2 (a `403` read aborts before minting),
-plus constraining plugin installs to control-api's covered namespaces (§8). If the
-gateway is absent (dev/no-cluster), it no-ops.
+*arbitrary* namespace is an explicit equality check against `config.mcpServersNamespace`
+(step 2) — not RBAC, which is broader than this rule allows (control-api holds
+`secrets:create` in six namespaces, `channels` among them). A `403` on the read is a
+second line of defence that aborts before any mint. If the gateway is absent
+(dev/no-cluster), the install routes are not registered at all, so nothing is attached
+either.
+
+Two invariants drive the whole algorithm:
+
+- **I1 — never write a Secret we do not own.** Ownership is decided *before* the payload
+  is examined, so a foreign Secret is left alone even when it looks broken. Adopting one
+  would seize an external operator's credential; repairing it in place would rotate the
+  org key out from under them.
+- **I2 — mint only when already committed to a write that can succeed.** The mint is
+  rotate-on-call (it revokes the org's previous key), so a mint followed by a failed
+  write strands *every other namespace's* Secret on a revoked credential.
 
 Algorithm:
 
-1. **Gate — no-op (`'skipped'`) unless all hold:**
-   - `registryConnectionMode === 'self-hosted'` (`config.ts:~76`);
-   - `isRegistryAuthActive()` true (`registryConnectionDb.ts:231-234`);
-   - `config.registryUrl` non-empty and allowlisted;
-   - `resolvePublishScope().orgName` is **non-null** (`registryClient.ts:650-662` —
-     it is nullable for curator/unresolved `/whoami`; `isRegistryAuthActive()` checks
-     credential presence, *not* org mapping). A null org means the connect flow has
-     not populated `org_name` yet — skip with a clear install-time error rather than
-     minting against `/org/null/keys`.
+1. **Legitimate no-ops (`'skipped'`)** — and *only* these two:
+   - `registryConnectionMode !== 'self-hosted'` → the managed operator owns the Secret;
+     never contend with it. This is the first statement, before any network or DB call.
+   - `registryHostFromUrl(config.registryUrl)` is null → no registry configured (the
+     attach predicate is false too, so this is unreachable in practice).
+2. **Hard preconditions — these THROW `PullSecretProvisionError`**, because from here on
+   the caller is about to attach a reference and a silent skip would recreate the exact
+   `ImagePullBackOff` this spec removes:
+   - `targetNs !== config.mcpServersNamespace` → `unsupported_namespace` (400). Confines
+     a registry credential to the namespace this deployment actually serves so a
+     caller-supplied `body.namespace` cannot plant it elsewhere (§8).
+   - `isRegistryAuthActive()` false → `registry_not_connected` (409).
+   - `resolvePublishScope().orgName` null → retry once with `{force:true}` (the cache is
+     module-level and a cold start can pin a null org, `registryClient.ts`), then
+     `org_unresolved` (409). The two sibling self-service routes already do this forced
+     refresh; this one must match.
+3. **Read + classify.** `getSecret` re-throws 404 (`secretService.ts:25-31`), so:
+   - `404` → **absent** → go to step 4.
+   - any other status (esp. **403**) → **abort before minting**.
+   - present and **not** labeled `managed-by=control-api` → **`'exists-foreign'`**,
+     returned unconditionally (I1). If it is also unusable we log a warning naming the
+     remedy (delete it), but we never write.
+   - present, ours, `type` correct, and the decoded blob's `auths` contains the current
+     host → **`'exists-ours'`**. Presence alone is not enough: a blob keyed on a previous
+     `CLERUM_REGISTRY_URL` can never be selected by the kubelet.
+   - present, ours, otherwise → **`'repaired'`**. When `type` is wrong the Secret is
+     **deleted and recreated** (`Secret.type` is immutable; an update would 422), and the
+     delete happens *before* the mint so a failed delete cannot strand a fresh key (I2).
+4. **Mint + create (absent).** Call the pull-only mint for the resolved org, then
+   `createSecret`. **Build the `dockerconfigjson` locally**, keyed on
+   `registryHostFromUrl(config.registryUrl)` — *not* the registry's
+   `registryTokenIssuer`-keyed response (§7.9-2).
+   On a create **`409`** (lost race): **re-read and adopt the winner** — do *not* mint
+   again, since a second mint would revoke the key the winner just stored.
 
-   This mirrors the attach predicate, so the Secret is provisioned exactly when a
-   private evenfire-hosted image is in play, and managed clusters stay inert.
-2. **Read.** `getSecret('evenfire-registry-pull', ns)`. **`getSecret` is NOT
-   404-aware — it re-throws the underlying K8s error including 404**
-   (`secretService.ts:25-31`, docstring explicit). So:
-   - `statusCode === 404` → treat as **absent** → go to step 3.
-   - Any other error (esp. **`403`** — namespace outside control-api's secrets RBAC)
-     → **abort** without minting (surface it; do not waste a key-cap slot).
-   - Present, **non-empty** `.dockerconfigjson`, **not** labeled
-     `clerum.io/managed-by=control-api` → **`'exists-foreign'`**: an external operator
-     owns it → return, never touch (coexistence guarantee, §7.4).
-   - Present, labeled `managed-by=control-api`, **non-empty** `.dockerconfigjson` →
-     **`'exists-ours'`**: reuse (rotation handled separately, §7.6).
-   - Present but `.dockerconfigjson` **missing/empty** (placeholder, truncated write,
-     wrong-typed same-named Secret), regardless of label → **`'repaired'`**: mint and
-     `updateSecret` (replace) — do **not** `createSecret` (it would 409). This closes
-     the gap where a create-409 is silently "treated as success" over a broken Secret.
-3. **Mint (only reached when the Secret is absent or broken).** Call the registry's
-   pull-only mint for `resolvePublishScope().orgName`
-   (`POST /org/:org/registry-pull-credential`, §6.1/§6.2). It is **rotate-on-call**
-   (revokes the org's prior pull key and inserts a fresh one under a lock,
-   `orgApiKeyService.ts:122-142`), so no explicit revoke-prior bookkeeping is needed —
-   but this is exactly why **step 2's read-before-mint is mandatory**: a blind re-mint
-   would orphan a working on-cluster key. **Build the `dockerconfigjson` locally**,
-   keyed on `registryHostFromUrl(config.registryUrl)` (the image host, per the attach
-   invariant) — *not* the registry's `registryTokenIssuer`-keyed response (§7.9-2) —
-   via `{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`
-   (`orgApiKeyService.ts:147-151`).
-4. **Write.** `createSecret` (absent) or `updateSecret` (repair) with
-   `type:'kubernetes.io/dockerconfigjson'`,
-   `data:{'.dockerconfigjson': <base64>}`,
-   `labels:{'clerum.io/managed-by':'control-api'}`, and an annotation carrying the
-   key id. On a create `409` (concurrent create) → re-read; if the winner is
-   `exists-ours`, treat as success (and revoke the key this call just minted to avoid
-   a leak); otherwise classify per step 2.
-
-**Failure contract (§7.3 wires this).** If the gate passes but mint or write throws,
-the caller **fails the install/upgrade loudly** with a `5xx`
-`registry_pull_secret_provision_failed` and does **not** attach an unresolvable
-`imagePullSecrets` ref — mirroring the existing fail-loud Secret write at
-`registry.ts:1226-1240`. A silent proceed-and-attach would reproduce the very
-`ImagePullBackOff` this spec removes. `authedFetch` does not itself time out, so the
-mint call should carry a bounded timeout.
+**Failure contract (§7.3 wires this).** Any throw from steps 2-4 fails the
+install/upgrade and does **not** persist an McpServer, so no unresolvable
+`imagePullSecrets` ref is ever written. Statuses are mapped by class, not collapsed:
+`PullSecretProvisionError` keeps its own status + `reason`; a registry rejection becomes
+**502** with the upstream status (a generic K8s mapping cannot read
+`RegistryProxyError.status` and would report every mint failure as a bare 500); anything
+else is 500. The mint carries a bounded timeout — `authedFetch` only bounds GETs.
 
 ### 7.2 The Secret contract (frozen — must match MCC byte-for-byte)
 
 | Field | Value | Source of truth |
 | --- | --- | --- |
 | `metadata.name` | `evenfire-registry-pull` | `EVENFIRE_REGISTRY_PULL_SECRET_NAME` (`registryImagePullSecret.ts:15`) |
-| `metadata.namespace` | **`targetNs`** = the McpServer's own namespace (`body.namespace \|\| config.mcpServersNamespace`) — must co-locate with the pod, since `imagePullSecrets` are namespace-local (§7.1) | `registry.ts:1011`, `reconciler.ts:946-948` |
+| `metadata.namespace` | **`targetNs`** = the McpServer's own namespace — must co-locate with the pod, since `imagePullSecrets` are namespace-local. Provisioning **refuses** any `targetNs` other than `config.mcpServersNamespace` (§7.1 step 2), so a `body.namespace` override cannot redirect the credential | `registry.ts:1011`, `reconciler.ts:946-948` |
 | `metadata.labels` | `clerum.io/managed-by: control-api` (provenance label — the ownership marker) | precedent `registry.ts:1206-1209`, `workflow-recipes secretFactory` |
 | `type` | `kubernetes.io/dockerconfigjson` | kubelet contract |
 | `data['.dockerconfigjson']` | base64 payload **verbatim** (do not double-encode; use `data`, not `stringData`) | `secretService.ts:44`; `secrets.ts:110-121` |
@@ -398,14 +400,14 @@ mint call should carry a bounded timeout.
 > #637 recipe↔Secret access model (`packages/workflow-runtime-core/src/secret-ownership.ts`)
 > and carry the wrong semantics for a namespace-wide shared credential.
 >
-> **Concurrency.** With multiple control-api replicas or concurrent install/upgrade
-> ops, the read→mint→write sequence can race. The create-`409` re-read (step 4)
-> collapses the Secret-write race, and an in-process mutex keyed on the Secret name
-> serializes provisioning within a replica. The mint itself is safe under races:
-> `mintPullKey` is rotate-on-call under a per-org advisory lock, so concurrent mints
-> converge on a single active pull key rather than accumulating — though a replica
-> that minted just before a peer's rotate must still re-read (a stale in-hand key is
-> discarded in favor of the on-cluster Secret).
+> **Concurrency.** Within a replica, concurrent ensures for the same
+> `(namespace, secret)` share a single in-flight promise (a dedupe map, not a mutex —
+> the second caller receives the first caller's result rather than re-running the state
+> machine), so two simultaneous installs cannot both mint. Across replicas, the
+> create-`409` path **re-reads and adopts the winner instead of minting again**; that is
+> what keeps the stored key and the registry's active key in agreement, since a second
+> mint would revoke the key the winner just stored. `mintPullKey` is itself rotate-on-call
+> under a per-org advisory lock, so keys never accumulate.
 
 ### 7.3 Trigger point
 
@@ -520,11 +522,11 @@ self-provisioning, keeping the constant and predicate (they are the local contra
   pull-secret name"); the scrub is computed over `control-api/test` as well as
   `control-api/src`, or G2 does not hold.
 
-**Adjacent — catalog, decide explicitly (likely follow-up):** these mention MCC or
-managed-mode topology but are *not* the pull secret. The "repo should know nothing
-about MCC" goal argues for scrubbing the literal word "MCC" (replace with "the
-managed operator" / "managed mode"), but the *behavior* they branch on is legitimate
-(control-api genuinely differs by `registryConnectionMode`):
+**Adjacent — DONE in this pass.** These mention managed-mode topology but are *not* the
+pull secret. The literal word "MCC" has been replaced with "the managed operator" /
+"managed" in each; the *behavior* they branch on is legitimate and unchanged
+(control-api genuinely differs by `registryConnectionMode`). `grep -rn '\bMCC\b'
+control-api/src control-api/test` now returns nothing:
 
 - `config.ts:62` — voucher-kid "Delivered by MCC in the registry-voucher Secret"
   (voucher-identity substrate; self-hosted reads kid from the `registry_connection`
@@ -681,10 +683,10 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 | --- | --- | --- |
 | R1 | Rotate-on-call mint orphans a working on-cluster key (blind re-mint). | Read-before-mint is mandatory — mint only when the Secret is absent/broken (§7.1); in-process serialization on the Secret name. |
 | R2 | Clobbering an operator/MCC Secret. | Mode gate + `managed-by` ownership read; foreign Secrets are never written (§7.4); unlabeled-⇒-foreign invariant noted (§7.2). |
-| R3 | Pull Secret in the wrong namespace → ref silently unresolved (`imagePullSecrets` are namespace-local). | Provision into `targetNs` (co-located with the McpServer + credentials Secret), not a fixed namespace; a namespace outside control-api's secrets-RBAC set fails the read `403` and aborts (§7.1/§8). |
-| R4 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | Gate on `isRegistryAuthActive()` **and** non-null `resolvePublishScope().orgName`; skip with a clear install-time error, never mint against `/org/null/…` (§7.1). Presupposes a working self-hosted connect flow. |
+| R3 | Pull Secret in the wrong namespace → ref silently unresolved (`imagePullSecrets` are namespace-local). | Provision into `targetNs` so it co-locates with the pod, and **refuse** any `targetNs` other than `config.mcpServersNamespace` (§7.1 step 2); a `403` read aborts before minting as a second line of defence. |
+| R4 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | **Throws** `registry_not_connected` / `org_unresolved` (409) rather than skipping, so the install fails instead of attaching an unresolvable ref; a cached null org is retried once with `{force:true}` before failing (§7.1 step 2). |
 | R5 | Registry unreachable, or the §6.2 endpoint change not yet deployed → mint 403/error. | control-api→registry egress already covered in base; the registry change ships in the same release and must be live before control-api mints (§14 ordering); fail-loud install surfaces it (§7.1). |
-| R6 | `targetNs` outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`) via a `body.namespace` override. | Default `targetNs` is `config.mcpServersNamespace` (`mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting (§7.1); operators exposing the override constrain it to the covered set (§8). |
+| R6 | A caller-supplied `body.namespace` redirects an org registry credential into another namespace (control-api holds `secrets:create` in six, incl. `channels`). | Provisioning **refuses** any namespace other than `config.mcpServersNamespace` with `unsupported_namespace` (400) before minting — RBAC alone is broader than this rule allows (§7.1 step 2, §8). |
 | R7 | Shared pull Secret wrongly torn down by a per-plugin rollback. | `ensureRegistryPullSecret` sits outside the Step-4 `secretCreated`/`deleteSecret` rollback scope; a CRD-create failure never deletes the namespace-shared pull Secret (§7.3). |
 | R8 | `.dockerconfigjson` keyed on the wrong host → present Secret still yields `ImagePullBackOff`. | Build the blob locally keyed on `registryHostFromUrl(config.registryUrl)` (= image host), not the registry's `registryTokenIssuer` (§7.9-2). |
 | R9 | Credential-less private-image plugin (`credRequired=false`) gets no pull Secret. | Hook is outside the `if (credRequired)` block, gated only on `shouldAttachEvenfirePullSecret` (§7.9-1). |
@@ -693,45 +695,69 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 
 ## 11. Test plan
 
-- **Unit** — `shouldAttachEvenfirePullSecret` unchanged; new
-  `ensureRegistryPullSecret` state machine: absent→created; ours→reuse;
-  foreign(unlabeled)→untouched; 409→success; gate off in managed/auth-off/empty-URL.
-- **Secret shape** — asserts type `kubernetes.io/dockerconfigjson`, single
-  `.dockerconfigjson` key, base64 not double-encoded, `managed-by=control-api` label,
-  namespace = `config.mcpServersNamespace`.
-- **Registry client** — machine `POST /org/:org/registry-pull-credential` mint returns
-  a pull-only `key`; org resolved from `resolvePublishScope`; dockerconfigjson built
-  locally, keyed on the `registryUrl` host.
-- **Registry (Workstream A)** — an org-bound `manage-keys` machine mints its own org's
-  pull key (`201`); a foreign org `403`s; `*`-admin still works.
-- **Integration / e2e (minikube, self-hosted)** — install a private evenfire-hosted
-  local plugin; assert the Secret is created and the plugin pod pulls (no
-  `ImagePullBackOff`); re-install is idempotent; a pre-seeded foreign Secret is
-  preserved.
-- **Coexistence** — with a pre-existing unlabeled Secret, ensure returns
-  `'exists-foreign'` and does not mint.
-- **Existing tests to revise (not just add).** `control-api/test/routes.registryInstall.test.ts`
-  asserts `createSecret` call counts that this change alters: `:864`
-  `toHaveBeenCalledTimes(1)` (now 2 for an evenfire-hosted plugin), and `:1148`/`:1204`
-  `not.toHaveBeenCalled()` (now called if the plugin is evenfire-hosted). These, and the
-  `evenfire imagePullSecrets attach` describe block (`:1424`), must be updated to
-  account for the pull-Secret create and to assert its shape/namespace.
-- **Host-keying** — the minted Secret's `.auths` key equals the image host
-  (`registryUrl` host), not `registryTokenIssuer`, verified against a config where the
-  two differ (§7.9-2).
-- **credRequired=false** — a private evenfire-hosted plugin with no credentials still
-  gets the pull Secret (hook outside the `credRequired` block, §7.9-1).
+**Shipped — `control-api/test/registryPullSecretService.test.ts` (state machine, 16 cases)**
+
+- No-ops: managed mode; no registry host configured.
+- Throws (not skips): inactive connection; org unresolved after a forced refresh;
+  `targetNs` outside the configured plugin namespace; a non-404 read (403); a mint
+  failure — each asserting **nothing was minted or written**.
+- Forced refresh: a cached null org is retried with `{force:true}` and then succeeds.
+- Provisioning: absent → created, with `type`, `managed-by` label, and an `.auths` map
+  keyed on the **image host** (the assertion that would catch a `registryTokenIssuer`
+  regression); ours+valid → reused without minting; ours+stale host → repaired;
+  ours+empty → repaired; ours+wrong `type` → **deleted and recreated**, with the delete
+  asserted to precede the mint.
+- Ownership: a foreign Secret **with** data and a foreign **empty** Secret are both left
+  byte-for-byte untouched and never relabelled.
+- Race: a create-`409` adopts the winner with **exactly one** mint.
+
+**Shipped — `control-api/test/routes.registryInstall.pullSecret.test.ts` (wiring, 4 cases)**
+
+Runs in `self-hosted` mode, which the pre-existing route suites never do (they default to
+`managed`, where the hook short-circuits — which is why the wiring previously had no real
+coverage). Asserts: a **credential-less** private plugin still gets the Secret (the hook
+is outside `credRequired`); a mint failure fails the install and persists **no**
+McpServer; an unresolved org returns `409 org_unresolved`; a non-evenfire image provisions
+nothing. Mutation-verified: gating the hook on `credRequired` fails 3 of these 4.
+
+**Not shipped (deliberate)**
+
+- **Integration / e2e (minikube, self-hosted)** — install a private plugin end-to-end and
+  assert the pod actually pulls. Requires the Workstream-A registry change deployed to a
+  reachable registry; worth adding once that lands.
+- **A `mintOrgPullCredential` transport test** (endpoint path, POST, timeout, key
+  validation). It is mocked in both suites above; its behavior is asserted only
+  indirectly.
 
 ---
 
 ## 12. Open questions / decisions for review
 
-1. **MCC-word scrub breadth (§7.8)** — scrub only pull-secret comments, or all
-   managed-mode "MCC" mentions? *(Recommendation: scrub wording, keep behavior.)*
-2. **Trigger (§7.3)** — lazy-at-attach only, or add the boot reconcile? *(Recommendation: lazy; boot optional.)*
-3. **Rotation policy (§7.6)** — reactive-only now, or add scheduled proactive rotation? *(Recommendation: reactive now, defer scheduled.)*
-4. **HCC presence-validation (§7.7)** — in this release or a follow-up? *(Recommendation: follow-up.)*
-5. **Managed-operator step retirement (§9.3)** — coordinate managed self-provisioning, or leave managed on the operator indefinitely behind the mode gate?
+**Resolved**
+
+- ~~MCC-word scrub breadth (§7.8)~~ — **done**: scrubbed repo-wide in comments, behavior
+  unchanged. `grep -rn '\bMCC\b' control-api/src control-api/test` returns nothing.
+- ~~Trigger (§7.3)~~ — **lazy**, at the install/upgrade Secret-write phase; no boot
+  reconcile (it would provision on clusters that never install a private plugin).
+
+**Still open**
+
+1. **Registry-side scope backfill (§9-1)** — admin-approved deployments lack
+   `registry:manage-keys` and 403 even after the gate relaxation ships. Needs the
+   two-line fix + migration in `evenfire-registry`. **This is the one item that gates
+   the release** for self-hosted clusters that were not auto-approved.
+2. **Rotation (§7.6)** — no reactive trigger shipped. A stale *host* is now self-healed
+   (content is validated), but a key revoked *out-of-band* is not. Add a re-provision
+   endpoint, or accept "delete the Secret and re-install" as the remedy?
+3. **HCC presence-validation (§7.7)** — follow-up PR, or never? It would turn a missing
+   Secret into a clean condition instead of `ImagePullBackOff`.
+4. **`enforceNamespace` on the install route** — this PR guards only the *credential*
+   write (§7.1 step 2). Applying the repo's existing `enforceNamespace` middleware to
+   `POST /admin/registry/install` would also constrain where the McpServer itself lands,
+   consistent with every other admin secret route — but that changes pre-existing install
+   semantics and was deliberately left out of scope here.
+5. **Managed-operator step retirement (§9-3)** — coordinate managed self-provisioning, or
+   leave managed on the operator indefinitely behind the mode gate?
 
 ---
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -1,7 +1,12 @@
 # Self-provisioning the `evenfire-registry-pull` image-pull Secret
 
-**Status:** Draft / proposed
-**Date:** 2026-08-03
+**Status:** Implemented — shipped in PR #243 (`control-api`), together with the recipe-workload
+extension in [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md).
+The registry-side gate this depends on (§6.2 / §14-A1) is `evenfire-registry` PR #64,
+**merged and deployed to production 2026-08-04** — including the scope backfill for
+admin-approved deployments (evenfire-registry#65 / migration 021, §9-1). Reactive rotation
+(§7.6) remains open.
+**Date:** 2026-08-03 (design) · 2026-08-04 (as-built)
 **Area:** control-api registry integration · image pull · self-hosted / open-core
 **Supersedes (in effect):** the "MCC mints + creates the secret" role in the registry
 bridge design `evenfire-registry/docs/superpowers/specs/2026-06-30-registry-phase2-4-grant-pull-credential-bridge-design.md` §4.2, for **self-hosted** deployments.
@@ -11,6 +16,11 @@ bridge design `evenfire-registry/docs/superpowers/specs/2026-06-30-registry-phas
 ---
 
 ## 1. Summary
+
+> **Reading note (as-built).** This document is written in the design's future tense
+> ("this spec makes…", "ships in the same release"). It shipped as specified; read those
+> as descriptions of the delivered behavior, except where a section is explicitly marked
+> **not shipped**. §11 already distinguishes shipped from deliberately-skipped tests.
 
 On a **managed** cluster, the hosted operator ("MCC", out of this repo) creates the
 `evenfire-registry-pull` dockerconfigjson Secret in the plugin namespace, and
@@ -273,7 +283,7 @@ required — e.g. `mintOrgPullCredential(orgName): Promise<{ key, keyId }>` — 
 `orgRegistryFetch`, mirroring the existing `createOrgGrant` pattern
 (`registryClient.ts:584`). Listed in §13.
 
-### 6.2 The registry change (ships in the same release)
+### 6.2 The registry change — SHIPPED (`evenfire-registry` PR #64, deployed 2026-08-04)
 
 Relax `POST /org/:org/registry-pull-credential` so an **org-bound machine holding
 `registry:manage-keys`** can mint a pull-only key for its **own** org. Today the gate
@@ -636,27 +646,32 @@ cluster" is the **self-hosted/dedicated** truth; the managed operator's own mode
 shared multi-tenant with per-`mcp-server-<slug>` isolation. This spec targets the
 self-hosted single-tenant slice and does not regress the managed per-namespace model.
 
-> **KNOWN LIMITATION — recipe plugins are NOT covered by this spec.**
+> **CLOSED — recipe plugins were not covered by this spec as first written.**
 >
-> The auto-attach fires only for registry-built `McpServer`s, which land in
-> `mcp-server[-slug]`. A `WorkflowRecipe` workload pulling a private evenfire image
-> resolves to `sandbox-recipes[-slug]` or `sandbox-ui[-slug]`
-> (`control-api/src/routes/admin/recipes.ts:66-80`), where this spec provisions nothing —
-> and `install-recipe` has no pull-secret hook at all. Worse, a *mixed* recipe (transport
+> *Historical, kept because it explains the shape of the extension.* The auto-attach fired
+> only for registry-built `McpServer`s, which land in `mcp-server[-slug]`. A
+> `WorkflowRecipe` workload pulling a private evenfire image resolves to
+> `sandbox-recipes[-slug]` or `sandbox-ui[-slug]`
+> (`control-api/src/routes/admin/recipes.ts:66-80`), where this spec provisioned nothing —
+> and `install-recipe` had no pull-secret hook. Worse, a *mixed* recipe (transport
 > + non-transport) that declares the Secret by name gets it **silently stripped**: the
 > Issue-#637 gate classifies our `managed-by`-only Secret as unlabeled → `denied`, and
 > `combineSecretAccess` makes a denial in one namespace denial everywhere.
 >
-> This is a design gap, not a configuration one — nothing in the platform can currently
-> create a usable pull Secret for a recipe namespace (`POST /admin/recipes/secrets`
-> hardcodes `type: 'Opaque'`, which the kubelet ignores for image pulls).
+> This was a design gap, not a configuration one — nothing in the platform could create a
+> usable pull Secret for a recipe namespace. (One half of that is still true:
+> `POST /admin/recipes/secrets` still hardcodes `type: 'Opaque'`, which the kubelet ignores
+> for image pulls — the third-party BYO-registry path, still open.)
 >
-> Closing it is specified in
-> [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md),
-> which extends this model with a single-mint fan-out and platform-side injection. **Do
-> not** close it by labelling this Secret `clerum.io/shared=true` — the #637 predicate is
-> shared between `envSecret` and `imagePullSecrets`, so that would let any recipe read the
-> credential out of its own environment (see that spec, §5.1).
+> **Closed in the same PR** by
+> [`registry-pull-secret-recipe-workloads.md`](registry-pull-secret-recipe-workloads.md):
+> `ensureRegistryPullSecrets` fans out from a **single** mint to all three platform workload
+> namespaces, and WRC **injects** the reference after the #637 filter so the recipe never
+> names it. Note that WRC's injection is **not** mode-gated (that spec §9.1) — on a managed
+> cluster the external operator must provision the Secret in all three namespaces. **Do
+> not** close any of this by labelling the Secret `clerum.io/shared=true` — the #637
+> predicate is shared between `envSecret` and `imagePullSecrets`, so that would let any
+> recipe read the credential out of its own environment (see that spec, §5.1).
 
 ---
 
@@ -664,22 +679,36 @@ self-hosted single-tenant slice and does not regress the managed per-namespace m
 
 1. **Deploy the registry gate change (§6.2) first or together** — control-api's mint
    `403`s until the relaxed endpoint is live, so the `evenfire-registry` deploy must
-   land before (or with) the control-api rollout. Both are part of this release.
+   land before (or with) the control-api rollout. **Done:** PR #64 is merged and deployed to
+   production (2026-08-04), ahead of the control-api rollout.
 
-   > **Precondition the gate alone does not satisfy.** The relaxed endpoint authorizes on
-   > `registry:manage-keys`, but only the registry's **auto-approve** path grants that
-   > scope (`routes/deployments.ts`). A deployment approved through the **admin approve**
-   > route (`POST /deployments/:id/approve`) falls back to `approveDeployment`'s default
-   > scope set, which omits it — and the backfill migration is scoped
+   > **Precondition the gate alone does not satisfy — RESOLVED in the same PR.** The relaxed
+   > endpoint authorizes on `registry:manage-keys`, and originally only the registry's
+   > **auto-approve** path granted that scope. A deployment approved through the **admin
+   > approve** route (`POST /deployments/:id/approve`) fell back to `approveDeployment`'s
+   > default scope set, which omitted it; migration 015's backfill was scoped
    > `WHERE created_by = 'mcc-admin'` while that path writes `created_by =
-   > 'deployment-approval'`, so it is not covered either. Those deployments 403 forever
-   > with no self-service remedy. **Registry-side fix required:** pass the same scope set
-   > from the admin approve route and widen the backfill. Until then, self-provisioning
-   > only works for auto-approved (open-registration) deployments.
+   > 'deployment-approval'`, so it was not covered either. Because
+   > `CLERUM_REGISTRY_OPEN_REGISTRATION` is absent from every overlay, auto-approve is
+   > unreachable in prod — so this was *every* self-hosted deployment, not a subset.
+   >
+   > Registry PR #64 fixed it (tracked as evenfire-registry#65) rather than leaving it as a
+   > follow-up: the optional `scopes` parameter was **removed** from `approveDeployment` in
+   > favour of one exported `SELF_HOSTED_DEPLOYMENT_SCOPES`, so both approve paths grant the
+   > identical set and `tsc` now rejects any divergent call site. **Migration 021** repairs
+   > existing rows, keyed on `registry_deployments.kind = 'self-hosted'` — deliberately *not*
+   > on `created_by`, which is precisely the blind spot that made 015 miss this population —
+   > and scoped to `client_id = d.id::text` so operator-bound extra clients bound to the same
+   > org are not silently widened. Verified in production after the deploy: all seven approved
+   > self-hosted deployment clients hold `registry:manage-keys`; the eight managed deployments
+   > have no matching client row and were untouched.
 2. **Ship control-api self-provisioning** gated on `self-hosted`, with the comment/doc
-   scrub (§7.8). Managed clusters are inert (the managed operator keeps owning the
-   Secret) — the mode gate guarantees no double-writer, so no cross-repo coordination
-   with the managed operator is needed.
+   scrub (§7.8). **Done in PR #243.** Managed clusters take no *write* (the managed operator
+   keeps owning the Secret) — the mode gate guarantees no double-writer, so no cross-repo
+   coordination is needed for provisioning. It **is** needed for the recipe extension that
+   shipped alongside: WRC's injection is not mode-gated, so the managed operator must widen
+   its provisioning to all three platform workload namespaces
+   (`registry-pull-secret-recipe-workloads.md` §9.1).
 3. **Retire the managed operator's `install_registry_pull_secret`** (shared + dedicated)
    — a separate change in that repo, sequenced *after* managed clusters also
    self-provision (a future extension of the mode gate) **or** left as-is if managed
@@ -757,21 +786,17 @@ nothing. Mutation-verified: gating the hook on `credRequired` fails 3 of these 4
 
 **Still open**
 
-1. **Registry-side scope backfill (§9-1)** — admin-approved deployments lack
-   `registry:manage-keys` and 403 even after the gate relaxation ships. Needs the
-   two-line fix + migration in `evenfire-registry`. **This is the one item that gates
-   the release** for self-hosted clusters that were not auto-approved.
-2. **Rotation (§7.6)** — no reactive trigger shipped. A stale *host* is now self-healed
+1. **Rotation (§7.6)** — no reactive trigger shipped. A stale *host* is now self-healed
    (content is validated), but a key revoked *out-of-band* is not. Add a re-provision
    endpoint, or accept "delete the Secret and re-install" as the remedy?
-3. **HCC presence-validation (§7.7)** — follow-up PR, or never? It would turn a missing
+2. **HCC presence-validation (§7.7)** — follow-up PR, or never? It would turn a missing
    Secret into a clean condition instead of `ImagePullBackOff`.
-4. **`enforceNamespace` on the install route** — this PR guards only the *credential*
+3. **`enforceNamespace` on the install route** — this PR guards only the *credential*
    write (§7.1 step 2). Applying the repo's existing `enforceNamespace` middleware to
    `POST /admin/registry/install` would also constrain where the McpServer itself lands,
    consistent with every other admin secret route — but that changes pre-existing install
    semantics and was deliberately left out of scope here.
-5. **Managed-operator step retirement (§9-3)** — coordinate managed self-provisioning, or
+4. **Managed-operator step retirement (§9-3)** — coordinate managed self-provisioning, or
    leave managed on the operator indefinitely behind the mode gate?
 
 ---
@@ -810,9 +835,10 @@ They can be built concurrently; the only ordering constraint is at **deploy** ti
 must be live before B mints — §9-1). control-api uses the least-privilege pull-only
 credential from the first commit; there is no interim publish-scoped step.
 
-### Workstream A — registry pull-credential gate (`evenfire-registry`)
+### Workstream A — registry pull-credential gate (`evenfire-registry`) — **shipped (PR #64)**
 
-- **A1 — Relax the gate** (`src/routes/org.ts`). In `POST /:org/registry-pull-credential`,
+- **A1 — Relax the gate** (`src/routes/org.ts`). **Shipped and deployed to production
+  2026-08-04.** In `POST /:org/registry-pull-credential`,
   replace the `*`-admin gate (`:376`) with
   `authorizeMachineForOrg(auth, orgName, 'registry:manage-keys')` (§6.2) so an org-bound
   machine mints a pull-only key for its **own** org. `mintPullKey` (rotate-on-call,
@@ -820,10 +846,11 @@ credential from the first commit; there is no interim publish-scoped step.
   *Accept:* an org-bound `manage-keys` machine gets `201`; a foreign org still `403`s;
   `*`-admin still works (managed operator unaffected); audit log preserved.
 
-### Workstream B — control-api self-provisioner (`evenfire`)
+### Workstream B — control-api self-provisioner (`evenfire`) — **shipped (PR #243)**
 
 Ordered so each task is independently reviewable; **B1–B3** are the functional core,
-**B4–B7** are decoupling/quality.
+**B4–B7** are decoupling/quality. B1–B6 shipped; **B7 (HCC presence-validation) was not
+taken** and remains the follow-up in §12-3.
 
 - **B1 — `registryClient.mintOrgPullCredential(orgName)`** (`control-api/src/services/registryClient.ts`).
   New exported fn on the private `orgRegistryFetch` (machine Bearer, prefixes `/api/v1`),

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -155,6 +155,42 @@ plane split documented at `evenfire-managed-cluster-control/docs/registry-auth.m
 Two facts fall out that shape our design: MCC's Secret is **unlabeled**, and its
 credential source (`*`-admin endpoint) is **unavailable to control-api**.
 
+### 4.4 The existing secrets-injection sequence (what we hook into)
+
+control-api already writes Secrets into the plugin namespace during install/upgrade,
+and self-provisioning must slot into that ordered flow — not bypass it. The **install
+handler** (`registry.ts`) runs:
+
+1. Build `mcpServerSpec`; set the in-memory `imagePullSecrets` **reference** (~1124)
+   — no K8s write yet.
+2. Preflight validation (422 on failure).
+3. Ownership metadata: `{ 'clerum.io/managed-by':'control-api',
+   'clerum.io/server-mode':… }` (labels) + catalog annotations.
+4. **Step 3 — create the per-plugin credentials Secret** (`<name>-credentials`,
+   `Opaque`, `stringData`) into `targetNs`, **fail-loud**
+   (`extractK8sError → res.status().json(); return`), set `secretCreated=true`
+   (`registry.ts:~1200-1250`).
+5. **Step 4 — create the McpServer CRD**; on failure, **rollback**: delete the
+   credentials Secret iff `secretCreated` (`registry.ts:1255-1272`).
+6. Step 5 — Context allowlist (rolls back too).
+
+The **upgrade handler** mirrors this and already uses the exact idempotent shape this
+spec proposes: read the existing Secret (`getSecret`, tolerating `404` via
+`k8sErr.status !== 404`) → `updateSecret` if present, else `createSecret`, labelled
+`managed-by:control-api` (`registry.ts:~1830-1875`).
+
+Three properties of this flow directly justify the design and are load-bearing for
+where we hook in:
+
+- **Label precedent** — the credentials Secret is *already* stamped
+  `clerum.io/managed-by:control-api`, so the pull Secret's ownership label (§7.2) is
+  the same marker the flow already uses, not a new convention.
+- **Fail-loud precedent** — Step 3 is the pattern §7.1/§7.3 mirror.
+- **Namespace + rollback** — the credentials Secret and CRD both land in `targetNs`,
+  and the credentials Secret is per-plugin (rolled back on CRD failure). The pull
+  Secret must therefore also target `targetNs` (co-location, §7.1) but sit **outside**
+  the per-plugin rollback (it is namespace-shared, §7.3).
+
 ---
 
 ## 5. Ownership: why control-api, not HCC/WRC
@@ -276,15 +312,21 @@ both phases; only the mint call changes.
 A control-api service (e.g. `services/registryPullSecretService.ts`) exposing:
 
 ```
-ensureRegistryPullSecret(): Promise<'created' | 'repaired' | 'exists-ours' | 'exists-foreign' | 'skipped'>
+ensureRegistryPullSecret(targetNs: string): Promise<'created' | 'repaired' | 'exists-ours' | 'exists-foreign' | 'skipped'>
 ```
 
 It takes the injected `K8sGateway` (for `getSecret`/`createSecret`/`updateSecret`,
-`k8s.ts:389-394`) and the new registry mint function (§6.1) as dependencies, and is
-invoked from the two attach sites with the gateway already in hand. It **always
-targets `config.mcpServersNamespace`** — it does **not** honor a caller-supplied
-`body.namespace` (see §7.2 and R7). If the gateway is absent (dev/no-cluster),
-it no-ops.
+`k8s.ts:389-394`) and the new registry mint function (§6.1) as dependencies. It is
+called with the **same `targetNs` the McpServer + credentials Secret use**
+(`targetNs = body.namespace || config.mcpServersNamespace`, `registry.ts:1011`),
+because `imagePullSecrets` are **namespace-local**: the pull Secret must live in the
+same namespace as the plugin pod (`server.namespace = targetNs`,
+`host-context-controller/src/reconciler.ts:946-948`) or the ref silently fails to
+resolve. It does **not** invent its own namespace — co-location with the McpServer is
+a correctness requirement, not a policy choice. The guardrail against writing into an
+arbitrary namespace is the RBAC check in step 2 (a `403` read aborts before minting),
+plus constraining plugin installs to control-api's covered namespaces (§8). If the
+gateway is absent (dev/no-cluster), it no-ops.
 
 Algorithm:
 
@@ -344,7 +386,7 @@ mint call should carry a bounded timeout.
 | Field | Value | Source of truth |
 | --- | --- | --- |
 | `metadata.name` | `evenfire-registry-pull` | `EVENFIRE_REGISTRY_PULL_SECRET_NAME` (`registryImagePullSecret.ts:15`) |
-| `metadata.namespace` | **`config.mcpServersNamespace` only** (`mcp-server` self-hosted / `mcp-server-<slug>` shared) — the provisioner ignores any `body.namespace` override (§7.1, R7) | `config.ts:285,460` |
+| `metadata.namespace` | **`targetNs`** = the McpServer's own namespace (`body.namespace \|\| config.mcpServersNamespace`) — must co-locate with the pod, since `imagePullSecrets` are namespace-local (§7.1) | `registry.ts:1011`, `reconciler.ts:946-948` |
 | `metadata.labels` | `clerum.io/managed-by: control-api` (provenance label — the ownership marker) | precedent `registry.ts:1206-1209`, `workflow-recipes secretFactory` |
 | `type` | `kubernetes.io/dockerconfigjson` | kubelet contract |
 | `data['.dockerconfigjson']` | base64 payload **verbatim** (do not double-encode; use `data`, not `stringData`) | `secretService.ts:44`; `secrets.ts:110-121` |
@@ -373,23 +415,34 @@ mint call should carry a bounded timeout.
 
 ### 7.3 Trigger point
 
-**Primary: lazy, at the attach site.** Call `ensureRegistryPullSecret()` (which
-targets `config.mcpServersNamespace`, §7.1) immediately before the two places the
-reference is attached (`registry.ts:~1117` install, `registry.ts:~1808` upgrade),
-when `shouldAttachEvenfirePullSecret` is true, using the router's existing
-`K8sGateway`. This:
+**Primary: lazy, co-located with the existing Secret write.** The install handler
+already has a dedicated Secret-write phase — *"Step 3: Create K8s Secret if
+credentials provided"* (`registry.ts:~1200-1250`) — that runs **before** *"Step 4:
+Create McpServer CRD"* (`registry.ts:~1255`). Call `ensureRegistryPullSecret(targetNs)`
+in that same Step-3 window (when `shouldAttachEvenfirePullSecret` is true), so the
+pull Secret exists before the CRD that references it is created. The upgrade handler
+has the symmetric phase (*"Step 4: Update credentials"* before the CRD update,
+`registry.ts:~1830-1875`). Both already hold the router's `K8sGateway`
+(`createAdminRegistryRouter(gateway?)`, `registry.ts:732`). This:
 
 - provisions exactly when a private evenfire-hosted plugin is installed/upgraded,
-- does zero work on clusters that never install such plugins,
+- targets the correct namespace (`targetNs`) automatically, co-located with the pod,
 - is idempotent via read-before-mint.
 
-The attach sites write via the router's `K8sGateway` today
-(`createAdminRegistryRouter(gateway?)`, `registry.ts:732`; the install write is the
-fail-loud pattern at `registry.ts:1226-1240`, and the upgrade path has the analogous
-write). Provisioning is **fail-loud**: on mint/write
-error, return the `5xx` `registry_pull_secret_provision_failed` and do not attach an
-unresolvable ref (§7.1 failure contract). When `gateway` is absent (dev/no-cluster),
-provisioning no-ops and the attach behaves as today.
+**Rollback scoping (important).** Step 4's CRD-create failure path **rolls back the
+per-plugin credentials Secret** (`registry.ts:1265-1272`, `deleteSecret` guarded by
+`secretCreated`). The pull Secret is **namespace-shared** across every plugin in
+`targetNs` — it MUST NOT be added to that rollback (deleting it would break other
+installed plugins and defeats idempotent reuse). So `ensureRegistryPullSecret` sits
+*outside* the per-plugin `secretCreated`/rollback bookkeeping; a later CRD failure
+leaves the pull Secret in place (correct — it is reused, not owned by this one
+install).
+
+**Fail-loud.** On mint/write error, return the `5xx`
+`registry_pull_secret_provision_failed` and do not attach an unresolvable ref (§7.1
+failure contract) — mirroring the existing fail-loud credentials write at
+`registry.ts:1226-1240`. When `gateway` is absent (dev/no-cluster), provisioning
+no-ops and the attach behaves as today.
 
 **Optional: boot-time reconcile.** A non-fatal pass in `main.ts` alongside
 `reconcileAllowedModelsConfigMapOnBoot` (`main.ts:~61`) can pre-create the Secret so
@@ -510,17 +563,21 @@ exactly one plugin namespace holds exactly one org's plugins, and a single
 cluster-scoped `evenfire-registry-pull` Secret carrying that org's identity is
 correct and safe.
 
-> **Guardrail.** Self-provisioning MUST write only into control-api's own configured
-> `mcpServersNamespace` and MUST NOT clobber an externally-provisioned Secret. This
-> is **enforced in code**, not by convention: `ensureRegistryPullSecret` ignores any
-> caller-supplied `body.namespace` (which `registry.ts:1011` otherwise honors for the
-> McpServer write) and always uses `config.mcpServersNamespace`. Do not lean on RBAC
-> as the backstop — control-api holds secrets-create in five namespaces
-> (`mcp-server`, `mcp-host`, `control-plane`, `sandbox-recipes`, `sandbox-ui`), which
-> is broader than this guardrail allows. If a deployment ever hosts more than one
-> org/namespace, the pull Secret must become **per-namespace** (one per
-> `mcp-server-<slug>`, as the managed operator already does) — re-verify before any
-> multi-org self-hosted mode ships.
+> **Guardrail.** The pull Secret is written into **`targetNs`** — the same namespace
+> as the McpServer + credentials Secret — because `imagePullSecrets` are
+> namespace-local and must co-locate with the pod (§7.1). It MUST NOT clobber an
+> externally-provisioned Secret (§7.4 ownership read). The safety property against a
+> caller directing the write into an *arbitrary* namespace is: the read/write goes
+> through the same `K8sGateway` under control-api's RBAC, so a namespace outside
+> control-api's secrets-RBAC set (`mcp-server`, `mcp-host`, `control-plane`,
+> `sandbox-recipes`, `sandbox-ui`) fails the read with `403` and **aborts before
+> minting** (§7.1 step 2, R7). Because self-hosted is single-tenant, in practice
+> `targetNs` is `config.mcpServersNamespace` (default `mcp-server`); an operator that
+> exposes the `body.namespace` override should constrain it to that covered set. If a
+> deployment ever hosts more than one org/namespace, the pull Secret is already
+> naturally per-namespace (it follows `targetNs`), but the *single-org-per-namespace*
+> assumption must be re-verified before any multi-org self-hosted mode ships — as the
+> managed operator already does with `mcp-server-<slug>`.
 
 Note the resolved contradiction between the two registry specs: "one org per
 cluster" is the **self-hosted/dedicated** truth; the managed operator's own model is
@@ -564,10 +621,11 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 | R1 | Phase 1 stores a **push-capable** standing key namespace-wide (blast radius — a workload with `secrets:get` RBAC or a mounted Secret could exfiltrate and `docker push`; `imagePullSecrets` themselves are kubelet-only, not container-mounted). | Ship Phase 2 pull-only mint as fast-follow (§6.2); security sign-off on the interim; non-expiring key with reactive rotation (§7.6). |
 | R2 | Clobbering an operator/MCC Secret. | Mode gate + `managed-by` ownership read; foreign Secrets are never written (§7.4); unlabeled-⇒-foreign invariant noted (§7.2). |
 | R3 | Key accumulation toward `MAX_ACTIVE_KEYS_PER_ORG=100` (additive `mintKey`, no revoke). | Revoke-prior control-api key before re-mint (§6.1/§7.1); read-before-mint; in-process serialization; revoke a key minted into a lost create-`409` race. |
-| R4 | Write to an unintended namespace via `body.namespace`. | `ensureRegistryPullSecret` ignores the override and always uses `config.mcpServersNamespace` (§7.2/§8). |
+| R4 | Pull Secret in the wrong namespace → ref silently unresolved (`imagePullSecrets` are namespace-local). | Provision into `targetNs` (co-located with the McpServer + credentials Secret), not a fixed namespace; a namespace outside control-api's secrets-RBAC set fails the read `403` and aborts (§7.1/§8). |
 | R5 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | Gate on `isRegistryAuthActive()` **and** non-null `resolvePublishScope().orgName`; skip with a clear install-time error, never mint against `/org/null/keys` (§7.1). Presupposes a working self-hosted connect flow. |
 | R6 | Registry unreachable. | control-api→registry egress already covered in base; kubelet→registry pull is a node/GKE firewall concern, not a pod NetworkPolicy (§7.8). |
-| R7 | Read/write in a namespace outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`). | Provisioner is pinned to `config.mcpServersNamespace` (default `mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting, so no key-cap slot is wasted (§7.1). |
+| R7 | `targetNs` outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`) via a `body.namespace` override. | Default `targetNs` is `config.mcpServersNamespace` (`mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting, so no key-cap slot is wasted (§7.1); operators exposing the override constrain it to the covered set (§8). |
+| R8 | Shared pull Secret wrongly torn down by a per-plugin rollback. | `ensureRegistryPullSecret` sits outside the Step-4 `secretCreated`/`deleteSecret` rollback scope; a CRD-create failure never deletes the namespace-shared pull Secret (§7.3). |
 
 ---
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -23,17 +23,21 @@ trial" (`docs/concepts/open-core-and-hosted.md`).
 This spec makes **control-api self-provision** the Secret when it runs in
 self-hosted mode, using credentials and Kubernetes RBAC it *already holds*, and
 removes the in-repo assumption that MCC provisions it. It coexists safely where an
-external operator already created the Secret, and requires **no new RBAC and no
-registry-side change** to ship the first phase.
+external operator already created the Secret, needs **no new Kubernetes RBAC**, and
+ships as **one coordinated release** across two repos: a single `evenfire-registry`
+gate change plus the control-api self-provisioner, using a least-privilege pull-only
+credential from day one (§14).
 
 The key enabling facts, all verified in code:
 
 - control-api's self-hosted registry client is provisioned with `registry:manage-keys`
   *specifically* "so a headless deployment can mint its own org efrk_ key (the
   docker credential)" — `evenfire-registry/src/routes/deployments.ts:237-247`.
-- That scope authorizes the **machine branch** of `POST /org/:org/keys`, which mints
-  a `['registry:read','registry:publish']` key and returns a ready
-  `dockerconfigjson` — `evenfire-registry/src/routes/org.ts:245,276,293-295`.
+- A one-line registry gate change lets that `manage-keys` machine mint a **pull-only**
+  key for its own org via `POST /org/:org/registry-pull-credential` (today `*`-admin
+  only, `org.ts:376`; `mintPullKey`/`buildDockerconfigjson` unchanged). The same scope
+  *also* already reaches the publish-scoped machine branch of `POST /org/:org/keys`
+  (`org.ts:245,276,293-295`) — the proven fallback, §6.3.
 - control-api already creates dockerconfigjson-shaped Secrets in the plugin
   namespace (`config.mcpServersNamespace`) with existing RBAC — `SecretService`
   (`control-api/src/services/secretService.ts:33-53`), Role grants
@@ -95,7 +99,7 @@ auth-related secrets (WRC / HCC). §5 assesses that proposal; the conclusion is 
   the managed/self-hosted branch is expressed via `registryConnectionMode`, not MCC.
 - **G3.** Idempotent coexistence: where an external operator (including MCC) already
   provisioned the Secret, control-api never clobbers, rotates, or orphans it.
-- **G4.** No new Kubernetes RBAC and (Phase 1) no registry-side change.
+- **G4.** No new Kubernetes RBAC; a single small `evenfire-registry` gate change (§6.2), shipped in the same release.
 - **G5.** The self-provisioned Secret is byte-compatible with MCC's — same name,
   namespace source, type, and data key — so either satisfies the same `McpServer`
   reference.
@@ -225,85 +229,69 @@ into a controller that would need registry credentials plumbed into it.
 
 ---
 
-## 6. Credential source (the one real design decision)
+## 6. Credential source
 
-### 6.1 What works today, with zero registry change
+The feature ships as **one coordinated release across two repos** (`evenfire-registry`
++ `evenfire`), not a sequence — see the parallel workstreams in §14. Because the
+registry change lands with control-api, the design uses a **least-privilege pull-only
+credential from day one**; there is no interim push-capable step.
+
+### 6.1 The credential — an org-scoped pull-only key
 
 control-api's self-hosted client holds `registry:manage-keys`
 (`deployments.ts:242-247`; also the standing `TENANT_DEFAULT_SCOPES`,
-`evenfire-registry/src/routes/clients.ts:44-50`). Its **machine Bearer** fetch
+`evenfire-registry/src/routes/clients.ts:44-50`), and has a **machine Bearer** fetch
 (`registryClient.authedFetch` / `orgRegistryFetch`,
-`control-api/src/services/registryClient.ts:191-207,538-552`) can call
-`POST /org/:org/keys`; the **machine branch** authorizes an org-bound machine with
-`registry:manage-keys` (`org.ts:245`), forces scopes `['registry:read','registry:publish']`
-(`org.ts:276`), and returns a server-built `dockerconfigjson` (`org.ts:293-295`).
-Org name comes from `resolvePublishScope().orgName`
-(`registryClient.ts:650-662`, resolved from the registry `/whoami` mapping).
+`control-api/src/services/registryClient.ts:191-207,551-582`). It mints a pull-only
+key for its own org via the registry's `POST /org/:org/registry-pull-credential`
+(relaxed to accept an org-bound `manage-keys` machine — §6.2), which calls
+`mintPullKey` (`orgApiKeyService.ts:122-142`, `kind:'pull'`). Org name comes from
+`resolvePublishScope().orgName` (`registryClient.ts:650-662`, from the registry
+`/whoami` mapping). control-api **builds the `dockerconfigjson` locally**, keyed on
+`registryHostFromUrl(config.registryUrl)` (§7.9-2), from the returned key.
 
-Advantages of this path over MCC's endpoint:
+Properties of the pull-only key that simplify the design vs a publish key:
 
-- **Works in both modes** (no org-owner user required — the existing
-  `orgApiKeyClient.createKey` user path 403s in managed orgs that have no owner).
-- **Not rotate-on-call.** `/org/:org/keys` `mintKey` is a plain `INSERT` with no
-  advisory lock and no revoke-prior (`orgApiKeyService.ts:70-88`), unlike the
-  pull-only `mintPullKey` which revoke-then-inserts under a lock
-  (`:122-142`). So a re-mint never *orphans/revokes* a working on-cluster key — the
-  footgun MCC must sequence around. The flip side is **accumulation**: naive
-  re-minting leaks keys toward `MAX_ACTIVE_KEYS_PER_ORG = 100`
-  (`orgApiKeyService.ts:23`; `/org/:org/keys` 409s `too_many_keys` at the cap,
-  `org.ts:280-287`). control-api must therefore **revoke its own prior
-  control-api-minted key before minting a replacement** (`DELETE /org/:org/keys/:id`,
-  reachable by the same manage-keys machine, `org.ts:334-349`) — see §7.6.
-- `expiresInDays` is supported for TTL (`orgApiKeyService.ts:70-88`).
+- **Least privilege** — pull-only (`kind:'pull'`) grants pull on the org's
+  own/granted/public repos, never push. A leaked Secret cannot push.
+- **Rotate-on-call, ≤1 per org** — `mintPullKey` revoke-then-inserts under an advisory
+  lock, so there is at most one active pull key per org. **No accumulation** toward
+  `MAX_ACTIVE_KEYS_PER_ORG` and **no explicit revoke-prior bookkeeping** needed. The
+  cost is that a blind re-mint *orphans* the on-cluster key, so **read-before-mint is
+  mandatory** (§7.1) — mint only when the Secret is absent/broken.
+- **Invisible to operators** — pull keys are excluded from the owner self-service key
+  list (`orgApiKeyService.ts:99,110`), so the auto-minted key does not clutter
+  `/admin/registry/keys` and cannot be confused with a user/CI key.
 
-**Implementation reality (call this out):** control-api has **no** existing method
-that does a *machine*-Bearer `POST /org/:org/keys`. The only key-mint wrapper today
-is `orgApiKeyClient.createKey`, which uses a per-admin **user** token
-(`userAuthedFetch`, `orgApiKeyClient.ts:115-164`) and hits the registry's *user*
-branch — it 403s in ownerless (managed) orgs. The generic machine-Bearer helpers
-`authedFetch` / `orgRegistryFetch` exist but are **module-private** and only wrap
-`/grants`, `/entries`, `/granted-to-me` (`registryClient.ts:551-626`). So Phase 1
-requires a **new exported `registryClient` method** — e.g.
-`mintOrgMachineKey(orgName): Promise<{ dockerconfigjson, keyId }>` — built on
-`orgRegistryFetch('/org/${orgName}/keys', {method:'POST'})`, mirroring the existing
-`createOrgGrant` pattern (`registryClient.ts:584`). This is listed in §13.
+**Implementation reality:** control-api has **no** existing method that mints against
+this endpoint. The only key-mint wrapper today is `orgApiKeyClient.createKey`, which
+uses a per-admin **user** token (`userAuthedFetch`, `orgApiKeyClient.ts:115-164`) — a
+different path. The generic machine-Bearer helpers `authedFetch` / `orgRegistryFetch`
+exist but are **module-private** and only wrap `/grants`, `/entries`, `/granted-to-me`
+(`registryClient.ts:551-626`). So a **new exported `registryClient` method** is
+required — e.g. `mintOrgPullCredential(orgName): Promise<{ key, keyId }>` — built on
+`orgRegistryFetch`, mirroring the existing `createOrgGrant` pattern
+(`registryClient.ts:584`). Listed in §13.
 
-**Tradeoff (the decision to record):** the minted key is
-**publish-scoped (push-capable)**, broader than MCC's pull-only key. `imagePullSecrets`
-are consumed by the kubelet and are *not* mounted into containers, so exfiltration
-requires a workload in the namespace with `secrets:get` RBAC (or the Secret
-volume-mounted) — not the default. The real concern is the **standing
-push-capable credential** living namespace-wide (blast radius independent of pod
-reachability), vs MCC's least-privilege pull-only key. Phase 2 (§6.2) closes it.
+### 6.2 The registry change (ships in the same release)
 
-### 6.2 Phase 2 — a least-privilege pull-only mint (registry-side)
+Relax `POST /org/:org/registry-pull-credential` so an **org-bound machine holding
+`registry:manage-keys`** can mint a pull-only key for its **own** org. Today the gate
+requires an `*`-admin machine (`org.ts:376`); the change replaces that with
+`authorizeMachineForOrg(auth, orgName, 'registry:manage-keys')`, reusing `mintPullKey`
+and `buildDockerconfigjson` unchanged (only the auth gate moves). `*`-admin callers
+(the managed operator) keep working; a foreign org still `403`s. This is the single
+`evenfire-registry` change and it is **in scope** for this work.
 
-To restore least privilege, add a **non-`*`** pull-only mint the tenant can call
-for its own org. Two shapes (either is a small registry change):
+### 6.3 Alternative considered — the publish-scoped machine `/org/:org/keys` path
 
-- **(a)** Relax `POST /org/:org/registry-pull-credential` to also accept an
-  org-bound machine holding `registry:manage-keys` (today `org.ts:376` requires `*`).
-  Keeps the existing rotate-on-call, pull-only semantics; control-api must then
-  read-before-mint (it already will).
-- **(b)** Add a `kind:'pull'` option to `POST /org/:org/keys` that mints a
-  pull-scoped, non-rotating key for a manage-keys machine.
-
-Recommendation **(a)** — it reuses `mintPullKey` and the existing
-`buildDockerconfigjson`, so the only change is the auth gate. `evenfire-registry`
-is in scope for this work.
-
-### 6.3 Recommendation
-
-Ship **Phase 1** with §6.1 (publish-scoped key, zero registry change) to unblock
-self-hosted immediately, and land **Phase 2** (§6.2, pull-only) as a fast follow so
-the standing credential is least-privilege. control-api reads the same Secret in
-both phases; only the mint call changes.
-
-> **Open decision for reviewers:** accept the publish-scoped key in Phase 1, or
-> block Phase 1 on the Phase 2 pull-only mint? The recommendation is to ship
-> phased; the security team should sign off on the interim publish-scoped key.
-
----
+The machine branch of `POST /org/:org/keys` (`org.ts:245,276,293-295`) is reachable by
+the same `manage-keys` machine **with no registry change** and returns a
+`dockerconfigjson`, but the key is **publish-scoped (push-capable)** and additive (no
+rotate, accumulates toward the 100-cap, visible in the operator key list). It proves
+the feasibility and is a viable **fallback** if the §6.2 registry change ever has to be
+decoupled — but because we ship both repos together, the pull-only credential (§6.1) is
+the design and this path is not used.
 
 ## 7. Design
 
@@ -357,18 +345,17 @@ Algorithm:
      wrong-typed same-named Secret), regardless of label → **`'repaired'`**: mint and
      `updateSecret` (replace) — do **not** `createSecret` (it would 409). This closes
      the gap where a create-409 is silently "treated as success" over a broken Secret.
-3. **Mint (revoke-prior first).** If a prior control-api-minted pull key id is on
-   record (Secret annotation or a small state row), **revoke it**
-   (`DELETE /org/:org/keys/:id`, `org.ts:334-349`) before minting, to bound
-   accumulation (§6.1). Scope revoke-prior to keys carrying control-api's fixed
-   pull-key **description marker** so it never revokes a user/CI key (§7.9-3). Then
-   call the registry mint for `resolvePublishScope().orgName` with that description
-   (Phase 1: machine `POST /org/:org/keys`; Phase 2: pull-only). **Build the
-   `dockerconfigjson` locally**, keyed on `registryHostFromUrl(config.registryUrl)`
-   (the image host, per the attach invariant) — *not* the registry's
-   `registryTokenIssuer`-keyed response (§7.9-2) — via
-   `{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`
-   (`orgApiKeyService.ts:147-151`). Record the returned key id for future revoke.
+3. **Mint (only reached when the Secret is absent or broken).** Call the registry's
+   pull-only mint for `resolvePublishScope().orgName`
+   (`POST /org/:org/registry-pull-credential`, §6.1/§6.2). It is **rotate-on-call**
+   (revokes the org's prior pull key and inserts a fresh one under a lock,
+   `orgApiKeyService.ts:122-142`), so no explicit revoke-prior bookkeeping is needed —
+   but this is exactly why **step 2's read-before-mint is mandatory**: a blind re-mint
+   would orphan a working on-cluster key. **Build the `dockerconfigjson` locally**,
+   keyed on `registryHostFromUrl(config.registryUrl)` (the image host, per the attach
+   invariant) — *not* the registry's `registryTokenIssuer`-keyed response (§7.9-2) —
+   via `{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`
+   (`orgApiKeyService.ts:147-151`).
 4. **Write.** `createSecret` (absent) or `updateSecret` (repair) with
    `type:'kubernetes.io/dockerconfigjson'`,
    `data:{'.dockerconfigjson': <base64>}`,
@@ -412,10 +399,13 @@ mint call should carry a bounded timeout.
 > and carry the wrong semantics for a namespace-wide shared credential.
 >
 > **Concurrency.** With multiple control-api replicas or concurrent install/upgrade
-> ops, the read→mint→write sequence can race (the additive mint has no server-side
-> lock, unlike `mintPullKey`). The create-`409` re-read (step 4) collapses the
-> Secret-write race; to bound duplicate *key* mints, serialize provisioning per
-> process (an in-process mutex keyed on the Secret name) and rely on revoke-prior.
+> ops, the read→mint→write sequence can race. The create-`409` re-read (step 4)
+> collapses the Secret-write race, and an in-process mutex keyed on the Secret name
+> serializes provisioning within a replica. The mint itself is safe under races:
+> `mintPullKey` is rotate-on-call under a per-org advisory lock, so concurrent mints
+> converge on a single active pull key rather than accumulating — though a replica
+> that minted just before a peer's rotate must still re-read (a stale in-hand key is
+> discarded in favor of the on-cluster Secret).
 
 ### 7.3 Trigger point
 
@@ -464,9 +454,10 @@ Two independent guarantees, both required:
    (unlabeled, or lacking `managed-by=control-api`) is left **untouched**
    (`'exists-foreign'`). control-api only ever writes a Secret it owns.
 
-Because Phase 1 mints via additive `/org/:org/keys` (not rotate-on-call), even a
-mistaken double-provision cannot orphan a working credential — but read-before-mint
-still applies to avoid key churn and the 100-key cap.
+Because the pull-only mint is **rotate-on-call**, a blind re-mint would orphan the
+working on-cluster key — so read-before-mint (§7.1 step 2) is the load-bearing
+idempotency guarantee: control-api mints only when the Secret is absent or broken, and
+never for an `'exists-ours'`/`'exists-foreign'` hit.
 
 ### 7.5 What stays unchanged
 
@@ -480,24 +471,24 @@ still applies to avoid key churn and the 100-key cap.
 ### 7.6 Rotation & lifecycle
 
 - **Rotation & liveness.** `'exists-ours'` reuse (§7.1 step 2) serves the embedded
-  key indefinitely, so the key must not silently die. Phase 1 posture: **mint the key
-  with no `expiresInDays`** (non-expiring) so reuse is safe by construction, and treat
-  an observed `401`/`ImagePullBackOff` (or an admin "re-provision" action) as the
-  rotation trigger — which revokes the prior control-api key (§6.1) and re-mints,
-  **replacing** the `'exists-ours'` Secret in place (never a foreign one). A scheduled
-  proactive rotation may be deferred (MCC defers it too), but the *reactive* trigger
-  and the non-expiring-key choice are **required** for Phase 1, else a revoked-out-of-band
-  or expired key strands the cluster with no self-heal. Posture in one line:
-  *control-api owns rotation for Secrets it owns and never touches a foreign Secret.*
+  key indefinitely, so the key must not silently die. The pull key carries no
+  expiry (`mintPullKey` sets none), so reuse is safe by construction. Treat an
+  observed `401`/`ImagePullBackOff` (or an admin "re-provision" action) as the
+  reactive rotation trigger — which re-mints (the endpoint rotates the org's pull
+  key) and **replaces** the `'exists-ours'` Secret in place (never a foreign one). A
+  scheduled proactive rotation may be deferred, but the *reactive* trigger is
+  **required**, else a revoked-out-of-band key strands the cluster with no self-heal.
+  Posture in one line: *control-api owns rotation for Secrets it owns and never
+  touches a foreign Secret.*
 - **GC.** Plugin uninstall deletes the per-plugin `<name>-credentials` Secret by name
   and does **not** touch the shared pull Secret (§7.9) — correct, since other plugins
   may still need it. The Secret is therefore a standing namespace credential for the
   cluster's lifetime; no ownerReference/finalizer is added (consistent with the
-  absence of ownerReferences anywhere in control-api today). Neither uninstall nor any
-  other path revokes the underlying `efrk_` key, so the registry-side key is a
-  standing credential too and can accrue across re-mints unless revoke-prior (§7.1) is
-  honored. Revoking the key on the last-plugin uninstall (and on `registryUrl`/host
-  change) is out of scope for Phase 1 but noted as a lifecycle follow-up.
+  absence of ownerReferences anywhere in control-api today). Because the pull key is
+  rotate-on-call (≤1 per org), it does **not** accumulate — but nothing revokes the
+  final key on teardown, so it remains a standing registry credential. Revoking it on
+  the last-plugin uninstall (and on `registryUrl`/host change) is out of scope but
+  noted as a lifecycle follow-up.
 
 ### 7.7 Optional HCC enhancement — presence validation
 
@@ -597,15 +588,15 @@ Traced against the current install/upgrade/uninstall code. **Cleared (safe today
    `shouldAttachEvenfirePullSecret` invariant guarantees equals the image host — rather
    than trust the registry's `registryTokenIssuer`-keyed response. Same pure formula
    (`{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`), local host.
-3. **Shared key cap, list visibility, and revoke safety.** control-api already exposes
+3. **No collision with operator `efrk_` keys.** control-api also exposes
    `/admin/registry/keys` (`registry.ts:2221-2247`), where operators mint/list/revoke
-   `efrk_` keys via the user-token path — all sharing `MAX_ACTIVE_KEYS_PER_ORG=100`.
-   The auto-minted pull key therefore (a) counts against that cap alongside CI/user
-   keys, and (b) appears in the user-facing key list. Mint it with a **fixed,
-   recognizable description** (e.g. `evenfire-registry-pull (auto)`), and scope
-   revoke-prior (§6.1) to keys carrying that marker so it never revokes a user/CI key.
-   Consider filtering it from the `/admin/registry/keys` GET list to avoid operator
-   confusion.
+   `efrk_` keys. Using the **pull-only** credential keeps these cleanly separate: pull
+   keys (`kind:'pull'`) are excluded from that operator list (`orgApiKeyService.ts:99,110`),
+   are rotate-on-call (≤1 per org, so negligible against `MAX_ACTIVE_KEYS_PER_ORG=100`),
+   and are managed entirely by the mint endpoint — so no description-marker, no
+   revoke-prior bookkeeping, and no risk of the provisioner revoking a user/CI key.
+   (This is a concrete reason the pull-only credential, §6.1, is preferable to the
+   publish-scoped fallback, §6.3, which *would* re-introduce all three concerns.)
 
 ---
 
@@ -649,18 +640,18 @@ future scope.
 
 ## 9. Rollout & migration
 
-1. **Ship control-api self-provisioning** gated on `self-hosted`. Managed clusters
-   are inert (MCC keeps owning the Secret). No coordination needed — the mode gate
-   guarantees no double-writer.
-2. **Fast-follow: Phase 2 pull-only mint** on the registry (§6.2); control-api
-   switches the mint call. Existing self-provisioned Secrets are replaced on next
-   ensure/rotation.
-3. **Retire MCC's `install_registry_pull_secret`** (shared + dedicated) — a separate
-   change in the MCC repo, sequenced *after* managed clusters also self-provision (a
-   future extension of the mode gate) **or** left as-is if managed stays on MCC. Do
-   not remove MCC's step until managed provisioning is guaranteed by another actor;
-   until then managed and self-hosted are cleanly partitioned by mode.
-4. **Doc + comment scrub** (§7.8) lands with step 1.
+1. **Deploy the registry gate change (§6.2) first or together** — control-api's mint
+   `403`s until the relaxed endpoint is live, so the `evenfire-registry` deploy must
+   land before (or with) the control-api rollout. Both are part of this release.
+2. **Ship control-api self-provisioning** gated on `self-hosted`, with the comment/doc
+   scrub (§7.8). Managed clusters are inert (the managed operator keeps owning the
+   Secret) — the mode gate guarantees no double-writer, so no cross-repo coordination
+   with the managed operator is needed.
+3. **Retire the managed operator's `install_registry_pull_secret`** (shared + dedicated)
+   — a separate change in that repo, sequenced *after* managed clusters also
+   self-provision (a future extension of the mode gate) **or** left as-is if managed
+   stays on the operator. Do not remove it until managed provisioning is guaranteed by
+   another actor; until then managed and self-hosted are cleanly partitioned by mode.
 
 No migration is required for existing managed tenants: their MCC-written Secret
 (unlabeled, `fieldManager mcc-rung35` on shared) is untouched by the self-hosted
@@ -672,17 +663,15 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 
 | # | Risk | Mitigation |
 | --- | --- | --- |
-| R1 | Phase 1 stores a **push-capable** standing key namespace-wide (blast radius — a workload with `secrets:get` RBAC or a mounted Secret could exfiltrate and `docker push`; `imagePullSecrets` themselves are kubelet-only, not container-mounted). | Ship Phase 2 pull-only mint as fast-follow (§6.2); security sign-off on the interim; non-expiring key with reactive rotation (§7.6). |
+| R1 | Rotate-on-call mint orphans a working on-cluster key (blind re-mint). | Read-before-mint is mandatory — mint only when the Secret is absent/broken (§7.1); in-process serialization on the Secret name. |
 | R2 | Clobbering an operator/MCC Secret. | Mode gate + `managed-by` ownership read; foreign Secrets are never written (§7.4); unlabeled-⇒-foreign invariant noted (§7.2). |
-| R3 | Key accumulation toward `MAX_ACTIVE_KEYS_PER_ORG=100` (additive `mintKey`, no revoke). | Revoke-prior control-api key before re-mint (§6.1/§7.1); read-before-mint; in-process serialization; revoke a key minted into a lost create-`409` race. |
-| R4 | Pull Secret in the wrong namespace → ref silently unresolved (`imagePullSecrets` are namespace-local). | Provision into `targetNs` (co-located with the McpServer + credentials Secret), not a fixed namespace; a namespace outside control-api's secrets-RBAC set fails the read `403` and aborts (§7.1/§8). |
-| R5 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | Gate on `isRegistryAuthActive()` **and** non-null `resolvePublishScope().orgName`; skip with a clear install-time error, never mint against `/org/null/keys` (§7.1). Presupposes a working self-hosted connect flow. |
-| R6 | Registry unreachable. | control-api→registry egress already covered in base; kubelet→registry pull is a node/GKE firewall concern, not a pod NetworkPolicy (§7.8). |
-| R7 | `targetNs` outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`) via a `body.namespace` override. | Default `targetNs` is `config.mcpServersNamespace` (`mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting, so no key-cap slot is wasted (§7.1); operators exposing the override constrain it to the covered set (§8). |
-| R8 | Shared pull Secret wrongly torn down by a per-plugin rollback. | `ensureRegistryPullSecret` sits outside the Step-4 `secretCreated`/`deleteSecret` rollback scope; a CRD-create failure never deletes the namespace-shared pull Secret (§7.3). |
-| R9 | `.dockerconfigjson` keyed on the wrong host → present Secret still yields `ImagePullBackOff`. | Build the blob locally keyed on `registryHostFromUrl(config.registryUrl)` (= image host), not the registry's `registryTokenIssuer` (§7.9-2). |
-| R10 | Auto-minted pull key collides with user/CI keys — shared 100-cap, appears in the operator key list, or revoke-prior nukes a user key. | Fixed description marker on the pull key; revoke-prior scoped to that marker only; optionally hide it from `/admin/registry/keys` GET (§7.9-3). |
-| R11 | Credential-less private-image plugin (`credRequired=false`) gets no pull Secret. | Hook is outside the `if (credRequired)` block, gated only on `shouldAttachEvenfirePullSecret` (§7.9-1). |
+| R3 | Pull Secret in the wrong namespace → ref silently unresolved (`imagePullSecrets` are namespace-local). | Provision into `targetNs` (co-located with the McpServer + credentials Secret), not a fixed namespace; a namespace outside control-api's secrets-RBAC set fails the read `403` and aborts (§7.1/§8). |
+| R4 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | Gate on `isRegistryAuthActive()` **and** non-null `resolvePublishScope().orgName`; skip with a clear install-time error, never mint against `/org/null/…` (§7.1). Presupposes a working self-hosted connect flow. |
+| R5 | Registry unreachable, or the §6.2 endpoint change not yet deployed → mint 403/error. | control-api→registry egress already covered in base; the registry change ships in the same release and must be live before control-api mints (§14 ordering); fail-loud install surfaces it (§7.1). |
+| R6 | `targetNs` outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`) via a `body.namespace` override. | Default `targetNs` is `config.mcpServersNamespace` (`mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting (§7.1); operators exposing the override constrain it to the covered set (§8). |
+| R7 | Shared pull Secret wrongly torn down by a per-plugin rollback. | `ensureRegistryPullSecret` sits outside the Step-4 `secretCreated`/`deleteSecret` rollback scope; a CRD-create failure never deletes the namespace-shared pull Secret (§7.3). |
+| R8 | `.dockerconfigjson` keyed on the wrong host → present Secret still yields `ImagePullBackOff`. | Build the blob locally keyed on `registryHostFromUrl(config.registryUrl)` (= image host), not the registry's `registryTokenIssuer` (§7.9-2). |
+| R9 | Credential-less private-image plugin (`credRequired=false`) gets no pull Secret. | Hook is outside the `if (credRequired)` block, gated only on `shouldAttachEvenfirePullSecret` (§7.9-1). |
 
 ---
 
@@ -694,8 +683,11 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 - **Secret shape** — asserts type `kubernetes.io/dockerconfigjson`, single
   `.dockerconfigjson` key, base64 not double-encoded, `managed-by=control-api` label,
   namespace = `config.mcpServersNamespace`.
-- **Registry client** — machine `POST /org/:org/keys` mint returns `dockerconfigjson`;
-  org resolved from `resolvePublishScope`.
+- **Registry client** — machine `POST /org/:org/registry-pull-credential` mint returns
+  a pull-only `key`; org resolved from `resolvePublishScope`; dockerconfigjson built
+  locally, keyed on the `registryUrl` host.
+- **Registry (Workstream A)** — an org-bound `manage-keys` machine mints its own org's
+  pull key (`201`); a foreign org `403`s; `*`-admin still works.
 - **Integration / e2e (minikube, self-hosted)** — install a private evenfire-hosted
   local plugin; assert the Secret is created and the plugin pod pulls (no
   `ImagePullBackOff`); re-install is idempotent; a pre-seeded foreign Secret is
@@ -718,15 +710,12 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 
 ## 12. Open questions / decisions for review
 
-1. **Credential scope (§6.3)** — accept the publish-scoped key in Phase 1, or block
-   on the Phase 2 pull-only mint? *(Recommendation: ship phased.)*
-2. **MCC-word scrub breadth (§7.8)** — scrub only pull-secret comments, or all
+1. **MCC-word scrub breadth (§7.8)** — scrub only pull-secret comments, or all
    managed-mode "MCC" mentions? *(Recommendation: scrub wording, keep behavior.)*
-3. **Trigger (§7.3)** — lazy-at-attach only, or add the boot reconcile? *(Recommendation: lazy; boot optional.)*
-4. **Rotation policy (§7.6)** — define now, or defer as MCC does? *(Recommendation: define posture, defer scheduled rotation.)*
-5. **HCC presence-validation (§7.7)** — in this spec or a follow-up? *(Recommendation: follow-up.)*
-6. **MCC step retirement (§9.3)** — coordinate managed self-provisioning, or leave
-   managed on MCC indefinitely behind the mode gate?
+2. **Trigger (§7.3)** — lazy-at-attach only, or add the boot reconcile? *(Recommendation: lazy; boot optional.)*
+3. **Rotation policy (§7.6)** — reactive-only now, or add scheduled proactive rotation? *(Recommendation: reactive now, defer scheduled.)*
+4. **HCC presence-validation (§7.7)** — in this release or a follow-up? *(Recommendation: follow-up.)*
+5. **Managed-operator step retirement (§9.3)** — coordinate managed self-provisioning, or leave managed on the operator indefinitely behind the mode gate?
 
 ---
 
@@ -737,7 +726,7 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 - `control-api/test/registryImagePullSecret.test.ts:10` — test description to reword (G2 scrub).
 - `control-api/src/routes/admin/registry.ts` — attach sites `:~1117-1124`,`:~1808-1818`; comment `:1114-1116`; existing fail-loud plugin-ns Secret write via gateway `:1226-1240`; router gateway param `:732`.
 - `control-api/src/services/registryPullSecretService.ts` — **new** (`ensureRegistryPullSecret`; takes `K8sGateway` + mint fn).
-- `control-api/src/services/registryClient.ts` — **new** exported `mintOrgMachineKey(orgName)` built on the private `orgRegistryFetch` (`:551`, machine Bearer, prefixes `/api/v1`), mirroring `createOrgGrant` (`:584`); `authedFetch` `:191`; `resolvePublishScope` `:650-662` (orgName nullable).
+- `control-api/src/services/registryClient.ts` — **new** exported `mintOrgPullCredential(orgName)` built on the private `orgRegistryFetch` (`:551`, machine Bearer, prefixes `/api/v1`), mirroring `createOrgGrant` (`:584`); `authedFetch` `:191`; `resolvePublishScope` `:650-662` (orgName nullable).
 - `control-api/src/services/orgApiKeyClient.ts:115-164` — existing **user-token** key mint (the path that 403s in ownerless orgs; *not* reused).
 - `control-api/src/k8s.ts:389-394` — `K8sGateway.getSecret/createSecret/updateSecret` (the write surface actually used at the attach sites).
 - `control-api/src/services/secretService.ts:25-53` — `getSecret` **re-throws 404** (not 404-aware); `createSecret` passes `type` through.
@@ -746,10 +735,10 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 - `host-context-controller/src/reconciler.ts:994-1002` — reference propagation (unchanged); `:436-453` — envSecret validation (model for §7.7).
 - `docs/how-to/connect-to-registry.md:59,70` — doc fix.
 
-**evenfire-registry (in scope; Phase 2)**
+**evenfire-registry (in scope; Workstream A)**
 - `src/routes/deployments.ts:237-247` — self-hosted client gets `registry:manage-keys` (the enabler).
-- `src/routes/org.ts:245,276,293-295` — machine-branch key mint + `dockerconfigjson`; `:371-388` — `*`-gated pull-only endpoint (Phase 2 relaxation target).
-- `src/services/orgApiKeyService.ts:70-88,122-151` — `mintKey`/`mintPullKey`/`buildDockerconfigjson`; `:23` — `MAX_ACTIVE_KEYS_PER_ORG`.
+- `src/routes/org.ts:371-388` — `*`-gated pull-only endpoint (`:376` gate is the A1 relaxation target); `:245,276,293-295` — publish-scoped machine branch (the §6.3 fallback).
+- `src/services/orgApiKeyService.ts:122-151` — `mintPullKey` (rotate-on-call, `kind:'pull'`) / `buildDockerconfigjson`; `:99,110` — pull keys excluded from the owner key list; `:23` — `MAX_ACTIVE_KEYS_PER_ORG`.
 
 **evenfire-managed-cluster-control (out of repo; sequenced retirement)**
 - `packages/backend/src/operations/handlers/tenant-install-shared.ts:476-496`, `evenfire-install.ts:356-378`, `install/secrets.ts:110-121,181-212`, `install/registry.ts:48-95` — the `install_registry_pull_secret` behavior being superseded.
@@ -758,33 +747,41 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 
 ## 14. Implementation plan
 
-Two phases. **Phase 1** unblocks self-hosted with **no registry change** (publish-scoped
-key). **Phase 2** swaps in a least-privilege pull-only credential and requires a small
-`evenfire-registry` change. control-api reads the *same* Secret in both; only the mint
-call and the key's scope/lifecycle change.
+**One release, two parallel workstreams** — Workstream A (`evenfire-registry`, one
+endpoint gate change) and Workstream B (`evenfire`/control-api, the self-provisioner).
+They can be built concurrently; the only ordering constraint is at **deploy** time (A
+must be live before B mints — §9-1). control-api uses the least-privilege pull-only
+credential from the first commit; there is no interim publish-scoped step.
 
-### Phase 1 — control-api self-provisioning (evenfire repo)
+### Workstream A — registry pull-credential gate (`evenfire-registry`)
 
-Ordered so each task is independently reviewable; **P1.1–P1.3** are the functional core,
-**P1.4–P1.7** are decoupling/quality.
+- **A1 — Relax the gate** (`src/routes/org.ts`). In `POST /:org/registry-pull-credential`,
+  replace the `*`-admin gate (`:376`) with
+  `authorizeMachineForOrg(auth, orgName, 'registry:manage-keys')` (§6.2) so an org-bound
+  machine mints a pull-only key for its **own** org. `mintPullKey` (rotate-on-call,
+  `kind:'pull'`) and `buildDockerconfigjson` unchanged — only the auth gate moves.
+  *Accept:* an org-bound `manage-keys` machine gets `201`; a foreign org still `403`s;
+  `*`-admin still works (managed operator unaffected); audit log preserved.
 
-- **P1.1 — `registryClient.mintOrgMachineKey(orgName)`** (`control-api/src/services/registryClient.ts`).
-  New exported fn built on the private `orgRegistryFetch` (machine Bearer, prefixes
-  `/api/v1`), mirroring `createOrgGrant`. `POST /org/${orgName}/keys` with a **fixed
-  description marker** (e.g. `evenfire-registry-pull (auto)`); returns
-  `{ keyId, key }`. Do **not** consume the response's `dockerconfigjson` (wrong host,
-  §7.9-2). Add `revokeOrgMachineKey(orgName, keyId)` (`DELETE /org/:org/keys/:id`) and a
-  `listOrgMachineKeys(orgName)` filtered to the marker (for revoke-prior + repair).
-  *Accept:* unit test hits a mocked registry, asserts machine-Bearer + marker.
-- **P1.2 — `registryPullSecretService.ensureRegistryPullSecret(targetNs)`**
+### Workstream B — control-api self-provisioner (`evenfire`)
+
+Ordered so each task is independently reviewable; **B1–B3** are the functional core,
+**B4–B7** are decoupling/quality.
+
+- **B1 — `registryClient.mintOrgPullCredential(orgName)`** (`control-api/src/services/registryClient.ts`).
+  New exported fn on the private `orgRegistryFetch` (machine Bearer, prefixes `/api/v1`),
+  mirroring `createOrgGrant`; `POST /org/${orgName}/registry-pull-credential`; returns
+  `{ key, keyId }`. Do **not** consume the response's `dockerconfigjson` (wrong host,
+  §7.9-2). *Accept:* unit test against a mocked registry asserts machine-Bearer + endpoint.
+- **B2 — `registryPullSecretService.ensureRegistryPullSecret(targetNs)`**
   (`control-api/src/services/registryPullSecretService.ts`, **new**). The §7.1 state
   machine: gate (mode/auth/url/non-null `orgName`) → read (404→absent, 403→abort,
-  classify ours/foreign/repair) → revoke-prior (marker-scoped) → mint (P1.1) → **build
+  classify ours/foreign/repair) → mint (B1, only when absent/broken) → **build
   dockerconfigjson locally** keyed on `registryHostFromUrl(config.registryUrl)` →
-  `createSecret`/`updateSecret` with `managed-by:control-api` + key-id annotation. In-process
-  mutex on the Secret name. Deps injected: `K8sGateway`, the P1.1 mint fns, `config`.
+  `createSecret`/`updateSecret` with `managed-by:control-api`. In-process mutex on the
+  Secret name. Deps injected: `K8sGateway`, the B1 mint fn, `config`.
   *Accept:* the §11 unit matrix (absent/ours/foreign/repair/409/gate-off) green.
-- **P1.3 — Wire into install + upgrade** (`control-api/src/routes/admin/registry.ts`).
+- **B3 — Wire into install + upgrade** (`control-api/src/routes/admin/registry.ts`).
   Call `ensureRegistryPullSecret(targetNs)` when `shouldAttachEvenfirePullSecret` is true,
   **outside the `if (credRequired)` block** (§7.9-1), in the Step-3 window **before** the
   Step-4 CRD create, and **outside** the per-plugin `secretCreated`/rollback bookkeeping
@@ -792,47 +789,28 @@ Ordered so each task is independently reviewable; **P1.1–P1.3** are the functi
   unresolvable ref. Same in the upgrade handler's credentials phase.
   *Accept:* e2e (minikube, self-hosted) — a private plugin pulls; a credential-less
   private plugin pulls; re-install idempotent; a pre-seeded foreign Secret is preserved.
-- **P1.4 — Revise existing tests** (`control-api/test/routes.registryInstall.test.ts`).
+- **B4 — Revise existing tests** (`control-api/test/routes.registryInstall.test.ts`).
   Update the `createSecret` call-count assertions (`:864`, `:1148`, `:1204`) and extend the
   `evenfire imagePullSecrets attach` block (`:1424`) to assert the pull-Secret create,
   shape, namespace (`targetNs`), and host-keying.
-- **P1.5 — Remove MCC knowledge** (§7.8). Rewrite comments at
+- **B5 — Remove MCC knowledge** (§7.8). Rewrite comments at
   `registryImagePullSecret.ts:6,12-13` and `registry.ts:1114-1116`; reword the test name at
   `registryImagePullSecret.test.ts:10`; scrub the adjacent managed-mode "MCC" wording
   (keep the `registryConnectionMode` behavior). *Gate:* `grep -rn '\bMCC\b' control-api/src
   control-api/test` returns only intentional, neutral phrasings.
-- **P1.6 — Docs** — fix `docs/how-to/connect-to-registry.md:59,70` to describe
+- **B6 — Docs** — fix `docs/how-to/connect-to-registry.md:59,70` to describe
   self-provisioning; add the node-level registry-egress note for remote-registry
   self-hosters (§7.8).
-- **P1.7 — (optional) HCC presence-validation** (§7.7) — separate PR; read-validate the
+- **B7 — (optional) HCC presence-validation** (§7.7) — separate PR; read-validate the
   pull Secret and emit a `SecretResolved`-style condition instead of silent
   `ImagePullBackOff`.
 
-### Phase 2 — least-privilege pull-only mint (evenfire-registry + control-api)
+### Release & sequencing (see §9)
 
-- **P2.1 — Registry: relax the pull-credential gate** (`evenfire-registry/src/routes/org.ts`).
-  In `POST /:org/registry-pull-credential`, replace the `*`-admin gate (`:376`) with
-  `authorizeMachineForOrg(auth, orgName, 'registry:manage-keys')` (option §6.2(a)) so an
-  org-bound machine can mint a pull-only key for its **own** org. Keep `mintPullKey`
-  (rotate-on-call, `kind:'pull'`) and the audit log; no change to `buildDockerconfigjson`.
-  *Accept:* an org-bound `manage-keys` machine gets `201`; a foreign org still `403`s;
-  `*`-admin still works (MCC unaffected).
-- **P2.2 — control-api: switch the mint call** (`registryClient.ts` + `registryPullSecretService.ts`).
-  Point the mint at the pull-only endpoint, extract `key`, build the dockerconfigjson
-  locally keyed on the `registryUrl` host (unchanged from P1). Since the pull endpoint is
-  **rotate-on-call** (revokes the org's prior pull key), the explicit revoke-prior (P1.1)
-  becomes redundant — but keep the **read-before-mint** discipline strict (a blind re-mint
-  now *orphans* the on-cluster key). This flips the key-lifecycle tradeoff: accumulation
-  (R3) disappears, the rotate-on-call footgun returns and is handled by read-before-mint.
-  *Accept:* the minted key carries only pull scope (`kind:'pull'`); re-provision with the
-  Secret present does not rotate.
-- **P2.3 — Security sign-off** on retiring the interim publish-scoped key (§6.3, §12-1);
-  once P2 ships, existing Phase-1 Secrets are replaced on next ensure/rotation.
-
-### Sequencing (see §9)
-
-`P1.1 → P1.2 → P1.3` land the fix; `P1.4–P1.6` land with them. `P2.*` is a fast follow.
-Retiring the managed operator's `install_registry_pull_secret` step (§9.3) is a separate,
-later change in that repo — **not** part of this plan, and only once managed-mode
-provisioning is guaranteed by another actor; until then the `registryConnectionMode` gate
-keeps managed and self-hosted cleanly partitioned.
+A and B are built in parallel and **released together**. The only hard ordering is at
+deploy: **A must be live before B mints** (else B `403`s — surfaced fail-loud, R5). An
+integration test exercises B against the A-updated registry before cutover. Retiring the
+managed operator's `install_registry_pull_secret` step (§9-3) is a separate, later change
+in that repo — **not** part of this release, and only once managed-mode provisioning is
+guaranteed by another actor; until then the `registryConnectionMode` gate keeps managed
+and self-hosted cleanly partitioned.

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -1,0 +1,629 @@
+# Self-provisioning the `evenfire-registry-pull` image-pull Secret
+
+**Status:** Draft / proposed
+**Date:** 2026-08-03
+**Area:** control-api registry integration · image pull · self-hosted / open-core
+**Supersedes (in effect):** the "MCC mints + creates the secret" role in the registry
+bridge design `evenfire-registry/docs/superpowers/specs/2026-06-30-registry-phase2-4-grant-pull-credential-bridge-design.md` §4.2, for **self-hosted** deployments.
+**Related:** `docs/concepts/open-core-and-hosted.md`, `docs/how-to/connect-to-registry.md`,
+`evenfire-registry/docs/superpowers/specs/2026-06-30-registry-phase2-4-delivery-design.md`
+
+---
+
+## 1. Summary
+
+On a **managed** cluster, the hosted operator ("MCC", out of this repo) creates the
+`evenfire-registry-pull` dockerconfigjson Secret in the plugin namespace, and
+control-api merely *references* it by name on the `McpServer` CRD. On a
+**self-hosted** cluster there is no MCC, nobody creates the Secret, and every
+private-image plugin fails with `ImagePullBackOff: unauthorized`. This silently
+breaks the open-core promise that self-hosting is "a first-class path, not a
+trial" (`docs/concepts/open-core-and-hosted.md`).
+
+This spec makes **control-api self-provision** the Secret when it runs in
+self-hosted mode, using credentials and Kubernetes RBAC it *already holds*, and
+removes the in-repo assumption that MCC provisions it. It coexists safely where an
+external operator already created the Secret, and requires **no new RBAC and no
+registry-side change** to ship the first phase.
+
+The key enabling facts, all verified in code:
+
+- control-api's self-hosted registry client is provisioned with `registry:manage-keys`
+  *specifically* "so a headless deployment can mint its own org efrk_ key (the
+  docker credential)" — `evenfire-registry/src/routes/deployments.ts:237-247`.
+- That scope authorizes the **machine branch** of `POST /org/:org/keys`, which mints
+  a `['registry:read','registry:publish']` key and returns a ready
+  `dockerconfigjson` — `evenfire-registry/src/routes/org.ts:245,276,293-295`.
+- control-api already creates dockerconfigjson-shaped Secrets in the plugin
+  namespace (`config.mcpServersNamespace`) with existing RBAC — `SecretService`
+  (`control-api/src/services/secretService.ts:33-53`), Role grants
+  `create/update/patch` on secrets in `mcp-server`
+  (`deploy/base/mcp-server/rbac.yaml:29-31`).
+- The managed/self-hosted split is already an **explicit** config discriminator
+  (`registryConnectionMode`, `control-api/src/config.ts:60-77,302-304`) — so
+  gating self-provisioning to `self-hosted` is exactly how we coexist with MCC
+  *without naming it*.
+
+---
+
+## 2. Problem
+
+### 2.1 The functional bug
+
+`control-api` attaches `imagePullSecrets: [{name: 'evenfire-registry-pull'}]` to a
+local-mode `McpServer` spec whenever the plugin image host equals the configured
+registry host (`shouldAttachEvenfirePullSecret`,
+`control-api/src/routes/admin/registryImagePullSecret.ts:51-61`; applied at
+`registry.ts:1117-1124` on install and `registry.ts:1808-1818` on upgrade). HCC then
+copies that reference verbatim onto the generated Deployment
+(`host-context-controller/src/reconciler.ts:994-1002`).
+
+Nothing in this repo ever **creates** the referenced Secret. HCC's own contract is
+explicit: "Creating the secrets an McpServer references is not the
+host-context-controller's responsibility" (`host-context-controller/README.md:57`).
+The Secret's existence is an unstated precondition satisfied **only by MCC**
+(`control-api/src/routes/admin/registryImagePullSecret.ts:6-8`: "provisioned onto
+the tenant cluster by MCC (out of this repo); control-api only references it by
+name"). No MCC → no Secret → `ImagePullBackOff`.
+
+### 2.2 The architectural coupling
+
+Even once the functional gap is closed, the repo carries **named knowledge of
+MCC** that violates the open-core boundary (the OSS platform must run standalone):
+
+- `registryImagePullSecret.ts:6,12-13` — "provisioned … by MCC", "Must stay in
+  sync with the MCC install step".
+- `registry.ts:1116` — "provisioned by MCC in the plugin namespace".
+- `config.ts:62` — "Delivered by MCC in the registry-voucher Secret" (adjacent
+  subsystem; see §7.8).
+
+Andy's framing (paraphrased): *this repo should not know anything about MCC*, and
+the pull-secret responsibility should sit with the controllers that already inject
+auth-related secrets (WRC / HCC). §5 assesses that proposal; the conclusion is that
+**control-api** is the correct owner, and gating on the existing
+`registryConnectionMode` discriminator is what actually removes the MCC coupling.
+
+---
+
+## 3. Goals / Non-goals
+
+### Goals
+
+- **G1.** A self-hosted cluster pulls private evenfire-registry plugin images with
+  no external operator — the Secret is created in-cluster by control-api.
+- **G2.** No named dependency on MCC in the control-api pull-secret code path;
+  the managed/self-hosted branch is expressed via `registryConnectionMode`, not MCC.
+- **G3.** Idempotent coexistence: where an external operator (including MCC) already
+  provisioned the Secret, control-api never clobbers, rotates, or orphans it.
+- **G4.** No new Kubernetes RBAC and (Phase 1) no registry-side change.
+- **G5.** The self-provisioned Secret is byte-compatible with MCC's — same name,
+  namespace source, type, and data key — so either satisfies the same `McpServer`
+  reference.
+
+### Non-goals
+
+- Changing MCC's managed-cluster behavior (that is a separate, sequenced retirement
+  of MCC's `install_registry_pull_secret` step — §9).
+- Self-provisioning the **infra** pull secret (`clerum`, HCC host/WFC default,
+  `host-context-controller/src/config.ts:480,527`). That is a distinct, out-of-band
+  concern (GCP node SA in prod, disabled in minikube) and is out of scope.
+- Multi-org-per-cluster placement. Self-hosted is single-tenant by design
+  (`docs/concepts/open-core-and-hosted.md:38`); see the §8 guardrail.
+- The voucher-identity substrate (`registry-voucher` Secret / voucher kid). This
+  spec **presupposes** a working self-hosted registry identity; it only adds the
+  pull-secret write on top (§7.8, §10-R5).
+
+---
+
+## 4. How it works today (grounded)
+
+### 4.1 The reference (already correct — keep it)
+
+| Concern | Where |
+| --- | --- |
+| Secret name constant | `EVENFIRE_REGISTRY_PULL_SECRET_NAME = 'evenfire-registry-pull'` — `registryImagePullSecret.ts:15` |
+| Attach predicate | `shouldAttachEvenfirePullSecret({isLocal,image,registryUrl})` — `registryImagePullSecret.ts:51-61` |
+| Attach on install | `registry.ts:1117-1124` |
+| Recompute/delete on upgrade | `registry.ts:1808-1818` (deletes the ref on evenfire→other host change) |
+| Identity fail-fast | imageRef repo path must equal scoped `@org/name` else 422 — `registryImageRefIdentity.ts:39-52`, consumed `registry.ts:1066-1077` |
+| HCC propagation | copies `spec.imagePullSecrets` verbatim to the Deployment — `reconciler.ts:994-1002` |
+
+The reference logic is correct and stays. **This spec only adds the create side.**
+
+### 4.2 The two credential planes (why the machine token can't docker-pull)
+
+The registry has a **separate OCI auth plane**: the docker token realm recognizes
+only `efrk_` org API keys and user tokens — a machine OAuth read-API token can
+never `docker pull`. So the pull Secret must be built from an `efrk_` key
+(`evenfire-registry/src/services/orgApiKeyService.ts:147` `buildDockerconfigjson`;
+plane split documented at `evenfire-managed-cluster-control/docs/registry-auth.md:44-57`).
+
+### 4.3 What MCC does today (being replaced / coexisted-with)
+
+- Mints a **pull-only** key via `POST /org/:org/registry-pull-credential`, which is
+  **`*`-admin-machine-only** (`org.ts:371-388`, gate at `:376`) and **rotates on
+  every call** (`orgApiKeyService.ts:122-142` `mintPullKey` revoke-then-insert).
+- Writes `{type:'kubernetes.io/dockerconfigjson', data:{'.dockerconfigjson': <base64>}}`
+  named `evenfire-registry-pull` into the tenant's `mcp-server[-slug]` namespace —
+  shared path SSA `fieldManager: mcc-rung35`
+  (`evenfire-managed-cluster-control/.../tenant-install-shared.ts:476-496`), dedicated
+  path plain create/replace (`.../evenfire-install.ts:356-378`,
+  `install/secrets.ts:110-121,181-212`). **No labels** on the Secret either way.
+- Because the mint rotates, MCC is **read-before-mint** (skip if the on-cluster
+  Secret already carries `.dockerconfigjson`).
+
+Two facts fall out that shape our design: MCC's Secret is **unlabeled**, and its
+credential source (`*`-admin endpoint) is **unavailable to control-api**.
+
+---
+
+## 5. Ownership: why control-api, not HCC/WRC
+
+Andy's proposal routes provisioning to WRC/HCC "because they already inject
+auth-related secrets." The review shows that premise is **only half true**, and the
+factoring it implies is the higher-cost path:
+
+- WRC/HCC mint only **self-issued** Opaque JWT/random secrets (coordinator tokens,
+  per-Host runtime tokens, `generateKeys`) — `workflow-recipes/src/workflow/secretFactory.ts`,
+  `host-context-controller/src/secretFactory.ts`. **None is a
+  `kubernetes.io/dockerconfigjson`.** For image-pull they only *reference* a Secret
+  by name; they never mint one. Minting a pull credential requires a **registry
+  round-trip with registry identity**, which neither controller has.
+- Making **HCC** the minter would require: (1) new RBAC — HCC has only
+  `get,list,watch` on secrets in `mcp-server` (`deploy/base/mcp-server/rbac.yaml:112-114`),
+  not create; (2) new config — HCC holds no registry credentials at all; (3) a new
+  namespace-singleton reconcile loop (the `McpServer` per-CRD grain is wrong for one
+  namespace-wide credential); (4) breaking the `README:57` "validates but does not
+  create referenced secrets" contract.
+- **control-api already has every piece**: create/update/patch RBAC on secrets in
+  the plugin namespace (`rbac.yaml:29-31`), the registry identity
+  (`registry:manage-keys`), the attach decision, and the managed/self-hosted
+  discriminator. It already writes credential Secrets into that exact namespace on
+  install (`registry.ts:1215-1248`).
+
+**Decision:** control-api self-provisions. HCC stays a pass-through of the reference
+(with an optional presence-validation enhancement, §7.7). This honors Andy's real
+goal — *the repo stops depending on MCC* — better than relocating the mint, because
+the dependency is removed by the `registryConnectionMode` gate, not by moving code
+into a controller that would need registry credentials plumbed into it.
+
+---
+
+## 6. Credential source (the one real design decision)
+
+### 6.1 What works today, with zero registry change
+
+control-api's self-hosted client holds `registry:manage-keys`
+(`deployments.ts:242-247`; also the standing `TENANT_DEFAULT_SCOPES`,
+`evenfire-registry/src/routes/clients.ts:44-50`). Its **machine Bearer** fetch
+(`registryClient.authedFetch` / `orgRegistryFetch`,
+`control-api/src/services/registryClient.ts:191-207,538-552`) can call
+`POST /org/:org/keys`; the **machine branch** authorizes an org-bound machine with
+`registry:manage-keys` (`org.ts:245`), forces scopes `['registry:read','registry:publish']`
+(`org.ts:276`), and returns a server-built `dockerconfigjson` (`org.ts:293-295`).
+Org name comes from `resolvePublishScope().orgName`
+(`registryClient.ts:650-662`, resolved from the registry `/whoami` mapping).
+
+Advantages of this path over MCC's endpoint:
+
+- **Works in both modes** (no org-owner user required — the existing
+  `orgApiKeyClient.createKey` user path 403s in managed orgs that have no owner).
+- **Not rotate-on-call.** `/org/:org/keys` `mintKey` is a plain `INSERT` with no
+  advisory lock and no revoke-prior (`orgApiKeyService.ts:70-88`), unlike the
+  pull-only `mintPullKey` which revoke-then-inserts under a lock
+  (`:122-142`). So a re-mint never *orphans/revokes* a working on-cluster key — the
+  footgun MCC must sequence around. The flip side is **accumulation**: naive
+  re-minting leaks keys toward `MAX_ACTIVE_KEYS_PER_ORG = 100`
+  (`orgApiKeyService.ts:23`; `/org/:org/keys` 409s `too_many_keys` at the cap,
+  `org.ts:280-287`). control-api must therefore **revoke its own prior
+  control-api-minted key before minting a replacement** (`DELETE /org/:org/keys/:id`,
+  reachable by the same manage-keys machine, `org.ts:334-349`) — see §7.6.
+- `expiresInDays` is supported for TTL (`orgApiKeyService.ts:70-88`).
+
+**Implementation reality (call this out):** control-api has **no** existing method
+that does a *machine*-Bearer `POST /org/:org/keys`. The only key-mint wrapper today
+is `orgApiKeyClient.createKey`, which uses a per-admin **user** token
+(`userAuthedFetch`, `orgApiKeyClient.ts:115-164`) and hits the registry's *user*
+branch — it 403s in ownerless (managed) orgs. The generic machine-Bearer helpers
+`authedFetch` / `orgRegistryFetch` exist but are **module-private** and only wrap
+`/grants`, `/entries`, `/granted-to-me` (`registryClient.ts:551-626`). So Phase 1
+requires a **new exported `registryClient` method** — e.g.
+`mintOrgMachineKey(orgName): Promise<{ dockerconfigjson, keyId }>` — built on
+`orgRegistryFetch('/org/${orgName}/keys', {method:'POST'})`, mirroring the existing
+`createOrgGrant` pattern (`registryClient.ts:584`). This is listed in §13.
+
+**Tradeoff (the decision to record):** the minted key is
+**publish-scoped (push-capable)**, broader than MCC's pull-only key. `imagePullSecrets`
+are consumed by the kubelet and are *not* mounted into containers, so exfiltration
+requires a workload in the namespace with `secrets:get` RBAC (or the Secret
+volume-mounted) — not the default. The real concern is the **standing
+push-capable credential** living namespace-wide (blast radius independent of pod
+reachability), vs MCC's least-privilege pull-only key. Phase 2 (§6.2) closes it.
+
+### 6.2 Phase 2 — a least-privilege pull-only mint (registry-side)
+
+To restore least privilege, add a **non-`*`** pull-only mint the tenant can call
+for its own org. Two shapes (either is a small registry change):
+
+- **(a)** Relax `POST /org/:org/registry-pull-credential` to also accept an
+  org-bound machine holding `registry:manage-keys` (today `org.ts:376` requires `*`).
+  Keeps the existing rotate-on-call, pull-only semantics; control-api must then
+  read-before-mint (it already will).
+- **(b)** Add a `kind:'pull'` option to `POST /org/:org/keys` that mints a
+  pull-scoped, non-rotating key for a manage-keys machine.
+
+Recommendation **(a)** — it reuses `mintPullKey` and the existing
+`buildDockerconfigjson`, so the only change is the auth gate. `evenfire-registry`
+is in scope for this work.
+
+### 6.3 Recommendation
+
+Ship **Phase 1** with §6.1 (publish-scoped key, zero registry change) to unblock
+self-hosted immediately, and land **Phase 2** (§6.2, pull-only) as a fast follow so
+the standing credential is least-privilege. control-api reads the same Secret in
+both phases; only the mint call changes.
+
+> **Open decision for reviewers:** accept the publish-scoped key in Phase 1, or
+> block Phase 1 on the Phase 2 pull-only mint? The recommendation is to ship
+> phased; the security team should sign off on the interim publish-scoped key.
+
+---
+
+## 7. Design
+
+### 7.1 New unit: `ensureRegistryPullSecret`
+
+A control-api service (e.g. `services/registryPullSecretService.ts`) exposing:
+
+```
+ensureRegistryPullSecret(): Promise<'created' | 'repaired' | 'exists-ours' | 'exists-foreign' | 'skipped'>
+```
+
+It takes the injected `K8sGateway` (for `getSecret`/`createSecret`/`updateSecret`,
+`k8s.ts:389-394`) and the new registry mint function (§6.1) as dependencies, and is
+invoked from the two attach sites with the gateway already in hand. It **always
+targets `config.mcpServersNamespace`** — it does **not** honor a caller-supplied
+`body.namespace` (see §7.2 and R7). If the gateway is absent (dev/no-cluster),
+it no-ops.
+
+Algorithm:
+
+1. **Gate — no-op (`'skipped'`) unless all hold:**
+   - `registryConnectionMode === 'self-hosted'` (`config.ts:~76`);
+   - `isRegistryAuthActive()` true (`registryConnectionDb.ts:231-234`);
+   - `config.registryUrl` non-empty and allowlisted;
+   - `resolvePublishScope().orgName` is **non-null** (`registryClient.ts:650-662` —
+     it is nullable for curator/unresolved `/whoami`; `isRegistryAuthActive()` checks
+     credential presence, *not* org mapping). A null org means the connect flow has
+     not populated `org_name` yet — skip with a clear install-time error rather than
+     minting against `/org/null/keys`.
+
+   This mirrors the attach predicate, so the Secret is provisioned exactly when a
+   private evenfire-hosted image is in play, and managed clusters stay inert.
+2. **Read.** `getSecret('evenfire-registry-pull', ns)`. **`getSecret` is NOT
+   404-aware — it re-throws the underlying K8s error including 404**
+   (`secretService.ts:25-31`, docstring explicit). So:
+   - `statusCode === 404` → treat as **absent** → go to step 3.
+   - Any other error (esp. **`403`** — namespace outside control-api's secrets RBAC)
+     → **abort** without minting (surface it; do not waste a key-cap slot).
+   - Present, **non-empty** `.dockerconfigjson`, **not** labeled
+     `clerum.io/managed-by=control-api` → **`'exists-foreign'`**: an external operator
+     owns it → return, never touch (coexistence guarantee, §7.4).
+   - Present, labeled `managed-by=control-api`, **non-empty** `.dockerconfigjson` →
+     **`'exists-ours'`**: reuse (rotation handled separately, §7.6).
+   - Present but `.dockerconfigjson` **missing/empty** (placeholder, truncated write,
+     wrong-typed same-named Secret), regardless of label → **`'repaired'`**: mint and
+     `updateSecret` (replace) — do **not** `createSecret` (it would 409). This closes
+     the gap where a create-409 is silently "treated as success" over a broken Secret.
+3. **Mint (revoke-prior first).** If a prior control-api-minted key id is on record
+   (Secret annotation or a small state row), **revoke it** (`DELETE /org/:org/keys/:id`,
+   `org.ts:334-349`) before minting, to bound accumulation (§6.1). Then call the
+   registry mint for `resolvePublishScope().orgName` (Phase 1: machine
+   `POST /org/:org/keys`; Phase 2: pull-only). Obtain the server-built
+   `dockerconfigjson` (already base64), or reproduce locally via the same pure formula
+   `{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`
+   (`orgApiKeyService.ts:147-151`). Record the returned key id for future revoke.
+4. **Write.** `createSecret` (absent) or `updateSecret` (repair) with
+   `type:'kubernetes.io/dockerconfigjson'`,
+   `data:{'.dockerconfigjson': <base64>}`,
+   `labels:{'clerum.io/managed-by':'control-api'}`, and an annotation carrying the
+   key id. On a create `409` (concurrent create) → re-read; if the winner is
+   `exists-ours`, treat as success (and revoke the key this call just minted to avoid
+   a leak); otherwise classify per step 2.
+
+**Failure contract (§7.3 wires this).** If the gate passes but mint or write throws,
+the caller **fails the install/upgrade loudly** with a `5xx`
+`registry_pull_secret_provision_failed` and does **not** attach an unresolvable
+`imagePullSecrets` ref — mirroring the existing fail-loud Secret write at
+`registry.ts:1226-1240`. A silent proceed-and-attach would reproduce the very
+`ImagePullBackOff` this spec removes. `authedFetch` does not itself time out, so the
+mint call should carry a bounded timeout.
+
+### 7.2 The Secret contract (frozen — must match MCC byte-for-byte)
+
+| Field | Value | Source of truth |
+| --- | --- | --- |
+| `metadata.name` | `evenfire-registry-pull` | `EVENFIRE_REGISTRY_PULL_SECRET_NAME` (`registryImagePullSecret.ts:15`) |
+| `metadata.namespace` | **`config.mcpServersNamespace` only** (`mcp-server` self-hosted / `mcp-server-<slug>` shared) — the provisioner ignores any `body.namespace` override (§7.1, R7) | `config.ts:285,460` |
+| `metadata.labels` | `clerum.io/managed-by: control-api` (provenance label — the ownership marker) | precedent `registry.ts:1206-1209`, `workflow-recipes secretFactory` |
+| `type` | `kubernetes.io/dockerconfigjson` | kubelet contract |
+| `data['.dockerconfigjson']` | base64 payload **verbatim** (do not double-encode; use `data`, not `stringData`) | `secretService.ts:44`; `secrets.ts:110-121` |
+
+`.dockerconfigjson` passes control-api's key validator unchanged
+(`SECRET_DATA_KEY_RE`, `secretKeys.ts:11,38-48`).
+
+> **Label note.** MCC stamps **no** labels on the pull Secret on either path
+> (`evenfire-managed-cluster-control/.../install/secrets.ts:110-121`; the shared path
+> SSA-applies that same unlabeled manifest), so "present + missing our
+> `managed-by=control-api` label ⇒ foreign" is a reliable discriminator *now*. This
+> is an **unenforced cross-repo invariant**: it holds because our check is
+> *positive-only* (any label other than ours still reads foreign), but to keep it
+> honest MCC should carry a regression assertion that its pull Secret does not stamp
+> `clerum.io/managed-by=control-api`. We deliberately choose the provenance label
+> `clerum.io/managed-by` (values `control-api`/`wrc` already exist) and **not** the
+> recipe access labels `clerum.io/owner-recipe` / `clerum.io/shared` — those are the
+> #637 recipe↔Secret access model (`packages/workflow-runtime-core/src/secret-ownership.ts`)
+> and carry the wrong semantics for a namespace-wide shared credential.
+>
+> **Concurrency.** With multiple control-api replicas or concurrent install/upgrade
+> ops, the read→mint→write sequence can race (the additive mint has no server-side
+> lock, unlike `mintPullKey`). The create-`409` re-read (step 4) collapses the
+> Secret-write race; to bound duplicate *key* mints, serialize provisioning per
+> process (an in-process mutex keyed on the Secret name) and rely on revoke-prior.
+
+### 7.3 Trigger point
+
+**Primary: lazy, at the attach site.** Call `ensureRegistryPullSecret()` (which
+targets `config.mcpServersNamespace`, §7.1) immediately before the two places the
+reference is attached (`registry.ts:~1117` install, `registry.ts:~1808` upgrade),
+when `shouldAttachEvenfirePullSecret` is true, using the router's existing
+`K8sGateway`. This:
+
+- provisions exactly when a private evenfire-hosted plugin is installed/upgraded,
+- does zero work on clusters that never install such plugins,
+- is idempotent via read-before-mint.
+
+The attach sites write via the router's `K8sGateway` today
+(`createAdminRegistryRouter(gateway?)`, `registry.ts:732`; the install write is the
+fail-loud pattern at `registry.ts:1226-1240`, and the upgrade path has the analogous
+write). Provisioning is **fail-loud**: on mint/write
+error, return the `5xx` `registry_pull_secret_provision_failed` and do not attach an
+unresolvable ref (§7.1 failure contract). When `gateway` is absent (dev/no-cluster),
+provisioning no-ops and the attach behaves as today.
+
+**Optional: boot-time reconcile.** A non-fatal pass in `main.ts` alongside
+`reconcileAllowedModelsConfigMapOnBoot` (`main.ts:~61`) can pre-create the Secret so
+it exists before any pod schedules. Deferred unless install-time latency is a
+concern; the lazy path suffices because HCC re-pulls once the Secret appears.
+
+### 7.4 Coexistence & idempotency
+
+Two independent guarantees, both required:
+
+1. **Mode gate.** `registryConnectionMode === 'self-hosted'` means the path never
+   runs on a managed (MCC-owned) cluster. This is how we coexist with MCC *without
+   the repo naming it* (G2).
+2. **Ownership read.** Within self-hosted, an external/operator-provisioned Secret
+   (unlabeled, or lacking `managed-by=control-api`) is left **untouched**
+   (`'exists-foreign'`). control-api only ever writes a Secret it owns.
+
+Because Phase 1 mints via additive `/org/:org/keys` (not rotate-on-call), even a
+mistaken double-provision cannot orphan a working credential — but read-before-mint
+still applies to avoid key churn and the 100-key cap.
+
+### 7.5 What stays unchanged
+
+- The attach/upgrade logic and `shouldAttachEvenfirePullSecret` (correct today).
+- HCC's reference propagation (`reconciler.ts:994-1002`) — no HCC change required
+  for delivery.
+- The infra `clerum` pull secret and its minikube empty-string override
+  (`deploy/overlays/minikube/patches/dynamic-images.yaml:29-34,61-64`).
+- The `registry-voucher` / voucher-kid substrate (§7.8).
+
+### 7.6 Rotation & lifecycle
+
+- **Rotation & liveness.** `'exists-ours'` reuse (§7.1 step 2) serves the embedded
+  key indefinitely, so the key must not silently die. Phase 1 posture: **mint the key
+  with no `expiresInDays`** (non-expiring) so reuse is safe by construction, and treat
+  an observed `401`/`ImagePullBackOff` (or an admin "re-provision" action) as the
+  rotation trigger — which revokes the prior control-api key (§6.1) and re-mints,
+  **replacing** the `'exists-ours'` Secret in place (never a foreign one). A scheduled
+  proactive rotation may be deferred (MCC defers it too), but the *reactive* trigger
+  and the non-expiring-key choice are **required** for Phase 1, else a revoked-out-of-band
+  or expired key strands the cluster with no self-heal. Posture in one line:
+  *control-api owns rotation for Secrets it owns and never touches a foreign Secret.*
+- **GC.** In self-hosted there is no MCC uninstall. The Secret is a standing
+  namespace credential for the cluster's lifetime; no ownerReference/finalizer is
+  added (consistent with the absence of ownerReferences anywhere in control-api
+  today). Revocation of the underlying `efrk_` key on teardown is out of scope for
+  Phase 1.
+
+### 7.7 Optional HCC enhancement — presence validation
+
+Today HCC validates `envSecret` existence but **not** `imagePullSecrets`
+(`reconciler.ts:436-453` vs `:994-1002`), so a missing pull Secret surfaces only as
+`ImagePullBackOff`. HCC could read-validate the referenced pull Secret and emit a
+clean `SecretResolved`-style condition. This is a small, contract-preserving
+addition (HCC already has `get` on secrets in `mcp-server`) that turns a silent
+failure into an actionable status. **Optional; not required for delivery.**
+
+### 7.8 Removing MCC knowledge from this repo (G2)
+
+**In scope — the pull-secret path:** rewrite the comments to describe
+self-provisioning, keeping the constant and predicate (they are the local contract):
+
+- `registryImagePullSecret.ts:6,12-13` — drop "provisioned … by MCC" / "stay in sync
+  with the MCC install step"; state control-api self-provisions in self-hosted mode
+  and may coexist with an externally pre-provisioned Secret.
+- `registry.ts:1114-1116` — rewrite the whole two-line comment ("… pull secret
+  (provisioned by / MCC in the plugin namespace). Attach the reference; HCC
+  propagates it.") so no dangling "provisioned by" remains.
+- `control-api/test/registryImagePullSecret.test.ts:10` — the test named
+  *"is the exact secret name MCC provisions"* must be reworded (e.g. "is the frozen
+  pull-secret name"); the scrub is computed over `control-api/test` as well as
+  `control-api/src`, or G2 does not hold.
+
+**Adjacent — catalog, decide explicitly (likely follow-up):** these mention MCC or
+managed-mode topology but are *not* the pull secret. Andy's "the repo should know
+nothing about MCC" argues for scrubbing the literal word "MCC" (replace with "the
+managed operator" / "managed mode"), but the *behavior* they branch on is legitimate
+(control-api genuinely differs by `registryConnectionMode`):
+
+- `config.ts:62` — voucher-kid "Delivered by MCC in the registry-voucher Secret"
+  (voucher-identity substrate; self-hosted reads kid from the `registry_connection`
+  DB row — a real, separate subsystem).
+- `k8s.ts:497`, `config.ts:750`, `adminProvisioning.ts:95`, `auth.ts:156,589` —
+  managed-mode install/topology notes.
+
+Recommendation: scrub the wording in this pass; keep the `registryConnectionMode`
+behavior. Do not conflate the voucher substrate with the pull secret.
+
+**Docs:** `docs/how-to/connect-to-registry.md:59,70` currently overstates that
+connecting alone yields working image pull. Update it to describe self-provisioning
+(the Secret is created by control-api on first private-image install in self-hosted
+mode).
+
+**Egress (two distinct planes — do not conflate):**
+
+- **control-api → registry (mint).** A pod-network egress concern, and it is
+  **already covered** in base by control-api's external-egress NetworkPolicy (the
+  same path the existing registry read-API/voucher calls use). No new policy needed.
+- **kubelet → registry (image pull).** Image pulls happen at the **node** level,
+  outside the pod network namespace, so Kubernetes `NetworkPolicy` does **not** gate
+  them — the `deny-all` egress on `mcp-server`
+  (`deploy/base/mcp-server/networkpolicies.yaml`) neither blocks pulls nor is a place
+  to "allow" them. The real requirement is **node/GKE firewall egress** to the
+  registry host, which is a cluster-infrastructure concern, not a manifest in this
+  repo. (Minikube sidesteps it entirely by loading images locally.)
+
+Net: no in-repo NetworkPolicy change is required for either plane; document the
+node-level firewall expectation for self-hosted operators pulling from a remote
+registry.
+
+---
+
+## 8. Multi-tenancy guardrail (Andy's §7, carried forward)
+
+The self-hosted / OSS platform is **single-tenant — one organization per
+deployment** (`docs/concepts/open-core-and-hosted.md:38`, `docs/faq.md:21`). So
+exactly one plugin namespace holds exactly one org's plugins, and a single
+cluster-scoped `evenfire-registry-pull` Secret carrying that org's identity is
+correct and safe.
+
+> **Guardrail.** Self-provisioning MUST write only into control-api's own configured
+> `mcpServersNamespace` and MUST NOT clobber an externally-provisioned Secret. This
+> is **enforced in code**, not by convention: `ensureRegistryPullSecret` ignores any
+> caller-supplied `body.namespace` (which `registry.ts:1011` otherwise honors for the
+> McpServer write) and always uses `config.mcpServersNamespace`. Do not lean on RBAC
+> as the backstop — control-api holds secrets-create in five namespaces
+> (`mcp-server`, `mcp-host`, `control-plane`, `sandbox-recipes`, `sandbox-ui`), which
+> is broader than this guardrail allows. If a deployment ever hosts more than one
+> org/namespace, the pull Secret must become **per-namespace** (one per
+> `mcp-server-<slug>`, as the managed operator already does) — re-verify before any
+> multi-org self-hosted mode ships.
+
+Note the resolved contradiction between the two registry specs: "one org per
+cluster" is the **self-hosted/dedicated** truth; the managed operator's own model is
+shared multi-tenant with per-`mcp-server-<slug>` isolation. This spec targets the
+self-hosted single-tenant slice and does not regress the managed per-namespace model.
+
+**Generality note:** the auto-attach only fires for registry-built `McpServer`s,
+which land in `mcp-server[-slug]`. A *non-transport* recipe workload pulling a
+private evenfire image would resolve its imagePullSecrets to `sandbox-recipes[-slug]`
+(`control-api/src/routes/admin/recipes.ts:66-80`) — not covered here. For now,
+private-image plugins are transport workloads; broadening to `sandbox-recipes` is
+future scope.
+
+---
+
+## 9. Rollout & migration
+
+1. **Ship control-api self-provisioning** gated on `self-hosted`. Managed clusters
+   are inert (MCC keeps owning the Secret). No coordination needed — the mode gate
+   guarantees no double-writer.
+2. **Fast-follow: Phase 2 pull-only mint** on the registry (§6.2); control-api
+   switches the mint call. Existing self-provisioned Secrets are replaced on next
+   ensure/rotation.
+3. **Retire MCC's `install_registry_pull_secret`** (shared + dedicated) — a separate
+   change in the MCC repo, sequenced *after* managed clusters also self-provision (a
+   future extension of the mode gate) **or** left as-is if managed stays on MCC. Do
+   not remove MCC's step until managed provisioning is guaranteed by another actor;
+   until then managed and self-hosted are cleanly partitioned by mode.
+4. **Doc + comment scrub** (§7.8) lands with step 1.
+
+No migration is required for existing managed tenants: their MCC-written Secret
+(unlabeled, `fieldManager mcc-rung35` on shared) is untouched by the self-hosted
+path and reads as `'exists-foreign'` if the mode ever flips.
+
+---
+
+## 10. Risks & mitigations
+
+| # | Risk | Mitigation |
+| --- | --- | --- |
+| R1 | Phase 1 stores a **push-capable** standing key namespace-wide (blast radius — a workload with `secrets:get` RBAC or a mounted Secret could exfiltrate and `docker push`; `imagePullSecrets` themselves are kubelet-only, not container-mounted). | Ship Phase 2 pull-only mint as fast-follow (§6.2); security sign-off on the interim; non-expiring key with reactive rotation (§7.6). |
+| R2 | Clobbering an operator/MCC Secret. | Mode gate + `managed-by` ownership read; foreign Secrets are never written (§7.4); unlabeled-⇒-foreign invariant noted (§7.2). |
+| R3 | Key accumulation toward `MAX_ACTIVE_KEYS_PER_ORG=100` (additive `mintKey`, no revoke). | Revoke-prior control-api key before re-mint (§6.1/§7.1); read-before-mint; in-process serialization; revoke a key minted into a lost create-`409` race. |
+| R4 | Write to an unintended namespace via `body.namespace`. | `ensureRegistryPullSecret` ignores the override and always uses `config.mcpServersNamespace` (§7.2/§8). |
+| R5 | Self-hosted registry identity / org mapping not yet established (no claimed client, `orgName` null). | Gate on `isRegistryAuthActive()` **and** non-null `resolvePublishScope().orgName`; skip with a clear install-time error, never mint against `/org/null/keys` (§7.1). Presupposes a working self-hosted connect flow. |
+| R6 | Registry unreachable. | control-api→registry egress already covered in base; kubelet→registry pull is a node/GKE firewall concern, not a pod NetworkPolicy (§7.8). |
+| R7 | Read/write in a namespace outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`). | Provisioner is pinned to `config.mcpServersNamespace` (default `mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting, so no key-cap slot is wasted (§7.1). |
+
+---
+
+## 11. Test plan
+
+- **Unit** — `shouldAttachEvenfirePullSecret` unchanged; new
+  `ensureRegistryPullSecret` state machine: absent→created; ours→reuse;
+  foreign(unlabeled)→untouched; 409→success; gate off in managed/auth-off/empty-URL.
+- **Secret shape** — asserts type `kubernetes.io/dockerconfigjson`, single
+  `.dockerconfigjson` key, base64 not double-encoded, `managed-by=control-api` label,
+  namespace = `config.mcpServersNamespace`.
+- **Registry client** — machine `POST /org/:org/keys` mint returns `dockerconfigjson`;
+  org resolved from `resolvePublishScope`.
+- **Integration / e2e (minikube, self-hosted)** — install a private evenfire-hosted
+  local plugin; assert the Secret is created and the plugin pod pulls (no
+  `ImagePullBackOff`); re-install is idempotent; a pre-seeded foreign Secret is
+  preserved.
+- **Coexistence** — with a pre-existing unlabeled Secret, ensure returns
+  `'exists-foreign'` and does not mint.
+
+---
+
+## 12. Open questions / decisions for review
+
+1. **Credential scope (§6.3)** — accept the publish-scoped key in Phase 1, or block
+   on the Phase 2 pull-only mint? *(Recommendation: ship phased.)*
+2. **MCC-word scrub breadth (§7.8)** — scrub only pull-secret comments, or all
+   managed-mode "MCC" mentions? *(Recommendation: scrub wording, keep behavior.)*
+3. **Trigger (§7.3)** — lazy-at-attach only, or add the boot reconcile? *(Recommendation: lazy; boot optional.)*
+4. **Rotation policy (§7.6)** — define now, or defer as MCC does? *(Recommendation: define posture, defer scheduled rotation.)*
+5. **HCC presence-validation (§7.7)** — in this spec or a follow-up? *(Recommendation: follow-up.)*
+6. **MCC step retirement (§9.3)** — coordinate managed self-provisioning, or leave
+   managed on MCC indefinitely behind the mode gate?
+
+---
+
+## 13. Appendix — touchpoint index
+
+**evenfire (this repo)**
+- `control-api/src/routes/admin/registryImagePullSecret.ts` — name/predicate; comments to rewrite (`:6,12-13`).
+- `control-api/test/registryImagePullSecret.test.ts:10` — test description to reword (G2 scrub).
+- `control-api/src/routes/admin/registry.ts` — attach sites `:~1117-1124`,`:~1808-1818`; comment `:1114-1116`; existing fail-loud plugin-ns Secret write via gateway `:1226-1240`; router gateway param `:732`.
+- `control-api/src/services/registryPullSecretService.ts` — **new** (`ensureRegistryPullSecret`; takes `K8sGateway` + mint fn).
+- `control-api/src/services/registryClient.ts` — **new** exported `mintOrgMachineKey(orgName)` built on the private `orgRegistryFetch` (`:551`, machine Bearer, prefixes `/api/v1`), mirroring `createOrgGrant` (`:584`); `authedFetch` `:191`; `resolvePublishScope` `:650-662` (orgName nullable).
+- `control-api/src/services/orgApiKeyClient.ts:115-164` — existing **user-token** key mint (the path that 403s in ownerless orgs; *not* reused).
+- `control-api/src/k8s.ts:389-394` — `K8sGateway.getSecret/createSecret/updateSecret` (the write surface actually used at the attach sites).
+- `control-api/src/services/secretService.ts:25-53` — `getSecret` **re-throws 404** (not 404-aware); `createSecret` passes `type` through.
+- `control-api/src/config.ts:~76,285,302-304,460` — `registryConnectionMode`, `mcpServersNamespace`.
+- `deploy/base/mcp-server/rbac.yaml:29-31` — control-api secrets RBAC (sufficient; broader set incl. `sandbox-ui`).
+- `host-context-controller/src/reconciler.ts:994-1002` — reference propagation (unchanged); `:436-453` — envSecret validation (model for §7.7).
+- `docs/how-to/connect-to-registry.md:59,70` — doc fix.
+
+**evenfire-registry (in scope; Phase 2)**
+- `src/routes/deployments.ts:237-247` — self-hosted client gets `registry:manage-keys` (the enabler).
+- `src/routes/org.ts:245,276,293-295` — machine-branch key mint + `dockerconfigjson`; `:371-388` — `*`-gated pull-only endpoint (Phase 2 relaxation target).
+- `src/services/orgApiKeyService.ts:70-88,122-151` — `mintKey`/`mintPullKey`/`buildDockerconfigjson`; `:23` — `MAX_ACTIVE_KEYS_PER_ORG`.
+
+**evenfire-managed-cluster-control (out of repo; sequenced retirement)**
+- `packages/backend/src/operations/handlers/tenant-install-shared.ts:476-496`, `evenfire-install.ts:356-378`, `install/secrets.ts:110-121,181-212`, `install/registry.ts:48-95` — the `install_registry_pull_secret` behavior being superseded.

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -77,8 +77,8 @@ MCC** that violates the open-core boundary (the OSS platform must run standalone
 - `config.ts:62` — "Delivered by MCC in the registry-voucher Secret" (adjacent
   subsystem; see §7.8).
 
-Andy's framing (paraphrased): *this repo should not know anything about MCC*, and
-the pull-secret responsibility should sit with the controllers that already inject
+A proposed direction: *this repo should not know anything about MCC*, and the
+pull-secret responsibility should sit with the controllers that already inject
 auth-related secrets (WRC / HCC). §5 assesses that proposal; the conclusion is that
 **control-api** is the correct owner, and gating on the existing
 `registryConnectionMode` discriminator is what actually removes the MCC coupling.
@@ -195,7 +195,7 @@ where we hook in:
 
 ## 5. Ownership: why control-api, not HCC/WRC
 
-Andy's proposal routes provisioning to WRC/HCC "because they already inject
+The proposal to route provisioning to WRC/HCC rests on "they already inject
 auth-related secrets." The review shows that premise is **only half true**, and the
 factoring it implies is the higher-cost path:
 
@@ -218,7 +218,7 @@ factoring it implies is the higher-cost path:
   install (`registry.ts:1215-1248`).
 
 **Decision:** control-api self-provisions. HCC stays a pass-through of the reference
-(with an optional presence-validation enhancement, §7.7). This honors Andy's real
+(with an optional presence-validation enhancement, §7.7). This honors the real
 goal — *the repo stops depending on MCC* — better than relocating the mint, because
 the dependency is removed by the `registryConnectionMode` gate, not by moving code
 into a controller that would need registry credentials plumbed into it.
@@ -525,8 +525,8 @@ self-provisioning, keeping the constant and predicate (they are the local contra
   `control-api/src`, or G2 does not hold.
 
 **Adjacent — catalog, decide explicitly (likely follow-up):** these mention MCC or
-managed-mode topology but are *not* the pull secret. Andy's "the repo should know
-nothing about MCC" argues for scrubbing the literal word "MCC" (replace with "the
+managed-mode topology but are *not* the pull secret. The "repo should know nothing
+about MCC" goal argues for scrubbing the literal word "MCC" (replace with "the
 managed operator" / "managed mode"), but the *behavior* they branch on is legitimate
 (control-api genuinely differs by `registryConnectionMode`):
 
@@ -609,7 +609,7 @@ Traced against the current install/upgrade/uninstall code. **Cleared (safe today
 
 ---
 
-## 8. Multi-tenancy guardrail (Andy's §7, carried forward)
+## 8. Multi-tenancy guardrail (carried forward from the registry bridge design §7)
 
 The self-hosted / OSS platform is **single-tenant — one organization per
 deployment** (`docs/concepts/open-core-and-hosted.md:38`, `docs/faq.md:21`). So

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -361,8 +361,23 @@ Algorithm:
    - `404` → **absent** → go to step 4.
    - any other status (esp. **403**) → **abort before minting**.
    - present and **not** labeled `managed-by=control-api` → **`'exists-foreign'`**,
-     returned unconditionally (I1). If it is also unusable we log a warning naming the
-     remedy (delete it), but we never write.
+     returned unconditionally (I1). We never write it, usable or not.
+
+     A foreign copy is not merely "skip this namespace", because the pull key is per-**org**
+     and the mint is rotate-on-call: minting for the namespaces we *do* own revokes the key
+     inside the foreign Secret as well, and I1 forbids us from repairing it afterwards. So a
+     **usable** foreign copy (right `type`, blob keyed on the current host) blocks the mint
+     for the whole pass — the org's credential is externally managed and this service must
+     not rotate it. Owned namespaces that needed that mint are recorded as blocked and
+     surfaced to callers that require them as `foreign_secret_would_be_revoked` (409); a
+     caller whose own namespaces are already current is unaffected.
+
+     An **unusable** foreign copy (wrong `type`, or a blob keyed on another host) does *not*
+     block the mint: the kubelet never selects it, so it cannot be serving pulls and
+     rotating breaks nothing. It still fails any caller that requires *its* namespace, with
+     `foreign_secret_unusable` (409). Both conditions are recorded during the pass rather
+     than thrown from it, because one pass is shared across callers with different required
+     sets — see the `blocked`/`unusable` maps in `registryPullSecretService.ts`.
    - present, ours, `type` correct, and the decoded blob's `auths` contains the current
      host → **`'exists-ours'`**. Presence alone is not enough: a blob keyed on a previous
      `CLERUM_REGISTRY_URL` can never be selected by the kubelet.
@@ -470,6 +485,13 @@ Because the pull-only mint is **rotate-on-call**, a blind re-mint would orphan t
 working on-cluster key — so read-before-mint (§7.1 step 2) is the load-bearing
 idempotency guarantee: control-api mints only when the Secret is absent or broken, and
 never for an `'exists-ours'`/`'exists-foreign'` hit.
+
+Leaving a foreign Secret unwritten is **not** on its own sufficient, because the key is
+per-org: a mint for any *other* namespace revokes the foreign copy's credential too, with
+no way to detect it (foreign copies are excluded from the fingerprint comparison) and no
+way to repair it (I1). A **usable** foreign copy therefore blocks the mint entirely for
+that pass — see §7.1 step 3. This is the same one-writer-per-org rule the registry
+enforces between operator and tenant, applied within a single cluster.
 
 ### 7.5 What stays unchanged
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -357,12 +357,16 @@ Algorithm:
      wrong-typed same-named Secret), regardless of label → **`'repaired'`**: mint and
      `updateSecret` (replace) — do **not** `createSecret` (it would 409). This closes
      the gap where a create-409 is silently "treated as success" over a broken Secret.
-3. **Mint (revoke-prior first).** If a prior control-api-minted key id is on record
-   (Secret annotation or a small state row), **revoke it** (`DELETE /org/:org/keys/:id`,
-   `org.ts:334-349`) before minting, to bound accumulation (§6.1). Then call the
-   registry mint for `resolvePublishScope().orgName` (Phase 1: machine
-   `POST /org/:org/keys`; Phase 2: pull-only). Obtain the server-built
-   `dockerconfigjson` (already base64), or reproduce locally via the same pure formula
+3. **Mint (revoke-prior first).** If a prior control-api-minted pull key id is on
+   record (Secret annotation or a small state row), **revoke it**
+   (`DELETE /org/:org/keys/:id`, `org.ts:334-349`) before minting, to bound
+   accumulation (§6.1). Scope revoke-prior to keys carrying control-api's fixed
+   pull-key **description marker** so it never revokes a user/CI key (§7.9-3). Then
+   call the registry mint for `resolvePublishScope().orgName` with that description
+   (Phase 1: machine `POST /org/:org/keys`; Phase 2: pull-only). **Build the
+   `dockerconfigjson` locally**, keyed on `registryHostFromUrl(config.registryUrl)`
+   (the image host, per the attach invariant) — *not* the registry's
+   `registryTokenIssuer`-keyed response (§7.9-2) — via
    `{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`
    (`orgApiKeyService.ts:147-151`). Record the returned key id for future revoke.
 4. **Write.** `createSecret` (absent) or `updateSecret` (repair) with
@@ -485,11 +489,15 @@ still applies to avoid key churn and the 100-key cap.
   and the non-expiring-key choice are **required** for Phase 1, else a revoked-out-of-band
   or expired key strands the cluster with no self-heal. Posture in one line:
   *control-api owns rotation for Secrets it owns and never touches a foreign Secret.*
-- **GC.** In self-hosted there is no MCC uninstall. The Secret is a standing
-  namespace credential for the cluster's lifetime; no ownerReference/finalizer is
-  added (consistent with the absence of ownerReferences anywhere in control-api
-  today). Revocation of the underlying `efrk_` key on teardown is out of scope for
-  Phase 1.
+- **GC.** Plugin uninstall deletes the per-plugin `<name>-credentials` Secret by name
+  and does **not** touch the shared pull Secret (§7.9) — correct, since other plugins
+  may still need it. The Secret is therefore a standing namespace credential for the
+  cluster's lifetime; no ownerReference/finalizer is added (consistent with the
+  absence of ownerReferences anywhere in control-api today). Neither uninstall nor any
+  other path revokes the underlying `efrk_` key, so the registry-side key is a
+  standing credential too and can accrue across re-mints unless revoke-prior (§7.1) is
+  honored. Revoking the key on the last-plugin uninstall (and on `registryUrl`/host
+  change) is out of scope for Phase 1 but noted as a lifecycle follow-up.
 
 ### 7.7 Optional HCC enhancement — presence validation
 
@@ -552,6 +560,52 @@ mode).
 Net: no in-repo NetworkPolicy change is required for either plane; document the
 node-level firewall expectation for self-hosted operators pulling from a remote
 registry.
+
+### 7.9 Verified side effects & interactions
+
+Traced against the current install/upgrade/uninstall code. **Cleared (safe today):**
+
+- **Uninstall never sweeps the pull Secret.** The uninstall handler deletes
+  `${resourceName}-credentials` **by name** (`registry.ts:1610`) and the McpServer by
+  name — never by label selector. `clerum.io/managed-by=control-api` is **not** used
+  as a list/delete selector anywhere in control-api (only `clerum.io/recipe` and pod
+  selectors are). So the namespace-shared pull Secret survives every per-plugin
+  uninstall.
+- **The #637 recipe↔Secret access gate does not apply.** That gate
+  (`parseSecretOwnership` / `isSecretAccessibleByRecipe`) only governs secrets a
+  recipe **projects into its pod**. An `imagePullSecrets` entry is consumed by the
+  kubelet, never projected — so the pull Secret's absence of `owner-recipe`/`shared`
+  labels is irrelevant and cannot trip recipe validation.
+
+**Must-handle (these will bite if missed):**
+
+1. **Hook placement is independent of `credRequired`.** The existing Step-3 Secret
+   write is gated on `if (credRequired)` (`registry.ts:1217`). A private evenfire-hosted
+   plugin with **no** required credentials (`credRequired === false`) creates *no*
+   credentials Secret — but still needs the pull Secret. `ensureRegistryPullSecret`
+   MUST therefore be called **outside** the `credRequired` block, gated only on
+   `shouldAttachEvenfirePullSecret`. Placing it inside would silently reintroduce
+   `ImagePullBackOff` for credential-less private-image plugins.
+2. **Build the dockerconfigjson locally, keyed on the image host.** The kubelet selects
+   the pull credential by matching the image's registry host against the
+   `.auths` keys. The registry's server-built blob is keyed on *its* `registryTokenIssuer`
+   (`org.ts:295` → `buildDockerconfigjson(config.registryTokenIssuer, key)`,
+   default `registry.evenfire.ai`), which is **independent config** from control-api's
+   `config.registryUrl`. control-api has no `registryTokenIssuer` field. So
+   `ensureRegistryPullSecret` MUST build the blob itself with
+   `registryHostFromUrl(config.registryUrl)` as the `.auths` host — which the
+   `shouldAttachEvenfirePullSecret` invariant guarantees equals the image host — rather
+   than trust the registry's `registryTokenIssuer`-keyed response. Same pure formula
+   (`{auths:{[host]:{username:'_',password:key,auth:base64('_:'+key)}}}`), local host.
+3. **Shared key cap, list visibility, and revoke safety.** control-api already exposes
+   `/admin/registry/keys` (`registry.ts:2221-2247`), where operators mint/list/revoke
+   `efrk_` keys via the user-token path — all sharing `MAX_ACTIVE_KEYS_PER_ORG=100`.
+   The auto-minted pull key therefore (a) counts against that cap alongside CI/user
+   keys, and (b) appears in the user-facing key list. Mint it with a **fixed,
+   recognizable description** (e.g. `evenfire-registry-pull (auto)`), and scope
+   revoke-prior (§6.1) to keys carrying that marker so it never revokes a user/CI key.
+   Consider filtering it from the `/admin/registry/keys` GET list to avoid operator
+   confusion.
 
 ---
 
@@ -626,6 +680,9 @@ path and reads as `'exists-foreign'` if the mode ever flips.
 | R6 | Registry unreachable. | control-api→registry egress already covered in base; kubelet→registry pull is a node/GKE firewall concern, not a pod NetworkPolicy (§7.8). |
 | R7 | `targetNs` outside control-api's secrets RBAC (`{mcp-server, mcp-host, control-plane, sandbox-recipes, sandbox-ui}`) via a `body.namespace` override. | Default `targetNs` is `config.mcpServersNamespace` (`mcp-server`, covered + pre-created); a non-404 read error (e.g. `403`) aborts before minting, so no key-cap slot is wasted (§7.1); operators exposing the override constrain it to the covered set (§8). |
 | R8 | Shared pull Secret wrongly torn down by a per-plugin rollback. | `ensureRegistryPullSecret` sits outside the Step-4 `secretCreated`/`deleteSecret` rollback scope; a CRD-create failure never deletes the namespace-shared pull Secret (§7.3). |
+| R9 | `.dockerconfigjson` keyed on the wrong host → present Secret still yields `ImagePullBackOff`. | Build the blob locally keyed on `registryHostFromUrl(config.registryUrl)` (= image host), not the registry's `registryTokenIssuer` (§7.9-2). |
+| R10 | Auto-minted pull key collides with user/CI keys — shared 100-cap, appears in the operator key list, or revoke-prior nukes a user key. | Fixed description marker on the pull key; revoke-prior scoped to that marker only; optionally hide it from `/admin/registry/keys` GET (§7.9-3). |
+| R11 | Credential-less private-image plugin (`credRequired=false`) gets no pull Secret. | Hook is outside the `if (credRequired)` block, gated only on `shouldAttachEvenfirePullSecret` (§7.9-1). |
 
 ---
 
@@ -645,6 +702,17 @@ path and reads as `'exists-foreign'` if the mode ever flips.
   preserved.
 - **Coexistence** — with a pre-existing unlabeled Secret, ensure returns
   `'exists-foreign'` and does not mint.
+- **Existing tests to revise (not just add).** `control-api/test/routes.registryInstall.test.ts`
+  asserts `createSecret` call counts that this change alters: `:864`
+  `toHaveBeenCalledTimes(1)` (now 2 for an evenfire-hosted plugin), and `:1148`/`:1204`
+  `not.toHaveBeenCalled()` (now called if the plugin is evenfire-hosted). These, and the
+  `evenfire imagePullSecrets attach` describe block (`:1424`), must be updated to
+  account for the pull-Secret create and to assert its shape/namespace.
+- **Host-keying** — the minted Secret's `.auths` key equals the image host
+  (`registryUrl` host), not `registryTokenIssuer`, verified against a config where the
+  two differ (§7.9-2).
+- **credRequired=false** — a private evenfire-hosted plugin with no credentials still
+  gets the pull Secret (hook outside the `credRequired` block, §7.9-1).
 
 ---
 

--- a/docs/architecture/registry-pull-secret-self-provisioning.md
+++ b/docs/architecture/registry-pull-secret-self-provisioning.md
@@ -470,16 +470,21 @@ never for an `'exists-ours'`/`'exists-foreign'` hit.
 
 ### 7.6 Rotation & lifecycle
 
-- **Rotation & liveness.** `'exists-ours'` reuse (§7.1 step 2) serves the embedded
-  key indefinitely, so the key must not silently die. The pull key carries no
-  expiry (`mintPullKey` sets none), so reuse is safe by construction. Treat an
-  observed `401`/`ImagePullBackOff` (or an admin "re-provision" action) as the
-  reactive rotation trigger — which re-mints (the endpoint rotates the org's pull
-  key) and **replaces** the `'exists-ours'` Secret in place (never a foreign one). A
-  scheduled proactive rotation may be deferred, but the *reactive* trigger is
-  **required**, else a revoked-out-of-band key strands the cluster with no self-heal.
-  Posture in one line: *control-api owns rotation for Secrets it owns and never
-  touches a foreign Secret.*
+- **Rotation & liveness.** The pull key carries no expiry (`mintPullKey` sets none), so
+  reuse is safe by construction. `'exists-ours'` is **not** a presence-only check: the
+  stored blob is decoded and its `auths` map must contain the currently-configured
+  registry host, so a Secret minted before `CLERUM_REGISTRY_URL` changed is detected as
+  broken and repaired on the next install. A wrong-`type` Secret is likewise detected and
+  recreated (`Secret.type` is immutable, so an in-place update would 422).
+  Posture in one line: *control-api owns rotation for Secrets it owns and never touches a
+  foreign Secret.*
+
+  **Not shipped (accepted gap):** there is no reactive trigger on an observed
+  `401`/`ImagePullBackOff`, and no admin "re-provision" action. A key revoked
+  **out-of-band** is therefore not self-healed — the stored blob still decodes and still
+  matches the host, so it reads as healthy. Today's remedy is to delete the Secret and
+  re-install, which re-provisions. A re-provision endpoint is the natural follow-up; it is
+  deliberately out of scope here rather than documented as if it exists.
 - **GC.** Plugin uninstall deletes the per-plugin `<name>-credentials` Secret by name
   and does **not** touch the shared pull Secret (§7.9) — correct, since other plugins
   may still need it. The Secret is therefore a standing namespace credential for the
@@ -643,6 +648,17 @@ future scope.
 1. **Deploy the registry gate change (§6.2) first or together** — control-api's mint
    `403`s until the relaxed endpoint is live, so the `evenfire-registry` deploy must
    land before (or with) the control-api rollout. Both are part of this release.
+
+   > **Precondition the gate alone does not satisfy.** The relaxed endpoint authorizes on
+   > `registry:manage-keys`, but only the registry's **auto-approve** path grants that
+   > scope (`routes/deployments.ts`). A deployment approved through the **admin approve**
+   > route (`POST /deployments/:id/approve`) falls back to `approveDeployment`'s default
+   > scope set, which omits it — and the backfill migration is scoped
+   > `WHERE created_by = 'mcc-admin'` while that path writes `created_by =
+   > 'deployment-approval'`, so it is not covered either. Those deployments 403 forever
+   > with no self-service remedy. **Registry-side fix required:** pass the same scope set
+   > from the admin approve route and widen the backfill. Until then, self-provisioning
+   > only works for auto-approved (open-registration) deployments.
 2. **Ship control-api self-provisioning** gated on `self-hosted`, with the comment/doc
    scrub (§7.8). Managed clusters are inert (the managed operator keeps owning the
    Secret) — the mode gate guarantees no double-writer, so no cross-repo coordination

--- a/docs/crds/mcpserver.md
+++ b/docs/crds/mcpserver.md
@@ -119,6 +119,29 @@ An McpServer with `spec.remote` must declare at least one `egressBinding`.
 | `spec.imagePullSecrets` | object[] | no | Image pull secrets for the container. |
 | `spec.imagePullSecrets[].name` | string | no | Name of the image pull Secret. |
 
+HCC copies `spec.imagePullSecrets` verbatim onto the generated Deployment and re-validates
+nothing, so whatever writes this field owns the decision.
+
+**Object references here, `string[]` on WorkflowRecipe — intentional.** A `WorkflowRecipe`
+workload declares `imagePullSecrets` as plain Secret **names**
+(`docs/crds/workflowrecipe.md` §3.4.2). When WRC delegates a transport workload to an
+McpServer it applies the Issue-#637 ownership filter to those names and then **normalizes
+them into the `{ name }` object form** this CRD (and Kubernetes `PodSpec`) requires. That is
+a documented format conversion at the contract boundary, **not** a desynchronization
+between the two CRDs — neither schema should be changed to match the other.
+
+**The platform registry credential is injected, not declared.** For an image hosted on the
+configured platform registry, the writer (Control API for direct installs, WRC for
+recipe-delegated servers) appends `evenfire-registry-pull` itself, after the ownership
+filter. It is provisioned by Control API and is deliberately unlabeled to the #637 model, so
+a recipe that names it is denied rather than honored. See
+`docs/architecture/registry-pull-secret-self-provisioning.md`.
+
+**`spec.envSecret` is a separate mechanism and must never carry registry credentials.**
+`envSecret` projects Secret values into the container's **environment**; `imagePullSecrets`
+is consumed by the **kubelet** and never reaches the container. A registry credential routed
+through `envSecret` is readable by the workload process itself.
+
 ### Security Context
 
 | Field | Type | Required | Description |

--- a/docs/crds/workflowrecipe.md
+++ b/docs/crds/workflowrecipe.md
@@ -844,6 +844,40 @@ install/upgrade (`422 workflowWorkloadSecretOwnershipDenied`) for early, clear
 feedback. An unlabeled Secret passes Control API (it may be labeled before the
 recipe runs) but still fails closed at the reconciler until labeled.
 
+### 3.4.2 Image Pull Secrets (format conversion + the platform credential)
+
+**`string[]` here, `{name}` objects downstream — this is intentional.** A WorkflowRecipe
+workload declares `imagePullSecrets` as a list of plain Secret **names**:
+
+```yaml
+imagePullSecrets:
+  - my-ghcr-creds
+```
+
+Kubernetes `PodSpec.imagePullSecrets` and the McpServer CRD (`spec.imagePullSecrets`) both
+take **object references** (`- name: my-ghcr-creds`). WRC performs that conversion: it
+applies the Issue-#637 ownership filter to the declared names, then normalizes the
+surviving names into `{ name }` references when it renders a pod template or an McpServer
+manifest. The recipe-facing string form is the ergonomic surface; the object form is the
+Kubernetes contract. **This is a documented format conversion at the contract boundary, not
+a desynchronization between the two CRDs** — do not "fix" either schema to match the other.
+
+**The platform registry credential is injected, never declared.** Images hosted on the
+platform registry are covered by a Secret named `evenfire-registry-pull`, provisioned by
+Control API and referenced automatically: WRC appends it **after** the ownership filter to
+any workload whose image host matches the configured registry host. A recipe must **not**
+name it in `imagePullSecrets` — the Secret is deliberately unlabeled to the #637 ownership
+model, so declaring it is `denied`, which denies the whole **workload** (it is torn down,
+not merely stripped). Recipes stay portable precisely because they never mention it. See
+`docs/architecture/registry-pull-secret-recipe-workloads.md`.
+
+**`envSecret` is a different mechanism — never use it for registry credentials.**
+`envSecret` (Section 3.4.1) projects Secret values into the container's **environment**;
+`imagePullSecrets` is consumed by the **kubelet** and never reaches the container. Routing a
+registry credential through `envSecret` hands it to the workload process (and to anything
+that can read that process's environment) — exactly the exfiltration path the #637
+ownership model exists to close.
+
 ### 3.5 Volume Mounts
 
 ```yaml

--- a/docs/get-started/registry-quickstart.md
+++ b/docs/get-started/registry-quickstart.md
@@ -121,6 +121,42 @@ pods they orchestrate:
 kubectl -n sandbox-recipes get workflowrecipes
 ```
 
+### Private images pull themselves
+
+If the connector or plugin you installed runs a **private** image on the evenfire
+registry, you do not create a pull Secret and you do not put credentials in the
+entry. On the first install that needs one, control-api mints a pull credential
+from your connection's own registry identity and writes it as a Secret named
+`evenfire-registry-pull` into all three platform workload namespaces:
+
+```bash
+kubectl get secret -A -l clerum.io/managed-by=control-api
+# NAMESPACE         NAME                     TYPE                             DATA
+# mcp-server        evenfire-registry-pull   kubernetes.io/dockerconfigjson   1
+# sandbox-recipes   evenfire-registry-pull   kubernetes.io/dockerconfigjson   1
+# sandbox-ui        evenfire-registry-pull   kubernetes.io/dockerconfigjson   1
+```
+
+Then the reference is attached for you. control-api writes it onto the `McpServer`
+for connectors, and workflow-recipes injects it into the rendered pod template for
+recipe workloads. Recipes never name it themselves. `evenfire-registry-pull` is a
+reserved name: declare it in a recipe's `imagePullSecrets` and the install is
+rejected, and the admin Secrets API refuses to create, modify or delete it.
+
+Two things follow from this that are worth knowing up front:
+
+- **It is one credential per organization, rotated on each mint.** All three copies
+  always hold the same key. That is why control-api writes all three together
+  rather than one namespace at a time.
+- **It repairs itself.** control-api re-checks the Secret at startup and every 10
+  minutes (`REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS`), so a copy that was
+  deleted or emptied comes back without an install to trigger it.
+
+If you would rather provision the Secret yourself, read the pre-provisioning rules
+in [Connect to the registry](../how-to/connect-to-registry.md#api-keys-for-programmatic-publishing)
+first. A half-external setup, where you supply some namespaces and leave others to
+control-api, is not supported.
+
 ## 5. Mint an org API key
 
 The Control UI publishes using the credential stored at connect time, so
@@ -219,22 +255,26 @@ Field-by-field reference and the update/delete routes are in
 
 ## Troubleshooting
 
-| Symptom                                               | Cause and fix                                                                                                                                                                                  |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `control-api` will not start, complains about the URL | `CLERUM_REGISTRY_URL` is not in the allowlist. Add it to `CLERUM_REGISTRY_URL_ALLOWLIST` (see step 1).                                                                                         |
-| No Connect panel, no banner                           | The deployment is in `managed` mode. Managed deployments are connected for you and have nothing to configure.                                                                                  |
-| `org_name_taken` on registration                      | Another deployment holds that organization name. Pick a different one and register again. Nothing was saved.                                                                                   |
-| `org_blocklisted` on registration                     | The name is reserved. Pick a different one.                                                                                                                                                    |
-| Connect panel stuck at **Finishing the connection**   | The inline redeem did not land. Press **Finish connecting**; it needs no token. Reach for **Start over** only when the panel says the credentials were issued but never stored.                |
-| `deployment_suspended`                                | Evenfire suspended the deployment. Contact support. Do **not** press Start over: a suspension is reversible, a destroyed keypair is not.                                                       |
-| `409 CONFLICT` on publish                             | That `name` + `version` already exists. Bump the version; versions are immutable.                                                                                                              |
-| `400 scope_required` on publish                       | The entry name is unscoped. Use `@<org>/<name>`.                                                                                                                                               |
-| `invalid reference format` from `docker`              | The `@` scope prefix is in the image path. It belongs in the entry name only: push to `registry.evenfire.ai/<org>/<name>`, not `/@<org>/<name>`.                                               |
-| `docker push` denied, credential is good              | Three quiet causes, likeliest first: a malformed repo path (the scope is dropped, not rejected), a key without `registry:publish`, or the self-hosted quota (10 repos / 2 GiB / 200 versions). |
-| `403 selfhosted_public_disabled`                      | An open-registration org cannot make an image repo public. Images stay private to your org; cross-org sharing needs a grant Evenfire issues.                                                   |
-| `422` naming the `imageRef`                           | The image repo path does not equal the entry name. `@acme/db-tools` needs `registry.evenfire.ai/acme/db-tools`. Checked at publish and install, since a mismatch denies the pull.              |
-| `403` when managing **grants**                        | Expected. Deployments that onboarded through self-hosted connect do not hold `registry:grant`. Receiving and installing granted plugins still works.                                           |
-| Connector installed but cannot reach its API          | Egress. Default-deny networking blocks anything not declared in the install's egress step.                                                                                                     |
+| Symptom                                               | Cause and fix                                                                                                                                                                                                                                                                                                                      |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `control-api` will not start, complains about the URL | `CLERUM_REGISTRY_URL` is not in the allowlist. Add it to `CLERUM_REGISTRY_URL_ALLOWLIST` (see step 1).                                                                                                                                                                                                                             |
+| No Connect panel, no banner                           | The deployment is in `managed` mode. Managed deployments are connected for you and have nothing to configure.                                                                                                                                                                                                                      |
+| `org_name_taken` on registration                      | Another deployment holds that organization name. Pick a different one and register again. Nothing was saved.                                                                                                                                                                                                                       |
+| `org_blocklisted` on registration                     | The name is reserved. Pick a different one.                                                                                                                                                                                                                                                                                        |
+| Connect panel stuck at **Finishing the connection**   | The inline redeem did not land. Press **Finish connecting**; it needs no token. Reach for **Start over** only when the panel says the credentials were issued but never stored.                                                                                                                                                    |
+| `deployment_suspended`                                | Evenfire suspended the deployment. Contact support. Do **not** press Start over: a suspension is reversible, a destroyed keypair is not.                                                                                                                                                                                           |
+| `409 CONFLICT` on publish                             | That `name` + `version` already exists. Bump the version; versions are immutable.                                                                                                                                                                                                                                                  |
+| `400 scope_required` on publish                       | The entry name is unscoped. Use `@<org>/<name>`.                                                                                                                                                                                                                                                                                   |
+| `invalid reference format` from `docker`              | The `@` scope prefix is in the image path. It belongs in the entry name only: push to `registry.evenfire.ai/<org>/<name>`, not `/@<org>/<name>`.                                                                                                                                                                                   |
+| `docker push` denied, credential is good              | Three quiet causes, likeliest first: a malformed repo path (the scope is dropped, not rejected), a key without `registry:publish`, or the self-hosted quota (10 repos / 2 GiB / 200 versions).                                                                                                                                     |
+| `403 selfhosted_public_disabled`                      | An open-registration org cannot make an image repo public. Images stay private to your org; cross-org sharing needs a grant Evenfire issues.                                                                                                                                                                                       |
+| `422` naming the `imageRef`                           | The image repo path does not equal the entry name. `@acme/db-tools` needs `registry.evenfire.ai/acme/db-tools`. Checked at publish and install, since a mismatch denies the pull.                                                                                                                                                  |
+| `403` when managing **grants**                        | Expected. Deployments that onboarded through self-hosted connect do not hold `registry:grant`. Receiving and installing granted plugins still works.                                                                                                                                                                               |
+| Connector installed but cannot reach its API          | Egress. Default-deny networking blocks anything not declared in the install's egress step.                                                                                                                                                                                                                                         |
+| `409 foreign_secret_would_be_revoked` on install      | You pre-provisioned `evenfire-registry-pull` in some platform namespaces but not all three. The pull key is one per org and rotate-on-call, so control-api will not mint and revoke your copy. Supply all three namespaces, or delete yours and let control-api manage them.                                                       |
+| `409 foreign_secret_unusable` on install              | An `evenfire-registry-pull` Secret you own sits in the namespace this install targets, and it cannot serve a pull: wrong `type`, or a `.dockerconfigjson` with no entry for your registry host or an entry carrying no credential. Fix it in place or delete it. Nothing was created; the install fails before the CRD is written. |
+| `422 workflowWorkloadSecretRefReserved` on install    | The recipe declares `evenfire-registry-pull` in `imagePullSecrets`. Remove it. The platform attaches the reference itself, after the ownership filter that would otherwise strip a declared name.                                                                                                                                  |
+| `ImagePullBackOff` on a private evenfire image        | Check the pod actually got the reference (`kubectl get pod <p> -o jsonpath='{.spec.imagePullSecrets}'`). If it is empty on a recipe workload, `CLERUM_REGISTRY_URL` differs between control-api and workflow-recipes: injection keys off the image host matching that URL. Both read the same `control-api-config` key by default. |
 
 ## Next steps
 

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -71,6 +71,13 @@ Once connected, browsing the public catalog, publishing, and image push/pull all
 work using the credential stored when you claimed the connection — no further
 setup is needed for those.
 
+> **In-cluster image pulls.** When you install a private plugin whose image lives on
+> the evenfire registry, control-api (in self-hosted mode) automatically provisions
+> the in-cluster `evenfire-registry-pull` Secret in the plugin namespace, so the
+> plugin pods can pull the image — you do not create that Secret by hand. It is
+> minted from your connection's own registry identity and left untouched if an
+> external operator already provided one.
+
 **Creating and managing API keys** (`efrk_` org keys, used for CI and other
 programmatic publishing) needs registry authentication active. In self-hosted,
 connecting is sufficient: authentication turns on automatically the moment

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -71,12 +71,30 @@ Once connected, browsing the public catalog, publishing, and image push/pull all
 work using the credential stored when you claimed the connection — no further
 setup is needed for those.
 
-> **In-cluster image pulls.** When you install a private plugin whose image lives on
-> the evenfire registry, control-api (in self-hosted mode) automatically provisions
-> the in-cluster `evenfire-registry-pull` Secret in the plugin namespace, so the
-> plugin pods can pull the image — you do not create that Secret by hand. It is
-> minted from your connection's own registry identity and left untouched if an
-> external operator already provided one.
+> **In-cluster image pulls.** When you install a private plugin or recipe whose image
+> lives on the evenfire registry, control-api (in self-hosted mode) automatically
+> provisions the in-cluster `evenfire-registry-pull` Secret in every platform workload
+> namespace — `mcp-server`, `sandbox-recipes` and `sandbox-ui` — so the pods can pull
+> the image. You do not create that Secret by hand. It is minted from your
+> connection's own registry identity.
+>
+> **If you pre-provision it yourself, do all three namespaces.** control-api never
+> writes a Secret it does not own (one without the `clerum.io/managed-by: control-api`
+> label), and the registry's pull credential is **per-organization and rotate-on-call**:
+> minting a key for one namespace revokes the key in every other copy, including yours.
+> So the moment control-api finds a **working** externally-provided copy in any of the
+> three namespaces, it stops minting entirely rather than silently invalidating your
+> credential. Installs that need a namespace you left empty then fail with
+> `foreign_secret_would_be_revoked`, naming both namespaces. Provide the Secret in all
+> three namespaces, or delete your copies and let control-api manage all three — a
+> half-external setup is not supported.
+>
+> A **malformed** external copy is treated differently: one with the wrong `type`, or a
+> `.dockerconfigjson` carrying no entry for your registry host, can never serve a pull,
+> so it does not hold control-api back from minting for the other namespaces. It does
+> fail any install that lands a workload in _its own_ namespace, with
+> `foreign_secret_unusable` — fix that Secret in place, or delete it and let control-api
+> manage that namespace.
 
 **Creating and managing API keys** (`efrk_` org keys, used for CI and other
 programmatic publishing) needs registry authentication active. In self-hosted,

--- a/docs/how-to/connect-to-registry.md
+++ b/docs/how-to/connect-to-registry.md
@@ -79,12 +79,20 @@ is needed for those.
 > three namespaces, or delete your copies and let control-api manage all three — a
 > half-external setup is not supported.
 >
-> A **malformed** external copy is treated differently: one with the wrong `type`, or a
-> `.dockerconfigjson` carrying no entry for your registry host, can never serve a pull,
-> so it does not hold control-api back from minting for the other namespaces. It does
-> fail any install that lands a workload in _its own_ namespace, with
-> `foreign_secret_unusable` — fix that Secret in place, or delete it and let control-api
-> manage that namespace.
+> A **malformed** external copy is treated differently. One with the wrong `type`, or a
+> `.dockerconfigjson` that carries no usable credential for your registry host, can never
+> serve a pull, so it does not hold control-api back from minting for the other
+> namespaces. "No usable credential" covers two cases: no entry for the host at all, and
+> an entry that is present but empty. `{"auths":{"registry.evenfire.ai":{}}}` parses fine
+> and matches the host, yet the kubelet finds nothing to send and pulls anonymously. An
+> entry has to carry at least one non-empty `auth`, `password`, `identitytoken` or
+> `registrytoken`. A malformed copy does fail any install that lands a workload in _its
+> own_ namespace, with `foreign_secret_unusable`. Fix that Secret in place, or delete it
+> and let control-api manage that namespace.
+>
+> This is a shape check, not a validity check. A well-formed copy is accepted even if its
+> key has since been revoked at the registry. Proving otherwise would cost a registry
+> round trip on every install.
 
 **Creating and managing API keys** (`efrk_` org keys, used for CI and other
 programmatic publishing) needs registry authentication active. In self-hosted,

--- a/docs/how-to/publish-plugin-to-registry.md
+++ b/docs/how-to/publish-plugin-to-registry.md
@@ -184,6 +184,25 @@ So your images install cleanly into your own clusters. Sharing one with another
 organization currently needs Evenfire to issue the grant. Plan around that
 before you build a distribution story on top of a self-hosted push.
 
+**Private is the normal case, and you do not ship credentials for it.** Because
+your images stay private to your org, every install of your entry is an
+authenticated pull. You do not put a pull Secret in the recipe, and you do not
+ask installers to create one. On the first install that needs it, the installing
+deployment mints its own pull credential from its own registry identity and
+attaches it to the workloads. Your entry stays credential-free and portable
+across the clusters your org runs.
+
+Two rules follow for anything you publish:
+
+- **Never declare `evenfire-registry-pull` in a workload's `imagePullSecrets`.**
+  The name is reserved. An entry that declares it is rejected at install with
+  `422 workflowWorkloadSecretRefReserved`. The platform attaches the reference
+  after the filter that would otherwise strip a recipe-declared Secret name.
+- **`imagePullSecrets` is still yours to use for a third-party registry.** If a
+  workload pulls from GHCR or Docker Hub, name your own Secret there as before.
+  The automatic credential covers images on the evenfire registry only, matched
+  by image host.
+
 ## 3. Publish — `POST /api/v1/entries`
 
 ## Step 2 — Write your recipe

--- a/packages/workflow-runtime-core/src/index.ts
+++ b/packages/workflow-runtime-core/src/index.ts
@@ -52,3 +52,10 @@ export type { PromptContext } from './injection/prompt'
 export type { SignalCallback } from './signal-poller/poller'
 export type { RuntimeTokenProvider } from './runtime-token-provider/provider'
 export type { ModelInjectionRequest } from './injection/model'
+
+export {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  registryHostFromUrl,
+  imageRefHost,
+  isPlatformRegistryImage,
+} from './registry-image'

--- a/packages/workflow-runtime-core/src/registry-image.ts
+++ b/packages/workflow-runtime-core/src/registry-image.ts
@@ -1,0 +1,69 @@
+// Platform image-pull identity — the SINGLE source of truth for "is this image hosted on
+// our own registry, and therefore covered by the platform pull credential?", shared by
+// every place that decides it: control-api (McpServer install/upgrade + recipe install)
+// and the WRC reconciler (pod templates + McpServer delegation).
+//
+// This lives in @clerum/workflow-runtime-core, not copied per service, for the same reason
+// the recipe/Secret ownership rule does (see secret-ownership.ts): two services answering
+// the same question from two copies is exactly how they drift. Here the drift would be
+// silent and ugly — WRC would decline to attach the pull secret to a workload whose image
+// control-api considers ours, producing an ImagePullBackOff with no failing request to
+// attribute it to.
+
+/**
+ * Name of the dockerconfigjson Secret carrying the platform registry pull credential.
+ *
+ * A cross-service contract: control-api WRITES it (one per platform workload namespace),
+ * WRC and control-api REFERENCE it in `imagePullSecrets`, and HCC materializes that
+ * reference verbatim onto the pod. Never inline the literal.
+ */
+export const EVENFIRE_REGISTRY_PULL_SECRET_NAME = 'evenfire-registry-pull'
+
+/**
+ * Extract the host (including any :port) from the configured registry URL.
+ * The registry URL always carries a scheme, so `new URL()` is correct here.
+ * Returns null when unset/whitespace/unparseable.
+ */
+export function registryHostFromUrl(registryUrl: string): string | null {
+  if (!registryUrl || !registryUrl.trim()) return null
+  try {
+    return new URL(registryUrl).host || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse the registry host of a BARE OCI image reference (no scheme). Splits on the first
+ * `/`; the first component is a registry host only if it contains `.` or `:` (mirroring
+ * Docker/OCI semantics, which distinguish a host from a docker-hub library/org path).
+ * Returns null when the ref has no explicit host (docker-hub `org/name`, or a
+ * single-segment `name[:tag]`).
+ */
+export function imageRefHost(image: string): string | null {
+  const trimmed = (image ?? '').trim()
+  if (!trimmed) return null
+  const slash = trimmed.indexOf('/')
+  if (slash === -1) return null
+  const first = trimmed.slice(0, slash)
+  return first.includes('.') || first.includes(':') ? first : null
+}
+
+/**
+ * True when `image` is hosted on the configured platform registry — i.e. the kubelet will
+ * need the platform pull credential to fetch it.
+ *
+ * Deliberately keyed on the IMAGE host matching the configured registry host, because that
+ * is what the kubelet matches on when selecting an entry from a dockerconfigjson `auths`
+ * map. The registry's own token-issuer hostname is independent config and must never be
+ * substituted here.
+ *
+ * Non-string images and an unset/unparseable `registryUrl` are false: with no registry
+ * configured there is no platform credential to attach.
+ */
+export function isPlatformRegistryImage(image: unknown, registryUrl: string): boolean {
+  if (typeof image !== 'string') return false
+  const registryHost = registryHostFromUrl(registryUrl)
+  if (!registryHost) return false
+  return imageRefHost(image) === registryHost
+}

--- a/packages/workflow-runtime-core/tests/unit/registry-image.test.ts
+++ b/packages/workflow-runtime-core/tests/unit/registry-image.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  imageRefHost,
+  isPlatformRegistryImage,
+  registryHostFromUrl,
+} from '../../src/registry-image'
+
+const REGISTRY_URL = 'https://registry.evenfire.ai'
+
+describe('EVENFIRE_REGISTRY_PULL_SECRET_NAME', () => {
+  // Cross-service contract: control-api writes it, WRC/control-api reference it, HCC
+  // materializes it. A rename here silently breaks image pulls everywhere.
+  it('is the frozen pull-secret name', () => {
+    expect(EVENFIRE_REGISTRY_PULL_SECRET_NAME).toBe('evenfire-registry-pull')
+  })
+})
+
+describe('registryHostFromUrl', () => {
+  it('extracts host, preserving a port', () => {
+    expect(registryHostFromUrl('https://registry.evenfire.ai')).toBe('registry.evenfire.ai')
+    expect(registryHostFromUrl('http://registry-api.registry.svc:5000')).toBe(
+      'registry-api.registry.svc:5000'
+    )
+  })
+
+  it('returns null for unset, blank, or unparseable input', () => {
+    expect(registryHostFromUrl('')).toBeNull()
+    expect(registryHostFromUrl('   ')).toBeNull()
+    expect(registryHostFromUrl('not a url')).toBeNull()
+  })
+})
+
+describe('imageRefHost', () => {
+  it('reads an explicit host', () => {
+    expect(imageRefHost('registry.evenfire.ai/acme/img:1.0')).toBe('registry.evenfire.ai')
+    expect(imageRefHost('localhost:5000/img')).toBe('localhost:5000')
+  })
+
+  it('returns null when there is no explicit host (docker-hub style)', () => {
+    // First component is a host only if it carries a '.' or ':' — otherwise it is a
+    // docker-hub org/library path, not a registry.
+    expect(imageRefHost('library/postgres:16')).toBeNull()
+    expect(imageRefHost('postgres:16')).toBeNull()
+    expect(imageRefHost('')).toBeNull()
+  })
+})
+
+describe('isPlatformRegistryImage', () => {
+  it('is true only when the image host equals the configured registry host', () => {
+    expect(isPlatformRegistryImage('registry.evenfire.ai/acme/img:1', REGISTRY_URL)).toBe(true)
+    expect(isPlatformRegistryImage('ghcr.io/acme/img:1', REGISTRY_URL)).toBe(false)
+    expect(isPlatformRegistryImage('postgres:16', REGISTRY_URL)).toBe(false)
+  })
+
+  it('is false when no registry is configured — there is no credential to attach', () => {
+    expect(isPlatformRegistryImage('registry.evenfire.ai/acme/img:1', '')).toBe(false)
+    expect(isPlatformRegistryImage('registry.evenfire.ai/acme/img:1', 'not a url')).toBe(false)
+  })
+
+  it('is false for a non-string image', () => {
+    expect(isPlatformRegistryImage(undefined, REGISTRY_URL)).toBe(false)
+    expect(isPlatformRegistryImage(null, REGISTRY_URL)).toBe(false)
+    expect(isPlatformRegistryImage(42, REGISTRY_URL)).toBe(false)
+  })
+
+  it('does not match on a host suffix or a lookalike host', () => {
+    // A naive `endsWith`/`includes` would wrongly accept an attacker-controlled host.
+    expect(isPlatformRegistryImage('evil-registry.evenfire.ai/x/y:1', REGISTRY_URL)).toBe(false)
+    expect(isPlatformRegistryImage('registry.evenfire.ai.evil.com/x/y:1', REGISTRY_URL)).toBe(false)
+  })
+
+  it('distinguishes a port difference', () => {
+    expect(isPlatformRegistryImage('localhost:5000/img:1', 'http://localhost:5001')).toBe(false)
+    expect(isPlatformRegistryImage('localhost:5000/img:1', 'http://localhost:5000')).toBe(true)
+  })
+})

--- a/packages/workflow-runtime-core/tests/unit/registry-image.test.ts
+++ b/packages/workflow-runtime-core/tests/unit/registry-image.test.ts
@@ -66,7 +66,13 @@ describe('isPlatformRegistryImage', () => {
 
   it('does not match on a host suffix or a lookalike host', () => {
     // A naive `endsWith`/`includes` would wrongly accept an attacker-controlled host.
-    expect(isPlatformRegistryImage('evil-registry.evenfire.ai/x/y:1', REGISTRY_URL)).toBe(false)
+    // The prefix case uses a neutral domain (the infra-identifier CI guard allows only
+    // registry/registration/brain `.evenfire.ai` in the public tree); the property under
+    // test is unchanged — `'evil-registry.example.com'.endsWith('registry.example.com')`
+    // is true, so only an exact host comparison rejects it.
+    expect(
+      isPlatformRegistryImage('evil-registry.example.com/x/y:1', 'https://registry.example.com')
+    ).toBe(false)
     expect(isPlatformRegistryImage('registry.evenfire.ai.evil.com/x/y:1', REGISTRY_URL)).toBe(false)
   })
 

--- a/scripts/e2e/run-vitest-e2e.sh
+++ b/scripts/e2e/run-vitest-e2e.sh
@@ -30,6 +30,12 @@ DEFAULT_VITEST_SUITES=(
   integration/mcp-hcc-upgrade-rollout.test.ts
   integration/mcp-server-readiness-regression.test.ts
   integration/mcp-secrets-access-guard.test.ts
+  # Platform image-pull credential self-provisioning. This is the only gate that executes
+  # the private-pull acceptance path: unit tests cannot observe namespace placement, HCC
+  # materialization, or whether the kubelet actually authenticated to the registry. It
+  # skips cleanly without the private fixtures, and fails rather than skips under
+  # E2E_REQUIRE_CLUSTER=1 / CI=true.
+  integration/registry-pull-secret-runtime.test.ts
   mcp-host/approval-endpoints.test.ts
   mcp-host/artifacts.e2e.test.ts
   mcp-host/crd.test.ts

--- a/tests/e2e/integration/registry-pull-secret-runtime.test.ts
+++ b/tests/e2e/integration/registry-pull-secret-runtime.test.ts
@@ -66,7 +66,7 @@
  * Everything this suite creates is prefixed `e2e-pullsecret-` and removed in afterAll.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { KUBE_CONTEXT, kubectl, sleep } from '../helpers.js'
 import { CONTROL_API_URL, fetchJson, isServiceUp } from './helpers.integration.js'
 
@@ -124,6 +124,26 @@ let nodeWasCold = false
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+/**
+ * Reject anything that is not a plain Kubernetes/OCI-shaped token before it reaches a
+ * command line.
+ *
+ * Every interpolated value here comes from either `process.env` or the registry catalog —
+ * both untrusted as far as CodeQL (and a careful reader) is concerned, since a crafted
+ * image ref or namespace would otherwise be able to inject shell. The charset is the union
+ * of what DNS-1123 names, namespaces and image references legitimately need; anything else
+ * is a bug or an attack, and throwing is correct for both.
+ */
+function safeToken(value: string, label: string): string {
+  if (!/^[A-Za-z0-9._@:/-]+$/.test(value)) {
+    throw new Error(
+      `[pull-secret-runtime] refusing to use ${label}=${JSON.stringify(value)} in a command: ` +
+        'only [A-Za-z0-9._@:/-] is allowed'
+    )
+  }
+  return value
+}
+
 /** kubectl that returns null instead of throwing (for existence probes). */
 function kubectlOrNull(args: string): string | null {
   try {
@@ -143,14 +163,21 @@ function kubectlJson<T = Record<string, unknown>>(args: string): T | null {
   }
 }
 
-/** Run a command inside the minikube node VM. Returns null on failure. */
+/**
+ * Run a command inside the minikube node VM. Returns null on failure.
+ *
+ * `execFileSync` with an argv array, NOT `execSync` with a template string: there is no
+ * local shell to inject into, so the profile name and the command cannot break out of
+ * their argument positions. The command itself is still interpreted by the node's shell
+ * over ssh, which is why every value interpolated into it passes `safeToken` first.
+ */
 function nodeExec(command: string): string | null {
   try {
-    return execSync(`minikube -p ${MINIKUBE_PROFILE} ssh -- ${command}`, {
-      encoding: 'utf-8',
-      timeout: 60_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim()
+    return execFileSync(
+      'minikube',
+      ['-p', safeToken(MINIKUBE_PROFILE, 'MINIKUBE_PROFILE'), 'ssh', '--', command],
+      { encoding: 'utf-8', timeout: 60_000, stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim()
   } catch {
     return null
   }
@@ -385,7 +412,11 @@ beforeAll(async () => {
     e => e.name === RECIPE_ENTRY && e.version === RECIPE_ENTRY_VERSION
   )
   const mcpEntry = catalog.find(e => e.name === MCP_ENTRY && e.version === MCP_ENTRY_VERSION)
-  mcpImage = mcpEntry?.mcp_server_meta?.imageRef ?? ''
+  // The image ref arrives from the registry catalog — remote data that later reaches a
+  // `docker` command on the node. Validate the shape here, at the point it enters the
+  // suite, rather than trusting it at each use site.
+  const rawImage = mcpEntry?.mcp_server_meta?.imageRef ?? ''
+  mcpImage = rawImage === '' ? '' : safeToken(rawImage, 'catalog imageRef')
   fixturesAvailable = Boolean(recipeEntry) && Boolean(mcpEntry) && mcpImage.startsWith(registryHost)
   if (!fixturesAvailable) {
     // Fatal under REQUIRE_CLUSTER: without private fixtures every runtime assertion in
@@ -507,12 +538,17 @@ async function restoreSandboxUiPullSecret(): Promise<void> {
   }
 
   try {
-    execSync(`kubectl --context=${KUBE_CONTEXT} apply -f -`, {
-      input: backup,
-      encoding: 'utf-8',
-      timeout: 30_000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
+    // argv array, no shell — the context name cannot break out of its argument position.
+    execFileSync(
+      'kubectl',
+      ['--context', safeToken(KUBE_CONTEXT, 'KUBE_CONTEXT'), 'apply', '-f', '-'],
+      {
+        input: backup,
+        encoding: 'utf-8',
+        timeout: 30_000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }
+    )
   } catch {
     // Nothing more we can do here; the reconcile cron re-provisions it on its next tick.
   }

--- a/tests/e2e/integration/registry-pull-secret-runtime.test.ts
+++ b/tests/e2e/integration/registry-pull-secret-runtime.test.ts
@@ -67,6 +67,9 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { KUBE_CONTEXT, kubectl, sleep } from '../helpers.js'
 import { CONTROL_API_URL, fetchJson, isServiceUp } from './helpers.integration.js'
 
@@ -136,6 +139,8 @@ let mcpInstalled = false
 let mcpImage = ''
 /** True only when the node's docker cache was actually made cold before the MCP install. */
 let nodeWasCold = false
+/** Content digest the kubelet actually resolved and ran, for the privacy re-proof. */
+let pulledDigest = ''
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -311,6 +316,73 @@ function hostFromUrl(url: string): string {
 }
 
 /** Find the `Pulled` event for `pod` that mentions `image`. */
+/**
+ * The registry host of an image reference, by parsing rather than prefix matching.
+ *
+ * An OCI reference's host is the first `/`-separated segment, and only when it looks like a
+ * host (contains a dot or colon, or is `localhost`) — otherwise the reference is a Docker
+ * Hub shorthand like `nginx:latest` with no host at all.
+ */
+function imageHostOf(image: string): string {
+  const first = image.split('/')[0] ?? ''
+  if (first === 'localhost' || first.includes('.') || first.includes(':')) return first
+  return ''
+}
+
+/** `registry.host/org/name:tag` → `org/name`, the path the registry API is addressed by. */
+function imageRepositoryOf(image: string): string {
+  const withoutHost = image.split('/').slice(1).join('/')
+  // Strip a digest first: `repo@sha256:…` also contains a colon, so tag-stripping alone
+  // would truncate the digest instead of the tag.
+  const withoutDigest = withoutHost.split('@')[0]
+  const lastColon = withoutDigest.lastIndexOf(':')
+  const lastSlash = withoutDigest.lastIndexOf('/')
+  return lastColon > lastSlash ? withoutDigest.slice(0, lastColon) : withoutDigest
+}
+
+/** The tag or digest an image reference points at. */
+function imageReferenceOf(image: string): string {
+  const withoutHost = image.split('/').slice(1).join('/')
+  const at = withoutHost.indexOf('@')
+  if (at !== -1) return withoutHost.slice(at + 1)
+  const lastColon = withoutHost.lastIndexOf(':')
+  const lastSlash = withoutHost.lastIndexOf('/')
+  return lastColon > lastSlash ? withoutHost.slice(lastColon + 1) : 'latest'
+}
+
+/**
+ * Ask the registry for a manifest with NO credentials.
+ *
+ * This is the privacy proof the suite was missing. Everything else here shows that a pull
+ * SUCCEEDED with the injected Secret; none of it shows the pull would have FAILED without
+ * one — and a public image on our own host satisfies every one of those assertions. A 401/403
+ * here is the registry itself stating the repository is not anonymously readable.
+ *
+ * Returns the HTTP status, or null if the request could not be made at all (which must not
+ * be read as "private" — the caller distinguishes the two).
+ */
+async function anonymousManifestStatus(
+  repository: string,
+  reference: string
+): Promise<number | null> {
+  try {
+    const res = await fetch(`https://${registryHost}/v2/${repository}/manifests/${reference}`, {
+      method: 'GET',
+      headers: {
+        Accept:
+          'application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json',
+        // The public host sits behind a UA filter that 403s some default agents; a 403 from
+        // the edge would be indistinguishable from a 403 from the registry's authz.
+        'User-Agent': 'curl/8.7.1',
+      },
+      signal: AbortSignal.timeout(20_000),
+    })
+    return res.status
+  } catch {
+    return null
+  }
+}
+
 function pulledEventMessage(pod: string, namespace: string, image: string): string | null {
   const events = kubectlJson<{ items?: Array<{ message?: string }> }>(
     `get events -n ${namespace} --field-selector involvedObject.name=${pod},reason=Pulled`
@@ -470,7 +542,11 @@ beforeAll(async () => {
   // suite, rather than trusting it at each use site.
   const rawImage = mcpEntry?.mcp_server_meta?.imageRef ?? ''
   mcpImage = rawImage === '' ? '' : safeToken(rawImage, 'catalog imageRef')
-  fixturesAvailable = Boolean(recipeEntry) && Boolean(mcpEntry) && mcpImage.startsWith(registryHost)
+  // Exact host, not a prefix. `startsWith` also accepts `registry.evenfire.ai.example.test/…`
+  // and anything else merely beginning with our host, letting a fixture that is NOT on our
+  // registry satisfy every assertion below.
+  fixturesAvailable =
+    Boolean(recipeEntry) && Boolean(mcpEntry) && imageHostOf(mcpImage) === registryHost
   if (!fixturesAvailable) {
     // Fatal under REQUIRE_CLUSTER: without private fixtures every runtime assertion in
     // this file is unreachable, so the suite would go green having proved nothing —
@@ -745,6 +821,145 @@ describe('registry pull secret — WRC materialization onto a recipe workload', 
   }, 300_000)
 })
 
+// ─── 2b. Negative control: the image is private and the pull NEEDS a credential ──
+
+/**
+ * Everything else in this file proves a pull SUCCEEDED with the credential we provisioned.
+ * None of it proves the pull would have FAILED without one — and a PUBLIC image on our own
+ * registry host satisfies every single one of those assertions. Without this block the suite
+ * can go green while the Secret is absent, malformed, ignored, or simply unnecessary.
+ *
+ * Two independent proofs, because each covers the other's blind spot:
+ *
+ *  1. The registry refuses an anonymous manifest read (401/403). That is the registry itself
+ *     stating the repository is not world-readable, independent of anything on the node.
+ *  2. A Pod running the same image with NO `imagePullSecrets` cannot start. That is the
+ *     kubelet demonstrating the credential is load-bearing on this exact cluster — which a
+ *     registry-level check alone cannot show (node-level ambient credentials, a mirror, or a
+ *     warm cache could all serve the image without our Secret).
+ *
+ * If the fixture were ever swapped for a public image, both fail. That is the point.
+ */
+describe('registry pull secret — negative control: the pull requires the credential', () => {
+  const NEG_POD = `e2e-pullsecret-negctl-${RUN_ID}`
+
+  it('the registry refuses an anonymous manifest read for the fixture', async () => {
+    if (!ready()) return
+
+    const status = await anonymousManifestStatus(
+      imageRepositoryOf(mcpImage),
+      imageReferenceOf(mcpImage)
+    )
+    if (status === null) {
+      unprovable(`could not reach ${registryHost} anonymously to prove the fixture is private`)
+      return
+    }
+    expect(
+      [401, 403],
+      `${mcpImage} is anonymously readable (HTTP ${status}) — it is NOT a private fixture, so ` +
+        'every "the credential worked" assertion in this suite would pass without the credential'
+    ).toContain(status)
+  }, 60_000)
+
+  it('a Pod without imagePullSecrets cannot pull the private image', async () => {
+    if (!ready()) return
+
+    // `Always` so the kubelet must contact the registry even if a layer is cached, and no
+    // service-account token so nothing ambient can stand in for the pull credential.
+    const manifest = JSON.stringify({
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name: NEG_POD,
+        namespace: MCP_SERVERS_NS,
+        labels: { 'e2e-negative-control': 'true' },
+      },
+      spec: {
+        automountServiceAccountToken: false,
+        restartPolicy: 'Never',
+        // Satisfies PodSecurity `restricted`. Without it the admission plugin only WARNS
+        // here, but a cluster that enforces the profile would reject the Pod outright — and
+        // this test would then report "could not create the negative-control Pod" and skip,
+        // quietly losing the assertion instead of failing.
+        securityContext: {
+          runAsNonRoot: true,
+          runAsUser: 65532,
+          seccompProfile: { type: 'RuntimeDefault' },
+        },
+        containers: [
+          {
+            name: 'probe',
+            image: mcpImage,
+            imagePullPolicy: 'Always',
+            securityContext: {
+              allowPrivilegeEscalation: false,
+              capabilities: { drop: ['ALL'] },
+            },
+          },
+        ],
+      },
+    })
+
+    // Via a file, not a heredoc: the manifest embeds an env-derived image reference, and
+    // interpolating it into a shell command is the taint path CodeQL already flagged in this
+    // file once. `apply -f <path>` keeps it out of the command line entirely.
+    const workDir = mkdtempSync(join(tmpdir(), 'e2e-pullsecret-negctl-'))
+    const manifestPath = join(workDir, 'pod.json')
+    writeFileSync(manifestPath, manifest, 'utf-8')
+
+    try {
+      const created = kubectlOrNull(`apply -n ${MCP_SERVERS_NS} -f ${manifestPath}`)
+      if (created === null) {
+        unprovable('could not create the negative-control Pod')
+        return
+      }
+
+      const failed = await waitFor(
+        () =>
+          kubectlJson<{
+            status?: {
+              phase?: string
+              containerStatuses?: Array<{ state?: { waiting?: { reason?: string } } }>
+            }
+          }>(`get pod ${NEG_POD} -n ${MCP_SERVERS_NS}`),
+        pod => {
+          const reason = pod?.status?.containerStatuses?.[0]?.state?.waiting?.reason ?? ''
+          return reason === 'ErrImagePull' || reason === 'ImagePullBackOff'
+        },
+        180_000
+      )
+
+      const observed = kubectlJson<{
+        status?: {
+          phase?: string
+          containerStatuses?: Array<{ ready?: boolean; state?: { waiting?: { reason?: string } } }>
+        }
+      }>(`get pod ${NEG_POD} -n ${MCP_SERVERS_NS}`)
+
+      // The failure that matters most: if this Pod RUNS, the image is pullable without our
+      // Secret and the entire positive path proves nothing.
+      expect(
+        observed?.status?.containerStatuses?.[0]?.ready ?? false,
+        `the no-credential Pod is RUNNING ${mcpImage} — the image does not require the pull ` +
+          'credential on this cluster, so this suite cannot prove the credential works'
+      ).toBe(false)
+      expect(
+        failed,
+        `the no-credential Pod never reported ErrImagePull/ImagePullBackOff; observed ${JSON.stringify(
+          observed?.status ?? {}
+        )}`
+      ).not.toBeNull()
+    } finally {
+      // Unconditional: a leftover ImagePullBackOff Pod in `mcp-server` reads as a product
+      // failure to the next person who looks at the namespace.
+      kubectlOrNull(
+        `delete pod ${NEG_POD} -n ${MCP_SERVERS_NS} --ignore-not-found=true --wait=false`
+      )
+      rmSync(workDir, { recursive: true, force: true })
+    }
+  }, 240_000)
+})
+
 // ─── 3. McpServer -> HCC -> Deployment, and a real private pull ─────────────
 
 describe('registry pull secret — McpServer delegation, HCC materialization, real pull', () => {
@@ -861,9 +1076,21 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
       readyPod?.images ?? [],
       `the Ready Pod is not running ${mcpImage}; it runs ${JSON.stringify(readyPod?.images ?? [])}`
     ).toContain(mcpImage)
-    expect(mcpImage.startsWith(registryHost), `${mcpImage} is not on the private registry`).toBe(
-      true
-    )
+    expect(imageHostOf(mcpImage), `${mcpImage} is not on the private registry`).toBe(registryHost)
+
+    // Pin the exact content that ran, not just the tag it was requested by. A tag can be
+    // repointed between the negative control and here; `imageID` is what the kubelet
+    // actually resolved and started.
+    const status = kubectlJson<{
+      status?: { containerStatuses?: Array<{ imageID?: string }> }
+    }>(`get pod ${podName} -n ${MCP_SERVERS_NS}`)
+    const imageID = status?.status?.containerStatuses?.[0]?.imageID ?? ''
+    const digestMatch = imageID.match(/sha256:[0-9a-f]{64}/)
+    pulledDigest = digestMatch?.[0] ?? ''
+    expect(
+      pulledDigest,
+      `the Ready Pod reports no content digest (imageID="${imageID}"), so there is nothing to prove privacy about`
+    ).not.toBe('')
   }, 300_000)
 
   it('the kubelet performed a REAL authenticated pull, not a cache hit', () => {
@@ -888,6 +1115,24 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
     expect(message).toContain('Successfully pulled image')
     expect(message, 'pull event carries no transferred byte count').toMatch(/Image size: \d+ bytes/)
   })
+
+  // Closes the loop on the negative control. That block proved the TAG is not anonymously
+  // readable; this proves it of the exact digest the kubelet actually pulled, so a tag
+  // repointed to a public image mid-run cannot slip between the two.
+  it('the exact digest that was pulled is itself not anonymously readable', async () => {
+    if (!mcpInstalled || !pulledDigest) return
+
+    const status = await anonymousManifestStatus(imageRepositoryOf(mcpImage), pulledDigest)
+    if (status === null) {
+      unprovable(`could not reach ${registryHost} anonymously to re-prove the pulled digest`)
+      return
+    }
+    expect(
+      [401, 403],
+      `the digest actually pulled (${pulledDigest}) is anonymously readable (HTTP ${status}) — ` +
+        'the credential was not required for this content'
+    ).toContain(status)
+  }, 60_000)
 })
 
 // ─── 4. Pre-persistence failure ─────────────────────────────────────────────
@@ -900,7 +1145,11 @@ describe('registry pull secret — a provisioning failure is pre-persistence', (
     try {
       planted = plantForeignSandboxUiPullSecret()
       if (!planted) {
-        console.log('[pull-secret-runtime] could not plant the foreign Secret — skipping')
+        // Same rule as everywhere else in this file: a precondition that cannot be met is
+        // not a pass. This scenario is part of the strict acceptance claim — "a provisioning
+        // failure never persists a CRD" — and a run that silently skipped it must not be
+        // counted as one that proved it.
+        unprovable('could not plant the foreign Secret, so the pre-persistence path never ran')
         return
       }
 

--- a/tests/e2e/integration/registry-pull-secret-runtime.test.ts
+++ b/tests/e2e/integration/registry-pull-secret-runtime.test.ts
@@ -82,22 +82,37 @@ const DOCKERCONFIG_KEY = '.dockerconfigjson'
 
 // ─── Cluster shape ──────────────────────────────────────────────────────────
 
-const MCP_SERVERS_NS = process.env.E2E_MCP_SERVERS_NAMESPACE ?? 'mcp-server'
-const SANDBOX_NS = process.env.E2E_SANDBOX_NAMESPACE ?? 'sandbox-recipes'
-const SANDBOX_UI_NS = process.env.E2E_SANDBOX_UI_NAMESPACE ?? 'sandbox-ui'
-const CONTROL_PLANE_NS = process.env.E2E_CONTROL_PLANE_NAMESPACE ?? 'control-plane'
+const MCP_SERVERS_NS = safeToken(process.env.E2E_MCP_SERVERS_NAMESPACE ?? 'mcp-server', 'ns')
+const SANDBOX_NS = safeToken(process.env.E2E_SANDBOX_NAMESPACE ?? 'sandbox-recipes', 'ns')
+const SANDBOX_UI_NS = safeToken(process.env.E2E_SANDBOX_UI_NAMESPACE ?? 'sandbox-ui', 'ns')
+const CONTROL_PLANE_NS = safeToken(process.env.E2E_CONTROL_PLANE_NAMESPACE ?? 'control-plane', 'ns')
 /** `platformWorkloadNamespaces()` in control-api/src/services/registryPullSecretService.ts. */
 const PLATFORM_NAMESPACES = [...new Set([MCP_SERVERS_NS, SANDBOX_NS, SANDBOX_UI_NS])]
 
-const MINIKUBE_PROFILE = process.env.MINIKUBE_PROFILE ?? KUBE_CONTEXT
+const MINIKUBE_PROFILE = safeToken(process.env.MINIKUBE_PROFILE ?? KUBE_CONTEXT, 'MINIKUBE_PROFILE')
 
 // ─── Fixtures (private, platform-registry-hosted) ───────────────────────────
 
-const RECIPE_ENTRY = process.env.E2E_PRIVATE_RECIPE_ENTRY ?? '@josete-pr243/pr243-registry-recipe'
-const RECIPE_ENTRY_VERSION = process.env.E2E_PRIVATE_RECIPE_VERSION ?? '1.0.0'
-const MCP_ENTRY = process.env.E2E_PRIVATE_MCP_ENTRY ?? '@josete-pr243/test-docgen'
-const MCP_ENTRY_VERSION = process.env.E2E_PRIVATE_MCP_VERSION ?? '1.0.5'
-const CONTEXT_REF = process.env.E2E_CONTEXT_ID ?? 'context1'
+// Sanitized even though these currently reach only HTTP bodies: the charset already covers
+// scoped entry names and semver, so it costs nothing and stops a future use site from
+// quietly reopening the taint path into a command line.
+const RECIPE_ENTRY = safeToken(
+  process.env.E2E_PRIVATE_RECIPE_ENTRY ?? '@josete-pr243/pr243-registry-recipe',
+  'E2E_PRIVATE_RECIPE_ENTRY'
+)
+const RECIPE_ENTRY_VERSION = safeToken(
+  process.env.E2E_PRIVATE_RECIPE_VERSION ?? '1.0.0',
+  'E2E_PRIVATE_RECIPE_VERSION'
+)
+const MCP_ENTRY = safeToken(
+  process.env.E2E_PRIVATE_MCP_ENTRY ?? '@josete-pr243/test-docgen',
+  'E2E_PRIVATE_MCP_ENTRY'
+)
+const MCP_ENTRY_VERSION = safeToken(
+  process.env.E2E_PRIVATE_MCP_VERSION ?? '1.0.5',
+  'E2E_PRIVATE_MCP_VERSION'
+)
+const CONTEXT_REF = safeToken(process.env.E2E_CONTEXT_ID ?? 'context1', 'E2E_CONTEXT_ID')
 
 const RUN_ID = Date.now().toString(36)
 const RECIPE_NAME = `e2e-pullsecret-recipe-${RUN_ID}`

--- a/tests/e2e/integration/registry-pull-secret-runtime.test.ts
+++ b/tests/e2e/integration/registry-pull-secret-runtime.test.ts
@@ -1,0 +1,827 @@
+/**
+ * Integration: platform image-pull credential — runtime acceptance
+ *
+ * This is the acceptance gate for PR #243 §13.5
+ * (`docs/architecture/registry-pull-secret-recipe-workloads.md`). Everything else covering
+ * this feature is unit- or route-level against a `MockGateway`, which by construction
+ * cannot detect a namespace mistake, a rollout that never happens, or a kubelet that
+ * rejects the blob. This suite runs the whole chain against a LIVE cluster and a LIVE
+ * private registry:
+ *
+ *   control-api mint  ->  Secret in every platform workload namespace
+ *                     ->  WRC / control-api inject the reference
+ *                     ->  McpServer CRD -> HCC -> Deployment
+ *                     ->  Pod Ready
+ *                     ->  a real `docker pull` of a private image using that credential
+ *
+ * What each block proves, and why it is here:
+ *
+ *  1. `Secret placement` — the Secret exists in EVERY platform workload namespace, is
+ *     `kubernetes.io/dockerconfigjson` (the only two types a kubelet honours for pulls),
+ *     is labelled ours, is keyed on OUR registry host, and — the load-bearing one — every
+ *     copy carries the SAME fingerprint. The registry's `mintPullKey` is rotate-on-call
+ *     with at most one active pull key per org, so three separate mints would leave the
+ *     first two namespaces holding revoked credentials while reporting success. One
+ *     fingerprint across all copies is the observable form of "one mint, fanned out"
+ *     (spec §6.3 / R1). It also asserts the Secret is NOT labelled `clerum.io/shared` or
+ *     `clerum.io/owner-recipe` — labelling it either way would make it readable by any
+ *     recipe's `envSecret` and turn a pull-only credential into an exfiltration primitive
+ *     (spec §5.1 / R4).
+ *
+ *  2. `Materialization` — WRC renders the recipe workload's PodTemplate with
+ *     `imagePullSecrets: [evenfire-registry-pull]`, while the WorkflowRecipe CRD itself
+ *     never declares it. That gap is the whole design: a declared name would be classified
+ *     by the Issue #637 ownership gate and stripped, so the reference has to be injected
+ *     after the filter (spec §6.1). For the MCP-server path the same assertion runs one
+ *     hop further out — control-api writes it onto the McpServer CRD and HCC materializes
+ *     it verbatim onto the Deployment it owns.
+ *
+ *  3. `Pod readiness + a REAL private pull` — the image is evicted from the node's docker
+ *     cache first. Without that the kubelet reuses the cached layers under
+ *     `imagePullPolicy: IfNotPresent`, no credential is ever exercised, and the assertion
+ *     passes vacuously. The two outcomes are distinguishable in the `Pulled` event: a
+ *     genuine pull logs `Successfully pulled image ... in Xs. Image size: N bytes.`, a
+ *     cache hit logs `Container image ... already present on machine`. This asserts the
+ *     former and explicitly rejects the latter.
+ *
+ *  4. `Pre-persistence failure` — a provisioning failure must fail the install BEFORE the
+ *     CRD is written. The alternative is the exact silent `ImagePullBackOff` this whole
+ *     mechanism exists to remove: a 201 on the API call and a workload that can never
+ *     pull.
+ *
+ * Deliberately NOT covered here — see the docs for why:
+ *  - The periodic reconcile cron (§13.1). Its interval is
+ *    `REGISTRY_PULL_SECRET_RECONCILE_INTERVAL_MS` (default 600_000) and shortening it
+ *    needs a redeploy, so a committed E2E cannot wait for a tick. Verified out-of-band.
+ *  - Managed-cluster behaviour (§9.1). control-api writes nothing there by design, so
+ *    there is no runtime outcome for this suite to observe.
+ *
+ * Requires (each guarded — the suite SKIPS rather than fails when unavailable):
+ *   - minikube cluster `clerum-test` running, kubectl context reachable
+ *   - control-api port-forwarded on :8090   (make minikube-pf-control-ui)
+ *   - admin credentials via TEST_ADMIN_PASSWORD (or ADMIN_PASSWORD)
+ *   - REGISTRY_CONNECTION_MODE=self-hosted with a connected registry org
+ *   - the private registry entries named below installable by this deployment
+ *
+ * Everything this suite creates is prefixed `e2e-pullsecret-` and removed in afterAll.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { execSync } from 'node:child_process'
+import { KUBE_CONTEXT, kubectl, sleep } from '../helpers.js'
+import { CONTROL_API_URL, fetchJson, isServiceUp } from './helpers.integration.js'
+
+// ─── Contract constants (must match the shipped implementation) ──────────────
+
+/** `EVENFIRE_REGISTRY_PULL_SECRET_NAME` in packages/workflow-runtime-core. */
+const PULL_SECRET = 'evenfire-registry-pull'
+const MANAGED_BY_LABEL = 'clerum.io/managed-by'
+const MANAGED_BY_VALUE = 'control-api'
+const FINGERPRINT_ANNOTATION = 'clerum.io/pull-key-fingerprint'
+const DOCKERCONFIG_TYPE = 'kubernetes.io/dockerconfigjson'
+const DOCKERCONFIG_KEY = '.dockerconfigjson'
+
+// ─── Cluster shape ──────────────────────────────────────────────────────────
+
+const MCP_SERVERS_NS = process.env.E2E_MCP_SERVERS_NAMESPACE ?? 'mcp-server'
+const SANDBOX_NS = process.env.E2E_SANDBOX_NAMESPACE ?? 'sandbox-recipes'
+const SANDBOX_UI_NS = process.env.E2E_SANDBOX_UI_NAMESPACE ?? 'sandbox-ui'
+const CONTROL_PLANE_NS = process.env.E2E_CONTROL_PLANE_NAMESPACE ?? 'control-plane'
+/** `platformWorkloadNamespaces()` in control-api/src/services/registryPullSecretService.ts. */
+const PLATFORM_NAMESPACES = [...new Set([MCP_SERVERS_NS, SANDBOX_NS, SANDBOX_UI_NS])]
+
+const MINIKUBE_PROFILE = process.env.MINIKUBE_PROFILE ?? KUBE_CONTEXT
+
+// ─── Fixtures (private, platform-registry-hosted) ───────────────────────────
+
+const RECIPE_ENTRY = process.env.E2E_PRIVATE_RECIPE_ENTRY ?? '@josete-pr243/pr243-registry-recipe'
+const RECIPE_ENTRY_VERSION = process.env.E2E_PRIVATE_RECIPE_VERSION ?? '1.0.0'
+const MCP_ENTRY = process.env.E2E_PRIVATE_MCP_ENTRY ?? '@josete-pr243/test-docgen'
+const MCP_ENTRY_VERSION = process.env.E2E_PRIVATE_MCP_VERSION ?? '1.0.5'
+const CONTEXT_REF = process.env.E2E_CONTEXT_ID ?? 'context1'
+
+const RUN_ID = Date.now().toString(36)
+const RECIPE_NAME = `e2e-pullsecret-recipe-${RUN_ID}`
+const MCP_NAME = `e2e-pullsecret-mcp-${RUN_ID}`
+const PREPERSIST_RECIPE_NAME = `e2e-pullsecret-prepersist-${RUN_ID}`
+
+// ─── State resolved in beforeAll ────────────────────────────────────────────
+
+let controlApiUp = false
+let clusterUp = false
+let adminCookie = ''
+/** Image host of the configured registry, e.g. `registry.evenfire.ai`. */
+let registryHost = ''
+let selfHosted = false
+/** Both private fixtures are present in this deployment's catalog. */
+let fixturesAvailable = false
+/** Set once the recipe install returns 201, so downstream blocks can bail cleanly. */
+let recipeInstalled = false
+let mcpInstalled = false
+/** Image of the MCP-server fixture, read from the catalog entry (not string-built). */
+let mcpImage = ''
+/** True only when the node's docker cache was actually made cold before the MCP install. */
+let nodeWasCold = false
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** kubectl that returns null instead of throwing (for existence probes). */
+function kubectlOrNull(args: string): string | null {
+  try {
+    return kubectl(args)
+  } catch {
+    return null
+  }
+}
+
+function kubectlJson<T = Record<string, unknown>>(args: string): T | null {
+  const out = kubectlOrNull(`${args} -o json`)
+  if (!out) return null
+  try {
+    return JSON.parse(out) as T
+  } catch {
+    return null
+  }
+}
+
+/** Run a command inside the minikube node VM. Returns null on failure. */
+function nodeExec(command: string): string | null {
+  try {
+    return execSync(`minikube -p ${MINIKUBE_PROFILE} ssh -- ${command}`, {
+      encoding: 'utf-8',
+      timeout: 60_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim()
+  } catch {
+    return null
+  }
+}
+
+async function waitFor<T>(
+  probe: () => T | Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs: number,
+  intervalMs = 3_000
+): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs
+  let last: T | null = null
+  while (Date.now() < deadline) {
+    last = await probe()
+    if (predicate(last)) return last
+    await sleep(intervalMs)
+  }
+  return predicate(last as T) ? last : null
+}
+
+type K8sSecret = {
+  type?: string
+  metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> }
+  data?: Record<string, string>
+}
+
+function readPullSecret(namespace: string): K8sSecret | null {
+  return kubectlJson<K8sSecret>(`get secret ${PULL_SECRET} -n ${namespace}`)
+}
+
+/** Hosts the dockerconfigjson blob carries credentials for. */
+function authHosts(secret: K8sSecret): string[] {
+  const blob = secret.data?.[DOCKERCONFIG_KEY]
+  if (!blob) return []
+  try {
+    const parsed = JSON.parse(Buffer.from(blob, 'base64').toString('utf8')) as {
+      auths?: Record<string, unknown>
+    }
+    return Object.keys(parsed.auths ?? {})
+  } catch {
+    return []
+  }
+}
+
+type PodTemplateHolder = {
+  spec?: { template?: { spec?: { imagePullSecrets?: Array<{ name?: string }> } } }
+  metadata?: { labels?: Record<string, string> }
+}
+
+function pullSecretNamesOnDeployment(name: string, namespace: string): string[] | null {
+  const dep = kubectlJson<PodTemplateHolder>(`get deployment ${name} -n ${namespace}`)
+  if (!dep) return null
+  return (dep.spec?.template?.spec?.imagePullSecrets ?? []).map(r => r.name ?? '')
+}
+
+/** POST/DELETE against control-api with the admin session cookie. */
+async function adminRequest<T = Record<string, unknown>>(
+  method: 'POST' | 'DELETE' | 'GET',
+  path: string,
+  body?: unknown
+): Promise<{ status: number; data: T }> {
+  return fetchJson<T>(`${CONTROL_API_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(adminCookie ? { Cookie: adminCookie } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+}
+
+/**
+ * Admin login. The session is delivered as a `Secure` HttpOnly cookie, not a bearer
+ * token, so the cookie pair has to be captured and replayed explicitly — `Secure` is
+ * advisory on the wire and the port-forward is plain HTTP.
+ */
+async function login(): Promise<string> {
+  const username = process.env.TEST_ADMIN_USERNAME ?? 'admin'
+  const password = process.env.TEST_ADMIN_PASSWORD ?? process.env.ADMIN_PASSWORD ?? ''
+  if (!password) return ''
+  try {
+    const res = await fetch(`${CONTROL_API_URL}/api/v1/admin/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (res.status !== 200) return ''
+    const raw =
+      typeof res.headers.getSetCookie === 'function'
+        ? res.headers.getSetCookie()
+        : [res.headers.get('set-cookie') ?? '']
+    return raw
+      .filter(Boolean)
+      .map(c => c.split(';')[0].trim())
+      .join('; ')
+  } catch {
+    return ''
+  }
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url).host
+  } catch {
+    return ''
+  }
+}
+
+/** Find the `Pulled` event for `pod` that mentions `image`. */
+function pulledEventMessage(pod: string, namespace: string, image: string): string | null {
+  const events = kubectlJson<{ items?: Array<{ message?: string }> }>(
+    `get events -n ${namespace} --field-selector involvedObject.name=${pod},reason=Pulled`
+  )
+  const match = (events?.items ?? []).find(e => (e.message ?? '').includes(image))
+  return match?.message ?? null
+}
+
+function podsFor(
+  labelSelector: string,
+  namespace: string
+): Array<{
+  name: string
+  ready: boolean
+  phase: string
+}> {
+  const list = kubectlJson<{
+    items?: Array<{
+      metadata?: { name?: string }
+      status?: { phase?: string; containerStatuses?: Array<{ ready?: boolean }> }
+    }>
+  }>(`get pods -n ${namespace} -l ${labelSelector}`)
+  return (list?.items ?? []).map(p => ({
+    name: p.metadata?.name ?? '',
+    phase: p.status?.phase ?? 'Unknown',
+    ready:
+      (p.status?.containerStatuses ?? []).length > 0 &&
+      (p.status?.containerStatuses ?? []).every(c => c.ready === true),
+  }))
+}
+
+// ─── Precondition handling: skip locally, FAIL in CI ────────────────────────
+
+/**
+ * Set by CI (and by anyone who wants the strict behaviour locally).
+ *
+ * This suite exists because green unit tests could not detect namespace, rollout or
+ * kubelet failures. A suite that silently skips has exactly that defect in a worse form:
+ * it reports "14 passed" in 250ms while proving nothing, and the wall of ticks looks like
+ * evidence. Observed for real twice while validating this file — once with
+ * TEST_ADMIN_PASSWORD unset, once with the port-forward down.
+ *
+ * So: locally an unwired harness is a normal state and skipping is right. Under
+ * E2E_REQUIRE_CLUSTER=1 (or CI=true) it is a hard failure.
+ */
+const REQUIRE_CLUSTER = process.env.E2E_REQUIRE_CLUSTER === '1' || process.env.CI === 'true'
+
+/**
+ * A precondition that means the HARNESS is not wired up (no control-api, no cluster, no
+ * credentials, no fixtures). Recoverable by configuring the environment, so it is fatal
+ * when the environment claims to be able to run this.
+ */
+function unmet(reason: string): void {
+  const msg = `[pull-secret-runtime] ${reason}`
+  if (REQUIRE_CLUSTER) {
+    throw new Error(
+      `${msg}. Refusing to skip: E2E_REQUIRE_CLUSTER/CI is set, and a silent skip here ` +
+        `would report success while asserting nothing. Fix the environment or unset the flag.`
+    )
+  }
+  console.log(`${msg} — suite will be skipped`)
+}
+
+/**
+ * A precondition that means the feature legitimately has no runtime outcome to assert
+ * HERE (a managed cluster, where control-api provisions nothing by design). Not a
+ * misconfiguration, so this skips even under REQUIRE_CLUSTER — failing would be wrong.
+ */
+function notApplicable(reason: string): void {
+  console.log(`[pull-secret-runtime] ${reason} — not applicable on this cluster, skipping`)
+}
+
+// ─── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  controlApiUp = await isServiceUp(CONTROL_API_URL)
+  if (!controlApiUp) {
+    unmet(`control-api not reachable at ${CONTROL_API_URL}`)
+    return
+  }
+
+  clusterUp = kubectlOrNull('get ns default -o name') !== null
+  if (!clusterUp) {
+    unmet(`kube context "${KUBE_CONTEXT}" unreachable`)
+    return
+  }
+
+  adminCookie = await login()
+  if (!adminCookie) {
+    unmet('admin login failed (set TEST_ADMIN_PASSWORD)')
+    return
+  }
+
+  // The provisioner is mode-gated: on a managed cluster control-api writes nothing and
+  // there is no runtime outcome to assert. Read the deployed config rather than assuming.
+  const mode = kubectlOrNull(
+    `get configmap control-api-config -n ${CONTROL_PLANE_NS} -o jsonpath={.data.REGISTRY_CONNECTION_MODE}`
+  )
+  const registryUrl = kubectlOrNull(
+    `get configmap control-api-config -n ${CONTROL_PLANE_NS} -o jsonpath={.data.CLERUM_REGISTRY_URL}`
+  )
+  selfHosted = mode === 'self-hosted'
+  registryHost = hostFromUrl(registryUrl ?? '')
+  if (!selfHosted || !registryHost) {
+    notApplicable(
+      `REGISTRY_CONNECTION_MODE=${mode ?? 'unset'} / registry=${registryUrl ?? 'unset'}`
+    )
+    return
+  }
+
+  // The fixtures are private entries owned by the connected org, so they exist only on a
+  // deployment that has published them. Without this probe an environment that simply
+  // lacks them would FAIL on a 404 install instead of skipping, which is not a signal
+  // about the feature.
+  const { status, data } = await adminRequest<{ data?: RegistryEntry[] }>(
+    'GET',
+    '/api/v1/admin/registry/entries?limit=200'
+  )
+  const catalog = status === 200 ? (data.data ?? []) : []
+  const recipeEntry = catalog.find(
+    e => e.name === RECIPE_ENTRY && e.version === RECIPE_ENTRY_VERSION
+  )
+  const mcpEntry = catalog.find(e => e.name === MCP_ENTRY && e.version === MCP_ENTRY_VERSION)
+  mcpImage = mcpEntry?.mcp_server_meta?.imageRef ?? ''
+  fixturesAvailable = Boolean(recipeEntry) && Boolean(mcpEntry) && mcpImage.startsWith(registryHost)
+  if (!fixturesAvailable) {
+    // Fatal under REQUIRE_CLUSTER: without private fixtures every runtime assertion in
+    // this file is unreachable, so the suite would go green having proved nothing —
+    // which is precisely the failure mode it was written to rule out.
+    unmet(
+      `private fixtures unavailable (recipe=${Boolean(recipeEntry)}, mcp=${Boolean(
+        mcpEntry
+      )}, image=${mcpImage || 'unset'}). ` +
+        'Set E2E_PRIVATE_RECIPE_ENTRY / E2E_PRIVATE_MCP_ENTRY to point at private ' +
+        'platform-registry entries this deployment can install'
+    )
+  }
+}, 120_000)
+
+/** Only the catalog fields this suite reads. */
+type RegistryEntry = {
+  name?: string
+  version?: string
+  mcp_server_meta?: { imageRef?: string } | null
+}
+
+/** Every block's precondition: a live self-hosted cluster with the private fixtures. */
+function ready(): boolean {
+  return controlApiUp && clusterUp && Boolean(adminCookie) && selfHosted && fixturesAvailable
+}
+
+afterAll(async () => {
+  if (!adminCookie) return
+
+  // Unconditional: a leaked foreign Secret would 409 every subsequent private install
+  // into that namespace and read as a product bug.
+  await restoreSandboxUiPullSecret()
+
+  if (recipeInstalled) {
+    await adminRequest('DELETE', `/api/v1/admin/registry/uninstall/${RECIPE_NAME}?type=recipe`)
+  }
+  if (mcpInstalled) {
+    await adminRequest('DELETE', `/api/v1/admin/registry/uninstall/${MCP_NAME}?type=mcp-server`)
+  }
+  // Belt and braces — the uninstall route is best-effort and returns warnings, not errors.
+  kubectlOrNull(`delete workflowrecipe ${RECIPE_NAME} -n ${SANDBOX_NS} --ignore-not-found=true`)
+  kubectlOrNull(
+    `delete workflowrecipe ${PREPERSIST_RECIPE_NAME} -n ${SANDBOX_NS} --ignore-not-found=true`
+  )
+  kubectlOrNull(`delete mcpserver ${MCP_NAME} -n ${MCP_SERVERS_NS} --ignore-not-found=true`)
+}, 300_000)
+
+// ─── Sandbox-ui Secret backup/restore, used by the pre-persistence block ─────
+
+let sandboxUiBackup: string | null = null
+
+/**
+ * Replace the sandbox-ui copy with an externally-owned Secret the kubelet cannot use
+ * (no `clerum.io/managed-by` label, wrong type). `classify()` reads that as
+ * `foreign` + `unusable`, which is a pure classification outcome — it does NOT depend on
+ * whether a mint is needed, so it cannot accidentally rotate the org's live credential.
+ */
+function plantForeignSandboxUiPullSecret(): boolean {
+  sandboxUiBackup = kubectlOrNull(`get secret ${PULL_SECRET} -n ${SANDBOX_UI_NS} -o json`)
+  if (
+    kubectlOrNull(`delete secret ${PULL_SECRET} -n ${SANDBOX_UI_NS} --ignore-not-found=true`) ===
+    null
+  ) {
+    return false
+  }
+  return (
+    kubectlOrNull(
+      `create secret generic ${PULL_SECRET} -n ${SANDBOX_UI_NS} --from-literal=note=e2e-foreign-fixture`
+    ) !== null
+  )
+}
+
+/**
+ * Remove the foreign fixture and put `sandbox-ui` back into a state control-api considers
+ * correct. Runs unconditionally: a leaked foreign copy would 409 every later private
+ * install into that namespace and read as a product bug.
+ *
+ * The backup is only replayed when it is still CURRENT. An `install-recipe` that runs while
+ * the fixture is planted can legitimately mint (an *unusable* foreign copy does not block
+ * the mint — only a usable one does), which rotates the org key and leaves the captured
+ * bytes holding a revoked credential. Restoring that would be worse than restoring nothing:
+ * the copy would look valid, and its fingerprint would silently disagree with the other
+ * namespaces. So when the backup is stale we delete instead — absent is a state the next
+ * provisioning pass (any install, or the reconcile cron) repairs by design, converging every
+ * namespace onto one fresh mint.
+ */
+async function restoreSandboxUiPullSecret(): Promise<void> {
+  const current = kubectlJson<K8sSecret>(`get secret ${PULL_SECRET} -n ${SANDBOX_UI_NS}`)
+  const isOurs = current?.metadata?.labels?.[MANAGED_BY_LABEL] === MANAGED_BY_VALUE
+  if (isOurs) {
+    sandboxUiBackup = null
+    return
+  }
+  if (current) {
+    kubectlOrNull(`delete secret ${PULL_SECRET} -n ${SANDBOX_UI_NS} --ignore-not-found=true`)
+  }
+  const backup = sandboxUiBackup
+  sandboxUiBackup = null
+  if (!backup) return
+
+  let backupFingerprint: string | undefined
+  try {
+    backupFingerprint = (JSON.parse(backup) as K8sSecret).metadata?.annotations?.[
+      FINGERPRINT_ANNOTATION
+    ]
+  } catch {
+    backupFingerprint = undefined
+  }
+  const liveFingerprint =
+    readPullSecret(MCP_SERVERS_NS)?.metadata?.annotations?.[FINGERPRINT_ANNOTATION]
+  if (!backupFingerprint || backupFingerprint !== liveFingerprint) {
+    console.log(
+      `[pull-secret-runtime] the captured ${SANDBOX_UI_NS} credential was rotated during the run ` +
+        `(${backupFingerprint ?? 'none'} vs ${liveFingerprint ?? 'none'}); leaving it absent so the ` +
+        'next provisioning pass re-mints and converges rather than restoring a revoked key'
+    )
+    return
+  }
+
+  try {
+    execSync(`kubectl --context=${KUBE_CONTEXT} apply -f -`, {
+      input: backup,
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+  } catch {
+    // Nothing more we can do here; the reconcile cron re-provisions it on its next tick.
+  }
+}
+
+// ─── 1. Secret placement ────────────────────────────────────────────────────
+
+describe('registry pull secret — placement after a private-image recipe install', () => {
+  it('installs the private recipe plugin', async () => {
+    if (!ready()) return
+
+    const { status, data } = await adminRequest('POST', '/api/v1/admin/registry/install-recipe', {
+      recipeName: RECIPE_NAME,
+      registryEntryName: RECIPE_ENTRY,
+      registryEntryVersion: RECIPE_ENTRY_VERSION,
+    })
+
+    expect(status, `install-recipe failed: ${JSON.stringify(data)}`).toBe(201)
+    recipeInstalled = true
+  }, 120_000)
+
+  it('provisions the Secret in EVERY platform workload namespace', () => {
+    if (!recipeInstalled) return
+
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = readPullSecret(ns)
+      expect(secret, `${PULL_SECRET} missing in namespace ${ns}`).not.toBeNull()
+      // Only dockerconfigjson/dockercfg are honoured by the kubelet for image pulls; an
+      // Opaque Secret is accepted by the API server and then silently ignored at pull time.
+      expect(secret!.type, `wrong Secret type in ${ns}`).toBe(DOCKERCONFIG_TYPE)
+      expect(secret!.data?.[DOCKERCONFIG_KEY], `no ${DOCKERCONFIG_KEY} in ${ns}`).toBeTruthy()
+      expect(secret!.metadata?.labels?.[MANAGED_BY_LABEL], `unowned Secret in ${ns}`).toBe(
+        MANAGED_BY_VALUE
+      )
+      // The blob must be keyed on OUR image host, not the registry's token issuer —
+      // otherwise the kubelet never selects this credential for the image being pulled.
+      expect(
+        authHosts(secret!),
+        `dockerconfigjson in ${ns} not keyed on ${registryHost}`
+      ).toContain(registryHost)
+    }
+  })
+
+  it('all copies share ONE fingerprint — a single mint fanned out, not three mints', () => {
+    if (!recipeInstalled) return
+
+    const fingerprints = new Map<string, string>()
+    for (const ns of PLATFORM_NAMESPACES) {
+      const secret = readPullSecret(ns)
+      const fp = secret?.metadata?.annotations?.[FINGERPRINT_ANNOTATION]
+      expect(fp, `no ${FINGERPRINT_ANNOTATION} on the copy in ${ns}`).toBeTruthy()
+      fingerprints.set(ns, fp!)
+    }
+
+    // The registry's mintPullKey is rotate-on-call with <=1 active pull key per org, so
+    // per-namespace minting would leave earlier namespaces holding revoked credentials
+    // while every Secret still looks present and well-formed. Divergent fingerprints are
+    // the only cluster-visible symptom.
+    const distinct = new Set(fingerprints.values())
+    expect(
+      distinct.size,
+      `pull credential diverged across namespaces: ${JSON.stringify(Object.fromEntries(fingerprints))}`
+    ).toBe(1)
+  })
+
+  it('is NOT recipe-accessible — no `shared` or `owner-recipe` label', () => {
+    if (!recipeInstalled) return
+
+    // spec §5.1 / R4: `isSecretAccessibleByRecipe` is the SAME predicate for envSecret and
+    // imagePullSecrets. Either label would let any recipe on the cluster mount the org's
+    // registry credential into its own environment.
+    for (const ns of PLATFORM_NAMESPACES) {
+      const labels = readPullSecret(ns)?.metadata?.labels ?? {}
+      expect(labels['clerum.io/shared'], `${PULL_SECRET} is shared in ${ns}`).toBeUndefined()
+      expect(
+        labels['clerum.io/owner-recipe'],
+        `${PULL_SECRET} is recipe-owned in ${ns}`
+      ).toBeUndefined()
+    }
+  })
+})
+
+// ─── 2. Materialization onto the recipe workload ────────────────────────────
+
+describe('registry pull secret — WRC materialization onto a recipe workload', () => {
+  let deploymentName = ''
+
+  it('WRC renders the workload Deployment with the injected reference', async () => {
+    if (!recipeInstalled) return
+
+    const dep = await waitFor(
+      () =>
+        kubectlJson<{ items?: Array<{ metadata?: { name?: string } }> }>(
+          `get deployments -n ${SANDBOX_NS} -l clerum.io/recipe=${RECIPE_NAME}`
+        ),
+      v => (v?.items?.length ?? 0) > 0,
+      120_000
+    )
+    expect(dep, `WRC never rendered a Deployment for recipe ${RECIPE_NAME}`).not.toBeNull()
+
+    deploymentName = dep!.items![0].metadata!.name!
+    const names = pullSecretNamesOnDeployment(deploymentName, SANDBOX_NS)
+    expect(names, `Deployment ${deploymentName} disappeared`).not.toBeNull()
+    expect(names, `no imagePullSecrets on ${deploymentName}`).toContain(PULL_SECRET)
+  }, 150_000)
+
+  it('the reference is INJECTED, not declared by the recipe', () => {
+    if (!recipeInstalled || !deploymentName) return
+
+    // If the recipe declared the name, the Issue #637 ownership gate would classify it
+    // `denied` (the Secret is deliberately unlabelled to that model) and tear the whole
+    // workload down. The reference on the Pod spec above must therefore come from WRC's
+    // post-filter injection, which is only true if the CRD does not carry it.
+    const recipe = kubectlJson<{
+      spec?: { workloads?: Array<{ imagePullSecrets?: string[] }> }
+    }>(`get workflowrecipe ${RECIPE_NAME} -n ${SANDBOX_NS}`)
+    expect(recipe, `WorkflowRecipe ${RECIPE_NAME} not found`).not.toBeNull()
+
+    for (const workload of recipe!.spec?.workloads ?? []) {
+      expect(
+        workload.imagePullSecrets ?? [],
+        'the recipe CRD declares the platform Secret; injection is no longer being proven'
+      ).not.toContain(PULL_SECRET)
+    }
+  })
+
+  it('the workload Pod reaches Ready', async () => {
+    if (!recipeInstalled) return
+
+    const pods = await waitFor(
+      () => podsFor(`clerum.io/recipe=${RECIPE_NAME}`, SANDBOX_NS),
+      list => list.length > 0 && list.some(p => p.ready),
+      240_000
+    )
+    expect(
+      pods,
+      `no Ready Pod for recipe ${RECIPE_NAME}; last seen ${JSON.stringify(
+        podsFor(`clerum.io/recipe=${RECIPE_NAME}`, SANDBOX_NS)
+      )}`
+    ).not.toBeNull()
+  }, 300_000)
+})
+
+// ─── 3. McpServer -> HCC -> Deployment, and a real private pull ─────────────
+
+describe('registry pull secret — McpServer delegation, HCC materialization, real pull', () => {
+  let deploymentName = ''
+  let podName = ''
+
+  it('evicts the private image from the node so the pull cannot be served from cache', async () => {
+    if (!ready()) return
+
+    // docker refuses to remove an image a running container still uses, so a workload on
+    // the same image makes a cold node impossible. Wait a little first — a container from an
+    // earlier block that is still terminating clears on its own — then give up honestly
+    // rather than deleting nothing and "proving" a pull that never happened.
+    // `null` means the node command itself failed, which is NOT the same as "no container";
+    // only an empty result proves the image is free, so a broken `minikube ssh` times out
+    // here and skips rather than being read as a green light to evict.
+    const free = await waitFor(
+      () => nodeExec(`docker ps --filter ancestor=${mcpImage} --format '{{.ID}}'`),
+      inUse => inUse === '',
+      60_000,
+      5_000
+    )
+    if (free === null) {
+      console.log(
+        `[pull-secret-runtime] ${mcpImage} is still held by a running container (or the node is unreachable) — cannot cold-start the node`
+      )
+      return
+    }
+
+    nodeExec(`docker rmi -f ${mcpImage}`)
+    const remaining = nodeExec(`docker images -q ${mcpImage}`)
+    nodeWasCold = !remaining
+    if (!nodeWasCold) {
+      console.log(`[pull-secret-runtime] failed to evict ${mcpImage} from the node docker cache`)
+    }
+  }, 120_000)
+
+  it('installs the private MCP-server plugin', async () => {
+    if (!ready()) return
+
+    const { status, data } = await adminRequest('POST', '/api/v1/admin/registry/install', {
+      serverName: MCP_NAME,
+      contextRef: CONTEXT_REF,
+      registryEntryName: MCP_ENTRY,
+      registryEntryVersion: MCP_ENTRY_VERSION,
+    })
+    expect(status, `install failed: ${JSON.stringify(data)}`).toBe(201)
+    mcpInstalled = true
+  }, 120_000)
+
+  it('the McpServer CRD carries the pull-secret reference', () => {
+    if (!mcpInstalled) return
+
+    const server = kubectlJson<{
+      spec?: { image?: string; imagePullSecrets?: Array<{ name?: string }> }
+    }>(`get mcpserver ${MCP_NAME} -n ${MCP_SERVERS_NS}`)
+    expect(server, `McpServer ${MCP_NAME} not found`).not.toBeNull()
+    expect(server!.spec?.image, 'fixture is not a platform-registry image').toContain(registryHost)
+    expect(
+      (server!.spec?.imagePullSecrets ?? []).map(r => r.name),
+      'control-api did not attach the pull-secret reference to the McpServer CRD'
+    ).toContain(PULL_SECRET)
+  })
+
+  it('HCC materializes the reference onto the Deployment it owns', async () => {
+    if (!mcpInstalled) return
+
+    // HCC copies the McpServer spec verbatim onto a Deployment it owns; this is the hop a
+    // MockGateway cannot exercise. The managed-by label is asserted so the test cannot pass
+    // on some other controller's Deployment that happens to share the name.
+    const dep = await waitFor(
+      () => kubectlJson<PodTemplateHolder>(`get deployment ${MCP_NAME} -n ${MCP_SERVERS_NS}`),
+      v => v !== null,
+      180_000
+    )
+    expect(dep, `HCC never created a Deployment for McpServer ${MCP_NAME}`).not.toBeNull()
+    deploymentName = MCP_NAME
+
+    expect(dep!.metadata?.labels?.[MANAGED_BY_LABEL]).toBe('host-context-controller')
+    expect(
+      (dep!.spec?.template?.spec?.imagePullSecrets ?? []).map(r => r.name),
+      'HCC dropped the pull-secret reference'
+    ).toContain(PULL_SECRET)
+  }, 200_000)
+
+  it('the Pod reaches Ready', async () => {
+    if (!mcpInstalled || !deploymentName) return
+
+    const pods = await waitFor(
+      () => podsFor(`app=${MCP_NAME}`, MCP_SERVERS_NS),
+      list => list.length > 0 && list.some(p => p.ready),
+      240_000
+    )
+    // Record the Pod name even when readiness fails, so the pull assertion below reports its
+    // OWN failure ("no Pulled event …") instead of chain-skipping. A missing credential
+    // should surface as two independent failures, not one plus a silent skip.
+    const observed = pods ?? podsFor(`app=${MCP_NAME}`, MCP_SERVERS_NS)
+    podName = (observed.find(p => p.ready) ?? observed[0])?.name ?? ''
+    expect(
+      pods,
+      `no Ready Pod for McpServer ${MCP_NAME}; last seen ${JSON.stringify(observed)}`
+    ).not.toBeNull()
+  }, 300_000)
+
+  it('the kubelet performed a REAL authenticated pull, not a cache hit', () => {
+    if (!mcpInstalled || !podName) return
+    if (!nodeWasCold) {
+      // Asserting a genuine pull against a warm node proves nothing: `IfNotPresent` would
+      // short-circuit and the credential would never be exercised. Say so instead of
+      // silently downgrading the assertion.
+      console.log(
+        '[pull-secret-runtime] node was not cold — skipping the genuine-pull assertion (this run does NOT prove the private pull)'
+      )
+      return
+    }
+
+    const message = pulledEventMessage(podName, MCP_SERVERS_NS, mcpImage)
+    expect(message, `no Pulled event for ${mcpImage} on pod ${podName}`).not.toBeNull()
+
+    // A cache hit and a genuine pull are distinguishable only in this message.
+    expect(
+      message,
+      'kubelet served the image from cache — the credential was never used'
+    ).not.toContain('already present on machine')
+    expect(message).toContain('Successfully pulled image')
+    expect(message, 'pull event carries no transferred byte count').toMatch(/Image size: \d+ bytes/)
+  })
+})
+
+// ─── 4. Pre-persistence failure ─────────────────────────────────────────────
+
+describe('registry pull secret — a provisioning failure is pre-persistence', () => {
+  it('fails the install and persists NO WorkflowRecipe', async () => {
+    if (!ready()) return
+
+    let planted = false
+    try {
+      planted = plantForeignSandboxUiPullSecret()
+      if (!planted) {
+        console.log('[pull-secret-runtime] could not plant the foreign Secret — skipping')
+        return
+      }
+
+      const { status, data } = await adminRequest('POST', '/api/v1/admin/registry/install-recipe', {
+        recipeName: PREPERSIST_RECIPE_NAME,
+        registryEntryName: RECIPE_ENTRY,
+        registryEntryVersion: RECIPE_ENTRY_VERSION,
+      })
+
+      expect(status, `expected the install to be refused, got ${JSON.stringify(data)}`).toBe(409)
+      const body = data as { error?: string; reason?: string }
+      expect(body.error).toBe('registry_pull_secret_provision_failed')
+      expect(body.reason).toBe('foreign_secret_unusable')
+
+      // The whole point: the credential could not be provisioned, so the CRD that would
+      // reference it must never have been written. A 4xx with a persisted recipe behind it
+      // is the silent ImagePullBackOff this mechanism exists to remove.
+      // `2>/dev/null` because NotFound is the expected, passing outcome here — without it
+      // kubectl's error line lands in the run log and reads like a failure.
+      const persisted = kubectlOrNull(
+        `get workflowrecipe ${PREPERSIST_RECIPE_NAME} -n ${SANDBOX_NS} -o name 2>/dev/null`
+      )
+      expect(persisted, 'the failed install left a WorkflowRecipe behind').toBeNull()
+    } finally {
+      // Unconditional — a leaked foreign Secret 409s every later private install here.
+      await restoreSandboxUiPullSecret()
+    }
+  }, 180_000)
+})

--- a/tests/e2e/integration/registry-pull-secret-runtime.test.ts
+++ b/tests/e2e/integration/registry-pull-secret-runtime.test.ts
@@ -239,7 +239,14 @@ function authHosts(secret: K8sSecret): string[] {
 }
 
 type PodTemplateHolder = {
-  spec?: { template?: { spec?: { imagePullSecrets?: Array<{ name?: string }> } } }
+  spec?: {
+    template?: {
+      spec?: {
+        imagePullSecrets?: Array<{ name?: string }>
+        containers?: Array<{ image?: string }>
+      }
+    }
+  }
   metadata?: { labels?: Record<string, string> }
 }
 
@@ -319,10 +326,12 @@ function podsFor(
   name: string
   ready: boolean
   phase: string
+  images: string[]
 }> {
   const list = kubectlJson<{
     items?: Array<{
       metadata?: { name?: string }
+      spec?: { containers?: Array<{ image?: string }> }
       status?: { phase?: string; containerStatuses?: Array<{ ready?: boolean }> }
     }>
   }>(`get pods -n ${namespace} -l ${labelSelector}`)
@@ -332,6 +341,10 @@ function podsFor(
     ready:
       (p.status?.containerStatuses ?? []).length > 0 &&
       (p.status?.containerStatuses ?? []).every(c => c.ready === true),
+    // The image the kubelet was actually told to run. Readiness alone cannot tell a pod
+    // running the PRIVATE image from one running a public or stale one, so a suite that
+    // asserts only Ready can go green without the pull credential ever mattering.
+    images: (p.spec?.containers ?? []).map(c => c.image ?? ''),
   }))
 }
 
@@ -374,6 +387,31 @@ function unmet(reason: string): void {
  */
 function notApplicable(reason: string): void {
   console.log(`[pull-secret-runtime] ${reason} — not applicable on this cluster, skipping`)
+}
+
+/**
+ * The harness is fine and the test CAN run — but the specific thing it exists to prove is
+ * not provable in this state. Concretely: the node still holds the image, so `IfNotPresent`
+ * short-circuits and the kubelet never presents a credential to the registry.
+ *
+ * This is the subtler sibling of `unmet`, and the more dangerous one. An unwired harness at
+ * least fails visibly at the first assertion; a warm cache lets every assertion pass while
+ * the single claim this suite exists to make — "a private image pulled with the credential
+ * we provisioned" — is quietly not made. A run that stops making it must not be reported as
+ * one that did, so under REQUIRE_CLUSTER this is a failure, not a downgrade.
+ *
+ * Locally it stays a warning: a developer re-running the suite against a warm node is a
+ * normal state, and the log line says plainly that this run proves less.
+ */
+function unprovable(reason: string): void {
+  const msg = `[pull-secret-runtime] ${reason}`
+  if (REQUIRE_CLUSTER) {
+    throw new Error(
+      `${msg}. Refusing to pass: E2E_REQUIRE_CLUSTER/CI is set, and this run would otherwise ` +
+        `report success without ever exercising the pull credential.`
+    )
+  }
+  console.log(`${msg} — this run does NOT prove the private pull`)
 }
 
 // ─── Setup / teardown ───────────────────────────────────────────────────────
@@ -730,8 +768,8 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
       5_000
     )
     if (free === null) {
-      console.log(
-        `[pull-secret-runtime] ${mcpImage} is still held by a running container (or the node is unreachable) — cannot cold-start the node`
+      unprovable(
+        `${mcpImage} is still held by a running container (or the node is unreachable) — cannot cold-start the node`
       )
       return
     }
@@ -740,7 +778,7 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
     const remaining = nodeExec(`docker images -q ${mcpImage}`)
     nodeWasCold = !remaining
     if (!nodeWasCold) {
-      console.log(`[pull-secret-runtime] failed to evict ${mcpImage} from the node docker cache`)
+      unprovable(`failed to evict ${mcpImage} from the node docker cache`)
     }
   }, 120_000)
 
@@ -790,9 +828,16 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
       (dep!.spec?.template?.spec?.imagePullSecrets ?? []).map(r => r.name),
       'HCC dropped the pull-secret reference'
     ).toContain(PULL_SECRET)
+    // The reference is only meaningful if the workload it rides on is actually the private
+    // image. Without this, a Deployment carrying the pull secret but running some public or
+    // stale image would satisfy every other assertion in this block.
+    expect(
+      (dep!.spec?.template?.spec?.containers ?? []).map(c => c.image),
+      `HCC materialized a Deployment that does not run the private image ${mcpImage}`
+    ).toContain(mcpImage)
   }, 200_000)
 
-  it('the Pod reaches Ready', async () => {
+  it('the Pod reaches Ready, running the private registry image', async () => {
     if (!mcpInstalled || !deploymentName) return
 
     const pods = await waitFor(
@@ -804,22 +849,31 @@ describe('registry pull secret — McpServer delegation, HCC materialization, re
     // OWN failure ("no Pulled event …") instead of chain-skipping. A missing credential
     // should surface as two independent failures, not one plus a silent skip.
     const observed = pods ?? podsFor(`app=${MCP_NAME}`, MCP_SERVERS_NS)
-    podName = (observed.find(p => p.ready) ?? observed[0])?.name ?? ''
+    const readyPod = observed.find(p => p.ready) ?? observed[0]
+    podName = readyPod?.name ?? ''
     expect(
       pods,
       `no Ready Pod for McpServer ${MCP_NAME}; last seen ${JSON.stringify(observed)}`
     ).not.toBeNull()
+    // Ready is not the claim — "Ready ON THE PRIVATE IMAGE" is. A pod that came up on a
+    // public or cached image proves the plumbing and nothing about the credential.
+    expect(
+      readyPod?.images ?? [],
+      `the Ready Pod is not running ${mcpImage}; it runs ${JSON.stringify(readyPod?.images ?? [])}`
+    ).toContain(mcpImage)
+    expect(mcpImage.startsWith(registryHost), `${mcpImage} is not on the private registry`).toBe(
+      true
+    )
   }, 300_000)
 
   it('the kubelet performed a REAL authenticated pull, not a cache hit', () => {
     if (!mcpInstalled || !podName) return
     if (!nodeWasCold) {
       // Asserting a genuine pull against a warm node proves nothing: `IfNotPresent` would
-      // short-circuit and the credential would never be exercised. Say so instead of
-      // silently downgrading the assertion.
-      console.log(
-        '[pull-secret-runtime] node was not cold — skipping the genuine-pull assertion (this run does NOT prove the private pull)'
-      )
+      // short-circuit and the credential would never be exercised. Under REQUIRE_CLUSTER
+      // that is a failure — this is the assertion the whole suite is built around, and a
+      // run that skips it must not be counted as one that made it.
+      unprovable('node was not cold, so the kubelet never had to present a credential')
       return
     }
 

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.56",
+      "version": "0.1.57",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.256",
+      "version": "0.1.257",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.257",
+      "version": "0.1.258",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.258",
+  "version": "0.1.260",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.258",
+      "version": "0.1.260",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.258",
+  "version": "0.1.260",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/src/config.test.ts
+++ b/workflow-recipes/src/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { loadConfig } from './config'
+import { loadConfig, registryUrlStartupWarning } from './config'
 
 describe('loadConfig', () => {
   const originalEnv = process.env
@@ -251,5 +251,39 @@ describe('loadConfig', () => {
     delete process.env.CLERUM_DEV_MODE
     const config = loadConfig()
     expect(config.devMode).toBe(false)
+  })
+})
+
+// An unset/unparseable CLERUM_REGISTRY_URL makes isPlatformRegistryImage() return false
+// for EVERY image, which turns off platform pull-credential injection entirely — while
+// control-api still mints and writes the Secret. Recipe pods then ImagePullBackOff and
+// nothing in the logs says why. This warning is the announcement of that state.
+describe('registryUrlStartupWarning', () => {
+  it('returns null when a parseable registry URL is configured', () => {
+    expect(registryUrlStartupWarning('https://registry.evenfire.ai')).toBeNull()
+    expect(registryUrlStartupWarning('http://registry-api.registry.svc.cluster.local:8085')).toBe(
+      null
+    )
+  })
+
+  it('warns that pull-credential injection is disabled when the URL is unset', () => {
+    for (const unset of ['', '   ']) {
+      const warning = registryUrlStartupWarning(unset)
+      expect(warning).toMatch(/CLERUM_REGISTRY_URL/)
+      expect(warning).toMatch(/not set/)
+      expect(warning).toMatch(/ImagePullBackOff/)
+    }
+  })
+
+  it('warns when the URL is set but unparseable — same silent-disable effect', () => {
+    const warning = registryUrlStartupWarning('registry.evenfire.ai')
+    expect(warning).toMatch(/CLERUM_REGISTRY_URL/)
+    expect(warning).toMatch(/registry\.evenfire\.ai/)
+    expect(warning).toMatch(/ImagePullBackOff/)
+  })
+
+  it('does not depend on ambient env — it reports on the value it is given', () => {
+    process.env.CLERUM_REGISTRY_URL = 'https://registry.evenfire.ai'
+    expect(registryUrlStartupWarning('')).not.toBeNull()
   })
 })

--- a/workflow-recipes/src/config.ts
+++ b/workflow-recipes/src/config.ts
@@ -36,6 +36,14 @@ export interface OperatorConfig {
    */
   sandboxUiNamespace: string
   hostNamespace: string
+  /**
+   * Base URL of the evenfire registry. Deliberately the SAME variable control-api reads
+   * (`CLERUM_REGISTRY_URL`), because both services must agree on which images are ours:
+   * control-api provisions the platform pull credential for those images, WRC attaches it.
+   * A divergence here means recipe pods silently get no credential while MCP servers do.
+   * Empty (the default) disables platform pull-secret injection entirely.
+   */
+  registryUrl: string
   selfName: string
   internalControlJwtWrcHmacSecret: string
   enableCustomCoordinatorImage: boolean
@@ -248,6 +256,7 @@ export function loadConfig(): OperatorConfig {
     sandboxNamespace: getEnv('CLERUM_SANDBOX_NAMESPACE', 'sandbox-recipes'),
     sandboxUiNamespace: getEnv('CLERUM_SANDBOX_UI_NAMESPACE', 'sandbox-ui'),
     hostNamespace: getEnv('CLERUM_HOST_NAMESPACE', 'mcp-host'),
+    registryUrl: getEnv('CLERUM_REGISTRY_URL', ''),
     selfName: getEnv('CLERUM_OPERATOR_NAME', 'workflow-recipes'),
     internalControlJwtWrcHmacSecret: getEnv('INTERNAL_CONTROL_JWT_WRC_HMAC_SECRET', ''),
     enableCustomCoordinatorImage: getEnvBool('WRC_ENABLE_CUSTOM_COORDINATOR_IMAGE', false),

--- a/workflow-recipes/src/config.ts
+++ b/workflow-recipes/src/config.ts
@@ -2,6 +2,7 @@
  * Workload Recipes Controller (WRC) configuration.
  * Follows the same env-config pattern as host-context-controller/src/config.ts
  */
+import { registryHostFromUrl } from '@clerum/workflow-runtime-core'
 
 export interface DbConfig {
   connectionString?: string
@@ -174,6 +175,34 @@ function getNetworkPolicyEnforcementMode(): NetworkPolicyEnforcementMode {
   if (value === 'warn' || value === 'required') return value
   throw new Error(
     `Invalid value for CLERUM_NETWORK_POLICY_ENFORCEMENT_MODE: "${value}" (must be "warn" or "required")`
+  )
+}
+
+/**
+ * Startup warning for a `CLERUM_REGISTRY_URL` the platform-registry predicate cannot use.
+ *
+ * `isPlatformRegistryImage(image, registryUrl)` derives a host from this URL and returns
+ * false for EVERY image when it cannot — so an unset or unparseable value silently turns
+ * off platform image-pull credential injection altogether. control-api still mints and
+ * writes the pull Secret and reports success; WRC just never references it, and recipe
+ * pods sit in ImagePullBackOff with no failing request to attribute it to. Unset is a
+ * legitimate configuration (no platform registry), so this warns rather than throwing —
+ * but it must not be silent. Risk R3 in
+ * docs/architecture/registry-pull-secret-recipe-workloads.md.
+ *
+ * Returns null when the URL yields a host, otherwise the message to log.
+ */
+export function registryUrlStartupWarning(registryUrl: string): string | null {
+  if (registryHostFromUrl(registryUrl)) return null
+  const cause = registryUrl?.trim()
+    ? `CLERUM_REGISTRY_URL="${registryUrl.trim()}" has no parseable host (it needs a scheme, e.g. https://)`
+    : 'CLERUM_REGISTRY_URL is not set'
+  return (
+    `[Clerum] WARN: ${cause} — platform registry image-pull credential injection is DISABLED. ` +
+    'Recipe workloads whose images come from the platform registry will fail with ImagePullBackOff ' +
+    '("unauthorized: authentication required") even though control-api provisioned the credential. ' +
+    'Project control-api-config.CLERUM_REGISTRY_URL into this Deployment — see ' +
+    'deploy/base/control-plane/workflow-recipes.yaml.'
   )
 }
 

--- a/workflow-recipes/src/main.ts
+++ b/workflow-recipes/src/main.ts
@@ -10,7 +10,7 @@
  * Source of truth: PHASE-4-MCP-SERVER-INTERFACE.md §5.4
  */
 import * as k8s from '@kubernetes/client-node'
-import { OperatorConfig, loadConfig } from './config'
+import { OperatorConfig, loadConfig, registryUrlStartupWarning } from './config'
 import { WorkflowRecipeProvider, createWorkflowRecipeProvider } from './k8sClient'
 import { ClerumMcpServer } from './mcp/server'
 import { assertInternalControlJwtHmacSecret } from './utils/internalControlSigner'
@@ -87,9 +87,15 @@ async function main(): Promise<void> {
   console.log(`  Port: ${config.port}`)
   console.log(`  McpServer namespace: ${config.namespace}`)
   console.log(`  WorkflowRecipe namespace: ${config.sandboxNamespace}`)
+  console.log(`  Registry URL: ${config.registryUrl || '(unset)'}`)
   console.log(`  NetworkPolicy enforcement mode: ${config.networkPolicyEnforcementMode}`)
   console.log(`  NetworkPolicy enforcement confirmed: ${config.networkPolicyEnforcementConfirmed}`)
   console.log('─────────────────────────────────────────')
+
+  // A registry URL the platform-registry predicate cannot use disables pull-credential
+  // injection for every workload, silently. Say so once, loudly, at startup.
+  const registryWarning = registryUrlStartupWarning(config.registryUrl)
+  if (registryWarning) console.warn(registryWarning)
 
   // Initialize K8s client (shared for validation + MCP server)
   const kc = new k8s.KubeConfig()

--- a/workflow-recipes/src/reconciler/mcpDelegation.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.ts
@@ -10,6 +10,11 @@
  * - stdio workloads: managed: true — HCC owns Deployment (stdio-bridge sidecar)
  */
 import * as k8s from '@kubernetes/client-node'
+import {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  isPlatformRegistryImage,
+} from '@clerum/workflow-runtime-core'
+import { loadConfig } from '../config'
 import { WorkflowRecipeCRD, WorkloadDef } from '../types'
 import { CRD_GROUP, CRD_VERSION } from './crdConstants'
 import { getErrorCode } from './k8sErrors'
@@ -231,6 +236,16 @@ export function buildMcpServerManifest(
   const projectableImagePullSecrets = (workload.imagePullSecrets ?? []).filter(secretName =>
     transportSecretProjectable(secretAccess, secretName)
   )
+  // The PLATFORM pull credential is injected AFTER the ownership filter for any workload
+  // whose image is hosted on our own registry (see resourceBuilder for the full rationale:
+  // control-api provisions it, it is intentionally unlabeled to the #637 model, and making
+  // it recipe-referencable would either deny it or expose it as an envSecret).
+  if (
+    isPlatformRegistryImage(workload.image, loadConfig().registryUrl) &&
+    !projectableImagePullSecrets.includes(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  ) {
+    projectableImagePullSecrets.push(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  }
 
   return {
     apiVersion: `${CRD_GROUP}/${CRD_VERSION}`,

--- a/workflow-recipes/src/reconciler/platformPullSecret.test.ts
+++ b/workflow-recipes/src/reconciler/platformPullSecret.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Platform image-pull credential injection.
+ *
+ * control-api provisions `evenfire-registry-pull` and labels it
+ * `clerum.io/managed-by=control-api` only — which is *unlabeled* to the Issue #637
+ * ownership model. That is deliberate: it means a recipe can neither project it nor mount
+ * it as an envSecret. WRC therefore INJECTS the reference itself, after the ownership
+ * filter, for any workload whose image is hosted on our own registry.
+ *
+ * These tests pin both halves: the injection happens for our images, and the credential
+ * stays unreachable to recipe-authored references.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
+import type { DeploymentDef, WorkflowRecipeCRD, WorkloadDef } from '../types'
+import { buildMcpServerManifest } from './mcpDelegation'
+import { type SecretAccess, buildDeployment } from './resourceBuilder'
+
+const REGISTRY_HOST = 'registry.evenfire.ai'
+const PLATFORM_IMAGE = `${REGISTRY_HOST}/acme/plugin:1.0`
+const FOREIGN_IMAGE = 'ghcr.io/acme/plugin:1.0'
+
+const recipe = {
+  apiVersion: 'clerum.io/v1alpha1',
+  kind: 'WorkflowRecipe',
+  metadata: { name: 'demo', namespace: 'sandbox-recipes' },
+  spec: { workloads: [] },
+} as unknown as WorkflowRecipeCRD
+
+function workload(over: Partial<WorkloadDef> = {}): WorkloadDef {
+  return { id: 'w1', type: 'deployment', image: PLATFORM_IMAGE, ...over } as WorkloadDef
+}
+
+/** Pull-secret names on a built Deployment's pod spec. */
+function podPullNames(
+  w: Partial<WorkloadDef> = {},
+  access?: ReadonlyMap<string, SecretAccess>
+): string[] {
+  const dep = buildDeployment(workload(w) as DeploymentDef, recipe, 'minimal', access)
+  return (dep.spec?.template.spec?.imagePullSecrets ?? []).map(s => s.name as string)
+}
+
+/** Pull-secret names on a built McpServer manifest. */
+function mcpPullNames(
+  w: Partial<WorkloadDef> = {},
+  access?: ReadonlyMap<string, SecretAccess>
+): string[] {
+  const m = buildMcpServerManifest(
+    workload({ transport: { type: 'stdio' } as never, ...w }),
+    recipe,
+    'mcp-server',
+    access
+  ) as { spec?: { imagePullSecrets?: Array<{ name: string }> } } | null
+  return (m?.spec?.imagePullSecrets ?? []).map(s => s.name)
+}
+
+let saved: string | undefined
+
+beforeEach(() => {
+  saved = process.env.CLERUM_REGISTRY_URL
+  process.env.CLERUM_REGISTRY_URL = `https://${REGISTRY_HOST}`
+})
+
+afterEach(() => {
+  if (saved === undefined) delete process.env.CLERUM_REGISTRY_URL
+  else process.env.CLERUM_REGISTRY_URL = saved
+})
+
+describe('pod template — platform pull secret injection', () => {
+  it('injects the credential for an image on our registry', () => {
+    expect(podPullNames()).toEqual([EVENFIRE_REGISTRY_PULL_SECRET_NAME])
+  })
+
+  it('does not inject for a third-party image', () => {
+    expect(podPullNames({ image: FOREIGN_IMAGE })).not.toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  })
+
+  it('does not inject when no registry is configured', () => {
+    process.env.CLERUM_REGISTRY_URL = ''
+    expect(podPullNames()).not.toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  })
+
+  it("preserves a recipe's own third-party pull secrets alongside the injected one", () => {
+    expect(podPullNames({ imagePullSecrets: ['my-ghcr-creds'] })).toEqual([
+      'my-ghcr-creds',
+      EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+    ])
+  })
+
+  it('injects even though the #637 filter would DENY a recipe-declared reference', () => {
+    // The credential is unlabeled to the ownership model, so a recipe naming it is denied.
+    // Injection happens after that filter, so the workload still gets a working pull —
+    // and exactly once.
+    const access = new Map<string, SecretAccess>([
+      [EVENFIRE_REGISTRY_PULL_SECRET_NAME, { state: 'denied' }],
+    ])
+    expect(
+      podPullNames({ imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME] }, access)
+    ).toEqual([EVENFIRE_REGISTRY_PULL_SECRET_NAME])
+  })
+
+  it('drops a denied third-party secret while still injecting ours', () => {
+    const access = new Map<string, SecretAccess>([['victim-pull', { state: 'denied' }]])
+    expect(podPullNames({ imagePullSecrets: ['victim-pull'] }, access)).toEqual([
+      EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+    ])
+  })
+})
+
+describe('McpServer delegation — platform pull secret injection', () => {
+  it('injects for a transport workload on our registry', () => {
+    expect(mcpPullNames()).toEqual([EVENFIRE_REGISTRY_PULL_SECRET_NAME])
+  })
+
+  it('does not inject for a third-party transport image', () => {
+    expect(mcpPullNames({ image: FOREIGN_IMAGE })).not.toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  })
+
+  it('injects past a denied recipe-declared reference', () => {
+    const access = new Map<string, SecretAccess>([
+      [EVENFIRE_REGISTRY_PULL_SECRET_NAME, { state: 'denied' }],
+    ])
+    expect(
+      mcpPullNames({ imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME] }, access)
+    ).toEqual([EVENFIRE_REGISTRY_PULL_SECRET_NAME])
+  })
+})

--- a/workflow-recipes/src/reconciler/platformPullSecret.test.ts
+++ b/workflow-recipes/src/reconciler/platformPullSecret.test.ts
@@ -9,6 +9,14 @@
  *
  * These tests pin both halves: the injection happens for our images, and the credential
  * stays unreachable to recipe-authored references.
+ *
+ * Layering note — these are BUILDER tests, not reconciler tests. The builders are the
+ * normalization layer (filter the declared names, then append ours exactly once). The
+ * authoritative gate for a recipe that declares the reserved name lives one level up, in
+ * the reconciler's ownership pass: a `denied` imagePullSecrets ref denies the whole
+ * WORKLOAD, which is then torn down rather than rendered. Cases below that feed the
+ * builders a `denied` access map are pinning the lower layer; see each one for how (or
+ * whether) production reaches it.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
@@ -87,10 +95,16 @@ describe('pod template — platform pull secret injection', () => {
     ])
   })
 
-  it('injects even though the #637 filter would DENY a recipe-declared reference', () => {
-    // The credential is unlabeled to the ownership model, so a recipe naming it is denied.
-    // Injection happens after that filter, so the workload still gets a working pull —
-    // and exactly once.
+  it('normalizes a denied recipe-declared reference: stripped, then injected exactly once', () => {
+    // Defense-in-depth on the normalization layer — NOT the path a recipe author hits.
+    // A recipe that declares the reserved name is denied and TORN DOWN by the reconciler
+    // (collectSecretOwnership counts imagePullSecrets refs into deniedWorkloadIds, and the
+    // workload is never rendered), so this input does not reach the builder that way.
+    // It does reach it via the StatefulSet revocation re-render: teardownDeniedWorkload
+    // re-renders the StatefulSet with the denied access map to strip the credential, and
+    // that goes through this same shared buildPodTemplate. The property pinned here is
+    // that re-entry with a denied map still yields the injected name once, not zero or
+    // twice.
     const access = new Map<string, SecretAccess>([
       [EVENFIRE_REGISTRY_PULL_SECRET_NAME, { state: 'denied' }],
     ])
@@ -116,7 +130,13 @@ describe('McpServer delegation — platform pull secret injection', () => {
     expect(mcpPullNames({ image: FOREIGN_IMAGE })).not.toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
   })
 
-  it('injects past a denied recipe-declared reference', () => {
+  it('normalizes a denied recipe-declared reference on the delegation path too', () => {
+    // Also defense-in-depth, and more strictly so than the pod-template case: a transport
+    // workload with a denied ref is filtered out in preDeployMcpServers before this builder
+    // is called, and the reconciler tears the workload down anyway. Kept because
+    // buildMcpServerManifest is the last checkpoint before HCC — which materializes
+    // spec.imagePullSecrets verbatim — so the filter-then-inject order must hold here
+    // independently of the caller that happens to guard it today.
     const access = new Map<string, SecretAccess>([
       [EVENFIRE_REGISTRY_PULL_SECRET_NAME, { state: 'denied' }],
     ])

--- a/workflow-recipes/src/reconciler/reconciler.test.ts
+++ b/workflow-recipes/src/reconciler/reconciler.test.ts
@@ -3,6 +3,7 @@ import * as k8s from '@kubernetes/client-node'
 import { loadAll } from 'js-yaml'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
 import { loadConfig } from '../config'
 import { CronJobDef, WorkflowRecipeCRD, WorkflowRecipeGfsIntentSpec, WorkloadDef } from '../types'
 import { INHERITED_PARENT_RESOURCES_ANNOTATION } from '../workflow/childRecipeFactory'
@@ -4438,6 +4439,57 @@ describe('WorkflowRecipeReconciler', () => {
       db_name: 'clerum',
       db_mode: 'readonly',
     })
+  })
+
+  it('DENIES and tears down a workload that declares the reserved platform pull secret (Issue #637)', async () => {
+    // The orchestrator-level counterpart to the builder tests in platformPullSecret.test.ts.
+    // The platform credential is injected, never declared: control-api labels it
+    // `managed-by=control-api` only, which is *unlabeled* to the #637 ownership model. So a
+    // recipe that names it in imagePullSecrets does NOT get "the declared copy stripped and
+    // ours injected" — the whole WORKLOAD is denied here, in the reconciler, and torn down
+    // instead of rendered. This is the authoritative gate; the builders only normalize.
+    mockCoreApi.readNamespacedSecret.mockImplementation((args: { name: string }) =>
+      args.name === EVENFIRE_REGISTRY_PULL_SECRET_NAME
+        ? Promise.resolve({
+            metadata: {
+              resourceVersion: '1',
+              // Exactly what registryPullSecretService writes — provenance only, no
+              // owner-recipe/shared label (labelling it `shared` would open the envSecret
+              // exfiltration path, so it must stay denied).
+              labels: { 'clerum.io/managed-by': 'control-api' },
+            },
+            type: 'kubernetes.io/dockerconfigjson',
+            data: { '.dockerconfigjson': 'eA==' },
+          })
+        : Promise.resolve({ metadata: { resourceVersion: '1' } })
+    )
+
+    const recipe = makeRecipe({
+      spec: {
+        workloads: [
+          {
+            id: 'app',
+            type: 'deployment',
+            image: 'registry.evenfire.ai/acme/plugin:1.0',
+            port: 8080,
+            imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME],
+          },
+        ],
+      },
+    })
+
+    const r = await reconciler.reconcile(recipe)
+
+    const cond = (r.secretOwnershipConditions ?? []).find(
+      c => c.type === 'EnvSecretOwnershipDenied'
+    )
+    expect(cond?.status).toBe('True')
+    expect(cond?.message).toContain(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+    expect(r.workloadStatuses[0]).toMatchObject({ id: 'app', phase: 'failed', ready: false })
+
+    // Not rendered — and any prior instance torn down (revocation, not a silent strip).
+    expect(mockAppsApi.createNamespacedDeployment).not.toHaveBeenCalled()
+    expect(mockAppsApi.deleteNamespacedDeployment).toHaveBeenCalled()
   })
 
   it('surfaces EnvSecretOwnershipDenied from the WORKFLOW build path (Issue #637)', async () => {

--- a/workflow-recipes/src/reconciler/resourceBuilder.ts
+++ b/workflow-recipes/src/reconciler/resourceBuilder.ts
@@ -1,6 +1,11 @@
 import * as k8s from '@kubernetes/client-node'
 import { createHash, randomBytes } from 'node:crypto'
 import {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
+  isPlatformRegistryImage,
+} from '@clerum/workflow-runtime-core'
+import { loadConfig } from '../config'
+import {
   ConfigMapResourceDef,
   CronJobDef,
   DaemonSetDef,
@@ -879,8 +884,22 @@ function buildPodTemplate(
     const st = secretKeys?.get(name)?.state
     return st !== 'denied' && st !== 'error'
   })
+  // The PLATFORM pull credential is injected here, AFTER the ownership filter, for any
+  // workload whose image is hosted on our own registry. It is deliberately not something
+  // a recipe declares: control-api provisions it and labels it `managed-by=control-api`
+  // only, which is *unlabeled* to the #637 model — so a recipe naming it would be denied,
+  // and making it `shared` would let any recipe mount it as an envSecret and read the
+  // credential. Injecting it means the recipe never references it, so it is never
+  // classified, and there is no path for a recipe to reach its contents.
+  const pullSecretNames = [...allowedPullSecrets]
+  if (
+    isPlatformRegistryImage(workload.image, loadConfig().registryUrl) &&
+    !pullSecretNames.includes(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  ) {
+    pullSecretNames.push(EVENFIRE_REGISTRY_PULL_SECRET_NAME)
+  }
   const imagePullSecrets =
-    allowedPullSecrets.length > 0 ? allowedPullSecrets.map(name => ({ name })) : undefined
+    pullSecretNames.length > 0 ? pullSecretNames.map(name => ({ name })) : undefined
   const ownershipInitContainer = buildVolumeOwnershipInitContainer(workload)
 
   const pluginSdkEnv = buildPluginWorkloadSdkEnv(

--- a/workflow-recipes/src/reconciler/secretOwnershipBackfill.test.ts
+++ b/workflow-recipes/src/reconciler/secretOwnershipBackfill.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { EVENFIRE_REGISTRY_PULL_SECRET_NAME } from '@clerum/workflow-runtime-core'
 import {
   type BackfillNamespaces,
   type BackfillRecipe,
@@ -130,6 +131,60 @@ describe('planSecretOwnershipBackfill', () => {
     ]
     const plan = planSecretOwnershipBackfill(recipes, NS, reader({ 'sandbox-recipes/regcred': {} }))
     expect(plan.stamp).toEqual([
+      { namespace: 'sandbox-recipes', secret: 'regcred', ownerRecipe: 'r' },
+    ])
+  })
+
+  // The platform registry pull credential is control-api-owned infrastructure. It carries
+  // `clerum.io/managed-by: control-api` and NEITHER ownership label, so it reads as
+  // legacy-unlabeled here. A recipe referencing the reserved name — persisted before the
+  // reserved-name validation, or applied straight with kubectl — would otherwise make
+  // `--apply` stamp `clerum.io/owner-recipe` on it, which flips
+  // isSecretAccessibleByRecipe to true and stops the #637 gate from denying and tearing
+  // down that workload. Never a candidate, in any bucket.
+  it('never plans the platform registry pull secret, even with exactly one referencer', () => {
+    const recipes: BackfillRecipe[] = [
+      {
+        name: 'squatter',
+        workloads: [{ id: 'api', imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME] }],
+      },
+    ]
+    const plan = planSecretOwnershipBackfill(
+      recipes,
+      NS,
+      reader({
+        [`sandbox-recipes/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`]: {
+          'clerum.io/managed-by': 'control-api',
+        },
+      })
+    )
+    expect(plan).toEqual({ stamp: [], ambiguous: [], alreadyLabeled: [], missing: [] })
+  })
+
+  it('still stamps genuine unlabeled secrets alongside the excluded platform one', () => {
+    const recipes: BackfillRecipe[] = [
+      {
+        name: 'r',
+        workloads: [
+          {
+            id: 'api',
+            imagePullSecrets: [EVENFIRE_REGISTRY_PULL_SECRET_NAME, 'regcred'],
+            envSecret: { name: 'app-env' },
+          },
+        ],
+      },
+    ]
+    const plan = planSecretOwnershipBackfill(
+      recipes,
+      NS,
+      reader({
+        [`sandbox-recipes/${EVENFIRE_REGISTRY_PULL_SECRET_NAME}`]: {},
+        'sandbox-recipes/regcred': {},
+        'sandbox-recipes/app-env': {},
+      })
+    )
+    expect(plan.stamp).toEqual([
+      { namespace: 'sandbox-recipes', secret: 'app-env', ownerRecipe: 'r' },
       { namespace: 'sandbox-recipes', secret: 'regcred', ownerRecipe: 'r' },
     ])
   })

--- a/workflow-recipes/src/reconciler/secretOwnershipBackfill.ts
+++ b/workflow-recipes/src/reconciler/secretOwnershipBackfill.ts
@@ -21,8 +21,10 @@
 // (could be a legitimate shared Secret an operator must mark `clerum.io/shared`,
 // or the exact cross-recipe reference #637 guards against) and is never
 // auto-claimed. Already-labeled Secrets (including those owned by a different
-// recipe, or conflicting owner+shared) are left untouched.
+// recipe, or conflicting owner+shared) are left untouched. The platform registry
+// pull credential is excluded outright — see the note in `addRef` below.
 import {
+  EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   OWNER_RECIPE_LABEL_KEY,
   SHARED_LABEL_KEY,
   parseSecretOwnership,
@@ -197,6 +199,17 @@ export function planSecretOwnershipBackfill(
   const refs = new Map<string, string[]>()
   const order: string[] = []
   const addRef = (namespace: string, name: string, recipe: string) => {
+    // The platform registry pull credential is control-api-owned infrastructure, not a
+    // recipe Secret: control-api writes it into each platform workload namespace labeled
+    // only `clerum.io/managed-by: control-api`. It carries NEITHER ownership label, so
+    // isUnlabeled() reads it as legacy-unlabeled — and a recipe that references the
+    // reserved name (persisted before the reserved-name validation landed, or applied
+    // straight with kubectl) would make `--apply` stamp `clerum.io/owner-recipe` on it.
+    // That would flip isSecretAccessibleByRecipe to true, so the #637 gate would stop
+    // denying and tearing down the very workload it exists to deny — and the claim would
+    // hold until the next mint rewrites the Secret. Never a back-fill candidate: not
+    // stampable, not ambiguous, not reportable as missing.
+    if (name === EVENFIRE_REGISTRY_PULL_SECRET_NAME) return
     const key = `${namespace}${SEP}${name}`
     let recipesForKey = refs.get(key)
     if (!recipesForKey) {

--- a/workflow-recipes/tests/unit/workflow/deployManifest.test.ts
+++ b/workflow-recipes/tests/unit/workflow/deployManifest.test.ts
@@ -29,4 +29,42 @@ describe('workflow-recipes deployment manifest', () => {
       )
     }
   })
+
+  // Guard for risk R3 in docs/architecture/registry-pull-secret-recipe-workloads.md.
+  // WRC decides whether to attach the platform image-pull credential by comparing the
+  // workload image host against its OWN CLERUM_REGISTRY_URL, while control-api mints and
+  // writes that credential from its copy. When the two disagree — or WRC's is simply
+  // unset, which `isPlatformRegistryImage` treats as "no platform registry" — control-api
+  // still writes the Secret and returns 201, but WRC never emits `imagePullSecrets`, so
+  // recipe pods sit in ImagePullBackOff while McpServer installs keep working (control-api
+  // writes that reference itself). Projecting the ONE key that defines the URL makes the
+  // divergence unrepresentable; a literal here would silently reintroduce it.
+  it('sources the registry URL from the same control-api ConfigMap key, never a literal', () => {
+    const manifest = readRepo('deploy/base/control-plane/workflow-recipes.yaml')
+
+    expect(manifest).toMatch(
+      new RegExp(
+        [
+          '- name: CLERUM_REGISTRY_URL',
+          '\\s+valueFrom:',
+          '\\s+configMapKeyRef:',
+          '\\s+name: control-api-config',
+          '\\s+key: CLERUM_REGISTRY_URL',
+          // The base ConfigMap ships no such key (only overlays set it), so a hard
+          // reference would CreateContainerConfigError on a plain `deploy/base` install.
+          '\\s+optional: true',
+        ].join('\\n')
+      )
+    )
+
+    // Exactly one declaration, and not a hardcoded second copy of the URL.
+    expect(manifest.match(/- name: CLERUM_REGISTRY_URL$/gm)?.length).toBe(1)
+    expect(manifest).not.toMatch(/- name: CLERUM_REGISTRY_URL\n\s+value:/)
+  })
+
+  it('does not let the minikube overlay redeclare the registry URL it already inherits', () => {
+    const patch = readRepo('deploy/overlays/minikube/patches/registry-env.yaml')
+
+    expect(patch).not.toMatch(/- name: CLERUM_REGISTRY_URL$/m)
+  })
 })


### PR DESCRIPTION
## Summary

On a **self-hosted** cluster there is no managed operator to create the `evenfire-registry-pull` dockerconfigjson Secret that private evenfire-registry plugin images need, so every private-image plugin failed with `ImagePullBackOff: unauthorized`. control-api only ever *referenced* the Secret by name; nothing in this repo created it. This makes **control-api self-provision** it, and removes the in-repo "provisioned by MCC" assumption — restoring the open-core promise that self-hosting is a first-class path.

Design + rationale (deep review, side-effect audit, and the two-workstream plan): [`docs/architecture/registry-pull-secret-self-provisioning.md`](docs/architecture/registry-pull-secret-self-provisioning.md) (included in this PR).

**What changed (control-api):**
- `registryClient.mintOrgPullCredential(orgName)` — mints a **pull-only** key via the registry's pull-credential endpoint using our org-bound machine identity. The returned `dockerconfigjson` is deliberately ignored; the blob is built locally, keyed on the **image host** (`registryUrl`), not the registry's token-issuer.
- `registryPullSecretService.ensureRegistryPullSecret(gateway, targetNs)` — read-before-mint state machine. Gated to `self-hosted` mode + active registry auth + a resolved org. Coexists idempotently with an externally-provisioned Secret via a `clerum.io/managed-by=control-api` ownership label (unlabeled ⇒ foreign ⇒ left untouched); repairs an empty Secret; tolerates create races.
- Wired into the **install + upgrade** handlers: runs when the pull-secret reference is attached, **outside** the `credRequired` block (credential-less plugins still need it), **before** the McpServer CRD is created, and **outside** the per-plugin rollback (the Secret is namespace-shared). Fail-loud with `registry_pull_secret_provision_failed`.
- Scrubbed the "provisioned by MCC" framing from the pull-secret path.

**Design points enforced in code:** the Secret lands in `targetNs` (co-located with the pod — `imagePullSecrets` are namespace-local); the `.dockerconfigjson` is keyed on the configured registry host so the kubelet matches it; a foreign Secret is never clobbered; the whole path no-ops in `managed` mode.

**Dependency / rollout:** requires the companion `evenfire-registry` change that relaxes the pull-credential gate to an org-bound `registry:manage-keys` machine (separate PR). **Deploy the registry change first** — until then `mintOrgPullCredential` returns 403 and installs fail loud rather than silently.

## Testing

- [x] `npm test` passes for changed services — control-api: **3656 passed / 51 skipped**, incl. the full `routes.registryInstall` suite (unchanged, still green) and 8 new `registryPullSecretService` state-machine tests
- [x] `npx tsc --noEmit` clean

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWLkwHG9uAQjptdxZhJBr4)_