### PR TITLE
chore(release): cut v0.6.0

### DIFF
--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evenfire",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evenfire",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@clerum/desktop-app-links": "file:../packages/desktop-app-links",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evenfire",
   "productName": "Evenfire",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "license": "MPL-2.0",
   "description": "Evenfire desktop client for secure agent and workflow access",

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -7,9 +7,9 @@ export type ReleaseManifest = {
 }
 
 export const releaseManifest: ReleaseManifest = {
-  releaseId: 'dev-fe20a73f',
+  releaseId: 'v0.6.0',
   externalRestApiVersion: '0.1.61',
   rpcProxyVersion: '0.1.62',
-  desktopVersion: '0.5.1',
+  desktopVersion: '0.6.0',
   minimumDesktopVersion: '0.1.252',
 }


### PR DESCRIPTION
Cuts **v0.6.0**. Written by `scripts/release/prepare-release.mjs --version 0.6.0 --release-id v0.6.0` — the single writer for every release coordinate.

## Coordinates

| coordinate | from | to |
| --- | --- | --- |
| `desktop-app/package.json` (+ lockfile) | 0.5.1 | 0.6.0 |
| `releaseManifest.desktopVersion` | 0.5.1 | 0.6.0 |
| `releaseManifest.releaseId` | `dev-fe20a73f` | `v0.6.0` |
| ghcr component `newTag` (23 rows) | v0.6.0 | v0.6.0 (already staged) |
| `releaseManifest.minimumDesktopVersion` | 0.1.252 | **unchanged** |

`minimumDesktopVersion` is a compatibility floor, not a version. Raising it force-updates every existing client, so it stays put unless deliberately raised.

`validate-release-tag.mjs --version 0.6.0` → `all 8 coordinates agree`.

## What is new about this release

This is the first cut where the **ghcr component pin is a checked coordinate**. The images `make minikube-setup` pulls and the desktop version can no longer drift apart, and a half-applied rewrite fails loudly instead of shipping mixed tags.

0.5.1 was bumped manually and never tagged, so this skips it.

## After this merges

1. `dev` → `main`
2. Tag `v0.6.0` on `main` → `release-images.yml` `crane copy`s the digests already proven on `:latest` into `:v0.6.0`. No rebuild, so release images are byte-identical to what was tested.
3. `gh workflow run desktop-release.yml -R keyper-labs/evenfire-infra -f tag=v0.6.0` (approve apple-signing)

**Tag promptly after the `main` merge.** In the window between them, `main` pins `v0.6.0` while those images do not exist yet, so a fresh clone in that gap fails until the tag lands.

Once tagged, `make minikube-setup` works with no `MINIKUBE_IMAGE_TAG` override — the new-contributor path this release exists to enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqtLT5fQeqbc3m8DsUPgRT