### PR TITLE
feat(minikube): add `make prereqs` doctor + plumb all 21 LLM providers into the secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ TEST_SERVICES := \
 # ── Optional OSS-launch tooling (public snapshot / infra carve) — monorepo-only
 -include Makefile.oss
 
+# ── Prerequisites ────────────────────────────────────────────────────
+.PHONY: prereqs
+prereqs: ## Check every dependency for minikube-setup up front (Docker/minikube/kubectl/node/…) with per-platform install commands
+	@bash scripts/check-prereqs.sh
+
+.PHONY: doctor
+doctor: prereqs ## Alias for 'prereqs'
+
 # ── Install ──────────────────────────────────────────────────────────
 .PHONY: install-git-hooks
 install-git-hooks: ## Configure Git to use tracked hooks from .githooks
@@ -306,16 +314,9 @@ minikube-apply-secrets: ## Apply all secrets to cluster (LLM keys read from .env
 	else \
 	  echo "Channel file not present; per-Host channel values are managed through Control UI/control-api."; \
 	fi
-	@# LLM API keys — read from the main checkout .env when running from a worktree
-	@ENV_FILE=""; GIT_COMMON_DIR="$$(git rev-parse --git-common-dir 2>/dev/null || true)"; if [ -n "$$GIT_COMMON_DIR" ]; then case "$$GIT_COMMON_DIR" in /*) GIT_COMMON_ABS="$$GIT_COMMON_DIR" ;; *) GIT_COMMON_ABS="$$(cd "$$GIT_COMMON_DIR" && pwd)" ;; esac; MAIN_REPO_DIR="$$(cd "$$GIT_COMMON_ABS/.." && pwd)"; if [ -f "$$MAIN_REPO_DIR/.env" ]; then ENV_FILE="$$MAIN_REPO_DIR/.env"; fi; fi; if [ -z "$$ENV_FILE" ] && [ -f .env ]; then ENV_FILE=".env"; fi; if [ -f "$$ENV_FILE" ]; then set -a && . "$$ENV_FILE" && set +a; fi; \
-	  kubectl --context=$(MINIKUBE_PROFILE) create secret generic chatllm-api-keys \
-	    --namespace=mcp-host \
-	    --from-literal=openai-api-key="$${OPENAI_API_KEY:-sk-test-placeholder-openai-key-00000000000000000000}" \
-	    --from-literal=claude-api-key="$${CLAUDE_API_KEY:-sk-ant-api03-test-placeholder-claude-key-000000000000000000000000000000000000000000000000000000}" \
-	    --from-literal=zai-api-key="$${ZAI_API_KEY:-zai-test-placeholder-zai-key-00000000000000000000}" \
-	    --from-literal=bailian-api-key="$${BAILIAN_API_KEY:-sk-test-placeholder-bailian-key-00000000000000000000}" \
-	    --dry-run=client -o yaml | kubectl --context=$(MINIKUBE_PROFILE) apply -f -
-	@echo "  LLM API keys applied (provider: $${CLERUM_MODEL_PROVIDER:-zai})"
+	@# LLM API keys — all 21 providers from the registry; reads the main checkout
+	@# .env when running from a worktree. Original four keep placeholder fallbacks.
+	@CONTEXT=$(MINIKUBE_PROFILE) bash scripts/minikube/apply-llm-secret.sh
 
 .PHONY: minikube-apply-namespaces
 minikube-apply-namespaces: ## Create all namespaces

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,8 @@ minikube-stop: ## Stop minikube cluster
 	minikube stop -p $(MINIKUBE_PROFILE)
 
 .PHONY: minikube-setup
-minikube-setup: ## Clean install from scratch (rebuilds the DB; REUSE_DB=true keeps it). SKIP_UIS=true omits Control/Profile UI. Needs ADMIN_PASSWORD in .env.
+minikube-setup: ## Clean install from scratch (rebuilds the DB; REUSE_DB=true keeps it). SKIP_UIS=true omits Control/Profile UI. Runs 'prereqs' first (SKIP_PREREQS=true to bypass). Needs ADMIN_PASSWORD in .env.
+	@if [ "$(SKIP_PREREQS)" != "true" ]; then $(MAKE) --no-print-directory prereqs; fi
 	@MINIKUBE_SKIP_UIS="$(SKIP_UIS)" MINIKUBE_SEED_PROFILE="$(SEED_PROFILE)" REUSE_DB="$(REUSE_DB)" \
 		scripts/minikube/full-setup.sh $(ARGS)
 

--- a/docs/deploy/minikube.md
+++ b/docs/deploy/minikube.md
@@ -43,12 +43,16 @@ Ready before E2E results are interpreted.
 
 ## Prerequisites
 
-- **Docker Desktop** installed and running
+- **Docker Desktop** installed and running (**≥10 GB RAM / 6 CPUs**)
 - **minikube** v1.30+ (`brew install minikube`)
 - **kubectl** (`brew install kubectl`)
 - **python3** (for JWT key sync)
 - **Node.js** 24+ (for building services and desktop app)
+- **git**, **make**, and **ruby** (ruby renders the control-api DB migration overlay)
 - `.env` file at project root with LLM API keys (optional — uses placeholders if missing)
+
+> Tip: run `make prereqs` (alias `make doctor`) to verify all of the above at
+> once, with per-platform install commands for anything missing.
 
 ---
 

--- a/docs/get-started/minikube.md
+++ b/docs/get-started/minikube.md
@@ -13,6 +13,11 @@ Docker Desktop with **≥10 GB RAM / 6 CPUs** · `minikube` v1.30+ · `kubectl` 
 `python3` · Node.js 24+ · `git` · `make` · `ruby` (renders the control-api DB
 migration overlay; ships with macOS, `apt-get install ruby` on Debian/Ubuntu).
 
+Run `make prereqs` (alias `make doctor`) to check every one of these at once —
+it prints the exact install command per platform for anything missing, and
+flags a `.env` without `ADMIN_PASSWORD` or an LLM key. `make minikube-setup`
+runs it automatically first (bypass with `SKIP_PREREQS=true`).
+
 ## Bring the platform up
 
 ```bash

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -16,7 +16,12 @@ named `chatllm` you can message immediately.
 - **kubectl**
 - **python3** (used by the JWT key sync)
 - **Node.js 24+** (service builds; desktop app)
-- One LLM API key: OpenAI, Anthropic Claude, Z.AI, or Alibaba Bailian
+- **git**, **make**, and **ruby** (ruby renders the control-api DB migration
+  overlay; ships with macOS, `apt-get install ruby` on Debian/Ubuntu)
+- One LLM API key from any of the 21 supported providers (e.g. OpenAI,
+  Anthropic Claude, Google Gemini, Groq, Mistral, Z.AI, Alibaba Bailian) —
+  optional for setup (it boots with placeholders), but the agent can't call a
+  model without one. Full list: [../deploy/llm-providers.md](../deploy/llm-providers.md)
 
 ## 1. Configure
 

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -270,9 +270,11 @@ azure:AZURE_OPENAI_API_KEY"
   if [ -n "$LLM_KEYS_SET" ]; then
     ok ".env     LLM key set —$LLM_KEYS_SET"
   else
-    err ".env     no LLM key set (need ONE of 21 providers, e.g. OPENAI_API_KEY / CLAUDE_API_KEY / GEMINI_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY …)"
-    echo    "        Set one in .env; setup infers the matching provider. Full list: docs/deploy/llm-providers.md"
-    MISSING=$((MISSING + 1))
+    # Non-fatal: setup boots with test placeholders (default zai). The agent
+    # just can't reach a model until a real key is added — matches the
+    # "optional" behavior documented in docs/deploy/minikube.md.
+    warn ".env     no LLM key set — setup will boot with placeholders (default zai); the agent can't call a model until you add one"
+    echo    "        Set one of 21 providers in .env (OPENAI_API_KEY / CLAUDE_API_KEY / GEMINI_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY …); setup infers the provider. Full list: docs/deploy/llm-providers.md"
   fi
 
   # Provider/key consistency — non-fatal, catches a common mismatch.

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# ======================================================================
+# Prerequisite Check (make prereqs / make doctor)
+# ======================================================================
+#
+# Verifies EVERY dependency needed by `make minikube-setup` BEFORE any
+# work starts, and prints the exact install command per platform for
+# whatever is missing. Fails fast with a single summary instead of
+# surfacing a bare "docker is not running" / "minikube: command not
+# found" halfway through setup.
+#
+# Usage:
+#   ./scripts/check-prereqs.sh
+#   make prereqs      # or: make doctor
+#
+# Exit codes:
+#   0  all required prerequisites satisfied
+#   1  one or more required prerequisites missing or too old
+# ======================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log()  { echo -e "${CYAN}[PREREQS]${NC} $*"; }
+ok()   { echo -e "  ${GREEN}OK${NC}    $*"; }
+warn() { echo -e "  ${YELLOW}WARN${NC}  $*"; }
+err()  { echo -e "  ${RED}MISSING${NC} $*"; }
+
+# ── Platform detection ─────────────────────────────────────────────────
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) K8S_ARCH="amd64" ;;
+  arm64|aarch64) K8S_ARCH="arm64" ;;
+  *) K8S_ARCH="amd64" ;;
+esac
+case "$OS" in
+  Darwin) K8S_OS="darwin" ;;
+  Linux)  K8S_OS="linux" ;;
+  *)      K8S_OS="linux" ;;
+esac
+
+MISSING=0
+
+# Print a per-platform install hint block.
+#   $1 = macOS (brew) command   $2 = Debian/Ubuntu (apt) command
+hint() {
+  local mac="$1" deb="$2"
+  if [ "$OS" = "Darwin" ]; then
+    echo -e "        macOS:         ${BOLD}$mac${NC}"
+  elif [ "$OS" = "Linux" ]; then
+    echo -e "        Debian/Ubuntu: ${BOLD}$deb${NC}"
+  else
+    echo -e "        macOS:         ${BOLD}$mac${NC}"
+    echo -e "        Debian/Ubuntu: ${BOLD}$deb${NC}"
+  fi
+}
+
+# Compare two dotted versions: returns 0 if $1 >= $2.
+version_ge() {
+  [ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+log "Checking prerequisites for 'make minikube-setup' on ${OS}/${ARCH}..."
+echo
+
+# ── git ────────────────────────────────────────────────────────────────
+if command -v git >/dev/null 2>&1; then
+  ok "git      $(git --version | awk '{print $3}')"
+else
+  err "git      not found"
+  hint "brew install git" "sudo apt-get install -y git"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── make ───────────────────────────────────────────────────────────────
+if command -v make >/dev/null 2>&1; then
+  ok "make     $(make --version 2>/dev/null | head -n1 | awk '{print $3}')"
+else
+  err "make     not found"
+  hint "xcode-select --install" "sudo apt-get install -y make"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── Node.js (>= 24) ────────────────────────────────────────────────────
+if command -v node >/dev/null 2>&1; then
+  NODE_VER="$(node --version | sed 's/^v//')"
+  if version_ge "$NODE_VER" "24.0.0"; then
+    ok "node     v${NODE_VER}"
+  else
+    err "node     v${NODE_VER} (need >= 24)"
+    hint "brew install node@24" "curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs"
+    MISSING=$((MISSING + 1))
+  fi
+else
+  err "node     not found (need >= 24)"
+  hint "brew install node@24" "curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash - && sudo apt-get install -y nodejs"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── python3 ────────────────────────────────────────────────────────────
+if command -v python3 >/dev/null 2>&1; then
+  ok "python3  $(python3 --version 2>&1 | awk '{print $2}')"
+else
+  err "python3  not found"
+  hint "brew install python3" "sudo apt-get install -y python3"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── ruby ───────────────────────────────────────────────────────────────
+# Renders the control-api DB migration overlay; ships with macOS.
+if command -v ruby >/dev/null 2>&1; then
+  ok "ruby     $(ruby --version 2>/dev/null | awk '{print $2}')"
+else
+  err "ruby     not found (renders the control-api DB migration overlay)"
+  hint "ships with macOS — reinstall via 'brew install ruby'" "sudo apt-get install -y ruby"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── kubectl ────────────────────────────────────────────────────────────
+if command -v kubectl >/dev/null 2>&1; then
+  KV="$(kubectl version --client -o json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["clientVersion"]["gitVersion"])' 2>/dev/null \
+        || kubectl version --client --short 2>/dev/null | awk '/Client/{print $NF}')"
+  ok "kubectl  ${KV:-installed}"
+else
+  err "kubectl  not found"
+  hint "brew install kubectl" "sudo apt-get install -y kubectl  (or use the curl installer below)"
+  echo    "        one-shot, no sudo (into ~/.local/bin):"
+  echo -e "          ${BOLD}curl -fsSLo ~/.local/bin/kubectl \"https://dl.k8s.io/release/\$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/${K8S_OS}/${K8S_ARCH}/kubectl\" && chmod +x ~/.local/bin/kubectl${NC}"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── minikube (>= 1.30) ─────────────────────────────────────────────────
+if command -v minikube >/dev/null 2>&1; then
+  MK_VER="$(minikube version --short 2>/dev/null | sed 's/^v//')"
+  if [ -n "$MK_VER" ] && version_ge "$MK_VER" "1.30.0"; then
+    ok "minikube v${MK_VER}"
+  else
+    warn "minikube v${MK_VER:-unknown} (recommended >= 1.30)"
+  fi
+else
+  err "minikube not found (need >= 1.30)"
+  hint "brew install minikube" "use the curl installer below"
+  echo    "        one-shot, no sudo (into ~/.local/bin):"
+  echo -e "          ${BOLD}curl -fsSLo ~/.local/bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-${K8S_OS}-${K8S_ARCH} && chmod +x ~/.local/bin/minikube${NC}"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── Docker (installed AND running) ─────────────────────────────────────
+if command -v docker >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    ok "docker   daemon reachable"
+    # Best-effort resource check: minikube-setup needs >= 10 GB RAM / 6 CPUs.
+    MEM_BYTES="$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)"
+    CPUS="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo 0)"
+    if [ "${MEM_BYTES:-0}" -gt 0 ]; then
+      MEM_GB=$((MEM_BYTES / 1024 / 1024 / 1024))
+      if [ "$MEM_GB" -lt 10 ]; then
+        warn "docker has ~${MEM_GB} GB RAM allocated (setup wants >= 10 GB — raise it in Docker Desktop → Settings → Resources)"
+      else
+        ok "docker   ~${MEM_GB} GB RAM allocated"
+      fi
+    fi
+    if [ "${CPUS:-0}" -gt 0 ] && [ "$CPUS" -lt 6 ]; then
+      warn "docker has ${CPUS} CPUs allocated (setup wants >= 6)"
+    elif [ "${CPUS:-0}" -ge 6 ]; then
+      ok "docker   ${CPUS} CPUs allocated"
+    fi
+  else
+    err "docker   installed but daemon not reachable"
+    if [ "$OS" = "Darwin" ]; then
+      echo -e "        Start it: ${BOLD}open -a 'Docker Desktop'${NC} (then re-run 'make prereqs')"
+    else
+      echo -e "        Start it: ${BOLD}sudo systemctl start docker${NC}  (and add yourself: ${BOLD}sudo usermod -aG docker \$USER${NC}, then re-login)"
+    fi
+    MISSING=$((MISSING + 1))
+  fi
+else
+  err "docker   not found"
+  hint "install Docker Desktop: https://www.docker.com/products/docker-desktop/" "sudo apt-get install -y docker.io  (then: sudo usermod -aG docker \$USER)"
+  MISSING=$((MISSING + 1))
+fi
+
+# ── .env content check ─────────────────────────────────────────────────
+# `make minikube-setup` requires ADMIN_PASSWORD and at least one LLM key.
+# Parse the specific keys instead of sourcing .env (never execute it).
+env_value() {
+  # Last non-comment assignment wins; strips surrounding quotes/whitespace.
+  local key="$1" file="$2" raw
+  raw="$(grep -E "^[[:space:]]*${key}=" "$file" 2>/dev/null | tail -n1)" || return 0
+  raw="${raw#*=}"
+  raw="${raw%\"}"; raw="${raw#\"}"
+  raw="${raw%\'}"; raw="${raw#\'}"
+  printf '%s' "$raw" | sed 's/[[:space:]]*$//'
+}
+
+echo
+ENV_FILE="$PROJECT_DIR/.env"
+if [ ! -f "$ENV_FILE" ]; then
+  err ".env     not found — setup aborts in Step 1"
+  echo -e "        Create it: ${BOLD}cp .env.example .env${NC}"
+  echo    "        then set ADMIN_PASSWORD (required, no default) and ONE LLM key"
+  MISSING=$((MISSING + 1))
+else
+  ok ".env     present"
+
+  # ADMIN_PASSWORD — required, no default ships.
+  if [ -n "$(env_value ADMIN_PASSWORD "$ENV_FILE")" ]; then
+    ok ".env     ADMIN_PASSWORD set"
+  else
+    err ".env     ADMIN_PASSWORD is empty (required — setup aborts in Step 1)"
+    echo -e "        Set it in .env: ${BOLD}ADMIN_PASSWORD=<choose-a-strong-password>${NC}"
+    MISSING=$((MISSING + 1))
+  fi
+
+  # At least one LLM key — setup infers the provider from whichever is set.
+  #
+  # Canonical provider→primary-credential map, mirrored from the registry in
+  # packages/llm-providers/index.cjs (PROVIDER_CREDENTIAL_SLOTS). All 21
+  # providers; the value is each provider's PRIMARY credential env var (vertex
+  # and bedrock also need secondary vars — see the per-provider note below).
+  # Keep in sync with that file if providers are added.
+  PROVIDER_KEYS="\
+openai:OPENAI_API_KEY \
+claude:CLAUDE_API_KEY \
+zai:ZAI_API_KEY \
+bailian:BAILIAN_API_KEY \
+vertex:VERTEX_SERVICE_ACCOUNT_JSON \
+bedrock:AWS_ACCESS_KEY_ID \
+openrouter:OPENROUTER_API_KEY \
+gemini:GEMINI_API_KEY \
+deepseek:DEEPSEEK_API_KEY \
+groq:GROQ_API_KEY \
+together:TOGETHER_API_KEY \
+fireworks:FIREWORKS_API_KEY \
+mistral:MISTRAL_API_KEY \
+xai:XAI_API_KEY \
+cerebras:CEREBRAS_API_KEY \
+deepinfra:DEEPINFRA_API_KEY \
+perplexity:PERPLEXITY_API_KEY \
+moonshot:MOONSHOT_API_KEY \
+nebius:NEBIUS_API_KEY \
+novita:NOVITA_API_KEY \
+azure:AZURE_OPENAI_API_KEY"
+
+  provider_key_for() {
+    local p="$1" pair
+    for pair in $PROVIDER_KEYS; do
+      if [ "${pair%%:*}" = "$p" ]; then printf '%s' "${pair#*:}"; return 0; fi
+    done
+    return 1
+  }
+
+  LLM_KEYS_SET=""
+  for pair in $PROVIDER_KEYS; do
+    k="${pair#*:}"
+    if [ -n "$(env_value "$k" "$ENV_FILE")" ]; then
+      LLM_KEYS_SET="$LLM_KEYS_SET $k"
+    fi
+  done
+  if [ -n "$LLM_KEYS_SET" ]; then
+    ok ".env     LLM key set —$LLM_KEYS_SET"
+  else
+    err ".env     no LLM key set (need ONE of 21 providers, e.g. OPENAI_API_KEY / CLAUDE_API_KEY / GEMINI_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY …)"
+    echo    "        Set one in .env; setup infers the matching provider. Full list: docs/deploy/llm-providers.md"
+    MISSING=$((MISSING + 1))
+  fi
+
+  # Provider/key consistency — non-fatal, catches a common mismatch.
+  PROVIDER="$(env_value CLERUM_MODEL_PROVIDER "$ENV_FILE")"
+  if [ -n "$PROVIDER" ]; then
+    if PROVIDER_KEY="$(provider_key_for "$PROVIDER")"; then
+      if [ -z "$(env_value "$PROVIDER_KEY" "$ENV_FILE")" ]; then
+        warn ".env     CLERUM_MODEL_PROVIDER='$PROVIDER' but $PROVIDER_KEY is empty"
+      fi
+      # Multi-credential providers need more than the primary key.
+      case "$PROVIDER" in
+        bedrock) [ -z "$(env_value AWS_SECRET_ACCESS_KEY "$ENV_FILE")" ] && \
+          warn ".env     provider 'bedrock' also needs AWS_SECRET_ACCESS_KEY (+ AWS_REGION)" ;;
+        vertex)  [ -z "$(env_value VERTEX_PROJECT_ID "$ENV_FILE")" ] && \
+          warn ".env     provider 'vertex' also needs VERTEX_PROJECT_ID" ;;
+        azure)   [ -z "$(env_value AZURE_OPENAI_ENDPOINT "$ENV_FILE")" ] && \
+          warn ".env     provider 'azure' also needs AZURE_OPENAI_ENDPOINT" ;;
+      esac
+    else
+      warn ".env     CLERUM_MODEL_PROVIDER='$PROVIDER' is not a known provider (see docs/deploy/llm-providers.md)"
+    fi
+  fi
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────
+echo
+if [ "$MISSING" -eq 0 ]; then
+  echo -e "${GREEN}${BOLD}All required prerequisites satisfied.${NC} Next: ${BOLD}make minikube-setup${NC}"
+  exit 0
+else
+  echo -e "${RED}${BOLD}${MISSING} required prerequisite(s) missing.${NC} Install the item(s) above, then re-run ${BOLD}make prereqs${NC}."
+  echo    "Full walkthrough: docs/get-started/minikube.md"
+  exit 1
+fi

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -163,7 +163,10 @@ if command -v docker >/dev/null 2>&1; then
     MEM_BYTES="$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)"
     CPUS="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo 0)"
     if [ "${MEM_BYTES:-0}" -gt 0 ]; then
-      MEM_GB=$((MEM_BYTES / 1024 / 1024 / 1024))
+      # Round to the nearest GB (+0.5 GB before the integer divide): docker's
+      # MemTotal sits a little below physical RAM, so a 10 GB allocation reports
+      # ~9.7 GB and would truncate to 9 → a spurious "wants >= 10 GB" warning.
+      MEM_GB=$(((MEM_BYTES + 512 * 1024 * 1024) / (1024 * 1024 * 1024)))
       if [ "$MEM_GB" -lt 10 ]; then
         warn "docker has ~${MEM_GB} GB RAM allocated (setup wants >= 10 GB — raise it in Docker Desktop → Settings → Resources)"
       else
@@ -195,8 +198,9 @@ fi
 # Parse the specific keys instead of sourcing .env (never execute it).
 env_value() {
   # Last non-comment assignment wins; strips surrounding quotes/whitespace.
+  # Tolerates an optional leading `export ` (a common .env habit).
   local key="$1" file="$2" raw
-  raw="$(grep -E "^[[:space:]]*${key}=" "$file" 2>/dev/null | tail -n1)" || return 0
+  raw="$(grep -E "^[[:space:]]*(export[[:space:]]+)?${key}=" "$file" 2>/dev/null | tail -n1)" || return 0
   raw="${raw#*=}"
   raw="${raw%\"}"; raw="${raw#\"}"
   raw="${raw%\'}"; raw="${raw#\'}"

--- a/scripts/minikube/apply-llm-secret.sh
+++ b/scripts/minikube/apply-llm-secret.sh
@@ -51,6 +51,10 @@ if [ -z "$ENV_FILE" ]; then
   if [ -z "$ENV_FILE" ] && [ -f .env ]; then ENV_FILE=".env"; fi
 fi
 if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  # Sourced by design (unlike check-prereqs.sh, which grep-parses .env): the
+  # per-provider `${!env_name}` indirect expansion below needs the real values
+  # in the environment. This mirrors the original inline Makefile behavior. A
+  # normal KEY=value .env is safe; a malformed line could abort under set -e.
   set -a; . "$ENV_FILE"; set +a
 fi
 

--- a/scripts/minikube/apply-llm-secret.sh
+++ b/scripts/minikube/apply-llm-secret.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# ======================================================================
+# Apply the chatllm-api-keys LLM Secret (all 21 providers)
+# ======================================================================
+#
+# Builds the `chatllm-api-keys` Secret (namespace: mcp-host) from whatever
+# LLM keys are present in .env, across ALL providers in the registry
+# (packages/llm-providers/index.cjs → PROVIDER_CREDENTIAL_SLOTS), not just
+# the four original ones. mcp-host reads only the slot(s) for the selected
+# CLERUM_MODEL_PROVIDER, so extra keys are harmless; the point is that
+# setting e.g. GROQ_API_KEY or MISTRAL_API_KEY in .env now actually reaches
+# the cluster.
+#
+# Backward compatible: the four original providers (openai/claude/zai/
+# bailian) keep their test-placeholder fallbacks so an empty .env (CI, first
+# boot) still stands up the default `zai` agent. Real values override the
+# placeholders; the other 17 providers appear only when their key is set.
+#
+# The Secret stores keys in the registry `dataKey` form (lowercase-hyphen,
+# e.g. `openai-api-key`), which is what mcp-host's LLM-secret watch expects.
+#
+# Usage:
+#   CONTEXT=clerum-test ./scripts/minikube/apply-llm-secret.sh
+#
+# Env:
+#   CONTEXT   kubectl context / minikube profile (default: clerum-test)
+# ======================================================================
+
+set -euo pipefail
+
+CONTEXT="${CONTEXT:-clerum-test}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_DIR"
+
+# ── Resolve .env — read the MAIN checkout's .env when run from a worktree ──
+# LLM_SECRET_ENV_FILE overrides resolution entirely (used by tests so they never
+# touch the working-tree .env).
+ENV_FILE="${LLM_SECRET_ENV_FILE:-}"
+if [ -z "$ENV_FILE" ]; then
+  GIT_COMMON_DIR="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+  if [ -n "$GIT_COMMON_DIR" ]; then
+    case "$GIT_COMMON_DIR" in
+      /*) GIT_COMMON_ABS="$GIT_COMMON_DIR" ;;
+      *)  GIT_COMMON_ABS="$(cd "$GIT_COMMON_DIR" && pwd)" ;;
+    esac
+    MAIN_REPO_DIR="$(cd "$GIT_COMMON_ABS/.." && pwd)"
+    if [ -f "$MAIN_REPO_DIR/.env" ]; then ENV_FILE="$MAIN_REPO_DIR/.env"; fi
+  fi
+  if [ -z "$ENV_FILE" ] && [ -f .env ]; then ENV_FILE=".env"; fi
+fi
+if [ -n "$ENV_FILE" ] && [ -f "$ENV_FILE" ]; then
+  set -a; . "$ENV_FILE"; set +a
+fi
+
+# ── Provider credential slots ─────────────────────────────────────────
+# One row per credential slot, mirrored from PROVIDER_CREDENTIAL_SLOTS in
+# packages/llm-providers/index.cjs. Format: "<dataKey>|<ENV_NAME>|<placeholder>"
+# Only the four original providers carry a placeholder (empty-.env fallback);
+# every other slot is emitted ONLY when its env var is set. Keep in sync with
+# the registry when providers/slots are added.
+SLOTS=(
+  "openai-api-key|OPENAI_API_KEY|sk-test-placeholder-openai-key-00000000000000000000"
+  "claude-api-key|CLAUDE_API_KEY|sk-ant-api03-test-placeholder-claude-key-000000000000000000000000000000000000000000000000000000"
+  "zai-api-key|ZAI_API_KEY|zai-test-placeholder-zai-key-00000000000000000000"
+  "bailian-api-key|BAILIAN_API_KEY|sk-test-placeholder-bailian-key-00000000000000000000"
+  "vertex-service-account-json|VERTEX_SERVICE_ACCOUNT_JSON|"
+  "aws-access-key-id|AWS_ACCESS_KEY_ID|"
+  "aws-secret-access-key|AWS_SECRET_ACCESS_KEY|"
+  "openrouter-api-key|OPENROUTER_API_KEY|"
+  "gemini-api-key|GEMINI_API_KEY|"
+  "deepseek-api-key|DEEPSEEK_API_KEY|"
+  "groq-api-key|GROQ_API_KEY|"
+  "together-api-key|TOGETHER_API_KEY|"
+  "fireworks-api-key|FIREWORKS_API_KEY|"
+  "mistral-api-key|MISTRAL_API_KEY|"
+  "xai-api-key|XAI_API_KEY|"
+  "cerebras-api-key|CEREBRAS_API_KEY|"
+  "deepinfra-api-key|DEEPINFRA_API_KEY|"
+  "perplexity-api-key|PERPLEXITY_API_KEY|"
+  "moonshot-api-key|MOONSHOT_API_KEY|"
+  "nebius-api-key|NEBIUS_API_KEY|"
+  "novita-api-key|NOVITA_API_KEY|"
+  "azure-openai-api-key|AZURE_OPENAI_API_KEY|"
+)
+
+# ── Build kubectl args; each dataKey is emitted at most once (no dup keys) ──
+ARGS=()
+REAL_KEYS=()
+for slot in "${SLOTS[@]}"; do
+  data_key="${slot%%|*}"
+  rest="${slot#*|}"
+  env_name="${rest%%|*}"
+  placeholder="${rest#*|}"
+  # Indirect expansion (bash 3.2-safe): value of the env var named $env_name.
+  value="${!env_name:-}"
+  if [ -n "$value" ]; then
+    ARGS+=( "--from-literal=${data_key}=${value}" )
+    REAL_KEYS+=( "$env_name" )
+  elif [ -n "$placeholder" ]; then
+    ARGS+=( "--from-literal=${data_key}=${placeholder}" )
+  fi
+done
+
+kubectl --context="$CONTEXT" create secret generic chatllm-api-keys \
+  --namespace=mcp-host \
+  "${ARGS[@]}" \
+  --dry-run=client -o yaml | kubectl --context="$CONTEXT" apply -f -
+
+if [ "${#REAL_KEYS[@]}" -gt 0 ]; then
+  echo "  LLM API keys applied — real keys from .env: ${REAL_KEYS[*]} (provider: ${CLERUM_MODEL_PROVIDER:-zai})"
+else
+  echo "  LLM API keys applied — no keys in .env; using test placeholders (provider: ${CLERUM_MODEL_PROVIDER:-zai})"
+fi


### PR DESCRIPTION
## What

Adds an up-front prerequisite check for the minikube quick-start and generalizes the LLM-key plumbing to all 21 supported providers.

### `make prereqs` (alias `make doctor`)
- New `scripts/check-prereqs.sh` verifies **every** dependency `make minikube-setup` needs — Docker (installed + daemon reachable + ≥10 GB RAM / ≥6 CPUs), minikube (≥1.30), kubectl, node (≥24), python3, ruby, git, make — **before** any cluster work, with per-platform install commands and no-sudo `curl` installers for kubectl/minikube.
- Validates `.env`: `ADMIN_PASSWORD` (fatal) and at least one LLM key across all 21 providers (warning — setup boots with placeholders), plus provider/key consistency hints.
- `make minikube-setup` now runs `prereqs` first (bypass with `SKIP_PREREQS=true`), so a missing dep fails fast instead of mid-flight.

### All 21 LLM providers in the minikube secret
- Extracts the inline `chatllm-api-keys` block from `minikube-apply-secrets` into `scripts/minikube/apply-llm-secret.sh`, mirrored from the registry (`packages/llm-providers/index.cjs`) (the slot list is hand-kept in sync with it, guarded by a comment). Setting e.g. `GROQ_API_KEY` / `MISTRAL_API_KEY` in `.env` now actually reaches the cluster — previously only the original 4 (openai/claude/zai/bailian) were wired.
- The original 4 keep their placeholder fallbacks, so an empty `.env` still boots the default `zai` agent; each dataKey is emitted once. `LLM_SECRET_ENV_FILE` allows testing without touching a live `.env`.

### Docs reconciled with the checker
- `get-started/quickstart.md`, `deploy/minikube.md`: add the missing `git` / `make` / `ruby` prerequisites.
- `quickstart.md`: "4 providers" → any of the 21 supported, marked optional (placeholders).
- `deploy/minikube.md`: add the ≥10 GB / 6 CPU spec + a `make prereqs` tip.
- `get-started/minikube.md`: add a `make prereqs` / `SKIP_PREREQS` tip.

## Testing
- `check-prereqs.sh` verified against fixtures: no-LLM-key → WARN (exit 0), missing `ADMIN_PASSWORD` → fatal (exit 1), all-set → OK.
- `apply-llm-secret.sh` verified via a stubbed `kubectl`: empty `.env` → 4 placeholders only, real keys override + extra providers added, bedrock's two slots both plumbed, no duplicate keys.
- `minikube-setup` gating verified via `make -n`: `prereqs` runs before `full-setup.sh`; `SKIP_PREREQS=true` bypasses; a failing check aborts before setup.
- No CI regression: no workflow invokes `minikube-setup`, and the `test-minikube-full-setup.sh` REUSE_DB assertion greps an unrelated line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
