### PR TITLE
fix(deploy): make the HCC rollout wait a budget that can actually elapse

### DIFF
--- a/deploy/base/control-plane/host-context-controller.yaml
+++ b/deploy/base/control-plane/host-context-controller.yaml
@@ -13,6 +13,22 @@ metadata:
     app: host-context-controller
 spec:
   replicas: 1
+  # HCC's /ready stays 503 until its initial fleet reconciliation finishes, so time-to-Ready
+  # scales with the McpServer/Context fleet rather than with process start. clerum-dev took
+  # 651s on 2026-08-05 at 108 McpServers / 22 Contexts.
+  #
+  # Unset, this defaults to 600s, and that default is what actually governed the deploy:
+  # `kubectl rollout status` aborts the instant the controller sets ProgressDeadlineExceeded,
+  # so provision-gfs-runtime.sh's --timeout could never exceed the deadline remaining. The
+  # clock also starts several steps earlier, at apply-inter-service-tokens.sh's `rollout
+  # restart` of HCC, so the wait inherits only what is left. On 2026-08-05 that was 600-160
+  # = 440s against a 480s timeout: the timeout raised in #202 never bound, and the deploy
+  # failed 50s before HCC came Ready.
+  #
+  # 1200s covers the 900s wait plus a 300s head-start allowance. This is a mitigation, not
+  # the fix — evenfire-ai/evenfire#205 decouples readiness from fleet convergence, after
+  # which both numbers should come back down.
+  progressDeadlineSeconds: 1200
   selector:
     matchLabels:
       app: host-context-controller

--- a/deploy/scripts/provision-gfs-runtime.sh
+++ b/deploy/scripts/provision-gfs-runtime.sh
@@ -173,7 +173,19 @@ finalize_credentials_after_overlay() {
   fi
 
   log "Waiting for the post-overlay HCC rollout"
-  kctl -n control-plane rollout status deployment/host-context-controller --timeout=480s
+  # HCC serves 503 on /ready until its initial fleet reconciliation completes, so
+  # time-to-Ready scales with the McpServer/Context fleet. clerum-dev (108 McpServers,
+  # 22 Contexts) took 651s on 2026-08-05; clerum-prod (7/6) is far quicker.
+  #
+  # This number is only half the budget. `kubectl rollout status` aborts as soon as the
+  # Deployment controller sets Progressing=False/ProgressDeadlineExceeded, so it can never
+  # outlast progressDeadlineSeconds on the Deployment — and that clock starts earlier, when
+  # apply-inter-service-tokens.sh `rollout restart`s HCC several steps before this one.
+  # Keep this UNDER (progressDeadlineSeconds - that head start) or it silently does nothing:
+  # at 480s against the unset-hence-600s default it never once bound. The manifest now sets
+  # progressDeadlineSeconds: 1200; scripts/tests/test-provision-gfs-runtime.sh pins the
+  # relationship so the two cannot drift apart again.
+  kctl -n control-plane rollout status deployment/host-context-controller --timeout=900s
   wait_for_gfsc_secret_references
 
   log "Finalizing staged GFS credentials after the overlay"

--- a/scripts/tests/test-provision-gfs-runtime.sh
+++ b/scripts/tests/test-provision-gfs-runtime.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# The HCC post-overlay wait, and the two facts that decide whether it can actually elapse.
+# Kept here so the script, the Deployment manifest and this test cannot drift apart.
+HCC_ROLLOUT_TIMEOUT_S=900
+# Observed head start from apply-inter-service-tokens.sh's `rollout restart` of HCC to this
+# script's wait: 160s on clerum-dev 2026-08-05. Rounded up for slower deploys.
+HCC_RESTART_HEAD_START_S=300
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 mkdir -p "$TMP/bin" "$TMP/overlay/instances"
@@ -48,8 +56,35 @@ reconcile="$ROOT/deploy/scripts/reconcile-gfs-deploy-credentials.sh"
   echo 'FAIL: post-overlay credential reconciliation did not run once per deploy' >&2
   exit 1
 }
-[ "$(grep -Fc 'rollout status deployment/host-context-controller --timeout=480s' "$CALL_LOG")" -eq 3 ] || {
-  echo 'FAIL: HCC post-overlay rollout did not use its dedicated 480s timeout' >&2
+[ "$(grep -Fc "rollout status deployment/host-context-controller --timeout=${HCC_ROLLOUT_TIMEOUT_S}s" "$CALL_LOG")" -eq 3 ] || {
+  echo "FAIL: HCC post-overlay rollout did not use its dedicated ${HCC_ROLLOUT_TIMEOUT_S}s timeout" >&2
+  exit 1
+}
+
+# The timeout above is only ever the REAL budget if the Deployment's own
+# progressDeadlineSeconds outlasts it. `kubectl rollout status` aborts the moment the
+# Deployment controller sets Progressing=False/ProgressDeadlineExceeded, so a --timeout
+# larger than the remaining progress deadline is dead code.
+#
+# Two things make the margin bigger than it looks. The deadline clock starts when the new
+# ReplicaSet is created — that is apply-inter-service-tokens.sh's `rollout restart` of HCC,
+# several deploy steps EARLIER — not when this script starts waiting. And the deadline is
+# absolute, so the head start is subtracted from the budget this script thinks it has.
+#
+# On clerum-dev 2026-08-05 the head start was 160s: RS created 10:34:02, this wait began
+# 10:36:42, and with progressDeadlineSeconds unset (k8s default 600) the controller
+# aborted at 10:44:03 — 39s before the then-480s timeout would have fired. #202 raised
+# that timeout and nothing changed, because it could never bind.
+hcc_manifest="$ROOT/deploy/base/control-plane/host-context-controller.yaml"
+deadline="$(awk '/^  progressDeadlineSeconds:/ { print $2; exit }' "$hcc_manifest")"
+[ -n "$deadline" ] || {
+  echo "FAIL: $hcc_manifest does not declare progressDeadlineSeconds, so it defaults to 600s" >&2
+  echo '      and silently caps the rollout-status timeout above.' >&2
+  exit 1
+}
+[ "$deadline" -ge "$(( HCC_ROLLOUT_TIMEOUT_S + HCC_RESTART_HEAD_START_S ))" ] || {
+  echo "FAIL: progressDeadlineSeconds=${deadline}s cannot cover a ${HCC_ROLLOUT_TIMEOUT_S}s wait that" >&2
+  echo "      starts ${HCC_RESTART_HEAD_START_S}s after the restart — the deadline would abort first." >&2
   exit 1
 }
 for deployment in gfsc-writer gfsc-reader; do


### PR DESCRIPTION
## The failure

The clerum-dev deploy for `449d2ff` (#253) failed at step 23, *Provision GFS runtime and dev CRD instances*:

```
[provision-gfs-runtime] Waiting for the post-overlay HCC rollout
Waiting for deployment "host-context-controller" rollout to finish: 1 old replicas are pending termination...
error: deployment "host-context-controller" exceeded its progress deadline
```

`Commit per-service pin bump` was skipped as a result, so `gcp-dev` is still pinned at `sha-75e44f8` while the cluster runs `sha-449d2ff`. Since `promote-dev-tags.sh` copies the **overlay pins**, that also silently blocks a correct dev → prod promotion.

## Root cause

Two separate things, and only together are they fatal.

**1. HCC takes a long time to become Ready.** `/ready` serves 503 until initial fleet reconciliation completes, so time-to-Ready scales with the fleet rather than with process start (#204; #205 decouples it). clerum-dev is at **108 McpServers / 22 Contexts / 11 Hosts** and took **651s**. clerum-prod is at 7/6/5 and was never close.

**2. The wait had no real budget.** `kubectl rollout status` aborts the instant the Deployment controller sets `Progressing=False`/`ProgressDeadlineExceeded`, so its `--timeout` can never outlast `progressDeadlineSeconds` — and that field was **never declared** on the HCC Deployment, so it was the Kubernetes default of 600s. Worse, the clock starts earlier than the wait: `apply-inter-service-tokens.sh:311` does a `rollout restart` of HCC several deploy steps before `provision-gfs-runtime.sh` starts waiting.

The 2026-08-05 numbers:

| event | time |
|---|---|
| new ReplicaSet created (step 19 restart) | 10:34:02 |
| step 23 begins waiting | 10:36:42 |
| controller aborts (`10:34:02 + 600s`) | **10:44:03** |
| `--timeout=480s` would have fired | 10:44:42 |
| HCC actually Ready | 10:44:53 |

The effective budget was `600 − 160 = 440s` against a 480s timeout. **The timeout raised in #202 has never once bound** — it was dead code. And the deploy gave up 50s before HCC came Ready.

## The fix

Both halves, so the intended budget is the real one:

- `deploy/base/control-plane/host-context-controller.yaml` declares `progressDeadlineSeconds: 1200` (the 900s wait plus a 300s head-start allowance; observed head start was 160s).
- `deploy/scripts/provision-gfs-runtime.sh` waits `900s`, comfortably over the observed 651s.

Against the numbers above this would have passed: HCC's 651s lands inside both the 900s wait and the 1200s deadline.

## Test

`scripts/tests/test-provision-gfs-runtime.sh` now pins the *relationship* between the two numbers, which is the thing #202 missed. Verified it fails for both regressions, not just that it passes:

```
FAIL: ... does not declare progressDeadlineSeconds, so it defaults to 600s
      and silently caps the rollout-status timeout above.

FAIL: progressDeadlineSeconds=900s cannot cover a 900s wait that
      starts 300s after the restart — the deadline would abort first.
```

## Scope and verification

- `bash -n` clean on both scripts. Shellcheck reports only a pre-existing SC2034 (present on `origin/dev` at line 33), left alone.
- `kubectl kustomize deploy/overlays/minikube` builds and renders `progressDeadlineSeconds: 1200`.
- No infra overlay sets `progressDeadlineSeconds`, so the base value applies unmodified to both `gcp-dev` and `gcp-prod`.

**This is a mitigation, not a cure.** #205 is the real fix — it decouples readiness from fleet convergence — after which both numbers should come back down. #205 is currently `CONFLICTING` and unreviewed, so this unblocks the dev deploy in the meantime.

`deploy/base` is shared with prod, so this rides along in the next promotion. On prod it is effectively inert: 7 McpServers, and a more generous deadline only ever delays a failure verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)