### PR TITLE
feat(release): release versioning spine

### DIFF
--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -311,6 +311,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
 
       - name: Run bash -n on all .sh files
         run: |
@@ -338,6 +340,18 @@ jobs:
 
       - name: Test minikube detect-k8s-api-ip template rendering
         run: bash scripts/tests/test-minikube-detect-k8s-api-ip.sh
+
+      - name: Test release coordinates (writer, checker, floor decoupling)
+        run: bash scripts/tests/test-release-coordinates.sh
+
+      - name: Test precommit release-manifest exemption
+        run: bash scripts/tests/test-precommit-release-manifest-ignore.sh
+
+      - name: Validate release manifest matches package versions
+        run: node scripts/release/update-desktop-release-manifest.mjs --validate-only
+
+      - name: Validate service version bumps
+        run: node scripts/release/validate-release-version-bumps.mjs --previous "${{ github.event.pull_request.base.sha || github.event.before }}"
 
   # ─── Platform NGINX image guard (CVE baseline) ────────────────────────────
   nginx-image-guard:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ Thanks for your interest! evenfire is **open source** under the
 [Mozilla Public License 2.0](LICENSE) (MPL-2.0) and requires a signed CLA.
 
 ## Dev loop (per service)
+
 Each service is a standalone Node/TypeScript package:
+
 ```bash
 cd <service>            # e.g. mcp-host, channel-reader, control-api
 npm install
@@ -12,23 +14,48 @@ npm run build
 npm test
 npx tsc --noEmit
 ```
+
 Many services run without Kubernetes via `CLERUM_DEV_MODE=true` (see each
 service README and the root README quickstart).
 
 ## Tests are required
+
 PRs must include tests for new behavior and keep `npm test` + `npx tsc --noEmit`
 green for every changed service. PRs without tests may be closed.
 
+## The pre-commit hook may edit your commit
+
+`core.hooksPath` is `.githooks`, so committing runs `npm run version:staged`
+then `npm run format:staged`. Two behaviours surprise people:
+
+- **Your commit can gain files you did not stage.** Changing source under
+  `external-rest-api/` or `rpc-proxy/` bumps that package's `package.json`
+  patch version, and because `external-rest-api/src/releaseManifest.ts`
+  declares those versions, the manifest is regenerated and staged to match.
+  That is intended: CI rejects a manifest that disagrees with the packages.
+  `desktop-app` is deliberately exempt — its version is the release version,
+  set only by `scripts/release/prepare-release.mjs`.
+- **A commit can be refused while `releaseManifest.ts` has unstaged changes**,
+  even if your commit is unrelated to it. The hook will not regenerate a file
+  you are mid-edit on. Stage or discard that file and commit again.
+
+Every refusal names the file and the fix. If you need to bypass the hook to
+get unstuck, say so in the PR rather than leaving it silent. The two release
+validators run in CI and will catch what the hook would have.
+
 ## What we accept
+
 - Bug fixes and improvements to the platform services and core CRDs.
 - New first-class capabilities — please open an issue to discuss first.
 
 ## What we do NOT accept as PRs
+
 - New third-party MCP servers or WorkflowRecipes. Publish these to the registry
   (see docs) — they are not merged into this repo. This keeps the core lean and
   maintainable (the same model LangChain and n8n use).
 
 ## CLA
+
 This project requires a signed Contributor License Agreement. The CLA-assistant
 bot will prompt you on your first PR. Contributions may be used in the project's
 commercial / managed editions.

--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evenfire",
-  "version": "0.1.333",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evenfire",
-      "version": "0.1.333",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@clerum/desktop-app-links": "file:../packages/desktop-app-links",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evenfire",
   "productName": "Evenfire",
-  "version": "0.1.333",
+  "version": "0.5.0",
   "private": true,
   "license": "MPL-2.0",
   "description": "Evenfire desktop client for secure agent and workflow access",

--- a/external-rest-api/package-lock.json
+++ b/external-rest-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-external-rest-api",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-external-rest-api",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/external-rest-api/package.json
+++ b/external-rest-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-external-rest-api",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "External REST API for profile, team management, and RPC token brokerage",
   "main": "dist/main.js",
   "engines": {

--- a/external-rest-api/src/config.ts
+++ b/external-rest-api/src/config.ts
@@ -124,7 +124,7 @@ export const config: Config = {
   desktopAppName: process.env.EXTERNAL_REST_API_DESKTOP_APP_NAME || 'Evenfire',
   desktopReleaseBaseUrl: (
     process.env.EXTERNAL_REST_API_DESKTOP_RELEASE_BASE_URL ||
-    'https://github.com/your-org/evenfire/releases'
+    'https://github.com/evenfire-ai/evenfire/releases'
   ).replace(/\/+$/, ''),
 }
 

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -7,9 +7,9 @@ export type ReleaseManifest = {
 }
 
 export const releaseManifest: ReleaseManifest = {
-  releaseId: 'master-440d8e0',
+  releaseId: 'dev-fe20a73f',
   externalRestApiVersion: '0.1.60',
   rpcProxyVersion: '0.1.51',
-  desktopVersion: '0.1.252',
+  desktopVersion: '0.5.0',
   minimumDesktopVersion: '0.1.252',
 }

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -8,7 +8,7 @@ export type ReleaseManifest = {
 
 export const releaseManifest: ReleaseManifest = {
   releaseId: 'dev-fe20a73f',
-  externalRestApiVersion: '0.1.60',
+  externalRestApiVersion: '0.1.61',
   rpcProxyVersion: '0.1.51',
   desktopVersion: '0.5.0',
   minimumDesktopVersion: '0.1.252',

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -8,8 +8,8 @@ export type ReleaseManifest = {
 
 export const releaseManifest: ReleaseManifest = {
   releaseId: 'master-440d8e0',
-  externalRestApiVersion: '0.1.56',
-  rpcProxyVersion: '0.1.36',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
   desktopVersion: '0.1.252',
   minimumDesktopVersion: '0.1.252',
 }

--- a/external-rest-api/src/routes/desktop.ts
+++ b/external-rest-api/src/routes/desktop.ts
@@ -17,7 +17,9 @@ export function createDesktopRouter(): Router {
   })
 
   router.get('/desktop/release', requireAuth, (_req, res) => {
-    const tag = `desktop-app-${releaseManifest.desktopVersion}`
+    // Real tags are v0.1.0 … v0.5.0. The old desktop-app-<version> shape has
+    // never existed, so every update prompt linked to a 404.
+    const tag = `v${releaseManifest.desktopVersion}`
     res.status(200).json({
       releaseId: releaseManifest.releaseId,
       externalRestApiVersion: releaseManifest.externalRestApiVersion,

--- a/external-rest-api/test/routes.desktop.test.ts
+++ b/external-rest-api/test/routes.desktop.test.ts
@@ -88,8 +88,14 @@ describe('routes/desktop', () => {
       rpcProxyVersion: releaseManifest.rpcProxyVersion,
       desktopVersion: releaseManifest.desktopVersion,
       minimumDesktopVersion: releaseManifest.minimumDesktopVersion,
-      releaseTag: `desktop-app-${releaseManifest.desktopVersion}`,
-      releaseUrl: `https://github.com/example/evenfire/releases/tag/desktop-app-${releaseManifest.desktopVersion}`,
+      releaseTag: `v${releaseManifest.desktopVersion}`,
+      releaseUrl: `https://github.com/example/evenfire/releases/tag/v${releaseManifest.desktopVersion}`,
     })
+  })
+
+  it('defaults the release base URL to the real repository', async () => {
+    delete process.env.EXTERNAL_REST_API_DESKTOP_RELEASE_BASE_URL
+    const { config } = await import('../src/config.js')
+    expect(config.desktopReleaseBaseUrl).toBe('https://github.com/evenfire-ai/evenfire/releases')
   })
 })

--- a/scripts/precommit/bump-staged-package-versions.mjs
+++ b/scripts/precommit/bump-staged-package-versions.mjs
@@ -122,7 +122,10 @@ function readIndexedPackageVersion(pkg) {
   }
 }
 
-const stagedFilesResult = run('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'])
+// D is included deliberately: a commit whose only change is a deletion still
+// changes the package's content, and omitting it let two different trees
+// report the same version with nothing at release time able to notice.
+const stagedFilesResult = run('git', ['diff', '--cached', '--name-only', '--diff-filter=ACDMR'])
 
 if (stagedFilesResult.status !== 0) {
   exitWithError(

--- a/scripts/precommit/bump-staged-package-versions.mjs
+++ b/scripts/precommit/bump-staged-package-versions.mjs
@@ -9,6 +9,27 @@ import { packageRoots } from '../prettier/paths.mjs'
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const sortedPackageRoots = [...packageRoots].sort((a, b) => b.length - a.length)
 
+// Files that live inside a package root but must never trigger its counter.
+// releaseManifest.ts declares the versions this script would bump. A later
+// task adds scripts/release/prepare-release.mjs as the writer of this file;
+// bumping external-rest-api in reaction to that write would make the
+// manifest stale the instant it is produced. validate-release-version-bumps.mjs
+// carries the identical exemption in its ignoredFiles.
+const IGNORED_FILES = ['external-rest-api/src/releaseManifest.ts']
+
+// Packages whose version releaseManifest.ts declares, and the manifest field
+// each maps to. Bumping one of these without updating the manifest makes
+// --validate-only throw on the next CI run, which would redden every PR
+// touching these services. desktop-app is deliberately absent: it is not in
+// packageRoots (this hook never bumps it), and desktopVersion is synced by a
+// separate desktop release flow, not by this pre-commit hook.
+const MANIFEST_PATH = 'external-rest-api/src/releaseManifest.ts'
+const MANIFEST_FIELD_BY_PACKAGE = {
+  'external-rest-api': 'externalRestApiVersion',
+  'rpc-proxy': 'rpcProxyVersion',
+}
+const MANIFEST_COUNTER_PACKAGES = Object.keys(MANIFEST_FIELD_BY_PACKAGE)
+
 function exitWithError(message, status = 1) {
   console.error(message)
   process.exit(status)
@@ -78,6 +99,34 @@ function bumpPatchVersion(version) {
   return `${major}.${minor}.${Number(patch) + 1}${prerelease}${build}`
 }
 
+function readManifestField(source, field) {
+  const match = source.match(new RegExp(`\\n {2}${field}: '([^']*)'`))
+  return match ? match[1] : null
+}
+
+// Reads a counter package's version out of the INDEX (git's staged content),
+// not the working tree. Only what's staged is what a commit actually records;
+// a disk read here would let an unstaged, never-to-be-committed edit decide
+// whether the manifest gets re-synced, and what value it gets re-synced to.
+function readIndexedPackageVersion(pkg) {
+  const packageJsonPath = `${pkg}/package.json`
+  const result = run('git', ['show', `:${packageJsonPath}`])
+
+  if (result.status !== 0) {
+    return null
+  }
+
+  try {
+    return JSON.parse(result.stdout).version ?? null
+  } catch (error) {
+    exitWithError(
+      `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) could not parse ` +
+        `the staged ${packageJsonPath} to check whether ${MANIFEST_PATH} needs re-syncing: ${error.message}\n` +
+        `Fix ${packageJsonPath} (e.g. resolve merge conflict markers) and re-stage it, then retry the commit.`
+    )
+  }
+}
+
 const stagedFilesResult = run('git', ['diff', '--cached', '--name-only', '--diff-filter=ACMR'])
 
 if (stagedFilesResult.status !== 0) {
@@ -93,6 +142,7 @@ const affectedPackages = [
       .split(/\r?\n/)
       .map(file => file.trim())
       .filter(Boolean)
+      .filter(file => !IGNORED_FILES.includes(file))
       .map(getPackageRootForFile)
       .filter(Boolean)
   ),
@@ -163,4 +213,123 @@ for (const packageRoot of affectedPackages) {
   }
 
   console.log(`${packageJsonPath}: ${headPackage.version} -> ${currentPackage.version}`)
+}
+
+// Re-sync the manifest whenever a counter it declares has drifted from the
+// package.json it tracks -- not only when this run performed the bump. A
+// bump that lands in one pre-commit invocation and a re-sync that then fails
+// (bad manifest, missing floor, ...) must still converge on a retry. Keying
+// this off "does the manifest currently disagree with disk" rather than off
+// which packages this run happened to bump makes the retry path self-healing
+// instead of a bump that permanently disarms its own re-sync: on retry the
+// bumped package.json no longer equals HEAD, so the bump loop above skips it
+// via the currentPackage.version !== headPackage.version check, and a
+// bumpedPackages-style flag would stay empty forever.
+const manifestAbsolutePath = join(repoRoot, MANIFEST_PATH)
+const relevantCounterPackages = MANIFEST_COUNTER_PACKAGES.filter(pkg =>
+  existsSync(join(repoRoot, `${pkg}/package.json`))
+)
+
+if (relevantCounterPackages.length > 0) {
+  // Checked BEFORE the manifest is read for drift purposes, not just before
+  // the re-sync runs. The manifest read below feeds the "is anything out of
+  // sync" decision itself (it reads the working tree, same as the file this
+  // guard inspects); a dirty manifest that happens to already read as
+  // in-sync would make outOfSyncPackages empty and skip the refusal
+  // entirely if it lived inside that branch, silently committing a
+  // package.json bump alongside a manifest that was never staged to match
+  // it. Moving the check up here means a dirty manifest can never influence
+  // the decision -- it always blocks first.
+  if (hasUnstagedChanges(MANIFEST_PATH)) {
+    exitWithError(
+      `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) is refusing to ` +
+        `auto-sync ${MANIFEST_PATH} because it has unstaged changes. Stage or discard them first.`
+    )
+  }
+
+  let manifestSource
+
+  try {
+    manifestSource = readFileSync(manifestAbsolutePath, 'utf8')
+  } catch (error) {
+    exitWithError(
+      `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) could not read ` +
+        `${MANIFEST_PATH} to check whether it needs re-syncing after a version bump: ${error.message}\n` +
+        `Restore the file (e.g. \`git checkout HEAD -- ${MANIFEST_PATH}\`) or regenerate it with ` +
+        `\`node scripts/release/update-desktop-release-manifest.mjs\`, then retry the commit.`
+    )
+  }
+
+  const outOfSyncPackages = relevantCounterPackages.filter(pkg => {
+    const currentVersion = readIndexedPackageVersion(pkg)
+    const manifestVersion = readManifestField(manifestSource, MANIFEST_FIELD_BY_PACKAGE[pkg])
+    return currentVersion && currentVersion !== manifestVersion
+  })
+
+  if (outOfSyncPackages.length > 0) {
+    // The updater re-reads every counter package's package.json from disk on
+    // each invocation, not just the one that triggered this re-sync (absent
+    // --previous it always treats every counter field as changed). An
+    // unrelated unstaged edit anywhere in MANIFEST_COUNTER_PACKAGES would
+    // therefore leak an uncommitted version into the manifest we are about
+    // to stage, even though it correctly did not trigger this re-sync itself.
+    for (const pkg of relevantCounterPackages) {
+      const trackedPackageJsonPath = `${pkg}/package.json`
+      if (hasUnstagedChanges(trackedPackageJsonPath)) {
+        exitWithError(
+          `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) is refusing to ` +
+            `re-sync ${MANIFEST_PATH} because ${trackedPackageJsonPath} has unstaged changes. The ` +
+            `updater reads every counter package.json from disk, so an unrelated unstaged edit would ` +
+            `leak an uncommitted version into the manifest. Stage or discard them first.`
+        )
+      }
+    }
+
+    // The updater defaults releaseId to the literal 'local' when --release-id
+    // is absent, which would ship in a customer-facing manifest. Carry the
+    // existing value through instead of fabricating one: a counter bump is
+    // not a release.
+    const releaseId = readManifestField(manifestSource, 'releaseId')
+
+    if (!releaseId) {
+      exitWithError(
+        `Could not read a releaseId out of ${MANIFEST_PATH} to preserve during the pre-commit ` +
+          `re-sync. Refusing to fabricate one -- the updater defaults to 'local' when --release-id ` +
+          `is omitted, and that must never land in a customer-facing manifest. Fix the releaseId ` +
+          `field in ${MANIFEST_PATH} and retry the commit.`
+      )
+    }
+
+    const resync = run('node', [
+      'scripts/release/update-desktop-release-manifest.mjs',
+      '--release-id',
+      releaseId,
+      // This re-sync only ever moves the external-rest-api/rpc-proxy
+      // counters, never a desktop release. Without --defer-desktop-release
+      // the updater also copies desktop-app/package.json's version into
+      // desktopVersion, which would publish an unreleased desktop build to
+      // every client polling the manifest off the back of an ordinary
+      // service PR. The "never use this flag" rule is narrower than it
+      // sounds: it forbids using the flag to silence a --validate-only
+      // failure, not this re-sync, where leaving desktopVersion untouched is
+      // the entire point -- a counter bump is not a desktop release.
+      '--defer-desktop-release',
+    ])
+
+    if (resync.status !== 0) {
+      const detail = (resync.stderr || '').trim()
+      exitWithError(
+        `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) could not ` +
+          `re-sync ${MANIFEST_PATH} via scripts/release/update-desktop-release-manifest.mjs after ` +
+          `${outOfSyncPackages.join(', ')} moved. Resolve the issue below, then either fix ` +
+          `${MANIFEST_PATH} directly or run the updater manually with the flags it needs (e.g. ` +
+          `--minimum-desktop-version) and \`git add ${MANIFEST_PATH}\` before retrying the commit.` +
+          (detail ? `\n\nUnderlying error:\n${detail}` : ''),
+        resync.status
+      )
+    }
+
+    stageFile(MANIFEST_PATH)
+    console.log(`${MANIFEST_PATH}: re-synced after ${outOfSyncPackages.join(', ')}`)
+  }
 }

--- a/scripts/precommit/bump-staged-package-versions.mjs
+++ b/scripts/precommit/bump-staged-package-versions.mjs
@@ -5,7 +5,6 @@ import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { packageRoots } from '../prettier/paths.mjs'
-import { parseManifest } from '../release/release-coordinates.mjs'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const sortedPackageRoots = [...packageRoots].sort((a, b) => b.length - a.length)
@@ -253,6 +252,23 @@ if (relevantCounterPackages.length > 0) {
         `${MANIFEST_PATH} to check whether it needs re-syncing after a version bump: ${error.message}\n` +
         `Restore the file (e.g. \`git checkout HEAD -- ${MANIFEST_PATH}\`) or regenerate it with ` +
         `\`node scripts/release/update-desktop-release-manifest.mjs\`, then retry the commit.`
+    )
+  }
+
+  // Loaded lazily rather than imported at the top. A static import makes the
+  // hook fail at MODULE-LOAD time in any tree that has scripts/precommit but
+  // not scripts/release (a sparse checkout, a partial clone), which blocks
+  // every commit with a raw ESM stack trace before any of the messaging below
+  // can run. The re-sync is the only thing that needs it.
+  let parseManifest
+  try {
+    ;({ parseManifest } = await import('../release/release-coordinates.mjs'))
+  } catch (error) {
+    exitWithError(
+      `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) needs ` +
+        `scripts/release/release-coordinates.mjs to keep ${MANIFEST_PATH} in sync after a ` +
+        `version bump, and could not load it: ${error.message}\n` +
+        `If this is a sparse or partial checkout, include scripts/release/ in it.`
     )
   }
 

--- a/scripts/precommit/bump-staged-package-versions.mjs
+++ b/scripts/precommit/bump-staged-package-versions.mjs
@@ -11,8 +11,8 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const sortedPackageRoots = [...packageRoots].sort((a, b) => b.length - a.length)
 
 // Files that live inside a package root but must never trigger its counter.
-// releaseManifest.ts declares the versions this script would bump. A later
-// task adds scripts/release/prepare-release.mjs as the writer of this file;
+// releaseManifest.ts declares the versions this script would bump.
+// scripts/release/prepare-release.mjs writes that file at release time;
 // bumping external-rest-api in reaction to that write would make the
 // manifest stale the instant it is produced. validate-release-version-bumps.mjs
 // carries the identical exemption in its ignoredFiles.

--- a/scripts/precommit/bump-staged-package-versions.mjs
+++ b/scripts/precommit/bump-staged-package-versions.mjs
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { packageRoots } from '../prettier/paths.mjs'
+import { parseManifest } from '../release/release-coordinates.mjs'
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
 const sortedPackageRoots = [...packageRoots].sort((a, b) => b.length - a.length)
@@ -97,11 +98,6 @@ function bumpPatchVersion(version) {
 
   const [, major, minor, patch, prerelease = '', build = ''] = match
   return `${major}.${minor}.${Number(patch) + 1}${prerelease}${build}`
-}
-
-function readManifestField(source, field) {
-  const match = source.match(new RegExp(`\\n {2}${field}: '([^']*)'`))
-  return match ? match[1] : null
 }
 
 // Reads a counter package's version out of the INDEX (git's staged content),
@@ -260,9 +256,22 @@ if (relevantCounterPackages.length > 0) {
     )
   }
 
+  let manifest
+
+  try {
+    manifest = parseManifest(manifestSource)
+  } catch (error) {
+    exitWithError(
+      `The pre-commit hook (scripts/precommit/bump-staged-package-versions.mjs) could not parse ` +
+        `${MANIFEST_PATH} to check whether it needs re-syncing after a version bump: ${error.message}\n` +
+        `Restore the file (e.g. \`git checkout HEAD -- ${MANIFEST_PATH}\`) or regenerate it with ` +
+        `\`node scripts/release/update-desktop-release-manifest.mjs\`, then retry the commit.`
+    )
+  }
+
   const outOfSyncPackages = relevantCounterPackages.filter(pkg => {
     const currentVersion = readIndexedPackageVersion(pkg)
-    const manifestVersion = readManifestField(manifestSource, MANIFEST_FIELD_BY_PACKAGE[pkg])
+    const manifestVersion = manifest ? manifest[MANIFEST_FIELD_BY_PACKAGE[pkg]] : undefined
     return currentVersion && currentVersion !== manifestVersion
   })
 
@@ -289,7 +298,7 @@ if (relevantCounterPackages.length > 0) {
     // is absent, which would ship in a customer-facing manifest. Carry the
     // existing value through instead of fabricating one: a counter bump is
     // not a release.
-    const releaseId = readManifestField(manifestSource, 'releaseId')
+    const releaseId = manifest ? manifest.releaseId : undefined
 
     if (!releaseId) {
       exitWithError(

--- a/scripts/prettier/paths.mjs
+++ b/scripts/prettier/paths.mjs
@@ -21,7 +21,6 @@ export const packageRoots = [
   'channel-reader',
   'control-api',
   'control-ui',
-  'desktop-app',
   'external-rest-api',
   'host-context-controller',
   'mcp-host',

--- a/scripts/release/prepare-release.mjs
+++ b/scripts/release/prepare-release.mjs
@@ -5,11 +5,29 @@
 //
 //   node scripts/release/prepare-release.mjs --version 0.6.0 --release-id <id> \
 //        [--minimum-desktop-version 0.6.0]
-import { execFileSync } from 'node:child_process'
+import { execFileSync, execFileSync as run } from 'node:child_process'
 import process from 'node:process'
 import { COORDINATES, SEMVER_RE, argValue, compareVersions } from './release-coordinates.mjs'
 
 const ROOT = process.cwd()
+
+// The monotonic guard below must compare against the last COMMITTED desktop
+// version, not the working file. A cut that failed after writing package.json
+// leaves the new version on disk; comparing against that makes re-running the
+// very command this script and validate-release-tag.mjs tell you to run fail
+// with "not greater than", which is a dead end.
+function committedDesktopVersion() {
+  try {
+    const raw = run('git', ['show', 'HEAD:desktop-app/package.json'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return JSON.parse(raw).version
+  } catch {
+    return null
+  }
+}
 
 function die(message) {
   console.error(message)
@@ -35,7 +53,18 @@ if (minimumDesktopVersion && !SEMVER_RE.test(minimumDesktopVersion)) {
   die(`--minimum-desktop-version must be MAJOR.MINOR.PATCH, got: ${minimumDesktopVersion}`)
 }
 
-const current = COORDINATES.find(c => c.name === 'desktop-app/package.json').read(ROOT)
+// Range-check the floor BEFORE writing anything. The delegated updater rejects
+// a floor above desktopVersion, and discovering that after the coordinate loop
+// has already written package.json leaves the tree half-cut.
+if (minimumDesktopVersion && compareVersions(minimumDesktopVersion, version) > 0) {
+  die(
+    `--minimum-desktop-version ${minimumDesktopVersion} is greater than --version ${version}. ` +
+      `The floor is a compatibility minimum; it can never exceed the release itself.`
+  )
+}
+
+const onDisk = COORDINATES.find(c => c.name === 'desktop-app/package.json').read(ROOT)
+const current = committedDesktopVersion() ?? onDisk
 if (compareVersions(version, current) <= 0) {
   die(`--version ${version} is not greater than the current desktop version ${current}`)
 }
@@ -53,6 +82,18 @@ const manifestArgs = [
 if (minimumDesktopVersion) {
   manifestArgs.push('--minimum-desktop-version', minimumDesktopVersion)
 }
-execFileSync('node', manifestArgs, { cwd: ROOT, stdio: 'inherit' })
+try {
+  execFileSync('node', manifestArgs, { cwd: ROOT, stdio: 'inherit' })
+} catch (error) {
+  // The coordinate loop above has already written package.json and the lockfile.
+  // Say so, rather than leaving a raw stack trace and a half-written tree.
+  die(
+    `The release cut wrote desktop-app/package.json and package-lock.json to ${version}, ` +
+      `then the manifest update failed (${error.message}).\n` +
+      `The tree is half-cut. Either re-run this same command once the cause is fixed ` +
+      `(it compares against the last committed version, so re-running is safe), ` +
+      `or discard with \`git checkout -- desktop-app/package.json desktop-app/package-lock.json\`.`
+  )
+}
 
 console.log(`prepared release ${version}`)

--- a/scripts/release/prepare-release.mjs
+++ b/scripts/release/prepare-release.mjs
@@ -7,14 +7,9 @@
 //        [--minimum-desktop-version 0.6.0]
 import { execFileSync } from 'node:child_process'
 import process from 'node:process'
-import { COORDINATES, SEMVER_RE, compareVersions } from './release-coordinates.mjs'
+import { COORDINATES, SEMVER_RE, argValue, compareVersions } from './release-coordinates.mjs'
 
 const ROOT = process.cwd()
-
-function argValue(name) {
-  const i = process.argv.indexOf(name)
-  return i >= 0 ? process.argv[i + 1] : ''
-}
 
 function die(message) {
   console.error(message)

--- a/scripts/release/prepare-release.mjs
+++ b/scripts/release/prepare-release.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// The one release-cut writer. Writes every coordinate in the table, then
+// delegates the manifest to update-desktop-release-manifest.mjs rather than
+// duplicating its renderer.
+//
+//   node scripts/release/prepare-release.mjs --version 0.6.0 --release-id <id> \
+//        [--minimum-desktop-version 0.6.0]
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+import { COORDINATES, SEMVER_RE, compareVersions } from './release-coordinates.mjs'
+
+const ROOT = process.cwd()
+
+function argValue(name) {
+  const i = process.argv.indexOf(name)
+  return i >= 0 ? process.argv[i + 1] : ''
+}
+
+function die(message) {
+  console.error(message)
+  process.exit(1)
+}
+
+const version = argValue('--version')
+const releaseId = argValue('--release-id')
+const minimumDesktopVersion = argValue('--minimum-desktop-version')
+
+if (!SEMVER_RE.test(version)) {
+  die(`--version must be MAJOR.MINOR.PATCH, got: ${version || '(missing)'}`)
+}
+
+// releaseId is required, never defaulted. update-desktop-release-manifest.mjs
+// falls back to the string 'local', which would ship in a customer-facing
+// manifest if this script stayed silent.
+if (!releaseId) {
+  die('--release-id is required (it reaches a customer-facing manifest)')
+}
+
+if (minimumDesktopVersion && !SEMVER_RE.test(minimumDesktopVersion)) {
+  die(`--minimum-desktop-version must be MAJOR.MINOR.PATCH, got: ${minimumDesktopVersion}`)
+}
+
+const current = COORDINATES.find(c => c.name === 'desktop-app/package.json').read(ROOT)
+if (compareVersions(version, current) <= 0) {
+  die(`--version ${version} is not greater than the current desktop version ${current}`)
+}
+
+for (const coordinate of COORDINATES) {
+  // Rows without a write are owned by the delegated updater below.
+  coordinate.write?.(ROOT, version)
+}
+
+const manifestArgs = [
+  'scripts/release/update-desktop-release-manifest.mjs',
+  '--release-id',
+  releaseId,
+]
+if (minimumDesktopVersion) {
+  manifestArgs.push('--minimum-desktop-version', minimumDesktopVersion)
+}
+execFileSync('node', manifestArgs, { cwd: ROOT, stdio: 'inherit' })
+
+console.log(`prepared release ${version}`)

--- a/scripts/release/release-coordinates.mjs
+++ b/scripts/release/release-coordinates.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // The release coordinates: every place in the tree that must agree with the
 // release tag. One writer (prepare-release.mjs) and one checker
 // (validate-release-tag.mjs) both import this list, so a coordinate cannot be
@@ -9,10 +8,11 @@
 //   equals   - must equal the release version (build inputs, declarations)
 //   floor    - a compatibility floor; must be <= the version, moves only on request
 //   counter  - a per-service counter; must equal ITS OWN package.json, not the version
-//   pointer  - names an artifact; equality here, existence checked by release-images.yml
+//   pointer  - names an artifact; equality here, plus existence checking once a
+//              release-images.yml workflow exists (it does not exist in this repo yet)
 //
-// Workstream D appends the ghcr component pointer row. Do not add it before
-// deploy/components/ghcr-images/kustomization.yaml exists.
+// A future workstream would append the ghcr component pointer row. Do not add
+// it before deploy/components/ghcr-images/kustomization.yaml exists.
 import fs from 'node:fs'
 import path from 'node:path'
 

--- a/scripts/release/release-coordinates.mjs
+++ b/scripts/release/release-coordinates.mjs
@@ -16,6 +16,13 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+// Shared argv reader. Returns '' when the flag is absent, and undefined when
+// the flag is last with no value after it -- callers must treat both as unset.
+export function argValue(name) {
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : ''
+}
+
 export const SEMVER_RE = /^\d+\.\d+\.\d+$/
 
 export function compareVersions(a, b) {

--- a/scripts/release/release-coordinates.mjs
+++ b/scripts/release/release-coordinates.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// The release coordinates: every place in the tree that must agree with the
+// release tag. One writer (prepare-release.mjs) and one checker
+// (validate-release-tag.mjs) both import this list, so a coordinate cannot be
+// written without being checked.
+//
+// The coordinates are NOT all the same kind of thing, which is why each row
+// carries its own assertion:
+//   equals   - must equal the release version (build inputs, declarations)
+//   floor    - a compatibility floor; must be <= the version, moves only on request
+//   counter  - a per-service counter; must equal ITS OWN package.json, not the version
+//   pointer  - names an artifact; equality here, existence checked by release-images.yml
+//
+// Workstream D appends the ghcr component pointer row. Do not add it before
+// deploy/components/ghcr-images/kustomization.yaml exists.
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const SEMVER_RE = /^\d+\.\d+\.\d+$/
+
+export function compareVersions(a, b) {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1
+  }
+  return 0
+}
+
+function readJson(root, rel) {
+  return JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'))
+}
+
+function writeJson(root, rel, obj) {
+  fs.writeFileSync(path.join(root, rel), `${JSON.stringify(obj, null, 2)}\n`)
+}
+
+// Parses the `releaseManifest` export specifically, not just any object in
+// the file that happens to declare the same field names. A field-by-field
+// line regex over the whole file (the earlier approach here) would match the
+// FIRST line anywhere that looks like `  field: 'value'` -- including a
+// decoy object placed above the real export, or nothing at all if the export
+// were renamed, in which case a naive per-field regex silently returns ''
+// per field instead of failing loudly. Anchoring on the export statement and
+// parsing the whole object closes both holes at once. This is the same
+// parser update-desktop-release-manifest.mjs uses, imported from here so
+// there is exactly one implementation.
+export function parseManifest(raw) {
+  const match = raw.match(/export const releaseManifest: ReleaseManifest = (\{[\s\S]*?\n\})/)
+  if (!match) return null
+  const normalized = match[1]
+    .replace(/([{,]\s*)([a-zA-Z][a-zA-Z0-9]*):/g, '$1"$2":')
+    .replace(/'/g, '"')
+    .replace(/,\s*}/g, '}')
+  return JSON.parse(normalized)
+}
+
+function manifestField(root, field) {
+  const raw = fs.readFileSync(path.join(root, 'external-rest-api/src/releaseManifest.ts'), 'utf8')
+  const manifest = parseManifest(raw)
+  return manifest ? String(manifest[field] ?? '') : ''
+}
+
+// A row carries `write` only when it owns its own write. The manifest fields
+// are written by update-desktop-release-manifest.mjs, which prepare-release
+// delegates to rather than duplicating its renderer, so those rows declare
+// `writtenBy` instead. The writer skips any row without a `write`.
+export const COORDINATES = [
+  {
+    name: 'desktop-app/package.json',
+    assert: 'equals',
+    read: root => readJson(root, 'desktop-app/package.json').version,
+    write: (root, version) => {
+      const j = readJson(root, 'desktop-app/package.json')
+      j.version = version
+      writeJson(root, 'desktop-app/package.json', j)
+    },
+  },
+  {
+    name: 'desktop-app/package-lock.json',
+    assert: 'equals',
+    read: root => {
+      const j = readJson(root, 'desktop-app/package-lock.json')
+      // Both sites must agree; report a mismatch as an unmistakable value.
+      const rootVersion = j.version
+      const pkgVersion = j.packages?.['']?.version
+      return rootVersion === pkgVersion ? rootVersion : `${rootVersion}/${pkgVersion}`
+    },
+    write: (root, version) => {
+      const j = readJson(root, 'desktop-app/package-lock.json')
+      j.version = version
+      if (j.packages?.['']) j.packages[''].version = version
+      writeJson(root, 'desktop-app/package-lock.json', j)
+    },
+  },
+  {
+    name: 'releaseManifest.desktopVersion',
+    assert: 'equals',
+    read: root => manifestField(root, 'desktopVersion'),
+    writtenBy: 'update-desktop-release-manifest.mjs',
+  },
+  {
+    name: 'releaseManifest.minimumDesktopVersion',
+    assert: 'floor',
+    read: root => manifestField(root, 'minimumDesktopVersion'),
+    writtenBy: 'update-desktop-release-manifest.mjs --minimum-desktop-version',
+  },
+  {
+    name: 'releaseManifest.releaseId',
+    assert: 'explicit',
+    read: root => manifestField(root, 'releaseId'),
+    writtenBy: 'update-desktop-release-manifest.mjs --release-id',
+  },
+  {
+    name: 'releaseManifest.externalRestApiVersion',
+    assert: 'counter',
+    counterPackage: 'external-rest-api/package.json',
+    read: root => manifestField(root, 'externalRestApiVersion'),
+    writtenBy: 'update-desktop-release-manifest.mjs',
+  },
+  {
+    name: 'releaseManifest.rpcProxyVersion',
+    assert: 'counter',
+    counterPackage: 'rpc-proxy/package.json',
+    read: root => manifestField(root, 'rpcProxyVersion'),
+    writtenBy: 'update-desktop-release-manifest.mjs',
+  },
+]
+
+export function readCounterPackage(root, rel) {
+  return readJson(root, rel).version
+}

--- a/scripts/release/update-desktop-release-manifest.mjs
+++ b/scripts/release/update-desktop-release-manifest.mjs
@@ -87,6 +87,25 @@ export const releaseManifest: ReleaseManifest = ${JSON.stringify(manifest, null,
 `
 }
 
+const SEMVER_RE = /^\d+\.\d+\.\d+$/
+
+// Numeric MAJOR.MINOR.PATCH comparison. Deliberately matches the semantics of
+// compareSemverLike in desktop-app/src/appService.ts:177, which is what the
+// update gate at :840 evaluates at runtime. No prerelease handling on either
+// side, so the two cannot disagree.
+//
+// TEMPORARY: Task 5 creates scripts/release/release-coordinates.mjs and
+// replaces this local definition with an import from it. It lives here now
+// only because that module does not exist yet.
+function compareVersions(a, b) {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i += 1) {
+    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1
+  }
+  return 0
+}
+
 function validate(manifest, versions, options = {}) {
   const fields = options.deferDesktopRelease
     ? ['externalRestApiVersion', 'rpcProxyVersion']
@@ -96,13 +115,21 @@ function validate(manifest, versions, options = {}) {
       throw new Error(`${field}=${manifest[field]} does not match package.json ${versions[field]}`)
     }
   }
-  if (manifest.minimumDesktopVersion !== manifest.desktopVersion) {
-    throw new Error('minimumDesktopVersion must match desktopVersion for this release model')
+  if (!SEMVER_RE.test(manifest.minimumDesktopVersion)) {
+    throw new Error(
+      `minimumDesktopVersion=${manifest.minimumDesktopVersion} is not MAJOR.MINOR.PATCH`
+    )
+  }
+  if (compareVersions(manifest.minimumDesktopVersion, manifest.desktopVersion) > 0) {
+    throw new Error(
+      `minimumDesktopVersion=${manifest.minimumDesktopVersion} is greater than desktopVersion=${manifest.desktopVersion}`
+    )
   }
 }
 
 const previousRef = argValue('--previous')
 const releaseId = argValue('--release-id') || 'local'
+const minimumDesktopVersion = argValue('--minimum-desktop-version')
 const validateOnly = process.argv.includes('--validate-only')
 const deferDesktopRelease = process.argv.includes('--defer-desktop-release')
 
@@ -117,12 +144,30 @@ if (validateOnly) {
   process.exit(0)
 }
 
-const previous = previousManifest(previousRef) || {
-  releaseId,
-  externalRestApiVersion: versions.externalRestApiVersion,
-  rpcProxyVersion: versions.rpcProxyVersion,
-  desktopVersion: versions.desktopVersion,
-  minimumDesktopVersion: versions.desktopVersion,
+let previous = previousManifest(previousRef)
+
+// HEAD's floor always outranks one read via --previous: HEAD reflects the
+// most recent operator decision. Never synthesize a floor from
+// desktopVersion -- if nothing readable carries a floor, the operator must
+// say so explicitly.
+const inherited = manifestAtHead?.minimumDesktopVersion || previous?.minimumDesktopVersion
+
+if (!inherited && !minimumDesktopVersion) {
+  throw new Error(
+    'no minimumDesktopVersion could be read; pass ' +
+      '--minimum-desktop-version explicitly rather than ' +
+      'defaulting it to desktopVersion'
+  )
+}
+
+if (!previous) {
+  previous = {
+    releaseId,
+    externalRestApiVersion: versions.externalRestApiVersion,
+    rpcProxyVersion: versions.rpcProxyVersion,
+    desktopVersion: versions.desktopVersion,
+    minimumDesktopVersion: inherited || minimumDesktopVersion,
+  }
 }
 const prevVersions = previousVersions(previousRef)
 
@@ -147,7 +192,22 @@ if (
     next.desktopVersion !== versions.desktopVersion)
 ) {
   next.desktopVersion = versions.desktopVersion
-  next.minimumDesktopVersion = versions.desktopVersion
+  changed = true
+}
+
+// The floor is a compatibility control, not a version. It moves ONLY when the
+// operator asks. Advancing it with every release would show "update required"
+// to every user of the previous release. See appService.ts:840.
+//
+// `previous` may carry a floor copied from an old --previous ref; always
+// re-apply `inherited` (HEAD-first) before letting an explicit flag win, so
+// a floor already raised on HEAD is never silently reverted.
+if (inherited && next.minimumDesktopVersion !== inherited) {
+  next.minimumDesktopVersion = inherited
+  changed = true
+}
+if (minimumDesktopVersion) {
+  next.minimumDesktopVersion = minimumDesktopVersion
   changed = true
 }
 

--- a/scripts/release/update-desktop-release-manifest.mjs
+++ b/scripts/release/update-desktop-release-manifest.mjs
@@ -74,7 +74,8 @@ function renderManifest(manifest) {
 
 export const releaseManifest: ReleaseManifest = ${JSON.stringify(manifest, null, 2)
     .replace(/"([^"]+)":/g, '$1:')
-    .replace(/: "([^"]*)"/g, ": '$1'")}
+    .replace(/: "([^"]*)"/g, ": '$1'")
+    .replace(/\n}$/, ',\n}')}
 `
 }
 
@@ -99,98 +100,116 @@ function validate(manifest, versions, options = {}) {
   }
 }
 
-const previousRef = argValue('--previous')
-const releaseId = argValue('--release-id') || 'local'
-const minimumDesktopVersion = argValue('--minimum-desktop-version')
-const validateOnly = process.argv.includes('--validate-only')
-const deferDesktopRelease = process.argv.includes('--defer-desktop-release')
+function main() {
+  const previousRef = argValue('--previous')
+  const releaseId = argValue('--release-id') || 'local'
+  const minimumDesktopVersion = argValue('--minimum-desktop-version')
+  const validateOnly = process.argv.includes('--validate-only')
+  const deferDesktopRelease = process.argv.includes('--defer-desktop-release')
 
-const versions = currentVersions()
-const manifestAtHead = currentManifest()
-if (validateOnly) {
-  if (!manifestAtHead) {
-    throw new Error(`${MANIFEST_PATH} does not contain a releaseManifest export`)
+  const versions = currentVersions()
+  const manifestAtHead = currentManifest()
+  if (validateOnly) {
+    if (!manifestAtHead) {
+      throw new Error(`${MANIFEST_PATH} does not contain a releaseManifest export`)
+    }
+    validate(manifestAtHead, versions, { deferDesktopRelease })
+    console.log(JSON.stringify(manifestAtHead, null, 2))
+    process.exit(0)
   }
-  validate(manifestAtHead, versions, { deferDesktopRelease })
-  console.log(JSON.stringify(manifestAtHead, null, 2))
-  process.exit(0)
-}
 
-let previous = previousManifest(previousRef)
+  let previous = previousManifest(previousRef)
 
-// HEAD's floor always outranks one read via --previous: HEAD reflects the
-// most recent operator decision. Never synthesize a floor from
-// desktopVersion -- if nothing readable carries a floor, the operator must
-// say so explicitly.
-const inherited = manifestAtHead?.minimumDesktopVersion || previous?.minimumDesktopVersion
+  // HEAD's floor always outranks one read via --previous: HEAD reflects the
+  // most recent operator decision. Never synthesize a floor from
+  // desktopVersion -- if nothing readable carries a floor, the operator must
+  // say so explicitly.
+  const inherited = manifestAtHead?.minimumDesktopVersion || previous?.minimumDesktopVersion
 
-if (!inherited && !minimumDesktopVersion) {
-  throw new Error(
-    'no minimumDesktopVersion could be read; pass ' +
-      '--minimum-desktop-version explicitly rather than ' +
-      'defaulting it to desktopVersion'
-  )
-}
-
-if (!previous) {
-  previous = {
-    releaseId,
-    externalRestApiVersion: versions.externalRestApiVersion,
-    rpcProxyVersion: versions.rpcProxyVersion,
-    desktopVersion: versions.desktopVersion,
-    minimumDesktopVersion: inherited || minimumDesktopVersion,
+  if (!inherited && !minimumDesktopVersion) {
+    throw new Error(
+      'no minimumDesktopVersion could be read; pass ' +
+        '--minimum-desktop-version explicitly rather than ' +
+        'defaulting it to desktopVersion'
+    )
   }
-}
-const prevVersions = previousVersions(previousRef)
 
-const next = { ...previous, releaseId }
-let changed = false
+  if (!previous) {
+    previous = {
+      releaseId,
+      externalRestApiVersion: versions.externalRestApiVersion,
+      rpcProxyVersion: versions.rpcProxyVersion,
+      desktopVersion: versions.desktopVersion,
+      minimumDesktopVersion: inherited || minimumDesktopVersion,
+    }
+  }
+  const prevVersions = previousVersions(previousRef)
 
-for (const field of ['externalRestApiVersion', 'rpcProxyVersion']) {
+  const next = { ...previous, releaseId }
+  let changed = false
+
+  for (const field of ['externalRestApiVersion', 'rpcProxyVersion']) {
+    if (
+      !prevVersions[field] ||
+      prevVersions[field] !== versions[field] ||
+      next[field] !== versions[field]
+    ) {
+      next[field] = versions[field]
+      changed = true
+    }
+  }
+
   if (
-    !prevVersions[field] ||
-    prevVersions[field] !== versions[field] ||
-    next[field] !== versions[field]
+    !deferDesktopRelease &&
+    (!prevVersions.desktopVersion ||
+      prevVersions.desktopVersion !== versions.desktopVersion ||
+      next.desktopVersion !== versions.desktopVersion)
   ) {
-    next[field] = versions[field]
+    next.desktopVersion = versions.desktopVersion
     changed = true
   }
+
+  // The floor is a compatibility control, not a version. It moves ONLY when the
+  // operator asks. Advancing it with every release would show "update required"
+  // to every user of the previous release. See appService.ts:840.
+  //
+  // `previous` may carry a floor copied from an old --previous ref; always
+  // re-apply `inherited` (HEAD-first) before letting an explicit flag win, so
+  // a floor already raised on HEAD is never silently reverted.
+  if (inherited && next.minimumDesktopVersion !== inherited) {
+    next.minimumDesktopVersion = inherited
+    changed = true
+  }
+  if (minimumDesktopVersion) {
+    next.minimumDesktopVersion = minimumDesktopVersion
+    changed = true
+  }
+
+  if (!changed && manifestAtHead) {
+    Object.assign(next, manifestAtHead)
+  }
+
+  validate(next, versions, { deferDesktopRelease })
+
+  if (!validateOnly) {
+    fs.writeFileSync(path.join(ROOT, MANIFEST_PATH), renderManifest(next))
+  }
+
+  console.log(JSON.stringify(next, null, 2))
 }
 
-if (
-  !deferDesktopRelease &&
-  (!prevVersions.desktopVersion ||
-    prevVersions.desktopVersion !== versions.desktopVersion ||
-    next.desktopVersion !== versions.desktopVersion)
-) {
-  next.desktopVersion = versions.desktopVersion
-  changed = true
+try {
+  main()
+} catch (error) {
+  // Matches validate-release-version-bumps.mjs's ::error:: style so a
+  // contributor sees an actionable GitHub annotation instead of a raw stack
+  // trace on the ci-public.yml step. The underlying detail is preserved
+  // verbatim in the annotation; the remediation line is appended separately.
+  console.error(`::error::${error.message}`)
+  console.error(
+    `Fix ${MANIFEST_PATH} so it agrees with the current package.json versions (or pass the ` +
+      `correct --release-id / --minimum-desktop-version flags), then re-run ` +
+      '`node scripts/release/update-desktop-release-manifest.mjs`.'
+  )
+  process.exit(1)
 }
-
-// The floor is a compatibility control, not a version. It moves ONLY when the
-// operator asks. Advancing it with every release would show "update required"
-// to every user of the previous release. See appService.ts:840.
-//
-// `previous` may carry a floor copied from an old --previous ref; always
-// re-apply `inherited` (HEAD-first) before letting an explicit flag win, so
-// a floor already raised on HEAD is never silently reverted.
-if (inherited && next.minimumDesktopVersion !== inherited) {
-  next.minimumDesktopVersion = inherited
-  changed = true
-}
-if (minimumDesktopVersion) {
-  next.minimumDesktopVersion = minimumDesktopVersion
-  changed = true
-}
-
-if (!changed && manifestAtHead) {
-  Object.assign(next, manifestAtHead)
-}
-
-validate(next, versions, { deferDesktopRelease })
-
-if (!validateOnly) {
-  fs.writeFileSync(path.join(ROOT, MANIFEST_PATH), renderManifest(next))
-}
-
-console.log(JSON.stringify(next, null, 2))

--- a/scripts/release/update-desktop-release-manifest.mjs
+++ b/scripts/release/update-desktop-release-manifest.mjs
@@ -2,7 +2,7 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
-import { SEMVER_RE, compareVersions, parseManifest } from './release-coordinates.mjs'
+import { SEMVER_RE, argValue, compareVersions, parseManifest } from './release-coordinates.mjs'
 
 const ROOT = process.cwd()
 const MANIFEST_PATH = 'external-rest-api/src/releaseManifest.ts'
@@ -10,11 +10,6 @@ const PACKAGE_PATHS = {
   externalRestApiVersion: 'external-rest-api/package.json',
   rpcProxyVersion: 'rpc-proxy/package.json',
   desktopVersion: 'desktop-app/package.json',
-}
-
-function argValue(name) {
-  const index = process.argv.indexOf(name)
-  return index >= 0 ? process.argv[index + 1] : ''
 }
 
 function readJsonFile(filePath) {

--- a/scripts/release/update-desktop-release-manifest.mjs
+++ b/scripts/release/update-desktop-release-manifest.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { SEMVER_RE, compareVersions, parseManifest } from './release-coordinates.mjs'
 
 const ROOT = process.cwd()
 const MANIFEST_PATH = 'external-rest-api/src/releaseManifest.ts'
@@ -30,16 +31,6 @@ function gitShow(ref, filePath) {
   } catch {
     return ''
   }
-}
-
-function parseManifest(raw) {
-  const match = raw.match(/export const releaseManifest: ReleaseManifest = (\{[\s\S]*?\n\})/)
-  if (!match) return null
-  const normalized = match[1]
-    .replace(/([{,]\s*)([a-zA-Z][a-zA-Z0-9]*):/g, '$1"$2":')
-    .replace(/'/g, '"')
-    .replace(/,\s*}/g, '}')
-  return JSON.parse(normalized)
 }
 
 function currentManifest() {
@@ -85,25 +76,6 @@ export const releaseManifest: ReleaseManifest = ${JSON.stringify(manifest, null,
     .replace(/"([^"]+)":/g, '$1:')
     .replace(/: "([^"]*)"/g, ": '$1'")}
 `
-}
-
-const SEMVER_RE = /^\d+\.\d+\.\d+$/
-
-// Numeric MAJOR.MINOR.PATCH comparison. Deliberately matches the semantics of
-// compareSemverLike in desktop-app/src/appService.ts:177, which is what the
-// update gate at :840 evaluates at runtime. No prerelease handling on either
-// side, so the two cannot disagree.
-//
-// TEMPORARY: Task 5 creates scripts/release/release-coordinates.mjs and
-// replaces this local definition with an import from it. It lives here now
-// only because that module does not exist yet.
-function compareVersions(a, b) {
-  const pa = a.split('.').map(Number)
-  const pb = b.split('.').map(Number)
-  for (let i = 0; i < 3; i += 1) {
-    if (pa[i] !== pb[i]) return pa[i] < pb[i] ? -1 : 1
-  }
-  return 0
 }
 
 function validate(manifest, versions, options = {}) {

--- a/scripts/release/validate-release-tag.mjs
+++ b/scripts/release/validate-release-tag.mjs
@@ -12,16 +12,12 @@ import process from 'node:process'
 import {
   COORDINATES,
   SEMVER_RE,
+  argValue,
   compareVersions,
   readCounterPackage,
 } from './release-coordinates.mjs'
 
 const ROOT = process.cwd()
-
-function argValue(name) {
-  const i = process.argv.indexOf(name)
-  return i >= 0 ? process.argv[i + 1] : ''
-}
 
 const version = (argValue('--version') || '').replace(/^v/, '')
 if (!SEMVER_RE.test(version)) {
@@ -85,7 +81,14 @@ for (const coordinate of COORDINATES) {
 }
 
 if (failures.length > 0) {
-  console.error(`release ${version} has ${failures.length} disagreeing coordinate(s):`)
+  // ::error:: so this reads as an annotation once the release-cut job runs it,
+  // matching update-desktop-release-manifest.mjs and validate-release-version-bumps.mjs.
+  // prepare-release.mjs deliberately does NOT do this: it is run by a human at
+  // release time, where an annotation prefix is noise.
+  console.error(
+    `::error::release ${version} has ${failures.length} disagreeing coordinate(s); ` +
+      `run scripts/release/prepare-release.mjs --version ${version} --release-id <id> to write them`
+  )
   for (const f of failures) console.error(`  ${f}`)
   process.exit(1)
 }

--- a/scripts/release/validate-release-tag.mjs
+++ b/scripts/release/validate-release-tag.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// The declared-agreement half of the release checker. Pure tree reads, so it
+// runs locally and on the release-prep PR, before any tag exists.
+//
+// It deliberately does NOT check that the artifacts exist. The v<version>
+// images are created by release-images.yml on the tag, so they cannot
+// pre-exist here. Existence is that workflow's job.
+//
+//   node scripts/release/validate-release-tag.mjs --version 0.6.0
+import process from 'node:process'
+import {
+  COORDINATES,
+  SEMVER_RE,
+  compareVersions,
+  readCounterPackage,
+} from './release-coordinates.mjs'
+
+const ROOT = process.cwd()
+
+function argValue(name) {
+  const i = process.argv.indexOf(name)
+  return i >= 0 ? process.argv[i + 1] : ''
+}
+
+const version = (argValue('--version') || '').replace(/^v/, '')
+if (!SEMVER_RE.test(version)) {
+  console.error(
+    `--version must be MAJOR.MINOR.PATCH (a leading v is stripped), got: ${version || '(missing)'}`
+  )
+  process.exit(1)
+}
+
+const failures = []
+
+for (const coordinate of COORDINATES) {
+  const actual = coordinate.read(ROOT)
+
+  if (coordinate.assert === 'equals' && actual !== version) {
+    failures.push(`${coordinate.name}=${actual}, expected ${version}`)
+  }
+
+  if (coordinate.assert === 'floor') {
+    if (!SEMVER_RE.test(actual)) {
+      failures.push(`${coordinate.name}=${actual} is not MAJOR.MINOR.PATCH`)
+    } else if (compareVersions(actual, version) > 0) {
+      failures.push(`${coordinate.name}=${actual} is greater than the release version ${version}`)
+    }
+  }
+
+  if (coordinate.assert === 'explicit' && (!actual || actual === 'local')) {
+    failures.push(`${coordinate.name}=${actual || '(empty)'} was never set explicitly`)
+  }
+
+  if (coordinate.assert === 'counter') {
+    const expected = readCounterPackage(ROOT, coordinate.counterPackage)
+    if (actual !== expected) {
+      failures.push(
+        `${coordinate.name}=${actual}, expected ${expected} from ${coordinate.counterPackage}`
+      )
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`release ${version} has ${failures.length} disagreeing coordinate(s):`)
+  for (const f of failures) console.error(`  ${f}`)
+  process.exit(1)
+}
+
+console.log(`release ${version}: all ${COORDINATES.length} coordinates agree`)

--- a/scripts/release/validate-release-tag.mjs
+++ b/scripts/release/validate-release-tag.mjs
@@ -3,8 +3,9 @@
 // runs locally and on the release-prep PR, before any tag exists.
 //
 // It deliberately does NOT check that the artifacts exist. The v<version>
-// images are created by release-images.yml on the tag, so they cannot
-// pre-exist here. Existence is that workflow's job.
+// images would be built by a future release-images.yml workflow on the tag
+// (not yet added to this repo), so they cannot pre-exist here. Existence
+// checking is that future workflow's job, not this one's.
 //
 //   node scripts/release/validate-release-tag.mjs --version 0.6.0
 import process from 'node:process'
@@ -35,27 +36,49 @@ const failures = []
 for (const coordinate of COORDINATES) {
   const actual = coordinate.read(ROOT)
 
-  if (coordinate.assert === 'equals' && actual !== version) {
-    failures.push(`${coordinate.name}=${actual}, expected ${version}`)
-  }
-
-  if (coordinate.assert === 'floor') {
-    if (!SEMVER_RE.test(actual)) {
-      failures.push(`${coordinate.name}=${actual} is not MAJOR.MINOR.PATCH`)
-    } else if (compareVersions(actual, version) > 0) {
-      failures.push(`${coordinate.name}=${actual} is greater than the release version ${version}`)
+  // A switch with a default is deliberate: an unrecognized `assert` kind
+  // (e.g. a `pointer` row added before its check is implemented) must fail
+  // loudly, naming the coordinate and the kind, rather than silently falling
+  // through every case the way independent `if`s with no `else` would.
+  switch (coordinate.assert) {
+    case 'equals': {
+      if (actual !== version) {
+        failures.push(`${coordinate.name}=${actual}, expected ${version}`)
+      }
+      break
     }
-  }
 
-  if (coordinate.assert === 'explicit' && (!actual || actual === 'local')) {
-    failures.push(`${coordinate.name}=${actual || '(empty)'} was never set explicitly`)
-  }
+    case 'floor': {
+      if (!SEMVER_RE.test(actual)) {
+        failures.push(`${coordinate.name}=${actual} is not MAJOR.MINOR.PATCH`)
+      } else if (compareVersions(actual, version) > 0) {
+        failures.push(`${coordinate.name}=${actual} is greater than the release version ${version}`)
+      }
+      break
+    }
 
-  if (coordinate.assert === 'counter') {
-    const expected = readCounterPackage(ROOT, coordinate.counterPackage)
-    if (actual !== expected) {
+    case 'explicit': {
+      if (!actual || actual === 'local') {
+        failures.push(`${coordinate.name}=${actual || '(empty)'} was never set explicitly`)
+      }
+      break
+    }
+
+    case 'counter': {
+      const expected = readCounterPackage(ROOT, coordinate.counterPackage)
+      if (actual !== expected) {
+        failures.push(
+          `${coordinate.name}=${actual}, expected ${expected} from ${coordinate.counterPackage}`
+        )
+      }
+      break
+    }
+
+    default: {
       failures.push(
-        `${coordinate.name}=${actual}, expected ${expected} from ${coordinate.counterPackage}`
+        `${coordinate.name} has assert kind "${coordinate.assert}", which this checker does not ` +
+          `implement -- a coordinate cannot be written without being checked, so add a case for it ` +
+          `in scripts/release/validate-release-tag.mjs before using this assert kind`
       )
     }
   }

--- a/scripts/release/validate-release-version-bumps.mjs
+++ b/scripts/release/validate-release-version-bumps.mjs
@@ -18,17 +18,6 @@ const PROJECTS = [
     codePrefixes: ['rpc-proxy/src/', 'rpc-proxy/test/'],
     codeFiles: ['rpc-proxy/tsconfig.json'],
   },
-  {
-    name: 'desktop-app',
-    packagePath: 'desktop-app/package.json',
-    codePrefixes: ['desktop-app/src/', 'desktop-app/ui/src/', 'desktop-app/test/'],
-    codeFiles: [
-      'desktop-app/forge.config.js',
-      'desktop-app/tsconfig.json',
-      'desktop-app/vitest.config.ts',
-      'desktop-app/ui/vite.config.ts',
-    ],
-  },
 ]
 
 function argValue(name) {

--- a/scripts/tests/test-precommit-release-manifest-ignore.sh
+++ b/scripts/tests/test-precommit-release-manifest-ignore.sh
@@ -143,19 +143,28 @@ assert_desktop_version_not_touched_by_counter_resync() {
     && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
   status=$?
 
-  local manifest_desktop manifest_ers
+  local manifest_desktop manifest_ers manifest_min
   manifest_desktop="$(manifest_field "$d" desktopVersion)"
   manifest_ers="$(manifest_field "$d" externalRestApiVersion)"
+  manifest_min="$(manifest_field "$d" minimumDesktopVersion)"
 
   # Assert the re-sync actually ran and succeeded (exit 0, ers moved), not
   # just that desktopVersion happens to be untouched -- a dead hook, or one
   # missing --defer-desktop-release entirely (which makes the updater's own
   # validate() reject 0.1.252 != 0.1.333 and exit nonzero), would ALSO leave
   # desktopVersion untouched, but only because the re-sync never completed.
-  if [ "$status" -eq 0 ] && [ "$manifest_ers" = "0.1.61" ] && [ "$manifest_desktop" = "0.1.252" ]; then
-    pass "a counter re-sync succeeds and never touches desktopVersion, even though desktop-app/package.json is ahead"
+  #
+  # minimumDesktopVersion is asserted explicitly here too, not just implied
+  # by desktopVersion staying put: this is the invariant the whole
+  # workstream protects (a floor that ever equals desktopVersion force-
+  # updates every existing desktop install), and the pre-commit path is the
+  # one most likely to run on an ordinary service PR, so it must guard the
+  # floor directly rather than by inference.
+  if [ "$status" -eq 0 ] && [ "$manifest_ers" = "0.1.61" ] && [ "$manifest_desktop" = "0.1.252" ] \
+    && [ "$manifest_min" = "0.1.252" ]; then
+    pass "a counter re-sync succeeds and never touches desktopVersion or minimumDesktopVersion, even though desktop-app/package.json is ahead"
   else
-    fail "status=$status externalRestApiVersion=$manifest_ers desktopVersion=$manifest_desktop; expected 0 / 0.1.61 / 0.1.252"
+    fail "status=$status externalRestApiVersion=$manifest_ers desktopVersion=$manifest_desktop minimumDesktopVersion=$manifest_min; expected 0 / 0.1.61 / 0.1.252 / 0.1.252"
   fi
   rm -rf "$d"
 }

--- a/scripts/tests/test-precommit-release-manifest-ignore.sh
+++ b/scripts/tests/test-precommit-release-manifest-ignore.sh
@@ -1,0 +1,504 @@
+#!/usr/bin/env bash
+set -u
+FAIL=0
+
+# The precommit bumper must ignore external-rest-api/src/releaseManifest.ts.
+# A later task adds scripts/release/prepare-release.mjs as that file's writer;
+# if staging it bumps external-rest-api/package.json, the manifest is stale
+# the instant it is written and --validate-only fails on every release-prep
+# PR, forever.
+#
+# It must also keep the manifest's own counters (externalRestApiVersion,
+# rpcProxyVersion) in sync with the package.json versions it bumps, without
+# ever touching desktopVersion (that's a separate release flow), without
+# fabricating a releaseId, without clobbering a contributor's unstaged
+# manifest edit, and without permanently disarming itself if a re-sync fails
+# partway through.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAIL=1; }
+
+# desktop-app/package.json is deliberately set ABOVE the manifest's
+# desktopVersion (0.1.333 vs 0.1.252). desktop-app is not in packageRoots (this
+# hook never bumps it) and is not a MANIFEST_COUNTER_PACKAGES entry, so a
+# fixture that pinned them equal would be structurally incapable of catching
+# a re-sync that wrongly published desktopVersion from desktop-app/package.json.
+make_repo() {
+  local d=$1
+  mkdir -p "$d/external-rest-api/src" "$d/rpc-proxy/src" "$d/desktop-app" "$d/scripts/precommit" "$d/scripts/prettier" "$d/scripts/release"
+  cp "$REPO_ROOT/scripts/precommit/bump-staged-package-versions.mjs" "$d/scripts/precommit/"
+  cp "$REPO_ROOT/scripts/prettier/paths.mjs" "$d/scripts/prettier/"
+  cp "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" "$d/scripts/release/"
+  printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' \
+    > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' \
+    > "$d/rpc-proxy/package.json"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.1.333"\n}\n' \
+    > "$d/desktop-app/package.json"
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  echo "export const x = 1" > "$d/external-rest-api/src/other.ts"
+  echo "export const y = 1" > "$d/rpc-proxy/src/other.ts"
+  ( cd "$d" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm init )
+}
+
+version_of() { grep '"version"' "$1/external-rest-api/package.json" | sed 's/.*: "\(.*\)".*/\1/'; }
+rpc_version_of() { grep '"version"' "$1/rpc-proxy/package.json" | sed 's/.*: "\(.*\)".*/\1/'; }
+manifest_field() {
+  # $1=dir $2=field name
+  grep -E "^  $2: '" "$1/external-rest-api/src/releaseManifest.ts" | sed "s/.*'\(.*\)'.*/\1/"
+}
+
+assert_release_manifest_does_not_bump() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" \
+    && echo "export const releaseManifest = { desktopVersion: '0.5.0' }" \
+       > external-rest-api/src/releaseManifest.ts \
+    && git add external-rest-api/src/releaseManifest.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  if [ "$(version_of "$d")" = "0.1.60" ]; then
+    pass "staging releaseManifest.ts does not bump external-rest-api"
+  else
+    fail "releaseManifest.ts bumped external-rest-api to $(version_of "$d")"
+  fi
+  rm -rf "$d"
+}
+
+assert_other_source_still_bumps() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" \
+    && echo "export const x = 2" > external-rest-api/src/other.ts \
+    && git add external-rest-api/src/other.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  if [ "$(version_of "$d")" = "0.1.61" ]; then
+    pass "an ordinary external-rest-api source change still bumps"
+  else
+    fail "expected 0.1.61 after an ordinary change, got $(version_of "$d")"
+  fi
+  rm -rf "$d"
+}
+
+assert_a_counter_bump_resyncs_the_manifest() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" \
+    && echo "export const x = 2" > external-rest-api/src/other.ts \
+    && git add external-rest-api/src/other.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+
+  local manifest_ers staged
+  manifest_ers="$(manifest_field "$d" externalRestApiVersion)"
+  staged="$(cd "$d" && git diff --cached --name-only | grep -c releaseManifest.ts)"
+
+  if [ "$manifest_ers" = "0.1.61" ] && [ "$staged" = "1" ]; then
+    pass "a counter bump re-syncs the manifest and stages it"
+  else
+    fail "manifest externalRestApiVersion=$manifest_ers staged=$staged, expected 0.1.61 / 1"
+  fi
+  rm -rf "$d"
+}
+
+assert_rpc_proxy_bump_resyncs_the_manifest() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" \
+    && echo "export const y = 2" > rpc-proxy/src/other.ts \
+    && git add rpc-proxy/src/other.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+
+  local pkg_rpc manifest_rpc
+  pkg_rpc="$(rpc_version_of "$d")"
+  manifest_rpc="$(manifest_field "$d" rpcProxyVersion)"
+
+  if [ "$pkg_rpc" = "0.1.52" ] && [ "$manifest_rpc" = "0.1.52" ]; then
+    pass "an rpc-proxy bump also re-syncs the manifest"
+  else
+    fail "rpc-proxy/package.json=$pkg_rpc manifest rpcProxyVersion=$manifest_rpc, expected 0.1.52 / 0.1.52"
+  fi
+  rm -rf "$d"
+}
+
+assert_desktop_version_not_touched_by_counter_resync() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  local status
+  ( cd "$d" \
+    && echo "export const x = 2" > external-rest-api/src/other.ts \
+    && git add external-rest-api/src/other.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status=$?
+
+  local manifest_desktop manifest_ers
+  manifest_desktop="$(manifest_field "$d" desktopVersion)"
+  manifest_ers="$(manifest_field "$d" externalRestApiVersion)"
+
+  # Assert the re-sync actually ran and succeeded (exit 0, ers moved), not
+  # just that desktopVersion happens to be untouched -- a dead hook, or one
+  # missing --defer-desktop-release entirely (which makes the updater's own
+  # validate() reject 0.1.252 != 0.1.333 and exit nonzero), would ALSO leave
+  # desktopVersion untouched, but only because the re-sync never completed.
+  if [ "$status" -eq 0 ] && [ "$manifest_ers" = "0.1.61" ] && [ "$manifest_desktop" = "0.1.252" ]; then
+    pass "a counter re-sync succeeds and never touches desktopVersion, even though desktop-app/package.json is ahead"
+  else
+    fail "status=$status externalRestApiVersion=$manifest_ers desktopVersion=$manifest_desktop; expected 0 / 0.1.61 / 0.1.252"
+  fi
+  rm -rf "$d"
+}
+
+assert_resync_preserves_the_release_id() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" \
+    && echo "export const x = 3" > external-rest-api/src/other.ts \
+    && git add external-rest-api/src/other.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  local rid ers
+  rid="$(manifest_field "$d" releaseId)"
+  ers="$(manifest_field "$d" externalRestApiVersion)"
+  # Also assert the counter actually moved, so this case can't pass simply
+  # because the re-sync never ran at all.
+  if [ "$rid" = "fixture-0000000" ] && [ "$ers" = "0.1.61" ]; then
+    pass "the re-sync preserves releaseId instead of stamping 'local'"
+  else
+    fail "releaseId='$rid' externalRestApiVersion=$ers; the updater defaults releaseId to 'local' when --release-id is omitted"
+  fi
+  rm -rf "$d"
+}
+
+assert_unstaged_manifest_changes_block_the_resync() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+
+  # Edit the manifest on disk WITHOUT staging it -- a contributor's scratch
+  # edit -- then trigger a counter bump that would otherwise re-sync it.
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/src/releaseManifest.ts <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'UNSTAGED-SCRATCH',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  )
+  ( cd "$d" && echo "export const x = 2" > external-rest-api/src/other.ts && git add external-rest-api/src/other.ts )
+
+  local status stderr_output
+  stderr_output="$( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs 2>&1 >/dev/null )"
+  status=$?
+
+  local rid staged
+  rid="$(manifest_field "$d" releaseId)"
+  staged="$(cd "$d" && git diff --cached --name-only | grep -c releaseManifest.ts)"
+
+  # Assert on the refusal MESSAGE, not just a nonzero exit code -- any other
+  # unrelated failure would also exit nonzero and leave the manifest
+  # untouched, which would let this case pass for the wrong reason.
+  if [ "$status" -ne 0 ] && [ "$rid" = "UNSTAGED-SCRATCH" ] && [ "$staged" = "0" ] \
+    && echo "$stderr_output" | grep -q "unstaged changes"; then
+    pass "an unstaged manifest edit blocks the re-sync with a refusal message, instead of being silently committed"
+  else
+    fail "expected nonzero exit + refusal message + untouched + unstaged manifest; got status=$status releaseId='$rid' staged=$staged stderr='$stderr_output'"
+  fi
+  rm -rf "$d"
+}
+
+assert_a_failed_resync_recovers_on_retry() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  ( cd "$d" && echo "export const x = 2" > external-rest-api/src/other.ts && git add external-rest-api/src/other.ts )
+
+  # Corrupt the manifest with conflict markers and STAGE the corruption, so
+  # the bump loop still runs cleanly (no unstaged-changes refusal) but the
+  # re-sync subprocess's own JSON.parse fails.
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/src/releaseManifest.ts <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+<<<<<<< HEAD
+  externalRestApiVersion: '0.1.60',
+=======
+  externalRestApiVersion: '0.1.99',
+>>>>>>> feature
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+    git add external-rest-api/src/releaseManifest.ts
+  )
+
+  local status1 ers_after_run1
+  ( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status1=$?
+  ers_after_run1="$(version_of "$d")"
+
+  # Resolve the "conflict": restore a valid, still-stale manifest and stage it.
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/src/releaseManifest.ts <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+    git add external-rest-api/src/releaseManifest.ts
+  )
+
+  local status2 ers_field_after_retry
+  ( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status2=$?
+  ers_field_after_retry="$(manifest_field "$d" externalRestApiVersion)"
+
+  if [ "$status1" -ne 0 ] && [ "$ers_after_run1" = "0.1.61" ] && [ "$status2" -eq 0 ] && [ "$ers_field_after_retry" = "0.1.61" ]; then
+    pass "a failed re-sync recovers on retry instead of permanently disarming itself"
+  else
+    fail "run1 status=$status1 package=$ers_after_run1; run2 status=$status2 manifest=$ers_field_after_retry"
+  fi
+  rm -rf "$d"
+}
+
+assert_missing_release_id_is_refused_not_fabricated() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/src/releaseManifest.ts <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+    git add external-rest-api/src/releaseManifest.ts
+    git -c user.email=t@t -c user.name=t commit -qm "drop releaseId"
+  )
+  ( cd "$d" && echo "export const x = 2" > external-rest-api/src/other.ts && git add external-rest-api/src/other.ts )
+
+  local status
+  ( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status=$?
+
+  if [ "$status" -ne 0 ] && ! grep -q "'local'" "$d/external-rest-api/src/releaseManifest.ts"; then
+    pass "a missing releaseId is refused instead of fabricated as 'local'"
+  else
+    fail "expected nonzero exit and no fabricated 'local' releaseId; got status=$status, manifest: $(tr '\n' ' ' < "$d/external-rest-api/src/releaseManifest.ts")"
+  fi
+  rm -rf "$d"
+}
+
+assert_unstaged_package_json_drift_is_not_leaked_into_the_manifest() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+
+  # Edit external-rest-api/package.json on disk WITHOUT staging it, then make
+  # an entirely unrelated staged commit (docs-only). Nothing about this commit
+  # legitimately touches external-rest-api or rpc-proxy, so the manifest must
+  # come out exactly as committed before -- reading disk here (instead of the
+  # index) would falsely report drift and leak the never-to-be-committed
+  # 0.9.99 into the manifest.
+  ( cd "$d" && printf '{\n  "name": "external-rest-api",\n  "version": "0.9.99"\n}\n' > external-rest-api/package.json )
+  ( cd "$d" && mkdir -p docs && echo "# docs" > docs/readme.md && git add docs/readme.md )
+
+  local status
+  ( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status=$?
+
+  local manifest_ers staged
+  manifest_ers="$(manifest_field "$d" externalRestApiVersion)"
+  staged="$(cd "$d" && git diff --cached --name-only | grep -c releaseManifest.ts)"
+
+  if [ "$status" -eq 0 ] && [ "$manifest_ers" = "0.1.60" ] && [ "$staged" = "0" ]; then
+    pass "an unstaged package.json edit is not read for drift detection (index, not disk)"
+  else
+    fail "status=$status manifest externalRestApiVersion=$manifest_ers staged=$staged; an unstaged 0.9.99 on disk must not leak into a committed manifest"
+  fi
+  rm -rf "$d"
+}
+
+assert_unrelated_unstaged_package_json_blocks_a_real_resync() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+
+  # rpc-proxy gets a legitimate, staged bump -- a real trigger for the
+  # re-sync -- while external-rest-api/package.json has an unrelated UNSTAGED
+  # edit. The updater re-reads every counter package.json from disk on every
+  # invocation (not just the one that triggered it), so without a guard this
+  # would leak the unstaged 0.9.99 into the manifest via a resync that had a
+  # legitimate reason to run.
+  ( cd "$d" && echo "export const y = 2" > rpc-proxy/src/other.ts && git add rpc-proxy/src/other.ts )
+  ( cd "$d" && printf '{\n  "name": "external-rest-api",\n  "version": "0.9.99"\n}\n' > external-rest-api/package.json )
+
+  local status
+  ( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  status=$?
+
+  local manifest_ers staged
+  manifest_ers="$(manifest_field "$d" externalRestApiVersion)"
+  staged="$(cd "$d" && git diff --cached --name-only | grep -c releaseManifest.ts)"
+
+  if [ "$status" -ne 0 ] && [ "$manifest_ers" = "0.1.60" ] && [ "$staged" = "0" ]; then
+    pass "a real resync (triggered by rpc-proxy) refuses to run while an unrelated counter package.json has unstaged changes"
+  else
+    fail "status=$status manifest externalRestApiVersion=$manifest_ers staged=$staged; unstaged 0.9.99 must not leak via a resync triggered by a different package"
+  fi
+  rm -rf "$d"
+}
+
+assert_a_self_concealing_manifest_edit_cannot_suppress_the_resync() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+
+  # Trigger a REAL counter bump (ers 0.1.60 -> 0.1.61 gets staged by the loop)...
+  ( cd "$d" && echo "export const x = 2" > external-rest-api/src/other.ts && git add external-rest-api/src/other.ts )
+
+  # ...then, BEFORE running the hook, hand-edit the manifest ON DISK (never
+  # staged) so its externalRestApiVersion already reads '0.1.61' -- the value
+  # package.json is about to become. A disk-based drift check would see
+  # currentVersion === manifestVersion and conclude nothing is out of sync,
+  # even though the manifest that will actually be COMMITTED (the index,
+  # still '0.1.60') was never touched. That's the self-concealing case: the
+  # dirty file's content happens to make the drift check stay silent.
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/src/releaseManifest.ts <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '0.1.61',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  )
+
+  local status stderr_output
+  stderr_output="$( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs 2>&1 >/dev/null )"
+  status=$?
+
+  local staged committed_ers
+  staged="$(cd "$d" && git diff --cached --name-only | grep -c releaseManifest.ts)"
+  committed_ers="$(cd "$d" && git show :external-rest-api/src/releaseManifest.ts 2>/dev/null | grep -E "^  externalRestApiVersion: '" | sed "s/.*'\(.*\)'.*/\1/")"
+
+  # Must refuse (nonzero exit, refusal message) precisely BECAUSE the
+  # unstaged-changes check now runs before the drift read can be fooled by
+  # it -- not just "the manifest wasn't staged", which is also true of a
+  # silent, broken success.
+  if [ "$status" -ne 0 ] && [ "$staged" = "0" ] && [ "$committed_ers" = "0.1.60" ] \
+    && echo "$stderr_output" | grep -q "unstaged changes"; then
+    pass "an unstaged manifest edit that happens to already match disk cannot suppress the re-sync"
+  else
+    fail "expected refusal; got status=$status staged=$staged committed externalRestApiVersion=$committed_ers stderr='$stderr_output'"
+  fi
+  rm -rf "$d"
+}
+
+assert_a_corrupted_committed_package_json_is_refused_not_crashed() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+
+  # Simulate a package.json that slipped through with conflict markers still
+  # in it (e.g. a bypassed hook, or a force-committed unresolved merge) --
+  # already COMMITTED, not staged in THIS run, so the ordinary bump loop
+  # (which only processes staged files) never touches it. The only code path
+  # that reads it here is the drift check's readIndexedPackageVersion.
+  (
+    cd "$d" || exit 1
+    cat > external-rest-api/package.json <<'EOF'
+{
+  "name": "external-rest-api",
+<<<<<<< HEAD
+  "version": "0.1.60"
+=======
+  "version": "0.1.61"
+>>>>>>> feature
+}
+EOF
+    git add external-rest-api/package.json
+    git -c user.email=t@t -c user.name=t commit -qm "corrupt external-rest-api/package.json"
+  )
+
+  # An entirely unrelated, legitimate trigger for the drift check to run at all.
+  ( cd "$d" && echo "export const y = 2" > rpc-proxy/src/other.ts && git add rpc-proxy/src/other.ts )
+
+  local status stderr_output
+  stderr_output="$( cd "$d" && node scripts/precommit/bump-staged-package-versions.mjs 2>&1 >/dev/null )"
+  status=$?
+
+  if [ "$status" -ne 0 ] && ! echo "$stderr_output" | grep -q "SyntaxError" \
+    && echo "$stderr_output" | grep -q "external-rest-api/package.json"; then
+    pass "a corrupted counter package.json is refused with a named message, not a raw parse-crash stack trace"
+  else
+    fail "expected nonzero exit naming external-rest-api/package.json with no raw SyntaxError; got status=$status stderr='$stderr_output'"
+  fi
+  rm -rf "$d"
+}
+
+assert_release_manifest_does_not_bump
+assert_other_source_still_bumps
+assert_a_counter_bump_resyncs_the_manifest
+assert_rpc_proxy_bump_resyncs_the_manifest
+assert_desktop_version_not_touched_by_counter_resync
+assert_resync_preserves_the_release_id
+assert_unstaged_manifest_changes_block_the_resync
+assert_a_failed_resync_recovers_on_retry
+assert_missing_release_id_is_refused_not_fabricated
+assert_unstaged_package_json_drift_is_not_leaked_into_the_manifest
+assert_unrelated_unstaged_package_json_blocks_a_real_resync
+assert_a_self_concealing_manifest_edit_cannot_suppress_the_resync
+assert_a_corrupted_committed_package_json_is_refused_not_crashed
+
+exit $FAIL

--- a/scripts/tests/test-precommit-release-manifest-ignore.sh
+++ b/scripts/tests/test-precommit-release-manifest-ignore.sh
@@ -497,6 +497,33 @@ EOF
   rm -rf "$d"
 }
 
+assert_a_deletion_only_change_still_bumps_the_counter() {
+  local d; d="$(mktemp -d)"; make_repo "$d"
+  # Add a file and commit the resulting bump, so the deletion below is the only
+  # staged change in its own commit.
+  ( cd "$d" \
+    && echo "export const foo = 1" > external-rest-api/src/foo.ts \
+    && git add external-rest-api/src/foo.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 \
+    && git -c user.email=t@t -c user.name=t commit -q --no-verify -m add )
+  local after_add; after_add="$(version_of "$d")"
+
+  ( cd "$d" && git rm -q external-rest-api/src/foo.ts \
+    && node scripts/precommit/bump-staged-package-versions.mjs >/dev/null 2>&1 )
+  local after_del; after_del="$(version_of "$d")"
+
+  # A deletion changes the package's content as surely as an addition does.
+  # With --diff-filter=ACMR (no D) the deletion was invisible, so two different
+  # trees reported the same version and the release-time counter check could
+  # not see it: both sides agreed by construction.
+  if [ "$after_add" = "0.1.61" ] && [ "$after_del" = "0.1.62" ]; then
+    pass "a deletion-only staged change still bumps the counter"
+  else
+    fail "after_add=$after_add after_delete=$after_del; expected 0.1.61 then 0.1.62"
+  fi
+  rm -rf "$d"
+}
+
 assert_release_manifest_does_not_bump
 assert_other_source_still_bumps
 assert_a_counter_bump_resyncs_the_manifest
@@ -510,5 +537,6 @@ assert_unstaged_package_json_drift_is_not_leaked_into_the_manifest
 assert_unrelated_unstaged_package_json_blocks_a_real_resync
 assert_a_self_concealing_manifest_edit_cannot_suppress_the_resync
 assert_a_corrupted_committed_package_json_is_refused_not_crashed
+assert_a_deletion_only_change_still_bumps_the_counter
 
 exit $FAIL

--- a/scripts/tests/test-precommit-release-manifest-ignore.sh
+++ b/scripts/tests/test-precommit-release-manifest-ignore.sh
@@ -3,7 +3,7 @@ set -u
 FAIL=0
 
 # The precommit bumper must ignore external-rest-api/src/releaseManifest.ts.
-# A later task adds scripts/release/prepare-release.mjs as that file's writer;
+# scripts/release/prepare-release.mjs is that file's writer;
 # if staging it bumps external-rest-api/package.json, the manifest is stale
 # the instant it is written and --validate-only fails on every release-prep
 # PR, forever.

--- a/scripts/tests/test-precommit-release-manifest-ignore.sh
+++ b/scripts/tests/test-precommit-release-manifest-ignore.sh
@@ -31,6 +31,7 @@ make_repo() {
   cp "$REPO_ROOT/scripts/precommit/bump-staged-package-versions.mjs" "$d/scripts/precommit/"
   cp "$REPO_ROOT/scripts/prettier/paths.mjs" "$d/scripts/prettier/"
   cp "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" "$d/scripts/release/"
+  cp "$REPO_ROOT/scripts/release/release-coordinates.mjs" "$d/scripts/release/"
   printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' \
     > "$d/external-rest-api/package.json"
   printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' \

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -4,7 +4,7 @@ FAIL=0
 
 # Tests for the release-cut scripts:
 #   scripts/release/update-desktop-release-manifest.mjs  (floor decoupling)
-#   scripts/release/prepare-release.mjs                  (the one writer)
+#   scripts/release/prepare-release.mjs                  (the one writer, added by a later task)
 #   scripts/release/validate-release-tag.mjs             (the checker)
 #
 # Each case builds a throwaway git repo containing only the files the script

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -240,11 +240,339 @@ assert_ordering_check_fails_against_unpatched_script() {
   rm -rf "$d"
 }
 
+assert_prepare_release_writes_every_coordinate() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  if ( cd "$d" && node scripts/release/prepare-release.mjs \
+        --version 0.6.0 --release-id test-1111111 >/dev/null 2>&1 ); then
+    local pv lv dv min
+    pv="$(grep '"version"' "$d/desktop-app/package.json" | sed 's/.*: "\(.*\)".*/\1/')"
+    lv="$(node -e 'const j=require(process.argv[1]);console.log(j.version,j.packages[""].version)' "$d/desktop-app/package-lock.json")"
+    dv="$(manifest_field "$d" desktopVersion)"
+    min="$(manifest_field "$d" minimumDesktopVersion)"
+    if [ "$pv" = "0.6.0" ] && [ "$lv" = "0.6.0 0.6.0" ] && [ "$dv" = "0.6.0" ] && [ "$min" = "0.1.252" ]; then
+      pass "prepare-release writes package.json, both lockfile sites, and the manifest"
+    else
+      fail "coordinates after prepare-release: pkg=$pv lock='$lv' manifest=$dv floor=$min"
+    fi
+  else
+    fail "prepare-release.mjs exited non-zero"
+  fi
+  rm -rf "$d"
+}
+
+assert_prepare_release_leaves_a_same_string_dependency_alone() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  node -e '
+    const fs = require("fs"), p = process.argv[1]
+    const j = JSON.parse(fs.readFileSync(p, "utf8"))
+    j.dependencies = { "some-dep": "0.5.0" }
+    fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n")
+  ' "$d/desktop-app/package.json"
+
+  ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.6.0 --release-id t >/dev/null 2>&1 )
+  local dep; dep="$(node -e 'console.log(require(process.argv[1]).dependencies["some-dep"])' "$d/desktop-app/package.json")"
+  if [ "$dep" = "0.5.0" ]; then
+    pass "a dependency pinned to the old version string is untouched"
+  else
+    fail "dependency pin was rewritten to $dep"
+  fi
+  rm -rf "$d"
+}
+
+assert_prepare_release_rejects_a_non_greater_version() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.5.0 --release-id t >/dev/null 2>&1 ); then
+    fail "prepare-release accepted a version not greater than current"
+  else
+    pass "prepare-release rejects a version not greater than current"
+  fi
+  rm -rf "$d"
+}
+
+assert_prepare_release_rejects_a_bad_version_shape() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.6 --release-id t >/dev/null 2>&1 ); then
+    fail "prepare-release accepted a non MAJOR.MINOR.PATCH version"
+  else
+    pass "prepare-release rejects a non MAJOR.MINOR.PATCH version"
+  fi
+  rm -rf "$d"
+}
+
+assert_release_id_is_never_local() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "prepare-release ran without --release-id"
+  else
+    pass "prepare-release requires an explicit --release-id"
+  fi
+  rm -rf "$d"
+}
+
+assert_validate_release_tag_catches_each_coordinate() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  if ! ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag rejected a coherent tree"
+    rm -rf "$d"; return
+  fi
+
+  # This breaks a single `equals` coordinate (desktop-app/package.json) and
+  # confirms the checker catches it. The other assertion kinds -- floor,
+  # explicit, counter -- get their own dedicated negative cases below
+  # (assert_floor_above_release_version_is_rejected_by_the_checker,
+  # assert_floor_non_semver_is_rejected_by_the_checker,
+  # assert_explicit_release_id_is_rejected_when_local_or_empty,
+  # assert_counter_mismatch_is_rejected_by_the_checker), not by looping here.
+  local broke_all=1
+  node -e '
+    const fs=require("fs"),p=process.argv[1]
+    const j=JSON.parse(fs.readFileSync(p,"utf8")); j.version="0.6.1"
+    fs.writeFileSync(p,JSON.stringify(j,null,2)+"\n")
+  ' "$d/desktop-app/package.json"
+  ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ) && broke_all=0
+
+  if [ "$broke_all" = "1" ]; then
+    pass "validate-release-tag catches a disagreeing coordinate"
+  else
+    fail "validate-release-tag passed with desktop-app/package.json at 0.6.1"
+  fi
+  rm -rf "$d"
+}
+
+assert_validate_release_tag_rejects_a_renamed_manifest_export() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/desktop-app" "$d/external-rest-api/src" "$d/rpc-proxy"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.6.0"\n}\n' > "$d/desktop-app/package.json"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.6.0",\n  "packages": {\n    "": {\n      "version": "0.6.0"\n    }\n  }\n}\n' > "$d/desktop-app/package-lock.json"
+  printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' > "$d/rpc-proxy/package.json"
+  # The export is renamed but the field values are otherwise coherent with
+  # the release. A field-by-field regex over the whole file would still find
+  # these lines and pass; manifestField must instead fail to find the
+  # `releaseManifest` export at all, so every manifest coordinate reads as
+  # empty and the checker rejects the tree.
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifestRENAMED: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.6.0',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag passed against a renamed releaseManifest export"
+  else
+    pass "validate-release-tag rejects a manifest whose export is renamed"
+  fi
+  rm -rf "$d"
+}
+
+assert_validate_release_tag_ignores_a_decoy_object() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/desktop-app" "$d/external-rest-api/src" "$d/rpc-proxy"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.6.0"\n}\n' > "$d/desktop-app/package.json"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.6.0",\n  "packages": {\n    "": {\n      "version": "0.6.0"\n    }\n  }\n}\n' > "$d/desktop-app/package-lock.json"
+  printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' > "$d/rpc-proxy/package.json"
+  # A decoy object with the SAME field names sits above the real export and
+  # carries values that would pass. The real `releaseManifest` export below
+  # it carries values that must fail. A field-by-field regex over the whole
+  # file matches the decoy's lines first (they appear first) and passes; the
+  # checker must read the actual `releaseManifest` export instead.
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+const decoy = {
+  releaseId: 'decoy-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.6.0',
+  minimumDesktopVersion: '0.1.252',
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'wrong-0000000',
+  externalRestApiVersion: '9.9.9',
+  rpcProxyVersion: '9.9.9',
+  desktopVersion: '9.9.9',
+  minimumDesktopVersion: '9.9.9',
+}
+EOF
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag passed by reading a decoy object instead of the real export"
+  else
+    pass "validate-release-tag reads the real releaseManifest export, not a decoy placed above it"
+  fi
+  rm -rf "$d"
+}
+
+assert_floor_is_checked_as_a_ceiling_not_an_equality() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    pass "a floor below the release version is accepted, not required to equal it"
+  else
+    fail "validate-release-tag required minimumDesktopVersion to equal the version"
+  fi
+  rm -rf "$d"
+}
+
+assert_floor_above_release_version_is_rejected_by_the_checker() {
+  local d; d="$(mktemp -d)"
+  # Floor 0.9.9 is ABOVE the release version 0.6.0 -- the dangerous
+  # direction. This whole workstream exists because a wrong floor
+  # force-updates every existing desktop install; the checker must catch
+  # this before the tag, not just accept a floor that happens to be low.
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.9.9 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag accepted a floor (0.9.9) above the release version (0.6.0)"
+  else
+    pass "validate-release-tag rejects a floor above the release version"
+  fi
+  rm -rf "$d"
+}
+
+assert_floor_non_semver_is_rejected_by_the_checker() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag accepted a non MAJOR.MINOR.PATCH floor (0.1)"
+  else
+    pass "validate-release-tag rejects a non MAJOR.MINOR.PATCH floor"
+  fi
+  rm -rf "$d"
+}
+
+assert_explicit_release_id_is_rejected_when_local_or_empty() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  local manifest="$d/external-rest-api/src/releaseManifest.ts"
+
+  sed -i.bak "s/releaseId: 'fixture-0000000'/releaseId: 'local'/" "$manifest"
+  local local_rejected=0
+  ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ) || local_rejected=1
+
+  sed -i.bak "s/releaseId: 'local'/releaseId: ''/" "$manifest"
+  local empty_rejected=0
+  ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ) || empty_rejected=1
+
+  if [ "$local_rejected" = "1" ] && [ "$empty_rejected" = "1" ]; then
+    pass "validate-release-tag rejects releaseId of 'local' and of an empty string"
+  else
+    fail "expected both 'local' and empty releaseId rejected (local_rejected=$local_rejected empty_rejected=$empty_rejected)"
+  fi
+  rm -rf "$d"
+}
+
+assert_counter_mismatch_is_rejected_by_the_checker() {
+  local d; d="$(mktemp -d)"
+  # manifest externalRestApiVersion (0.1.61) disagrees with
+  # external-rest-api/package.json (0.1.60) -- checked against the counter's
+  # OWN package, not the release version.
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1.252 0.1.61 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag accepted externalRestApiVersion disagreeing with external-rest-api/package.json"
+  else
+    pass "validate-release-tag rejects a counter that disagrees with its own package.json"
+  fi
+  rm -rf "$d"
+}
+
+assert_every_coordinate_has_a_case() {
+  local declared cases
+  declared="$(node -e '
+    import("'"$REPO_ROOT"'/scripts/release/release-coordinates.mjs")
+      .then(m => console.log(m.COORDINATES.length))
+  ')"
+  # Count DEFINITIONS only. A bare "^assert_" also counts every invocation in
+  # the call block at the bottom, which roughly doubles the number and makes
+  # this check pass no matter what.
+  cases="$(grep -cE '^assert_[a-z_]+\(\) \{' "$REPO_ROOT/scripts/tests/test-release-coordinates.sh")"
+  if [ "$cases" -ge "$declared" ]; then
+    pass "each declared coordinate has at least one case ($declared coordinates, $cases assertions)"
+  else
+    fail "$declared coordinates declared but only $cases assertions"
+  fi
+}
+
+# Guards against the opposite failure mode from assert_every_coordinate_has_a_case:
+# a case can be DEFINED (so it counts toward that check) and still never be
+# CALLED from the block below, which makes it permanently dead -- the suite
+# prints all-PASS while the dead case never runs. A stated PASS-count in a
+# plan document is a description, not a source of truth; this check compares
+# against what the file itself defines and calls, so it can't go stale that
+# way.
+assert_every_defined_case_is_invoked() {
+  local defined invoked missing
+  defined="$(grep -oE '^assert_[a-z_]+\(\) \{' "$REPO_ROOT/scripts/tests/test-release-coordinates.sh" \
+    | sed -E 's/\(\) \{$//' | sort -u)"
+  invoked="$(grep -oE '^assert_[a-z_]+$' "$REPO_ROOT/scripts/tests/test-release-coordinates.sh" | sort -u)"
+  missing="$(comm -23 <(printf '%s\n' "$defined") <(printf '%s\n' "$invoked"))"
+  if [ -z "$missing" ]; then
+    pass "every defined assert_ case is invoked in the call block"
+  else
+    fail "defined but never invoked: $(printf '%s ' $missing)"
+  fi
+}
+
 assert_floor_is_not_dragged_by_a_desktop_bump
 assert_floor_above_desktop_is_rejected
 assert_explicit_minimum_flag_is_honoured
 assert_unreadable_manifest_does_not_synthesize_a_floor
 assert_previous_ref_does_not_revert_a_raised_floor
 assert_ordering_check_fails_against_unpatched_script
+assert_prepare_release_writes_every_coordinate
+assert_prepare_release_leaves_a_same_string_dependency_alone
+assert_prepare_release_rejects_a_non_greater_version
+assert_prepare_release_rejects_a_bad_version_shape
+assert_release_id_is_never_local
+assert_validate_release_tag_catches_each_coordinate
+assert_validate_release_tag_rejects_a_renamed_manifest_export
+assert_validate_release_tag_ignores_a_decoy_object
+assert_floor_is_checked_as_a_ceiling_not_an_equality
+assert_floor_above_release_version_is_rejected_by_the_checker
+assert_floor_non_semver_is_rejected_by_the_checker
+assert_explicit_release_id_is_rejected_when_local_or_empty
+assert_counter_mismatch_is_rejected_by_the_checker
+assert_every_coordinate_has_a_case
+assert_every_defined_case_is_invoked
 
 exit $FAIL

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -516,6 +516,43 @@ assert_counter_mismatch_is_rejected_by_the_checker() {
   rm -rf "$d"
 }
 
+assert_unhandled_assert_kind_fails_closed() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.6.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  # Append an 8th coordinate whose assert kind ('pointer') the checker does
+  # not implement, carrying a deliberately garbage value that would never
+  # agree with anything. If an unrecognized assert kind falls through every
+  # branch instead of failing closed, this coordinate is never actually
+  # checked and the tree still reports success -- the exact bug this case
+  # guards against.
+  node -e '
+    const fs = require("fs")
+    const p = process.argv[1]
+    let s = fs.readFileSync(p, "utf8")
+    const marker = "export function readCounterPackage"
+    if (!s.includes(marker)) throw new Error("marker not found")
+    s = s.replace(
+      marker,
+      "COORDINATES.push({\n" +
+        "  name: \"test-only-pointer-coordinate\",\n" +
+        "  assert: \"pointer\",\n" +
+        "  read: () => \"garbage-value-that-is-never-checked\",\n" +
+        "})\n\n" +
+        marker
+    )
+    fs.writeFileSync(p, s)
+  ' "$d/scripts/release/release-coordinates.mjs"
+
+  if ( cd "$d" && node scripts/release/validate-release-tag.mjs --version 0.6.0 >/dev/null 2>&1 ); then
+    fail "validate-release-tag passed with an unhandled assert kind ('pointer') on a coordinate"
+  else
+    pass "validate-release-tag fails closed on an unhandled assert kind instead of skipping it silently"
+  fi
+  rm -rf "$d"
+}
+
 assert_every_coordinate_has_a_case() {
   local declared cases
   declared="$(node -e '
@@ -572,6 +609,7 @@ assert_floor_above_release_version_is_rejected_by_the_checker
 assert_floor_non_semver_is_rejected_by_the_checker
 assert_explicit_release_id_is_rejected_when_local_or_empty
 assert_counter_mismatch_is_rejected_by_the_checker
+assert_unhandled_assert_kind_fails_closed
 assert_every_coordinate_has_a_case
 assert_every_defined_case_is_invoked
 

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -590,6 +590,50 @@ assert_every_defined_case_is_invoked() {
   fi
 }
 
+assert_floor_above_version_is_rejected_before_any_write() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  ( cd "$d" && node scripts/release/prepare-release.mjs \
+      --version 0.6.0 --release-id t --minimum-desktop-version 0.7.0 >/dev/null 2>&1 )
+  local pkg; pkg="$(node -e 'console.log(require(process.argv[1]).version)' "$d/desktop-app/package.json")"
+
+  # The delegated updater rejects floor > desktopVersion. Discovering that AFTER
+  # the coordinate loop has written package.json leaves the tree half-cut, so
+  # the range check has to happen up front.
+  if [ "$pkg" = "0.5.0" ]; then
+    pass "a floor above the release version is rejected before any coordinate is written"
+  else
+    fail "desktop-app/package.json was written to $pkg despite an impossible floor"
+  fi
+  rm -rf "$d"
+}
+
+assert_a_half_cut_release_can_be_completed_by_rerunning() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+
+  # Force the manifest write to fail AFTER package.json has been written.
+  chmod -w "$d/external-rest-api/src/releaseManifest.ts"
+  ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.6.0 --release-id t >/dev/null 2>&1 )
+  chmod +w "$d/external-rest-api/src/releaseManifest.ts"
+
+  # Re-running the SAME command must work. The monotonic guard compares against
+  # the last COMMITTED version, not the value the failed run left on disk --
+  # otherwise the remediation both this script and validate-release-tag.mjs
+  # print is a dead end ("not greater than the current desktop version").
+  ( cd "$d" && node scripts/release/prepare-release.mjs --version 0.6.0 --release-id t >/dev/null 2>&1 )
+  local dv min; dv="$(manifest_field "$d" desktopVersion)"; min="$(manifest_field "$d" minimumDesktopVersion)"
+  if [ "$dv" = "0.6.0" ] && [ "$min" = "0.1.252" ]; then
+    pass "re-running a half-cut release completes it and leaves the floor alone"
+  else
+    fail "after re-run desktopVersion=$dv minimumDesktopVersion=$min; expected 0.6.0 / 0.1.252"
+  fi
+  rm -rf "$d"
+}
+
 assert_floor_is_not_dragged_by_a_desktop_bump
 assert_floor_above_desktop_is_rejected
 assert_explicit_minimum_flag_is_honoured
@@ -610,6 +654,8 @@ assert_floor_non_semver_is_rejected_by_the_checker
 assert_explicit_release_id_is_rejected_when_local_or_empty
 assert_counter_mismatch_is_rejected_by_the_checker
 assert_unhandled_assert_kind_fails_closed
+assert_floor_above_version_is_rejected_before_any_write
+assert_a_half_cut_release_can_be_completed_by_rerunning
 assert_every_coordinate_has_a_case
 assert_every_defined_case_is_invoked
 

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -u
+FAIL=0
+
+# Tests for the release-cut scripts:
+#   scripts/release/update-desktop-release-manifest.mjs  (floor decoupling)
+#   scripts/release/prepare-release.mjs                  (the one writer)
+#   scripts/release/validate-release-tag.mjs             (the checker)
+#
+# Each case builds a throwaway git repo containing only the files the script
+# under test reads, so nothing here depends on the real tree's versions.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAIL=1; }
+
+# Build a scratch repo with the given desktop/ers/rpc versions and manifest.
+# Usage: make_fixture <dir> <desktopVersion> <ersVersion> <rpcVersion> \
+#                     <manifestDesktop> <manifestMinimum> <manifestErs> <manifestRpc>
+make_fixture() {
+  local d=$1 dv=$2 ev=$3 rv=$4 mdv=$5 mmin=$6 mev=$7 mrv=$8
+  mkdir -p "$d/desktop-app" "$d/external-rest-api/src" "$d/rpc-proxy"
+  printf '{\n  "name": "desktop-app",\n  "version": "%s"\n}\n' "$dv" > "$d/desktop-app/package.json"
+  printf '{\n  "name": "desktop-app",\n  "version": "%s",\n  "packages": {\n    "": {\n      "version": "%s"\n    }\n  }\n}\n' "$dv" "$dv" > "$d/desktop-app/package-lock.json"
+  printf '{\n  "name": "external-rest-api",\n  "version": "%s"\n}\n' "$ev" > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "%s"\n}\n' "$rv" > "$d/rpc-proxy/package.json"
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<EOF
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '$mev',
+  rpcProxyVersion: '$mrv',
+  desktopVersion: '$mdv',
+  minimumDesktopVersion: '$mmin',
+}
+EOF
+  ( cd "$d" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm init )
+}
+
+manifest_field() {
+  # manifest_field <dir> <field>
+  # The quote in the pattern is load-bearing: renderManifest emits a TypeScript
+  # type block above the object, so "^  desktopVersion:" alone also matches
+  # "  desktopVersion: string" and sed passes that line straight through.
+  grep -E "^  $2: '" "$1/external-rest-api/src/releaseManifest.ts" | sed "s/.*'\(.*\)'.*/\1/"
+}
+
+assert_floor_is_not_dragged_by_a_desktop_bump() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.1.252 0.1.252 0.1.60 0.1.51
+
+  if ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --release-id test-0000000 >/dev/null 2>&1 ); then
+    local dv min
+    dv="$(manifest_field "$d" desktopVersion)"
+    min="$(manifest_field "$d" minimumDesktopVersion)"
+    if [ "$dv" = "0.5.0" ] && [ "$min" = "0.1.252" ]; then
+      pass "desktop bump advances desktopVersion and leaves the floor alone"
+    else
+      fail "expected desktopVersion=0.5.0 minimumDesktopVersion=0.1.252, got $dv / $min"
+    fi
+  else
+    fail "update-desktop-release-manifest.mjs rejected a floor below desktopVersion"
+  fi
+  rm -rf "$d"
+}
+
+assert_floor_above_desktop_is_rejected() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.9.9 0.1.60 0.1.51
+
+  if ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --validate-only >/dev/null 2>&1 ); then
+    fail "minimumDesktopVersion greater than desktopVersion was accepted"
+  else
+    pass "minimumDesktopVersion greater than desktopVersion is rejected"
+  fi
+  rm -rf "$d"
+}
+
+assert_explicit_minimum_flag_is_honoured() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.6.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+
+  # 0.5.5 deliberately differs from BOTH the old floor (0.1.252) and the new
+  # desktop version (0.6.0). Asking for 0.6.0 here would pass against the
+  # unpatched script too, since its forced write lands on exactly that value.
+  if ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --release-id test-0000000 --minimum-desktop-version 0.5.5 >/dev/null 2>&1 ); then
+    local min; min="$(manifest_field "$d" minimumDesktopVersion)"
+    if [ "$min" = "0.5.5" ]; then
+      pass "--minimum-desktop-version raises the floor when asked"
+    else
+      fail "expected floor 0.5.5 after explicit raise, got $min"
+    fi
+  else
+    fail "--minimum-desktop-version was not accepted"
+  fi
+  rm -rf "$d"
+}
+
+assert_unreadable_manifest_does_not_synthesize_a_floor() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/desktop-app" "$d/external-rest-api/src" "$d/rpc-proxy"
+  printf '{\n  "name": "desktop-app",\n  "version": "0.5.0"\n}\n' > "$d/desktop-app/package.json"
+  printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' > "$d/rpc-proxy/package.json"
+  # The export is renamed so parseManifest's regex cannot find `releaseManifest`
+  # and returns null -- simulates an unreadable/corrupted manifest with no
+  # --minimum-desktop-version flag to fall back on.
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifestRENAMED: ReleaseManifest = {
+  releaseId: 'fixture-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  ( cd "$d" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm init )
+
+  if ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --release-id t-3 >/dev/null 2>&1 ); then
+    fail "unreadable manifest with no explicit floor was silently accepted"
+  elif grep -q "minimumDesktopVersion: '0.5.0'" "$d/external-rest-api/src/releaseManifest.ts"; then
+    fail "unreadable manifest run was rejected but still wrote desktopVersion as the floor"
+  else
+    pass "unreadable manifest with no explicit floor is rejected, not silently defaulted to desktopVersion"
+  fi
+  rm -rf "$d"
+}
+
+assert_previous_ref_does_not_revert_a_raised_floor() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/desktop-app" "$d/external-rest-api/src" "$d/rpc-proxy"
+
+  # Earlier state, tagged v1: desktop 0.1.252, floor 0.1.252.
+  printf '{\n  "name": "desktop-app",\n  "version": "0.1.252"\n}\n' > "$d/desktop-app/package.json"
+  printf '{\n  "name": "external-rest-api",\n  "version": "0.1.60"\n}\n' > "$d/external-rest-api/package.json"
+  printf '{\n  "name": "rpc-proxy",\n  "version": "0.1.51"\n}\n' > "$d/rpc-proxy/package.json"
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'v1-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.1.252',
+  minimumDesktopVersion: '0.1.252',
+}
+EOF
+  ( cd "$d" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm v1 && git tag v1 )
+
+  # HEAD: an operator already raised the floor to 0.4.0 and bumped desktop to 0.5.0.
+  printf '{\n  "name": "desktop-app",\n  "version": "0.5.0"\n}\n' > "$d/desktop-app/package.json"
+  cat > "$d/external-rest-api/src/releaseManifest.ts" <<'EOF'
+export type ReleaseManifest = {
+  releaseId: string
+  externalRestApiVersion: string
+  rpcProxyVersion: string
+  desktopVersion: string
+  minimumDesktopVersion: string
+}
+
+export const releaseManifest: ReleaseManifest = {
+  releaseId: 'head-0000000',
+  externalRestApiVersion: '0.1.60',
+  rpcProxyVersion: '0.1.51',
+  desktopVersion: '0.5.0',
+  minimumDesktopVersion: '0.4.0',
+}
+EOF
+  ( cd "$d" && git add -A && git -c user.email=t@t -c user.name=t commit -qm head )
+
+  if ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --release-id t-2 --previous v1 >/dev/null 2>&1 ); then
+    local min; min="$(manifest_field "$d" minimumDesktopVersion)"
+    if [ "$min" = "0.4.0" ]; then
+      pass "--previous does not revert a floor already raised on HEAD"
+    else
+      fail "expected floor to stay at HEAD's 0.4.0, got $min (reverted to the --previous ref's floor)"
+    fi
+  else
+    fail "--previous v1 with a floor already raised on HEAD was unexpectedly rejected"
+  fi
+  rm -rf "$d"
+}
+
+assert_ordering_check_fails_against_unpatched_script() {
+  local d; d="$(mktemp -d)"
+  make_fixture "$d" 0.5.0 0.1.60 0.1.51 0.5.0 0.1.252 0.1.60 0.1.51
+
+  # Case 2 above (floor > desktopVersion) also gets rejected by the unpatched
+  # `!==` check, so it does not prove ordering semantics. This case uses a
+  # floor STRICTLY BELOW desktopVersion, which the unpatched equality check
+  # rejects (0.1.252 !== 0.5.0) but the patched ordering check accepts
+  # (0.1.252 <= 0.5.0) -- the only kind of case that discriminates the two.
+  local unpatched="$d/unpatched-update-desktop-release-manifest.mjs"
+  if ! git -C "$REPO_ROOT" show 75e44f8e:scripts/release/update-desktop-release-manifest.mjs \
+        > "$unpatched" 2>/dev/null; then
+    fail "could not materialise the unpatched script from 75e44f8e"
+    rm -rf "$d"
+    return
+  fi
+
+  local unpatched_exit patched_exit
+  ( cd "$d" && node "$unpatched" --validate-only >/dev/null 2>&1 )
+  unpatched_exit=$?
+  ( cd "$d" && node "$REPO_ROOT/scripts/release/update-desktop-release-manifest.mjs" \
+        --validate-only >/dev/null 2>&1 )
+  patched_exit=$?
+
+  if [ "$unpatched_exit" -ne 0 ] && [ "$patched_exit" -eq 0 ]; then
+    pass "ordering check (0.1.252 <= 0.5.0) is rejected by the unpatched equality check and accepted by the patched ordering check"
+  else
+    fail "expected unpatched exit!=0 and patched exit=0, got unpatched=$unpatched_exit patched=$patched_exit"
+  fi
+  rm -rf "$d"
+}
+
+assert_floor_is_not_dragged_by_a_desktop_bump
+assert_floor_above_desktop_is_rejected
+assert_explicit_minimum_flag_is_honoured
+assert_unreadable_manifest_does_not_synthesize_a_floor
+assert_previous_ref_does_not_revert_a_raised_floor
+assert_ordering_check_fails_against_unpatched_script
+
+exit $FAIL

--- a/scripts/tests/test-release-coordinates.sh
+++ b/scripts/tests/test-release-coordinates.sh
@@ -4,7 +4,7 @@ FAIL=0
 
 # Tests for the release-cut scripts:
 #   scripts/release/update-desktop-release-manifest.mjs  (floor decoupling)
-#   scripts/release/prepare-release.mjs                  (the one writer, added by a later task)
+#   scripts/release/prepare-release.mjs                  (the one writer)
 #   scripts/release/validate-release-tag.mjs             (the checker)
 #
 # Each case builds a throwaway git repo containing only the files the script


### PR DESCRIPTION
Workstream A of the release-versioning work. Makes `desktop-app/package.json` the
real release version instead of a per-commit counter, and gives the repo one
release-cut writer plus a checker.

## Why

`desktop-app/package.json` was serving two incompatible roles: a per-commit change
counter (auto-bumped by the pre-commit hook) and the release/compatibility version
that `releaseManifest.ts`, the update gate, and every artifact filename read. A
number that increments on every commit cannot also be a release version, and three
consequences were visible in the tree:

- The manifest had drifted. All three of its package fields disagreed with their
  `package.json` (`0.1.252/0.1.56/0.1.36` against `0.1.333/0.1.60/0.1.51`).
- The update prompt linked to a 404: the tag was built as
  `desktop-app-${version}`, a shape that has never existed, against a
  `your-org` placeholder base URL.
- Neither validator was wired into CI, which is why the drift went unnoticed.

## What changes

- `minimumDesktopVersion` is decoupled from `desktopVersion`, and
  `--minimum-desktop-version` — which the design assumed existed but never did — is
  implemented. Omitting it now means "leave the floor alone".
- The per-commit counter is retired for `desktop-app` only. `external-rest-api` and
  `rpc-proxy` keep theirs.
- The pre-commit hook keeps the manifest and those counters in sync in both
  directions. Staging `releaseManifest.ts` no longer bumps `external-rest-api`
  (otherwise the release-prep PR could never be green), and bumping a counter the
  manifest declares re-syncs the manifest (otherwise every PR touching those
  services goes red once `--validate-only` runs in CI).
- `desktop-app` goes to `0.5.0`; all three drifted manifest fields are repaired.
- New `prepare-release.mjs` (writer) and `validate-release-tag.mjs` (checker) over a
  shared coordinate table, so a coordinate cannot be written without being checked.
- The update prompt links to `v${version}` at a real default base URL, still
  overridable via `EXTERNAL_REST_API_DESKTOP_RELEASE_BASE_URL`.
- Both dormant validators and two new bash harnesses are wired into CI.

## Behaviour change to be aware of

Making versions coherent **activates** the update gate, which is inert today.
`minimumDesktopVersion` deliberately stays at `0.1.252`, so **nobody is gated by
this PR** — every shipped install reports `0.1.316`, comfortably above the floor.
Raising it is now a separate, explicit act. If it had been allowed to follow
`desktopVersion` to `0.5.0`, every existing user would have been force-updated to a
release page whose assets are named `0.1.316`.

## Not wired up yet, on purpose

`prepare-release.mjs` and `validate-release-tag.mjs` have no caller — no workflow, no
Makefile target. They are the release-cut half, and the job that invokes them belongs
to the image-publishing workstream that follows this one. They are fully tested in
the meantime.

## Verification

- `scripts/tests/test-release-coordinates.sh` — 22 cases
- `scripts/tests/test-precommit-release-manifest-ignore.sh` — 13 cases
- `external-rest-api` vitest — 24 files, 109 tests
- `update-desktop-release-manifest.mjs --validate-only`, `validate-release-tag.mjs
  --version 0.5.0`, and `validate-release-version-bumps.mjs` all pass locally

The harnesses use throwaway git fixtures and need no `node_modules`, so they run in
the existing `shell-syntax` job. That job's checkout gains `fetch-depth: 0`, without
which `validate-release-version-bumps.mjs` either throws or silently exits 0.

## Follow-ups deliberately left out

- `prepare-release.mjs` leaves the tree half-cut if the delegated updater fails;
  worth an up-front range check and a try/catch when the release-cut job is wired.
- The unstaged-manifest guard blocks any commit while `releaseManifest.ts` is dirty,
  which is broader than the existing `package.json` precedent. Fail-closed and
  actionable; narrow it by reading the manifest from the index if it bites.
- `desktop-app` client tests still hardcode the dead `desktop-app-0.1.250` shape as
  inert mock fixtures.
- `scripts/tests/gfs-legacy-standalone-grants.test.mjs` remains unwired; it needs a
  built `control-api`, so it cannot run in `shell-syntax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqtLT5fQeqbc3m8DsUPgRT