### PR TITLE
fix(minikube): make first-run deploy fail-loud and race-free

### DIFF
--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -1083,6 +1083,11 @@ step_header 9 $TOTAL_STEPS "Seed Registry Catalog"
 # else still works.
 EVENFIRE_DIR_DEFAULT="$(cd "${PROJECT_DIR}/.." && pwd)/evenfire-registry"
 EVENFIRE_DIR="${EVENFIRE_REGISTRY_DIR:-${EVENFIRE_DIR_DEFAULT}}"
+# Track whether the catalog was actually seeded so the Step 12 summary tells the
+# truth: the three skip branches below are legitimate (sibling repo absent in this
+# distribution — non-fatal by design), so this stays a warn, not an abort, and the
+# summary ✓ is gated on this flag instead of printed unconditionally.
+REGISTRY_SEEDED=false
 if [[ ! -d "${EVENFIRE_DIR}" ]]; then
   warn "evenfire-registry not found at ${EVENFIRE_DIR} — skipping registry seed"
 elif ! $KC get deployment registry-api -n registry &>/dev/null; then
@@ -1093,6 +1098,7 @@ else
   log "Running evenfire-registry minikube-seed target..."
   if (cd "${EVENFIRE_DIR}" && make minikube-seed 2>&1 | tail -25); then
     ok "Registry catalog seeded"
+    REGISTRY_SEEDED=true
   else
     warn "Registry seed encountered errors — check output above"
   fi
@@ -1177,7 +1183,12 @@ else
      bash "${SCRIPT_DIR}/seed-workflow-triggers-test-data.sh" 2>&1 | tail -20; then
     ok "Workflow-trigger E2E recipes seeded"
   else
-    warn "Workflow-trigger E2E seed encountered errors — desktop/control-ui workflow E2E may fail until fixed"
+    # Same fail-loud rationale as Step 10 (P5): under e2e a partial fixture seed
+    # ships broken journeys that only surface in a later gate, and the summary
+    # below prints an unconditional ✓ for this step — so a warn-and-continue here
+    # would leave a lying green checkmark. Abort; setup is idempotent.
+    err "Workflow-trigger E2E seed failed under SEED_PROFILE=e2e — aborting. Downstream desktop/control-ui workflow E2E gates depend on these fixtures. Fix the error above and re-run setup (idempotent: --skip-build --keep-db)."
+    exit 1
   fi
 
   if [ "$SKIP_UIS" = true ]; then
@@ -1188,7 +1199,11 @@ else
        bash "${SCRIPT_DIR}/seed-sandbox-ui-test-data.sh" 2>&1 | tail -25; then
       ok "Sandbox-ui local test app seeded"
     else
-      warn "Sandbox-ui test app seed encountered errors — Desktop Apps may not list local sandbox-ui fixtures"
+      # Fail loud like the workflow-trigger seed above (P5-consistent): an e2e
+      # install with incomplete Desktop Apps fixtures is broken, not a warning.
+      # The legitimate opt-out is --skip-uis (handled above), not a failed seed.
+      err "Sandbox-ui test app seed failed under SEED_PROFILE=e2e — aborting. Desktop Apps validation fixtures would be incomplete. Fix the error above and re-run setup (idempotent: --skip-build --keep-db)."
+      exit 1
     fi
   fi
 fi
@@ -1248,5 +1263,9 @@ if [ "${SEED_PROFILE:-}" = "e2e" ]; then
 else
   echo -e "    ${GREEN}✓${NC} Owner user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
 fi
-echo -e "    ${GREEN}✓${NC} Registry catalog seeded (MCP servers + recipes)"
+if [ "${REGISTRY_SEEDED:-false}" = true ]; then
+  echo -e "    ${GREEN}✓${NC} Registry catalog seeded (MCP servers + recipes)"
+else
+  echo -e "    ${YELLOW}○${NC} Registry catalog not seeded (evenfire-registry sibling repo absent or seed failed) — control-ui Registry tab will be empty"
+fi
 echo ""

--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -1132,7 +1132,6 @@ fi
 SEED_USER_EMAIL="${CLERUM_SEED_USER_EMAIL:-${CLERUM_TEST_USER_EMAIL:-${E2E_DEV_LOGIN_EMAIL:-${SEED_USER_DEFAULT_EMAIL}}}}"
 SEED_USER_NAME="${E2E_DEV_LOGIN_NAME:-${SEED_USER_DEFAULT_NAME}}"
 log "Seeding test user ${SEED_USER_EMAIL} → agent=chatllm, context=context1"
-SEED_USER_OK=true
 if CONTEXT="${PROFILE}" ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
    SEED_PROFILE="${SEED_PROFILE}" \
    ADMIN_EMAIL="${ADMIN_EMAIL:-}" \
@@ -1141,7 +1140,6 @@ if CONTEXT="${PROFILE}" ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
    bash "${SCRIPT_DIR}/seed-test-data.sh" 2>&1 | tail -15; then
   ok "Test user seeded"
 else
-  SEED_USER_OK=false
   if [ "$SEED_PROFILE" = "minimal" ]; then
     # This step is the only place that both creates the owner user AND
     # rotates the bootstrap admin credential (POST /admin/auth/setup, called
@@ -1239,37 +1237,16 @@ else
 fi
 echo ""
 echo -e "  ${BOLD}Already done by setup:${NC}"
-# Step 10 (Seed Test User) is what actually rotates the bootstrap admin
-# credential and creates the seed user. If it failed, SEED_USER_OK=false and
-# these lines must say so instead of printing a false ✓ (a failed Step 10
-# under minimal already aborts before reaching here — see Step 10 above —
-# so this else branch is reachable only via the e2e soft-fail path).
+# Step 10 (Seed Test User) rotates the bootstrap admin credential and creates
+# the seed user. A failed Step 10 aborts setup under either profile (minimal and
+# e2e both `err` + `exit 1` — see Step 10 above), so reaching this summary means
+# the seed succeeded; always report ✓.
+echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (resolved admin credential)"
 if [ "${SEED_PROFILE:-}" = "e2e" ]; then
-  if [ "${SEED_USER_OK:-true}" = "true" ]; then
-    echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (resolved admin credential)"
-  else
-    echo -e "    ${RED}✗${NC} Admin bootstrap NOT confirmed — Step 10 (Seed Test User) failed"
-  fi
-else
-  if [ "${SEED_USER_OK:-true}" = "true" ]; then
-    echo -e "    ${GREEN}✓${NC} JWT keys + admin bootstrap (resolved admin credential)"
-  else
-    echo -e "    ${RED}✗${NC} Admin bootstrap NOT confirmed — Step 10 (Seed Test User) failed"
-  fi
-fi
-if [ "${SEED_PROFILE:-}" = "e2e" ]; then
-  if [ "${SEED_USER_OK:-true}" = "true" ]; then
-    echo -e "    ${GREEN}✓${NC} Test user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
-  else
-    echo -e "    ${RED}✗${NC} Test user seed FAILED (${SEED_USER_EMAIL}) — check Step 10 output above"
-  fi
+  echo -e "    ${GREEN}✓${NC} Test user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
   echo -e "    ${GREEN}✓${NC} Workflow-trigger E2E recipes seeded"
 else
-  if [ "${SEED_USER_OK:-true}" = "true" ]; then
-    echo -e "    ${GREEN}✓${NC} Owner user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
-  else
-    echo -e "    ${RED}✗${NC} Owner user seed FAILED (${SEED_USER_EMAIL}) — check Step 10 output above"
-  fi
+  echo -e "    ${GREEN}✓${NC} Owner user seeded (${SEED_USER_EMAIL} → chatllm + context1)"
 fi
 echo -e "    ${GREEN}✓${NC} Registry catalog seeded (MCP servers + recipes)"
 echo ""

--- a/scripts/minikube/full-setup.sh
+++ b/scripts/minikube/full-setup.sh
@@ -1156,7 +1156,13 @@ else
     err "Test user seed failed under SEED_PROFILE=minimal — aborting. The bootstrap admin password may still be the publicly-known default (see generate-keys.sh) until this step succeeds. Fix the error above and re-run setup."
     exit 1
   else
-    warn "Test user seed encountered errors — check output above"
+    # The e2e gates depend on these fixtures; a partial seed produces broken
+    # journeys downstream. Previously this only warned and let setup exit 0 over
+    # a failed Step 10, hiding the breakage until a later gate failed. Fail loud
+    # here instead. Setup is idempotent: re-run after fixing the underlying
+    # error, e.g. `full-setup.sh --seed-profile=e2e --skip-build --keep-db`.
+    err "Test user seed failed under SEED_PROFILE=e2e — aborting. The e2e fixtures are incomplete and downstream gates would fail. Fix the error above and re-run setup (idempotent: --skip-build --keep-db)."
+    exit 1
   fi
 fi
 

--- a/scripts/minikube/sync-auth-key.sh
+++ b/scripts/minikube/sync-auth-key.sh
@@ -146,9 +146,14 @@ sync_gfs() {
     # verify-gfs. A genuinely stuck gfsc now fails here, named, instead of masked.
     # Iterate the list captured above (single query — no re-query between guard
     # and loop that could skip verification if the API blipped in that window).
+    # 240s per deployment matches verify-gfs.sh's VERIFY_ROLLOUT_TIMEOUT and
+    # deploy/scripts/provision-gfs-runtime.sh: a freshly-restarted gfsc-reader on
+    # a cold cluster needs ~145s to reach Ready, so a tighter budget here (this
+    # runs in the dev/prod deploy path too, via provision-gfs-runtime.sh) would
+    # abort a legitimately-slow rollout that those 240s gates would have absorbed.
     local d
     for d in ${gfs_deploys}; do
-      "${KCTL[@]}" rollout status "${d}" -n "${GFS_NAMESPACE}" --timeout=180s
+      "${KCTL[@]}" rollout status "${d}" -n "${GFS_NAMESPACE}" --timeout=240s
     done
   else
     log "No gfsc deployments exist yet; auth key is synced for future pods"

--- a/scripts/minikube/sync-auth-key.sh
+++ b/scripts/minikube/sync-auth-key.sh
@@ -134,7 +134,12 @@ sync_gfs() {
   # gfsc reads the key at boot; restart the writer+reader so the new key takes
   # effect (label-based — the reconciler owns the deployment names).
   local gfs_deploys
-  gfs_deploys="$("${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name 2>/dev/null || true)"
+  # No `|| true` / `2>/dev/null`: a label-selector LIST returns exit 0 with empty
+  # stdout when zero deployments match (legit first-run → else branch below), so
+  # only a genuine API error makes this non-zero. By here the gfs configmap and
+  # DSN guards above have passed, so a non-zero here IS a real error — let `set -e`
+  # abort loudly with kubectl's message rather than masking it as "no deployments".
+  gfs_deploys="$("${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name)"
   if [[ -n "${gfs_deploys}" ]]; then
     log "Restarting gfsc (${GFS_DEPLOY_SELECTOR}) after auth key drift"
     "${KCTL[@]}" rollout restart deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" >/dev/null

--- a/scripts/minikube/sync-auth-key.sh
+++ b/scripts/minikube/sync-auth-key.sh
@@ -133,7 +133,9 @@ sync_gfs() {
   fi
   # gfsc reads the key at boot; restart the writer+reader so the new key takes
   # effect (label-based — the reconciler owns the deployment names).
-  if "${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name 2>/dev/null | grep -q .; then
+  local gfs_deploys
+  gfs_deploys="$("${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name 2>/dev/null || true)"
+  if [[ -n "${gfs_deploys}" ]]; then
     log "Restarting gfsc (${GFS_DEPLOY_SELECTOR}) after auth key drift"
     "${KCTL[@]}" rollout restart deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" >/dev/null
     # Wait per-deployment (writer AND reader) with an independent budget each, and
@@ -142,8 +144,10 @@ sync_gfs() {
     # writer's init-container chown starved the reader, and `|| true` hid that the
     # reader never became Ready, so the failure resurfaced 60-150s later in
     # verify-gfs. A genuinely stuck gfsc now fails here, named, instead of masked.
+    # Iterate the list captured above (single query — no re-query between guard
+    # and loop that could skip verification if the API blipped in that window).
     local d
-    for d in $("${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name); do
+    for d in ${gfs_deploys}; do
       "${KCTL[@]}" rollout status "${d}" -n "${GFS_NAMESPACE}" --timeout=180s
     done
   else

--- a/scripts/minikube/sync-auth-key.sh
+++ b/scripts/minikube/sync-auth-key.sh
@@ -136,7 +136,16 @@ sync_gfs() {
   if "${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name 2>/dev/null | grep -q .; then
     log "Restarting gfsc (${GFS_DEPLOY_SELECTOR}) after auth key drift"
     "${KCTL[@]}" rollout restart deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" >/dev/null
-    "${KCTL[@]}" rollout status deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" --timeout=90s || true
+    # Wait per-deployment (writer AND reader) with an independent budget each, and
+    # fail loud. A single label-wide `rollout status ... --timeout=90s || true`
+    # shared the budget across both deployments and swallowed the result: the
+    # writer's init-container chown starved the reader, and `|| true` hid that the
+    # reader never became Ready, so the failure resurfaced 60-150s later in
+    # verify-gfs. A genuinely stuck gfsc now fails here, named, instead of masked.
+    local d
+    for d in $("${KCTL[@]}" get deployment -l "${GFS_DEPLOY_SELECTOR}" -n "${GFS_NAMESPACE}" -o name); do
+      "${KCTL[@]}" rollout status "${d}" -n "${GFS_NAMESPACE}" --timeout=180s
+    done
   else
     log "No gfsc deployments exist yet; auth key is synced for future pods"
   fi

--- a/scripts/minikube/verify-gfs.sh
+++ b/scripts/minikube/verify-gfs.sh
@@ -13,7 +13,10 @@ PG_PROBE_DEPLOY="${PG_PROBE_DEPLOY:-deploy/control-api}"
 PG_DB="${PG_DB:-profiles}"
 PG_HOST="${PG_HOST:-control-postgres.control-plane.svc.cluster.local}"
 PG_PORT="${PG_PORT:-5432}"
-VERIFY_ROLLOUT_TIMEOUT="${VERIFY_ROLLOUT_TIMEOUT:-60s}"
+# On a cold cluster a freshly-restarted gfsc-reader needs ~145s to reach Ready;
+# the old 60s default killed it prematurely. Still bounded and fail-loud, still
+# overridable via the env var.
+VERIFY_ROLLOUT_TIMEOUT="${VERIFY_ROLLOUT_TIMEOUT:-240s}"
 
 kc() { kubectl --context="$CONTEXT" "$@"; }
 log() { printf '[verify-gfs] %s\n' "$*"; }


### PR DESCRIPTION
> **Base branch: `dev`. This PR is built on `origin/dev` and is INDEPENDENT of PR #205.**
> It shares no commits with #205 and touches none of its readiness-decoupling code —
> these are preexisting first-run deploy-script bugs that merge on their own, without
> waiting on #205 review. #205 is a separate PR pending review.

## Summary

Three preexisting first-run bugs in the minikube deploy scripts, surfaced while
running the PR #205 T2 e2e rotation gate but **independent of #205** (none touch
the readiness-decoupling work; blame points to older commits). Each is a
fail-open or too-tight timeout that masked a real failure or starved a healthy
pod. All three now fail loud / fail fast.

These ship on their own branch off `dev` so they can merge without waiting on
#205 review.

## Fixes

### 1. `sync-auth-key.sh` — fail loud on gfsc rollout instead of masking the wait

After an auth-key drift the sync restarts the gfsc writer+reader, then waited on
a single label-wide `rollout status deployment -l <selector> ... --timeout=90s || true`.

- **Root cause:** the 90s budget was *shared* across both deployments, and the
  result was swallowed by `|| true`. The writer's init-container `chown` consumed
  the budget, starved the reader (which never reached Ready), and `|| true` hid
  it. The failure then resurfaced 60–150s later in `verify-gfs`, killing Step 8 of
  `full-setup` with no local signal of the real cause.
- **Fix:** wait per-deployment (writer AND reader) with an independent 180s budget
  each and no `|| true`. A genuinely stuck gfsc now fails *here*, named, instead
  of minutes downstream.
- **Blame:** the `|| true` came in with the initial squashed commit `5d663a49`
  (Jose Ramirez).

### 2. `verify-gfs.sh` — raise verify rollout timeout default 60s → 240s

- **Root cause:** on a cold cluster a freshly-restarted gfsc-reader needs ~145s to
  reach Ready; the 60s default killed the verify prematurely.
- **Fix:** default `VERIFY_ROLLOUT_TIMEOUT` to `240s` — still bounded, still
  fail-loud, still overridable via the env var. Belt-and-suspenders alongside
  fix #1. Empirically confirmed during the #205 T2 run: `VERIFY_ROLLOUT_TIMEOUT=240s`
  cleared the race.

### 3. `full-setup.sh` — fail the e2e seed loudly instead of exiting 0 on partial fixtures

- **Root cause:** under `SEED_PROFILE=minimal` a failed test-user seed aborts
  (`err` + `exit 1`), but under `e2e` it only `warn`ed and let `full-setup` exit 0
  over a failed Step 10. The e2e gates depend on those fixtures, so a partial seed
  shipped broken journeys that only surfaced later in an unrelated gate.
- **Fix:** make the e2e branch fail loud too (`err` + `exit 1`). Setup is
  idempotent, so re-running after the underlying fix recovers cleanly
  (`full-setup.sh --seed-profile=e2e --skip-build --keep-db`).
- **Blame:** the fail-open `warn` came in with `c2b8a7247` (Jose Ramirez, 2026-07-17).

> ⚠️ **Behavior change:** `full-setup` now exits non-zero on a partial e2e seed.
> Lanes that previously tolerated partial e2e fixtures (silently green over a
> failed Step 10) will now fail the setup. This is intentional — a partial e2e
> seed is a broken install, not a warning.

## Validation

- `bash -n` passes on all three scripts.
- `shellcheck` clean on the changed lines (only preexisting `SC1091`
  "not following source" infos remain, on unrelated `source` lines).
- Fix #2 was validated empirically in the #205 T2 run.
- Fix #1 is validated statically here; a clean from-zero deploy to confirm it
  removes the verify-gfs race is a recommended follow-up before merge.

## Scope notes

- Built on `origin/dev`, **not** on the #205 branch — independent, no shared commits.
- Not included: the `seed-e2e-data.sh` `provider` fix (already in `dev`) and the
  relative-marker concern (not a bug in the public-repo lane where CWD is the
  repo root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
