### PR TITLE
chore(ci): temporary probe to validate dev after #276 (do not merge)

### DIFF
--- a/.github/CI_VALIDATION_PROBE.md
+++ b/.github/CI_VALIDATION_PROBE.md
@@ -1,0 +1,2 @@
+
+<!-- ci validation probe: 3cbdf331 -->


### PR DESCRIPTION
**Throwaway. To be closed, not merged.**

`ci-public.yml` triggers on `push: [main, master]` and `pull_request` only, so merging #276 into `dev` never ran the CI workflow — and it merged during a GitHub Actions `major_outage`, so no run has ever validated it.

This forces a full CI run against current `dev` (which contains #276) to confirm the ~15 harnesses and typecheck matrix are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqtLT5fQeqbc3m8DsUPgRT