### PR TITLE
chore(release): promote v0.6.0 to main

### DIFF
--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evenfire",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evenfire",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@clerum/desktop-app-links": "file:../packages/desktop-app-links",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evenfire",
   "productName": "Evenfire",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "license": "MPL-2.0",
   "description": "Evenfire desktop client for secure agent and workflow access",

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -7,9 +7,9 @@ export type ReleaseManifest = {
 }
 
 export const releaseManifest: ReleaseManifest = {
-  releaseId: 'dev-fe20a73f',
+  releaseId: 'v0.6.0',
   externalRestApiVersion: '0.1.61',
   rpcProxyVersion: '0.1.62',
-  desktopVersion: '0.5.1',
+  desktopVersion: '0.6.0',
   minimumDesktopVersion: '0.1.252',
 }


### PR DESCRIPTION
Promotes `dev` to `main` so **v0.6.0** can be tagged.

## What is in this promotion

- `chore(release): cut v0.6.0` — every release coordinate written by `prepare-release.mjs`; `validate-release-tag.mjs --version 0.6.0` reports `all 8 coordinates agree`.
- The image consumption work (PR #276): `make minikube-setup` pulls published multi-arch images instead of building them.

`minimumDesktopVersion` stays **0.1.252**. It is a compatibility floor, not a version; raising it force-updates every existing client.

## Immediately after this merges

Tag `v0.6.0` on `main`. `release-images.yml` fires on `v*` and `crane copy`s the digests already proven on `:latest` into `:v0.6.0` — no rebuild, so the release images are byte-identical to what has been tested on `dev`.

**Tag promptly.** Between this merge and the tag, `main` pins `v0.6.0` while those images do not exist yet, so a fresh clone in that window fails until the tag lands. That gap is inherent to pinning the release tag in-tree.

Then `gh workflow run desktop-release.yml -R keyper-labs/evenfire-infra -f tag=v0.6.0` and approve apple-signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqtLT5fQeqbc3m8DsUPgRT