### PR TITLE
fix: reconcile Plugin Workload SDK credential-ticket ACL

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.421",
+  "version": "0.1.422",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.421",
+      "version": "0.1.422",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.421",
+  "version": "0.1.422",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/db.ts
+++ b/control-api/src/db.ts
@@ -8,6 +8,7 @@ import { config } from './config.js'
 import { applyMemberRegistrationCredentialsSchema } from './services/memberRegistrationCredentialsSchema.js'
 import {
   addPluginWorkloadSdkAttemptLedgerColumns,
+  addPluginWorkloadSdkCredentialTicketRuntimeAccess,
   addPluginWorkloadSdkJitCredentialTicketColumns,
   addPluginWorkloadSdkNotExecutedSpendOutcome,
   addPluginWorkloadSdkPolicyReviewProvenance,
@@ -5138,6 +5139,10 @@ export const CONTROL_API_MIGRATIONS: DbMigration[] = [
   {
     version: '0088_plugin_workload_sdk_policy_review_provenance',
     apply: addPluginWorkloadSdkPolicyReviewProvenance,
+  },
+  {
+    version: '0089_plugin_workload_sdk_credential_ticket_runtime_access',
+    apply: addPluginWorkloadSdkCredentialTicketRuntimeAccess,
   },
 ]
 

--- a/control-api/src/services/pluginWorkloadSdkSchema.ts
+++ b/control-api/src/services/pluginWorkloadSdkSchema.ts
@@ -545,6 +545,25 @@ export async function addPluginWorkloadSdkRuntimeAccess(db: DbClient): Promise<v
 }
 
 /**
+ * Reconciles the JIT credential-ticket table created after the original
+ * runtime-role migration. Existing clusters never received the broad 0062
+ * table grant for this relation, so rebuild its exact legacy-DML envelope in a
+ * forward-only migration. Revoking first also removes any accidental table
+ * privileges beyond the explicit runtime contract; repeated application is a
+ * no-op at the privilege boundary.
+ */
+export async function addPluginWorkloadSdkCredentialTicketRuntimeAccess(
+  db: DbClient
+): Promise<void> {
+  await db.query(`
+    REVOKE ALL PRIVILEGES ON TABLE plugin_workload_sdk_credential_ticket_jtis
+      FROM PUBLIC, control_api_runtime, trace_maintenance_runtime, workflow_recipes_runtime;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE plugin_workload_sdk_credential_ticket_jtis
+      TO control_api_runtime;
+  `)
+}
+
+/**
  * Durable spend outcome for a physical promptBridge attempt.  The provider
  * attempt ledger prevents a second execution, while this table preserves the
  * accounting truth when the provider response is known only to have possibly

--- a/control-api/test/db.pluginWorkloadSdkProtocolMigration.test.ts
+++ b/control-api/test/db.pluginWorkloadSdkProtocolMigration.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import {
   addPluginWorkloadSdkAttemptLedgerColumns,
+  addPluginWorkloadSdkCredentialTicketRuntimeAccess,
   addPluginWorkloadSdkNotExecutedSpendOutcome,
   addPluginWorkloadSdkPolicyReviewProvenance,
   addPluginWorkloadSdkProtocolAndRevocation,
@@ -32,6 +36,50 @@ describe('plugin workload SDK protocol migration', () => {
     expect(migrationSql).toContain('TO control_api_runtime')
     expect(migrationSql).toContain('plugin_workload_sdk_invocation_attempts')
     expect(migrationSql).toContain('plugin_workload_sdk_provider_attempts')
+  })
+
+  it('reconciles the credential-ticket JTI table to the exact control-api runtime contract', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 })
+
+    await addPluginWorkloadSdkCredentialTicketRuntimeAccess({ query } as never)
+
+    const migrationSql = String(query.mock.calls[0]?.[0])
+    expect(migrationSql).toContain(
+      'REVOKE ALL PRIVILEGES ON TABLE plugin_workload_sdk_credential_ticket_jtis'
+    )
+    expect(migrationSql).toContain(
+      'FROM PUBLIC, control_api_runtime, trace_maintenance_runtime, workflow_recipes_runtime'
+    )
+    expect(migrationSql).toContain(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE plugin_workload_sdk_credential_ticket_jtis'
+    )
+    expect(migrationSql).toContain('TO control_api_runtime')
+  })
+
+  it('declares credential-ticket JTI access as legacy DML in the deploy contract', () => {
+    const contractPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../deploy/scripts/control-api-runtime-access-profiles.tsv'
+    )
+    const contractEntries = readFileSync(contractPath, 'utf8')
+      .split('\n')
+      .filter(line => line && !line.startsWith('#'))
+      .map(line => line.split('\t'))
+      .filter(([relation]) => relation === 'plugin_workload_sdk_credential_ticket_jtis')
+
+    expect(contractEntries).toEqual([['plugin_workload_sdk_credential_ticket_jtis', 'legacy_dml']])
+  })
+
+  it('registers the credential-ticket ACL repair as migration 0089', () => {
+    const dbPath = join(dirname(fileURLToPath(import.meta.url)), '../src/db.ts')
+    const source = readFileSync(dbPath, 'utf8')
+
+    expect(source).toMatch(
+      /version: '0089_plugin_workload_sdk_credential_ticket_runtime_access',\s+apply: addPluginWorkloadSdkCredentialTicketRuntimeAccess/
+    )
+    expect(
+      source.indexOf("version: '0089_plugin_workload_sdk_credential_ticket_runtime_access'")
+    ).toBe(source.lastIndexOf("version: '"))
   })
 
   it('preserves only complete ordered active policies while adding the attempt ledger', async () => {


### PR DESCRIPTION
## Summary

- add forward-only migration `0089_plugin_workload_sdk_credential_ticket_runtime_access`
- reconcile `plugin_workload_sdk_credential_ticket_jtis` with the `control_api_runtime` `legacy_dml` contract
- revoke table privileges from public and non-control runtimes before granting only SELECT/INSERT/UPDATE/DELETE to `control_api_runtime`
- add focused migration and deploy-contract coverage

## Root cause

The JIT credential-ticket table was introduced by migration 0076 after the original runtime-role ACL migration. Migration 0083 repaired the invocation and provider attempt tables but omitted the credential-ticket table. The infra migration gate therefore correctly failed with four missing privileges on `control_api_runtime`.

## Validation

- focused Vitest: 1 file, 9 tests passed
- Prettier check passed
- `git diff --check` passed
- based on `origin/dev` at `ead3223ecba973b4e2e095c746cfb6d69eabcd3f`

The full checkout test/build remains pending in CI because this local worktree does not contain the complete dependency installation.