### PR TITLE
Harden live team session authorization

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.438",
+  "version": "0.1.439",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.438",
+      "version": "0.1.439",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.433",
+      "version": "0.1.434",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.432",
+  "version": "0.1.433",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.432",
+      "version": "0.1.433",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.434",
+      "version": "0.1.435",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.435",
+      "version": "0.1.436",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.441",
+  "version": "0.1.442",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.441",
+      "version": "0.1.442",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.436",
+      "version": "0.1.437",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.442",
+  "version": "0.1.443",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.442",
+      "version": "0.1.443",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.437",
+  "version": "0.1.438",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.437",
+      "version": "0.1.438",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.440",
+  "version": "0.1.441",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.440",
+      "version": "0.1.441",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.439",
+  "version": "0.1.440",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.439",
+      "version": "0.1.440",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.440",
+  "version": "0.1.441",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.442",
+  "version": "0.1.443",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.432",
+  "version": "0.1.433",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.439",
+  "version": "0.1.440",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.438",
+  "version": "0.1.439",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.437",
+  "version": "0.1.438",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.441",
+  "version": "0.1.442",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/middleware/externalSessionAuth.ts
+++ b/control-api/src/middleware/externalSessionAuth.ts
@@ -1,9 +1,14 @@
 import { NextFunction, Request, Response } from 'express'
 import { AuthClaims, TeamRole } from '../profileTypes.js'
+import {
+  type LiveTeamMembershipAuthorization,
+  authorizeLiveTeamMembership,
+} from '../services/directory/index.js'
 import { verifyExternalSessionToken } from '../utils/auth/externalSessionAuthToken.js'
 
 export type ExternalAuthedRequest = Request & {
   externalAuth?: AuthClaims
+  externalTeamAuth?: Extract<LiveTeamMembershipAuthorization, { status: 'active' }>['membership']
 }
 
 function extractUserSessionToken(req: Request): string {
@@ -43,14 +48,29 @@ export function requireExternalUserParamMatch(paramName = 'userId') {
   }
 }
 
-export function requireExternalTeamParamMatch(paramName = 'teamId') {
-  return (req: ExternalAuthedRequest, res: Response, next: NextFunction): void => {
+export function requireExternalTeamParamMatch(
+  paramName = 'teamId',
+  source: 'params' | 'query' = 'params'
+) {
+  return async (req: ExternalAuthedRequest, res: Response, next: NextFunction): Promise<void> => {
     const claims = req.externalAuth
-    const requestedTeamId = String(req.params?.[paramName] || '').trim()
+    const requestedTeamId = String(req[source]?.[paramName] || '').trim()
     if (!claims || !requestedTeamId || claims.teamId !== requestedTeamId) {
-      res.status(403).json({ error: 'Forbidden' })
+      res.status(403).json({ error: 'team_context_mismatch' })
       return
     }
+
+    const authorization = await authorizeLiveTeamMembership(claims.userId, requestedTeamId)
+    if (authorization.status === 'unavailable') {
+      res.status(503).json({ error: authorization.code })
+      return
+    }
+    if (authorization.status === 'denied') {
+      res.status(403).json({ error: authorization.code })
+      return
+    }
+
+    req.externalTeamAuth = authorization.membership
     next()
   }
 }
@@ -81,9 +101,9 @@ export function rejectBodyUserTeamMismatch(
 
 export function requireExternalRole(allowedRoles: TeamRole[]) {
   return (req: ExternalAuthedRequest, res: Response, next: NextFunction): void => {
-    const role = req.externalAuth?.role
+    const role = req.externalTeamAuth?.role
     if (!role || !allowedRoles.includes(role)) {
-      res.status(403).json({ error: 'Forbidden' })
+      res.status(403).json({ error: 'team_role_insufficient' })
       return
     }
     next()

--- a/control-api/src/routes/external/auth.ts
+++ b/control-api/src/routes/external/auth.ts
@@ -4,6 +4,7 @@ import type { K8sGateway } from '../../k8s.js'
 import { rateLimitMiddleware } from '../../middleware/rateLimitMiddleware.js'
 import { AuthClaims, RpcScope, TEAM_ROLES } from '../../profileTypes.js'
 import {
+  authorizeLiveTeamMembership,
   getTeamAgents,
   getUserAgents,
   googleLoginData,
@@ -186,6 +187,17 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
         return res.status(401).json({ error: 'Unauthorized' })
       const claims = verifyExternalSessionToken(sessionToken)
       if (!claims) return res.status(401).json({ error: 'Unauthorized' })
+      let currentRole = claims.role
+      if (claims.teamId) {
+        const teamAuthorization = await authorizeLiveTeamMembership(claims.userId, claims.teamId)
+        if (teamAuthorization.status === 'unavailable') {
+          return res.status(503).json({ error: teamAuthorization.code })
+        }
+        if (teamAuthorization.status === 'denied') {
+          return res.status(403).json({ error: teamAuthorization.code })
+        }
+        currentRole = teamAuthorization.membership.role
+      }
       const requestedScopes = normalizeRequestedScopes(req.body?.scopes)
       const hostRefs = normalizeRequestedHostRefs(req.body?.hostRefs)
       if (hostRefs.length === 0) {
@@ -229,7 +241,7 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
       ) {
         extraScopes.push('sandbox:ui:view')
       }
-      const auth = { userId: claims.userId, teamId: claims.teamId, role: claims.role }
+      const auth = { userId: claims.userId, teamId: claims.teamId, role: currentRole }
       const result = issueRpcAccessToken(auth, req.body?.scopes, hostRefs, extraScopes)
       if (!result) {
         // Distinguish "you need a team for this" from a generic scope failure so

--- a/control-api/src/routes/external/auth.ts
+++ b/control-api/src/routes/external/auth.ts
@@ -192,17 +192,6 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
         return res.status(401).json({ error: 'Unauthorized' })
       const claims = verifyExternalSessionToken(sessionToken)
       if (!claims) return res.status(401).json({ error: 'Unauthorized' })
-      let currentRole = claims.role
-      if (claims.teamId) {
-        const teamAuthorization = await authorizeLiveTeamMembership(claims.userId, claims.teamId)
-        if (teamAuthorization.status === 'unavailable') {
-          return res.status(503).json({ error: teamAuthorization.code })
-        }
-        if (teamAuthorization.status === 'denied') {
-          return res.status(403).json({ error: teamAuthorization.code })
-        }
-        currentRole = teamAuthorization.membership.role
-      }
       const requestedScopes = normalizeRequestedScopes(req.body?.scopes)
       const hostRefs = normalizeRequestedHostRefs(req.body?.hostRefs)
       if (hostRefs.length === 0) {
@@ -222,16 +211,52 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
       if (includesSandboxUiHostRef && agentHostRefs.length > 0) {
         return res.status(403).json({ error: 'sandbox_ui_host_ref_exclusive' })
       }
+
+      const directGrantedHostRefs = new Set<string>()
+      let directAgentAccess = true
       if (agentHostRefs.length > 0) {
         const userAgents = await getUserAgents(claims.userId)
-        const grantedHostRefs = new Set(userAgents.agentNames)
-        if (claims.teamId) {
-          const teamAgents = await getTeamAgents(claims.teamId)
-          for (const agentName of teamAgents.agentNames) grantedHostRefs.add(agentName)
+        for (const agentName of userAgents.agentNames) directGrantedHostRefs.add(agentName)
+        directAgentAccess = agentHostRefs.every(hostRef => directGrantedHostRefs.has(hostRef))
+      }
+
+      let currentRole = claims.role
+      let effectiveTeamId = claims.teamId
+      let directSandboxUiAccess: boolean | null = null
+      if (claims.teamId) {
+        const teamAuthorization = await authorizeLiveTeamMembership(claims.userId, claims.teamId)
+        if (teamAuthorization.status !== 'active') {
+          if (requestsSandboxUiScope) {
+            directSandboxUiAccess = await userHasUiBearingRecipeAccess(
+              claims.userId,
+              gateway,
+              pool,
+              null
+            )
+          }
+          const directOnlyRequest =
+            directAgentAccess && (!requestsSandboxUiScope || directSandboxUiAccess === true)
+          if (!directOnlyRequest) {
+            const status = teamAuthorization.status === 'unavailable' ? 503 : 403
+            return res.status(status).json({ error: teamAuthorization.code })
+          }
+          effectiveTeamId = null
+          currentRole = 'member'
+        } else {
+          currentRole = teamAuthorization.membership.role
         }
-        if (agentHostRefs.some(hostRef => !grantedHostRefs.has(hostRef))) {
+      }
+
+      if (agentHostRefs.length > 0 && !directAgentAccess) {
+        if (effectiveTeamId) {
+          const teamAgents = await getTeamAgents(effectiveTeamId)
+          const grantedHostRefs = new Set([...directGrantedHostRefs, ...teamAgents.agentNames])
+          if (agentHostRefs.some(hostRef => !grantedHostRefs.has(hostRef))) {
+            return res.status(403).json({ error: 'host_access_denied' })
+          }
+        } else {
           return res.status(403).json({
-            error: claims.teamId ? 'host_access_denied' : 'direct_host_access_required',
+            error: 'direct_host_access_required',
           })
         }
       }
@@ -242,11 +267,12 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
       // paying the sandbox UI recipe lookup cost or receiving unused grants.
       if (
         requestsSandboxUiScope &&
-        (await userHasUiBearingRecipeAccess(claims.userId, gateway, pool, claims.teamId))
+        (directSandboxUiAccess ??
+          (await userHasUiBearingRecipeAccess(claims.userId, gateway, pool, effectiveTeamId)))
       ) {
         extraScopes.push('sandbox:ui:view')
       }
-      const auth = { userId: claims.userId, teamId: claims.teamId, role: currentRole }
+      const auth = { userId: claims.userId, teamId: effectiveTeamId, role: currentRole }
       const result = issueRpcAccessToken(auth, req.body?.scopes, hostRefs, extraScopes)
       if (!result) {
         // Distinguish "you need a team for this" from a generic scope failure so

--- a/control-api/src/routes/external/auth.ts
+++ b/control-api/src/routes/external/auth.ts
@@ -158,18 +158,23 @@ export function createExternalAuthRouter(gateway: K8sGateway): Router {
       if (!userId || !email || !teamId || !TEAM_ROLES.includes(role)) {
         return res.status(400).json({ error: 'invalid payload' })
       }
-      const membership = await pool.query(
-        `SELECT 1
-           FROM users u
-           JOIN team_members tm ON tm.user_id = u.id
-          WHERE u.id = $1
-            AND LOWER(u.email) = LOWER($2)
-            AND tm.team_id = $3
-            AND tm.role = $4
-            AND tm.status = 'active'
-          LIMIT 1`,
-        [userId, email, teamId, role]
-      )
+      let membership
+      try {
+        membership = await pool.query(
+          `SELECT 1
+             FROM users u
+             JOIN team_members tm ON tm.user_id = u.id
+            WHERE u.id = $1
+              AND LOWER(u.email) = LOWER($2)
+              AND tm.team_id = $3
+              AND tm.role = $4
+              AND tm.status = 'active'
+            LIMIT 1`,
+          [userId, email, teamId, role]
+        )
+      } catch {
+        return res.status(503).json({ error: 'team_authorization_unavailable' })
+      }
       if ((membership.rowCount ?? 0) === 0) {
         return res.status(403).json({ error: 'membership_not_found' })
       }

--- a/control-api/src/routes/external/directory.ts
+++ b/control-api/src/routes/external/directory.ts
@@ -1,23 +1,28 @@
-import { Router } from "express";
-import { requireExternalTeamParamMatch, requireValidExternalSessionToken } from "../../middleware/externalSessionAuth.js";
-import { searchDirectory } from "../../services/directory/index.js";
+import { Router } from 'express'
+import {
+  requireExternalTeamParamMatch,
+  requireValidExternalSessionToken,
+} from '../../middleware/externalSessionAuth.js'
+import { searchDirectory } from '../../services/directory/index.js'
 
 export function createExternalDirectoryRouter(): Router {
-  const router = Router();
-  router.use("/external/directory", requireValidExternalSessionToken);
+  const router = Router()
+  router.use('/external/directory', requireValidExternalSessionToken)
 
-  router.get("/external/directory/search", 
-    requireExternalTeamParamMatch(), 
+  router.get(
+    '/external/directory/search',
+    requireExternalTeamParamMatch('teamId', 'query'),
     async (req, res, next) => {
-    try {
-      const teamId = String(req.query.teamId || "").trim();
-      const q = String(req.query.q || "").trim();
-      if (!teamId) return res.status(400).json({ error: "teamId is required" });
-      return res.status(200).json({ items: await searchDirectory(teamId, q) });
-    } catch (error) {
-      return next(error);
+      try {
+        const teamId = String(req.query.teamId || '').trim()
+        const q = String(req.query.q || '').trim()
+        if (!teamId) return res.status(400).json({ error: 'teamId is required' })
+        return res.status(200).json({ items: await searchDirectory(teamId, q) })
+      } catch (error) {
+        return next(error)
+      }
     }
-  });
+  )
 
-  return router;
+  return router
 }

--- a/control-api/src/routes/external/directory.ts
+++ b/control-api/src/routes/external/directory.ts
@@ -1,9 +1,14 @@
 import { Router } from 'express'
+import type { ExternalAuthedRequest } from '../../middleware/externalSessionAuth.js'
 import {
   requireExternalTeamParamMatch,
   requireValidExternalSessionToken,
 } from '../../middleware/externalSessionAuth.js'
+import { rateLimitMiddleware } from '../../middleware/rateLimitMiddleware.js'
 import { searchDirectory } from '../../services/directory/index.js'
+
+const DIRECTORY_SEARCH_MAX_QUERY_LENGTH = 128
+const DIRECTORY_SEARCH_MAX_PER_MINUTE = 30
 
 export function createExternalDirectoryRouter(): Router {
   const router = Router()
@@ -12,6 +17,26 @@ export function createExternalDirectoryRouter(): Router {
   router.get(
     '/external/directory/search',
     requireExternalTeamParamMatch('teamId', 'query'),
+    (req, res, next) => {
+      const q = String(req.query.q || '').trim()
+      if (q.length > DIRECTORY_SEARCH_MAX_QUERY_LENGTH) {
+        return res.status(400).json({
+          error: 'directory_query_too_long',
+          maxLength: DIRECTORY_SEARCH_MAX_QUERY_LENGTH,
+        })
+      }
+      next()
+    },
+    rateLimitMiddleware({
+      bucketType: 'external_directory_search',
+      maxPerMinute: DIRECTORY_SEARCH_MAX_PER_MINUTE,
+      getBucketKey: req => {
+        const externalReq = req as ExternalAuthedRequest
+        const userId = externalReq.externalAuth?.userId?.trim()
+        const teamId = String(req.query.teamId || '').trim()
+        return userId && teamId ? `external-directory-search:${userId}:${teamId}` : null
+      },
+    }),
     async (req, res, next) => {
       try {
         const teamId = String(req.query.teamId || '').trim()

--- a/control-api/src/routes/external/gfs.ts
+++ b/control-api/src/routes/external/gfs.ts
@@ -41,6 +41,15 @@ type ExternalGfsRequest = ExternalAuthedRequest & {
   gfsSubjectKeys?: string[]
 }
 
+class GfsTeamAuthorizationUnavailableError extends Error {
+  readonly code = 'team_authorization_unavailable'
+
+  constructor() {
+    super('GFS team authorization is unavailable')
+    this.name = 'GfsTeamAuthorizationUnavailableError'
+  }
+}
+
 function ridOf(resourceId: string): string {
   return resourceId.replace(/-/g, '').toLowerCase()
 }
@@ -60,11 +69,15 @@ function subjectColumns(subjects: Set<string>): { types: string[]; ids: string[]
 async function externalCallerSubjects(req: ExternalAuthedRequest): Promise<Set<string>> {
   const claims = req.externalAuth!
   const subjects = new Set<string>([`user:${claims.userId}`])
-  if (claims.teamId) subjects.add(`team:${claims.teamId}`)
-  const result = await pool.query(
-    `SELECT team_id FROM team_members WHERE user_id = $1 AND status = 'active'`,
-    [claims.userId]
-  )
+  let result
+  try {
+    result = await pool.query(
+      `SELECT team_id FROM team_members WHERE user_id = $1 AND status = 'active'`,
+      [claims.userId]
+    )
+  } catch {
+    throw new GfsTeamAuthorizationUnavailableError()
+  }
   for (const row of result.rows as { team_id: unknown }[]) {
     subjects.add(`team:${String(row.team_id)}`)
   }
@@ -73,11 +86,19 @@ async function externalCallerSubjects(req: ExternalAuthedRequest): Promise<Set<s
 
 async function attachExternalGfsCallerSubjects(
   req: import('express').Request,
-  _res: import('express').Response,
+  res: import('express').Response,
   next: NextFunction
 ): Promise<void> {
   const externalReq = req as ExternalGfsRequest
-  externalReq.gfsSubjectKeys = [...(await externalCallerSubjects(externalReq))]
+  try {
+    externalReq.gfsSubjectKeys = [...(await externalCallerSubjects(externalReq))]
+  } catch (error) {
+    if (error instanceof GfsTeamAuthorizationUnavailableError) {
+      res.status(503).json({ error: error.code })
+      return
+    }
+    throw error
+  }
   next()
 }
 
@@ -343,7 +364,16 @@ export function createExternalGfsRouter(): Router {
     '/external/gfs/resources',
     asyncHandler(async (req: ExternalAuthedRequest, res) => {
       const drive = driveOf(req.query.drive)
-      const subjects = await externalCallerSubjects(req)
+      let subjects: Set<string>
+      try {
+        subjects = await externalCallerSubjects(req)
+      } catch (error) {
+        if (error instanceof GfsTeamAuthorizationUnavailableError) {
+          res.status(503).json({ error: error.code })
+          return
+        }
+        throw error
+      }
       const { types, ids } = subjectColumns(subjects)
       if (types.length === 0) {
         res.status(200).json({ ok: true, data: { items: [], nextCursor: null } })

--- a/control-api/src/routes/external/sharedFilesystems.ts
+++ b/control-api/src/routes/external/sharedFilesystems.ts
@@ -10,7 +10,11 @@ import {
   listActiveContextIds,
   partitionAccessValues,
 } from '../../services/directory/accessReconciliation.js'
-import { getTeamContexts, getUserContexts } from '../../services/directory/index.js'
+import {
+  authorizeLiveTeamMembership,
+  getTeamContexts,
+  getUserContexts,
+} from '../../services/directory/index.js'
 import { K8sNotFoundError } from '../../services/resourceService.js'
 import { WFC_BROWSING_READ_SCOPE, signWfcBrowsingToken } from '../../utils/auth/wfcBrowsingToken.js'
 import { wfcServiceUrl } from '../../utils/wfcServiceUrl.js'
@@ -45,9 +49,14 @@ type ContextResource = {
 }
 
 type SharedFilesystemsRequestCache = {
-  accessibleContextIds?: Promise<Set<string>>
+  contextAccess?: Map<string, Promise<ContextAccessDecision>>
   contexts?: Map<string, Promise<ContextResource>>
 }
+
+type ContextAccessDecision =
+  | { status: 'authorized' }
+  | { status: 'denied'; code: 'Forbidden' | 'team_membership_inactive' }
+  | { status: 'unavailable'; code: 'team_authorization_unavailable' }
 
 class ContextAccessReconciliationError extends Error {
   constructor(cause: unknown) {
@@ -57,12 +66,12 @@ class ContextAccessReconciliationError extends Error {
   }
 }
 
-async function loadAccessibleContextIds(
+async function loadContextAccess(
   gateway: K8sGateway,
   userId: string,
-  teamId: string | null
-): Promise<Set<string>> {
-  const accessible = new Set<string>()
+  teamId: string | null,
+  contextId: string
+): Promise<ContextAccessDecision> {
   let activeContextIds: string[]
   try {
     activeContextIds = await listActiveContextIds(gateway)
@@ -70,19 +79,26 @@ async function loadAccessibleContextIds(
     console.warn('[external/shared-filesystems] context reconciliation failed:', err)
     throw new ContextAccessReconciliationError(err)
   }
+  if (!activeContextIds.includes(contextId)) {
+    return { status: 'denied', code: 'Forbidden' }
+  }
   const userCtx = await getUserContexts(userId)
   const userContextIds = partitionAccessValues(userCtx.contextIds, activeContextIds).active
-  for (const id of userContextIds) {
-    accessible.add(id)
+  if (userContextIds.includes(contextId)) {
+    return { status: 'authorized' }
   }
-  if (teamId && teamId.trim()) {
-    const teamCtx = await getTeamContexts(teamId.trim())
-    const teamContextIds = partitionAccessValues(teamCtx.contextIds, activeContextIds).active
-    for (const id of teamContextIds) {
-      accessible.add(id)
-    }
+  const normalizedTeamId = teamId?.trim() || ''
+  if (!normalizedTeamId) {
+    return { status: 'denied', code: 'Forbidden' }
   }
-  return accessible
+  const teamAuthorization = await authorizeLiveTeamMembership(userId, normalizedTeamId)
+  if (teamAuthorization.status !== 'active') return teamAuthorization
+
+  const teamCtx = await getTeamContexts(normalizedTeamId)
+  const teamContextIds = partitionAccessValues(teamCtx.contextIds, activeContextIds).active
+  return teamContextIds.includes(contextId)
+    ? { status: 'authorized' }
+    : { status: 'denied', code: 'Forbidden' }
 }
 
 function requestCache(res: { locals: Record<string, unknown> }): SharedFilesystemsRequestCache {
@@ -92,31 +108,41 @@ function requestCache(res: { locals: Record<string, unknown> }): SharedFilesyste
   return locals[key]
 }
 
-function loadAccessibleContextIdsForRequest(
+function loadContextAccessForRequest(
   gateway: K8sGateway,
   req: ExternalAuthedRequest,
-  res: { locals: Record<string, unknown> }
-): Promise<Set<string>> {
+  res: { locals: Record<string, unknown> },
+  contextId: string
+): Promise<ContextAccessDecision> {
   const cache = requestCache(res)
   const claims = req.externalAuth!
-  cache.accessibleContextIds ??= loadAccessibleContextIds(gateway, claims.userId, claims.teamId)
-  return cache.accessibleContextIds
+  cache.contextAccess ??= new Map()
+  let decision = cache.contextAccess.get(contextId)
+  if (!decision) {
+    decision = loadContextAccess(gateway, claims.userId, claims.teamId, contextId)
+    cache.contextAccess.set(contextId, decision)
+  }
+  return decision
 }
 
-async function resolveAccessibleContextIdsForRequest(
+async function authorizeContextForRequest(
   gateway: K8sGateway,
   req: ExternalAuthedRequest,
   res: {
     locals: Record<string, unknown>
     status: (code: number) => { json: (body: unknown) => void }
-  }
-): Promise<Set<string> | null> {
+  },
+  contextId: string
+): Promise<boolean> {
   try {
-    return await loadAccessibleContextIdsForRequest(gateway, req, res)
+    const decision = await loadContextAccessForRequest(gateway, req, res, contextId)
+    if (decision.status === 'authorized') return true
+    res.status(decision.status === 'unavailable' ? 503 : 403).json({ error: decision.code })
+    return false
   } catch (err) {
     if (!(err instanceof ContextAccessReconciliationError)) throw err
     res.status(503).json({ error: 'context_reconciliation_unavailable' })
-    return null
+    return false
   }
 }
 
@@ -209,12 +235,7 @@ export function createExternalSharedFilesystemsRouter(gateway: K8sGateway): Rout
         return
       }
 
-      const accessible = await resolveAccessibleContextIdsForRequest(gateway, req, res)
-      if (!accessible) return
-      if (!accessible.has(contextId)) {
-        res.status(403).json({ error: 'Forbidden' })
-        return
-      }
+      if (!(await authorizeContextForRequest(gateway, req, res, contextId))) return
 
       let ctx: ContextResource
       try {
@@ -295,12 +316,7 @@ export function createExternalSharedFilesystemsRouter(gateway: K8sGateway): Rout
       // SFS must actually be referenced by that Context. Without the second
       // check, a user with access to context A could browse any SFS in the
       // cluster by name.
-      const accessible = await resolveAccessibleContextIdsForRequest(gateway, req, res)
-      if (!accessible) return
-      if (!accessible.has(contextId)) {
-        res.status(403).json({ error: 'Forbidden' })
-        return
-      }
+      if (!(await authorizeContextForRequest(gateway, req, res, contextId))) return
 
       let ctx: ContextResource
       try {

--- a/control-api/src/routes/external/sharedFilesystems.ts
+++ b/control-api/src/routes/external/sharedFilesystems.ts
@@ -82,7 +82,12 @@ async function loadContextAccess(
   if (!activeContextIds.includes(contextId)) {
     return { status: 'denied', code: 'Forbidden' }
   }
-  const userCtx = await getUserContexts(userId)
+  let userCtx: Awaited<ReturnType<typeof getUserContexts>>
+  try {
+    userCtx = await getUserContexts(userId)
+  } catch (err) {
+    throw new ContextAccessReconciliationError(err)
+  }
   const userContextIds = partitionAccessValues(userCtx.contextIds, activeContextIds).active
   if (userContextIds.includes(contextId)) {
     return { status: 'authorized' }
@@ -94,7 +99,12 @@ async function loadContextAccess(
   const teamAuthorization = await authorizeLiveTeamMembership(userId, normalizedTeamId)
   if (teamAuthorization.status !== 'active') return teamAuthorization
 
-  const teamCtx = await getTeamContexts(normalizedTeamId)
+  let teamCtx: Awaited<ReturnType<typeof getTeamContexts>>
+  try {
+    teamCtx = await getTeamContexts(normalizedTeamId)
+  } catch (err) {
+    throw new ContextAccessReconciliationError(err)
+  }
   const teamContextIds = partitionAccessValues(teamCtx.contextIds, activeContextIds).active
   return teamContextIds.includes(contextId)
     ? { status: 'authorized' }

--- a/control-api/src/routes/external/teams.ts
+++ b/control-api/src/routes/external/teams.ts
@@ -72,6 +72,7 @@ export function createExternalTeamsRouter(gateway: K8sGateway): Router {
   router.put(
     '/external/teams/:teamId/name',
     requireExternalTeamParamMatch(),
+    requireExternalRole(['admin']),
     rejectBodyUserTeamMismatch,
     async (req, res, next) => {
       try {

--- a/control-api/src/routes/external/users.ts
+++ b/control-api/src/routes/external/users.ts
@@ -15,7 +15,7 @@ import {
   listActiveContextIds,
 } from '../../services/directory/accessReconciliation.js'
 import {
-  findMembership,
+  authorizeLiveTeamMembership,
   getMe,
   getTeamAgents,
   getTeamContexts,
@@ -160,14 +160,15 @@ export function createExternalUsersRouter(gateway: K8sGateway): Router {
   router.get(
     '/external/users/:userId/memberships/:teamId',
     requireExternalUserParamMatch(),
-    async (req, res, next) => {
-      try {
-        const membership = await findMembership(req.params.userId, req.params.teamId)
-        if (!membership) return res.status(404).json({ error: 'not_found' })
-        return res.status(200).json(membership)
-      } catch (error) {
-        return next(error)
+    async (req, res) => {
+      const authorization = await authorizeLiveTeamMembership(req.params.userId, req.params.teamId)
+      if (authorization.status === 'unavailable') {
+        return res.status(503).json({ error: authorization.code })
       }
+      if (authorization.status === 'denied') {
+        return res.status(403).json({ error: authorization.code })
+      }
+      return res.status(200).json(authorization.membership)
     }
   )
 

--- a/control-api/src/routes/external/workflows/read.routes.ts
+++ b/control-api/src/routes/external/workflows/read.routes.ts
@@ -20,7 +20,7 @@ export function createExternalWorkflowReadRoutes(gateway: K8sGateway): Router {
   router.get(
     BASE,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       const recipes = await getAuthorizedRecipeResources(caller, gateway)
@@ -31,7 +31,7 @@ export function createExternalWorkflowReadRoutes(gateway: K8sGateway): Router {
   router.get(
     `${BASE}/:ns/:name`,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       const { ns, name } = req.params
@@ -60,7 +60,7 @@ export function createExternalWorkflowReadRoutes(gateway: K8sGateway): Router {
   router.get(
     `${BASE}/:ns/:name/health`,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       const { ns, name } = req.params

--- a/control-api/src/routes/external/workflows/runs.routes.ts
+++ b/control-api/src/routes/external/workflows/runs.routes.ts
@@ -48,7 +48,7 @@ export function createExternalWorkflowRunsRoutes(gateway: K8sGateway): Router {
   router.get(
     `${BASE}/:ns/:name/runs`,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       const { ns, name } = req.params
@@ -70,7 +70,7 @@ export function createExternalWorkflowRunsRoutes(gateway: K8sGateway): Router {
   router.get(
     `${BASE}/:ns/:name/runs/:runId/artifacts`,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       try {
@@ -91,7 +91,7 @@ export function createExternalWorkflowRunsRoutes(gateway: K8sGateway): Router {
   router.get(
     `${BASE}/:ns/:name/runs/:runId/artifacts/:artifactName/download`,
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       try {

--- a/control-api/src/routes/external/workflows/trigger.routes.ts
+++ b/control-api/src/routes/external/workflows/trigger.routes.ts
@@ -23,7 +23,7 @@ export function createExternalWorkflowTriggerRoutes(gateway: K8sGateway): Router
     `${BASE}/:ns/:name/trigger`,
     workflowTriggerRateLimit(),
     asyncHandler(async (req: Request, res: Response) => {
-      const caller = requireExternalWorkflowCaller(req, res)
+      const caller = await requireExternalWorkflowCaller(req, res)
       if (!caller) return
 
       const { ns, name } = req.params

--- a/control-api/src/routes/gfs/grants.ts
+++ b/control-api/src/routes/gfs/grants.ts
@@ -95,7 +95,6 @@ export function resolveCaller(req: Request): GfsCaller {
     const preResolved = (req as RequestWithResolvedGfsSubjects).gfsSubjectKeys
     const subjects = new Set(preResolved && preResolved.length > 0 ? preResolved : [key])
     subjects.add(key)
-    if (external.teamId) subjects.add(`team:${external.teamId}`)
     return { isOperator: false, subjects, actorKey: key }
   }
   throw new GfsGrantError(401, 'unauthenticated')

--- a/control-api/src/routes/workflows/shared/auth.ts
+++ b/control-api/src/routes/workflows/shared/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import { isAdminTokenRevoked } from '../../../services/adminAuthService.js'
+import { authorizeLiveTeamMembership } from '../../../services/directory/index.js'
 import type { WorkflowCaller } from '../../../services/workflows/types.js'
 import { verifyAdminToken } from '../../../utils/auth/adminAuthToken.js'
 import { verifyExternalSessionToken } from '../../../utils/auth/externalSessionAuthToken.js'
@@ -7,8 +8,8 @@ import {
   type McpHostControlScope,
   verifyMcpHostControlJwt,
 } from '../../../utils/auth/mcpHostJwtToken.js'
-import { extractBearerToken } from '../../../utils/extractBearerToken.js'
 import { CONTROL_UI_ADMIN_SESSION_COOKIE, readCookie } from '../../../utils/auth/sessionCookies.js'
+import { extractBearerToken } from '../../../utils/extractBearerToken.js'
 
 function getUserSessionToken(req: Request): string {
   return String(req.header('x-user-session-token') || '').trim()
@@ -40,16 +41,32 @@ export async function requireAdminWorkflowCaller(
   return { kind: 'admin-ui', userId: adminClaims.sub }
 }
 
-export function requireExternalWorkflowCaller(
+export async function requireExternalWorkflowCaller(
   req: Request,
   res: Response
-): Extract<WorkflowCaller, { kind: 'user-session' }> | null {
+): Promise<Extract<WorkflowCaller, { kind: 'user-session' }> | null> {
   const userSessionToken = getUserSessionToken(req)
   if (!userSessionToken || userSessionToken.length > 4096) return unauthorized(res)
 
   const claims = verifyExternalSessionToken(userSessionToken)
   if (!claims) return unauthorized(res)
-  return { kind: 'user-session', claims }
+  if (!claims.teamId) return { kind: 'user-session', claims }
+
+  const teamAuthorization = await authorizeLiveTeamMembership(claims.userId, claims.teamId)
+  if (teamAuthorization.status === 'unavailable') {
+    res.status(503).json({ error: teamAuthorization.code })
+    return null
+  }
+  if (teamAuthorization.status === 'denied') {
+    return {
+      kind: 'user-session',
+      claims: { ...claims, teamId: null, role: 'member' },
+    }
+  }
+  return {
+    kind: 'user-session',
+    claims: { ...claims, role: teamAuthorization.membership.role },
+  }
 }
 
 export function requireMcpHostControlWorkflowCaller(

--- a/control-api/src/services/directory/index.ts
+++ b/control-api/src/services/directory/index.ts
@@ -26,6 +26,7 @@ export {
   acceptInvitation,
   acceptInvitationById,
   acceptInvitationForEmail,
+  authorizeLiveTeamMembership,
   getInvitationByToken,
   addMemberToTeam,
   createPasswordSetupInvitationForUser,
@@ -62,6 +63,7 @@ export {
   updateProfile,
   updateUserPassword,
 } from './membership.js'
+export type { LiveTeamMembershipAuthorization } from './membership.js'
 
 export {
   getTeamContexts,

--- a/control-api/src/services/directory/login.ts
+++ b/control-api/src/services/directory/login.ts
@@ -41,32 +41,6 @@ async function findFirstActiveMembership(
   )
 }
 
-async function findPendingInvitationMembership(
-  db: {
-    query: (
-      text: string,
-      values?: unknown[]
-    ) => Promise<{ rows: unknown[]; rowCount: number | null }>
-  },
-  email: string
-) {
-  return db.query(
-    `SELECT COALESCE(it.team_id, i.team_id) AS team_id,
-            COALESCE(it.role, i.role) AS role,
-            t.name AS team_name
-       FROM invitations i
-  LEFT JOIN invitation_teams it ON it.invitation_id = i.id
-       JOIN teams t ON t.id = COALESCE(it.team_id, i.team_id)
-      WHERE LOWER(i.email) = LOWER($1)
-        AND COALESCE(it.team_id, i.team_id) IS NOT NULL
-        AND i.status = 'pending'
-        AND i.expires_at > NOW()
-      ORDER BY i.created_at DESC
-      LIMIT 1`,
-    [email]
-  )
-}
-
 async function healAcceptedInvitationMemberships(
   db: {
     query: (
@@ -173,11 +147,7 @@ export async function googleLoginData(input: { email: string; name?: string; pic
     await healAcceptedInvitationMemberships(db, user.id, input.email)
     await linkAcceptedInvitationsToUser(db, user.id, input.email)
 
-    let membership = await findFirstActiveMembership(db, user.id)
-
-    if ((membership.rowCount ?? 0) === 0) {
-      membership = await findPendingInvitationMembership(db, input.email)
-    }
+    const membership = await findFirstActiveMembership(db, user.id)
 
     return {
       isNewUser,

--- a/control-api/src/services/directory/membership.ts
+++ b/control-api/src/services/directory/membership.ts
@@ -1399,22 +1399,23 @@ export async function acceptInvitationById(email: string, invitationId: string) 
 export async function searchDirectory(teamId: string, q: string) {
   const query = q.trim()
   if (!query) return []
+  const literalPattern = query.replace(/[\\%_]/g, character => `\\${character}`)
 
   const result = await pool.query(
-    `SELECT u.id, u.email, u.name, p.display_name, p.channels
+    `SELECT u.id, u.email, u.name, p.display_name
        FROM team_members tm
        JOIN users u ON u.id = tm.user_id
   LEFT JOIN profiles p ON p.user_id = u.id
       WHERE tm.team_id = $1
         AND tm.status = 'active'
         AND (
-          u.email ILIKE $2
-          OR COALESCE(u.name, '') ILIKE $2
-          OR COALESCE(p.display_name, '') ILIKE $2
+          u.email ILIKE $2 ESCAPE '\\'
+          OR COALESCE(u.name, '') ILIKE $2 ESCAPE '\\'
+          OR COALESCE(p.display_name, '') ILIKE $2 ESCAPE '\\'
         )
    ORDER BY COALESCE(p.display_name, u.name, u.email) ASC
       LIMIT 25`,
-    [teamId, `%${query}%`]
+    [teamId, `%${literalPattern}%`]
   )
   return result.rows
 }

--- a/control-api/src/services/directory/membership.ts
+++ b/control-api/src/services/directory/membership.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs'
 import { type DbClient, pool, withTransaction } from '../../db.js'
+import { rootLogger } from '../../observability/logger.js'
 import { registerAndSendInvitation } from '../invitationFlowRegistrationService.js'
 import { appendControlApiPermissionEventsInTransaction } from '../tracing/controlApiPermissionEvents.js'
 import type { InviteRole, TeamRole } from './types.js'
@@ -10,6 +11,8 @@ import {
   roleCanInviteMembers,
 } from './types.js'
 import { adminDeleteUser } from './users.js'
+
+const logger = rootLogger.child({ module: 'directory-membership' })
 
 export const INVITATION_TTL_HOURS = 48
 const DRAFT_INVITATION_CLEANUP_HOURS = 24
@@ -411,10 +414,28 @@ export async function authorizeLiveTeamMembership(
   try {
     const membership = await findMembership(userId, teamId)
     if (!membership) {
+      logger.info(
+        {
+          event: 'live_team_authorization_denied',
+          userId: userId.trim(),
+          teamId: teamId.trim(),
+          code: 'team_membership_inactive',
+        },
+        'Live team authorization denied'
+      )
       return { status: 'denied', code: 'team_membership_inactive' }
     }
     return { status: 'active', membership }
   } catch {
+    logger.warn(
+      {
+        event: 'live_team_authorization_unavailable',
+        userId: userId.trim(),
+        teamId: teamId.trim(),
+        code: 'team_authorization_unavailable',
+      },
+      'Live team authorization dependency unavailable'
+    )
     return { status: 'unavailable', code: 'team_authorization_unavailable' }
   }
 }

--- a/control-api/src/services/directory/membership.ts
+++ b/control-api/src/services/directory/membership.ts
@@ -396,6 +396,29 @@ export async function findMembership(userId: string, teamId: string) {
   )
 }
 
+export type LiveTeamMembershipAuthorization =
+  | {
+      status: 'active'
+      membership: { team_id: string; role: TeamRole; team_name: string }
+    }
+  | { status: 'denied'; code: 'team_membership_inactive' }
+  | { status: 'unavailable'; code: 'team_authorization_unavailable' }
+
+export async function authorizeLiveTeamMembership(
+  userId: string,
+  teamId: string
+): Promise<LiveTeamMembershipAuthorization> {
+  try {
+    const membership = await findMembership(userId, teamId)
+    if (!membership) {
+      return { status: 'denied', code: 'team_membership_inactive' }
+    }
+    return { status: 'active', membership }
+  } catch {
+    return { status: 'unavailable', code: 'team_authorization_unavailable' }
+  }
+}
+
 export async function getMe(userId: string, teamId: string) {
   const result = await pool.query(
     `SELECT u.id, u.email, u.name, u.picture,

--- a/control-api/test/db.realPostgresMigration.integration.test.ts
+++ b/control-api/test/db.realPostgresMigration.integration.test.ts
@@ -1,10 +1,16 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import express, { type Request as ExpressRequest } from 'express'
 import { randomBytes, randomUUID } from 'node:crypto'
 import { Pool, type PoolClient } from 'pg'
 import request from 'supertest'
 import { config } from '../src/config.js'
+import { pool as runtimePool } from '../src/db.js'
 import type { K8sGateway } from '../src/k8s.js'
+import { requireInternalToken } from '../src/middleware/internalServiceAuth.js'
+import { createExternalAuthRouter } from '../src/routes/external/auth.js'
+import { createExternalDirectoryRouter } from '../src/routes/external/directory.js'
+import { createExternalTeamsRouter } from '../src/routes/external/teams.js'
+import { createExternalUsersRouter } from '../src/routes/external/users.js'
 import {
   type GfsSubject,
   auditMutation,
@@ -12,7 +18,12 @@ import {
 } from '../src/routes/gfs/grants.js'
 import { writeGfsShareBatchInTransaction } from '../src/routes/gfs/shares.js'
 import { createRpcAccessUsersRouter } from '../src/routes/rpc-access/users.js'
-import { getCurrentTeam, getTeamAgents, getUserAgents } from '../src/services/directory/index.js'
+import {
+  getCurrentTeam,
+  getTeamAgents,
+  getUserAgents,
+  googleLoginData,
+} from '../src/services/directory/index.js'
 import { runWithAdministrativeRequestContext } from '../src/services/tracing/adminOperationContext.js'
 import { PostgresAdministrativeIntentLookup } from '../src/services/tracing/adminOperationService.js'
 import { AdministrativeEventService } from '../src/services/tracing/administrativeEvents.js'
@@ -29,7 +40,8 @@ import { PostgresGovernedEventReadRepository } from '../src/services/tracing/pos
 import { PostgresGovernedSessionReplayRepository } from '../src/services/tracing/postgresGovernedSessionReplayRepository.js'
 import { projectAcceptedUsageEvents } from '../src/services/tracing/usageProjection.js'
 import { ingestUsageEventsInTransaction } from '../src/services/usageEvents.js'
-import { signRpcAccessToken } from '../src/utils/auth/rpcAuthToken.js'
+import { signExternalSessionToken } from '../src/utils/auth/externalSessionAuthToken.js'
+import { signRpcAccessToken, verifyRpcAccessToken } from '../src/utils/auth/rpcAuthToken.js'
 
 type PrivilegeExpectation = Record<string, Set<string>>
 
@@ -1495,6 +1507,163 @@ describeRealPostgres('control-api real Postgres migrations', () => {
         }),
       ])
     )
+  }, 60_000)
+
+  it('enforces live membership states through real external routes and repository queries', async () => {
+    const { initDb } = await import('../src/db.js')
+    await initDb({ connect: () => dbPool.connect() })
+
+    const runtimeConnect = vi
+      .spyOn(runtimePool, 'connect')
+      .mockImplementation(() => dbPool.connect() as ReturnType<typeof runtimePool.connect>)
+    const runtimeQuery = vi
+      .spyOn(runtimePool, 'query')
+      .mockImplementation((text: never, values?: never) => dbPool.query(text, values) as never)
+
+    try {
+      const userId = randomUUID()
+      const teamId = randomUUID()
+      const directAgent = `direct-${randomUUID()}`
+      const directContext = `context-${randomUUID()}`
+      const email = `live-auth-${userId}@example.test`
+      await dbPool.query(
+        `INSERT INTO users (id, email, name) VALUES ($1, $2, 'Live Authorization User')`,
+        [userId, email]
+      )
+      await dbPool.query(`INSERT INTO teams (id, name) VALUES ($1, 'Live Authorization Team')`, [
+        teamId,
+      ])
+      await dbPool.query(
+        `INSERT INTO team_members (team_id, user_id, role, status)
+         VALUES ($1, $2, 'admin', 'active')`,
+        [teamId, userId]
+      )
+      await dbPool.query(`INSERT INTO user_agents (user_id, agent_name) VALUES ($1, $2)`, [
+        userId,
+        directAgent,
+      ])
+      await dbPool.query(`INSERT INTO user_contexts (user_id, context_id) VALUES ($1, $2)`, [
+        userId,
+        directContext,
+      ])
+
+      const sessionToken = signExternalSessionToken({
+        userId,
+        email,
+        teamId,
+        role: 'admin',
+      })
+      const gateway = {
+        listResource: async (plural: string) =>
+          plural === 'contexts'
+            ? [{ metadata: { name: directContext }, spec: { contextId: directContext } }]
+            : [],
+        getResource: async (plural: string, name: string) => {
+          if (plural === 'hosts' && name === directAgent) {
+            return { metadata: { name, namespace: config.hostsNamespace }, spec: { enabled: true } }
+          }
+          throw Object.assign(new Error('not found'), { statusCode: 404 })
+        },
+      } as unknown as K8sGateway
+      const app = express()
+      app.use(express.json())
+      app.use(requireInternalToken)
+      app.use(createExternalAuthRouter(gateway))
+      app.use(createExternalUsersRouter(gateway))
+      app.use(createExternalTeamsRouter(gateway))
+      app.use(createExternalDirectoryRouter())
+      const authorized = (req: request.Test) =>
+        req
+          .set('authorization', 'Bearer dev-external-rest-api-token')
+          .set('x-service-token', 'external-rest-api')
+          .set('x-user-session-token', sessionToken)
+
+      await authorized(
+        request(app).get(`/external/teams/${teamId}/users/${userId}/current`)
+      ).expect(200)
+      await authorized(request(app).put(`/external/teams/${teamId}/name`))
+        .send({ userId, name: 'Admin Rename' })
+        .expect(200)
+
+      await dbPool.query(
+        `UPDATE team_members SET role = 'member' WHERE team_id = $1 AND user_id = $2`,
+        [teamId, userId]
+      )
+      await authorized(request(app).put(`/external/teams/${teamId}/name`))
+        .send({ userId, name: 'Stale Admin Rename' })
+        .expect(403)
+        .expect({ error: 'team_role_insufficient' })
+      const unchanged = await dbPool.query<{ name: string }>(
+        `SELECT name FROM teams WHERE id = $1`,
+        [teamId]
+      )
+      expect(unchanged.rows[0]?.name).toBe('Admin Rename')
+
+      await dbPool.query(
+        `UPDATE team_members SET status = 'deleted' WHERE team_id = $1 AND user_id = $2`,
+        [teamId, userId]
+      )
+      await authorized(request(app).get(`/external/teams/${teamId}/members`))
+        .expect(403)
+        .expect({ error: 'team_membership_inactive' })
+      await authorized(request(app).get(`/external/directory/search?teamId=${teamId}&q=user`))
+        .expect(403)
+        .expect({ error: 'team_membership_inactive' })
+
+      await authorized(request(app).get(`/external/users/${userId}/agents`)).expect(200)
+      await authorized(request(app).get(`/external/users/${userId}/contexts`)).expect(200)
+      const rpcResponse = await authorized(request(app).post('/external/rpc/token'))
+        .send({
+          sessionToken,
+          scopes: ['host:message:invoke'],
+          hostRefs: [directAgent],
+        })
+        .expect(200)
+      expect(verifyRpcAccessToken(rpcResponse.body.token)).toMatchObject({
+        sub: userId,
+        accessScope: 'user',
+        teamId: null,
+        hostRefs: [directAgent],
+      })
+
+      const invitationCases = [
+        { label: 'pending', status: 'pending', expires: '48 hours' },
+        { label: 'rejected', status: 'revoked', expires: '48 hours' },
+        { label: 'expired', status: 'pending', expires: '-1 hour' },
+      ] as const
+      for (const invitationCase of invitationCases) {
+        const invitationTeamId = randomUUID()
+        const invitationEmail = `${invitationCase.label}-${randomUUID()}@example.test`
+        await dbPool.query(`INSERT INTO teams (id, name) VALUES ($1, $2)`, [
+          invitationTeamId,
+          `${invitationCase.label} invitation team`,
+        ])
+        await dbPool.query(
+          `INSERT INTO invitations (team_id, email, role, status, expires_at)
+           VALUES ($1, $2, 'admin', $3, NOW() + $4::interval)`,
+          [invitationTeamId, invitationEmail, invitationCase.status, invitationCase.expires]
+        )
+
+        const login = await googleLoginData({ email: invitationEmail, name: 'Invitee' })
+        expect(login.membership).toEqual({ team_id: null, role: 'member', team_name: null })
+        const teamlessToken = signExternalSessionToken({
+          userId: login.user.id,
+          email: invitationEmail,
+          teamId: null,
+          role: 'member',
+        })
+        await request(app)
+          .get(`/external/teams/${invitationTeamId}/members`)
+          .set('authorization', 'Bearer dev-external-rest-api-token')
+          .set('x-service-token', 'external-rest-api')
+          .set('x-user-session-token', teamlessToken)
+          .expect(403)
+          .expect({ error: 'team_context_mismatch' })
+      }
+    } finally {
+      runtimeQuery.mockRestore()
+      runtimeConnect.mockRestore()
+    }
   }, 60_000)
 
   it('executes the GFS audit append against the real migrated schema', async () => {

--- a/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
+++ b/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import {

--- a/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
+++ b/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
@@ -41,18 +41,22 @@ describe('external session live team authorization', () => {
     dbMocks.query.mockReset()
   })
 
-  it.each(['pending', 'rejected', 'expired', 'inactive', 'removed'])(
-    'denies a %s team state instead of trusting the unexpired token',
-    async () => {
-      dbMocks.query.mockResolvedValue({ rows: [], rowCount: 0 })
+  it('denies a deleted membership through the repository active-state predicate', async () => {
+    dbMocks.query.mockImplementation(async text =>
+      String(text).includes("tm.status = 'active'")
+        ? { rows: [], rowCount: 0 }
+        : {
+            rows: [{ team_id: 'team-1', role: 'admin', team_name: 'Team One' }],
+            rowCount: 1,
+          }
+    )
 
-      await request(buildApp())
-        .get('/teams/team-1')
-        .set('x-user-session-token', sessionToken())
-        .expect(403)
-        .expect({ error: 'team_membership_inactive' })
-    }
-  )
+    await request(buildApp())
+      .get('/teams/team-1')
+      .set('x-user-session-token', sessionToken())
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+  })
 
   it('enforces the current demoted role instead of the token role', async () => {
     dbMocks.query.mockResolvedValue({

--- a/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
+++ b/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import {
@@ -9,10 +9,15 @@ import {
 import { signExternalSessionToken } from '../src/utils/auth/externalSessionAuthToken.js'
 
 const dbMocks = vi.hoisted(() => ({ query: vi.fn() }))
+const logMocks = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn() }))
 
 vi.mock('../src/db.js', () => ({
   pool: { query: dbMocks.query },
   withTransaction: vi.fn(),
+}))
+
+vi.mock('../src/observability/logger.js', () => ({
+  rootLogger: { child: () => logMocks },
 }))
 
 function sessionToken(role: 'admin' | 'inviter' | 'member' = 'member') {
@@ -39,6 +44,8 @@ function buildApp(allowedRoles: Array<'admin' | 'inviter' | 'member'> = []) {
 describe('external session live team authorization', () => {
   beforeEach(() => {
     dbMocks.query.mockReset()
+    logMocks.info.mockReset()
+    logMocks.warn.mockReset()
   })
 
   it('denies a deleted membership through the repository active-state predicate', async () => {
@@ -56,6 +63,16 @@ describe('external session live team authorization', () => {
       .set('x-user-session-token', sessionToken())
       .expect(403)
       .expect({ error: 'team_membership_inactive' })
+
+    expect(logMocks.info).toHaveBeenCalledWith(
+      {
+        event: 'live_team_authorization_denied',
+        userId: 'user-1',
+        teamId: 'team-1',
+        code: 'team_membership_inactive',
+      },
+      'Live team authorization denied'
+    )
   })
 
   it('enforces the current demoted role instead of the token role', async () => {
@@ -92,5 +109,15 @@ describe('external session live team authorization', () => {
       .set('x-user-session-token', sessionToken())
       .expect(503)
       .expect({ error: 'team_authorization_unavailable' })
+
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      {
+        event: 'live_team_authorization_unavailable',
+        userId: 'user-1',
+        teamId: 'team-1',
+        code: 'team_authorization_unavailable',
+      },
+      'Live team authorization dependency unavailable'
+    )
   })
 })

--- a/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
+++ b/control-api/test/middleware.externalSessionAuth.liveMembership.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import {
+  requireExternalRole,
+  requireExternalTeamParamMatch,
+  requireValidExternalSessionToken,
+} from '../src/middleware/externalSessionAuth.js'
+import { signExternalSessionToken } from '../src/utils/auth/externalSessionAuthToken.js'
+
+const dbMocks = vi.hoisted(() => ({ query: vi.fn() }))
+
+vi.mock('../src/db.js', () => ({
+  pool: { query: dbMocks.query },
+  withTransaction: vi.fn(),
+}))
+
+function sessionToken(role: 'admin' | 'inviter' | 'member' = 'member') {
+  return signExternalSessionToken({
+    userId: 'user-1',
+    email: 'user@example.com',
+    teamId: 'team-1',
+    role,
+  })
+}
+
+function buildApp(allowedRoles: Array<'admin' | 'inviter' | 'member'> = []) {
+  const app = express()
+  app.get(
+    '/teams/:teamId',
+    requireValidExternalSessionToken,
+    requireExternalTeamParamMatch(),
+    ...(allowedRoles.length > 0 ? [requireExternalRole(allowedRoles)] : []),
+    (req, res) => res.status(200).json({ ok: true })
+  )
+  return app
+}
+
+describe('external session live team authorization', () => {
+  beforeEach(() => {
+    dbMocks.query.mockReset()
+  })
+
+  it.each(['pending', 'rejected', 'expired', 'inactive', 'removed'])(
+    'denies a %s team state instead of trusting the unexpired token',
+    async () => {
+      dbMocks.query.mockResolvedValue({ rows: [], rowCount: 0 })
+
+      await request(buildApp())
+        .get('/teams/team-1')
+        .set('x-user-session-token', sessionToken())
+        .expect(403)
+        .expect({ error: 'team_membership_inactive' })
+    }
+  )
+
+  it('enforces the current demoted role instead of the token role', async () => {
+    dbMocks.query.mockResolvedValue({
+      rows: [{ team_id: 'team-1', role: 'member', team_name: 'Team One' }],
+      rowCount: 1,
+    })
+
+    await request(buildApp(['admin']))
+      .get('/teams/team-1')
+      .set('x-user-session-token', sessionToken('admin'))
+      .expect(403)
+      .expect({ error: 'team_role_insufficient' })
+  })
+
+  it('uses the current promoted role for a valid membership', async () => {
+    dbMocks.query.mockResolvedValue({
+      rows: [{ team_id: 'team-1', role: 'admin', team_name: 'Team One' }],
+      rowCount: 1,
+    })
+
+    await request(buildApp(['admin']))
+      .get('/teams/team-1')
+      .set('x-user-session-token', sessionToken('member'))
+      .expect(200)
+      .expect({ ok: true })
+  })
+
+  it('fails closed when the live membership store is unavailable', async () => {
+    dbMocks.query.mockRejectedValue(new Error('database unavailable'))
+
+    await request(buildApp())
+      .get('/teams/team-1')
+      .set('x-user-session-token', sessionToken())
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
+  })
+})

--- a/control-api/test/routes.externalDirectorySearch.test.ts
+++ b/control-api/test/routes.externalDirectorySearch.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { requireInternalToken } from '../src/middleware/internalServiceAuth.js'
+import { createExternalDirectoryRouter } from '../src/routes/external/directory.js'
+import { signExternalSessionToken } from '../src/utils/auth/externalSessionAuthToken.js'
+
+const directory = vi.hoisted(() => ({
+  authorizeLiveTeamMembership: vi.fn(),
+  searchDirectory: vi.fn(),
+}))
+
+const limiter = vi.hoisted(() => ({
+  checkAndIncrement: vi.fn(),
+}))
+
+vi.mock('../src/services/directory/index.js', () => directory)
+vi.mock('../src/services/rateLimiterService.js', () => limiter)
+
+describe('external directory search', () => {
+  const sessionToken = signExternalSessionToken({
+    userId: 'user-1',
+    email: 'user@example.com',
+    teamId: 'team-1',
+    role: 'member',
+  })
+
+  function app() {
+    const instance = express()
+    instance.use(requireInternalToken)
+    instance.use(createExternalDirectoryRouter())
+    return instance
+  }
+
+  function search(query: string) {
+    return request(app())
+      .get(`/external/directory/search${query}`)
+      .set('authorization', 'Bearer dev-external-rest-api-token')
+      .set('x-service-token', 'external-rest-api')
+      .set('x-user-session-token', sessionToken)
+  }
+
+  beforeEach(() => {
+    directory.authorizeLiveTeamMembership.mockReset()
+    directory.searchDirectory.mockReset()
+    limiter.checkAndIncrement.mockReset()
+    directory.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'active',
+      membership: { team_id: 'team-1', role: 'member', team_name: 'Team One' },
+    })
+    directory.searchDirectory.mockResolvedValue([
+      { id: 'user-2', email: 'two@example.com', name: 'Two', display_name: 'Two' },
+    ])
+    limiter.checkAndIncrement.mockResolvedValue({
+      allowed: true,
+      remaining: 29,
+      resetMs: Date.now() + 60_000,
+      windowStartMs: Date.now(),
+      count: 1,
+    })
+  })
+
+  it('searches only the matching live team with the supported result shape', async () => {
+    await search('?teamId=team-1&q=two')
+      .expect(200)
+      .expect({
+        items: [{ id: 'user-2', email: 'two@example.com', name: 'Two', display_name: 'Two' }],
+      })
+
+    expect(directory.authorizeLiveTeamMembership).toHaveBeenCalledWith('user-1', 'team-1')
+    expect(limiter.checkAndIncrement).toHaveBeenCalledWith(
+      'external-directory-search:user-1:team-1',
+      30
+    )
+    expect(directory.searchDirectory).toHaveBeenCalledWith('team-1', 'two')
+  })
+
+  it.each(['?teamId=team-2&q=two', '?q=two'])(
+    'rejects a missing or mismatched query team before search: %s',
+    async query => {
+      await search(query).expect(403).expect({ error: 'team_context_mismatch' })
+      expect(limiter.checkAndIncrement).not.toHaveBeenCalled()
+      expect(directory.searchDirectory).not.toHaveBeenCalled()
+    }
+  )
+
+  it('rejects an oversized query before rate-limit or search work', async () => {
+    await search(`?teamId=team-1&q=${'a'.repeat(129)}`)
+      .expect(400)
+      .expect({ error: 'directory_query_too_long', maxLength: 128 })
+
+    expect(limiter.checkAndIncrement).not.toHaveBeenCalled()
+    expect(directory.searchDirectory).not.toHaveBeenCalled()
+  })
+
+  it('returns the standard 429 and never executes search when exhausted', async () => {
+    limiter.checkAndIncrement.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetMs: Date.now() + 30_000,
+      windowStartMs: Date.now(),
+      count: 31,
+    })
+
+    const response = await search('?teamId=team-1&q=two').expect(429)
+
+    expect(response.body).toMatchObject({ error: 'Too Many Requests' })
+    expect(response.headers['retry-after']).toBeDefined()
+    expect(directory.searchDirectory).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/routes.externalGfs.test.ts
+++ b/control-api/test/routes.externalGfs.test.ts
@@ -338,6 +338,29 @@ describe('PUT /external/gfs/grants (user delegation via existing engine)', () =>
     expect(res.status).toBe(200)
     const insert = mockQuery.mock.calls.find(c => String(c[0]).includes('INSERT INTO gfs_grants'))
     expect(insert?.[1]?.[6]).toBe(`user:${U1}`)
+    const authorityLookup = mockQuery.mock.calls.find(c =>
+      String(c[0]).includes('authority_grants AS')
+    )
+    expect(authorityLookup?.[1]?.[2]).toEqual(['user', 'team'])
+    expect(authorityLookup?.[1]?.[3]).toEqual([U1, T2])
+  })
+
+  it('fails closed when active-team subject expansion is unavailable', async () => {
+    auth()
+    mockQuery.mockRejectedValue(new Error('membership store unavailable'))
+
+    const app = await buildApp()
+    await request(app)
+      .put('/external/gfs/grants')
+      .set('x-user-session-token', 'sess')
+      .send({
+        resourceId: R,
+        subject: { type: 'user', id: U2 },
+        permissions: ['read'],
+        inherit: false,
+      })
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
   })
 
   it('rejects a non-UUID user subject id → 400 subject_invalid', async () => {
@@ -1139,6 +1162,18 @@ describe('user resource mutations via gfsc proxy', () => {
 })
 
 describe('GET /external/gfs/resources', () => {
+  it('fails closed when accessible-resource team expansion is unavailable', async () => {
+    auth()
+    mockQuery.mockRejectedValue(new Error('membership store unavailable'))
+
+    const app = await buildApp()
+    await request(app)
+      .get('/external/gfs/resources')
+      .set('x-user-session-token', 'sess')
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
+  })
+
   it('lists readable direct user resources and active-team resources as Desktop entry points', async () => {
     auth()
     mockQuery.mockImplementation(async (text: string, values?: unknown[]) => {

--- a/control-api/test/routes.externalRpcToken.liveMembership.test.ts
+++ b/control-api/test/routes.externalRpcToken.liveMembership.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { requireInternalToken } from '../src/middleware/internalServiceAuth.js'
+import { createExternalAuthRouter } from '../src/routes/external/auth.js'
+import { signExternalSessionToken } from '../src/utils/auth/externalSessionAuthToken.js'
+import { SANDBOX_UI_RPC_HOST_REF, verifyRpcAccessToken } from '../src/utils/auth/rpcAuthToken.js'
+
+const directory = vi.hoisted(() => ({
+  authorizeLiveTeamMembership: vi.fn(),
+  getTeamAgents: vi.fn(),
+  getUserAgents: vi.fn(),
+  googleLoginData: vi.fn(),
+  passwordLoginData: vi.fn(),
+  requestProfilePasswordReset: vi.fn(),
+}))
+
+const sandboxUi = vi.hoisted(() => ({
+  userHasUiBearingRecipeAccess: vi.fn(),
+}))
+
+vi.mock('../src/services/directory/index.js', () => directory)
+vi.mock('../src/utils/auth/sandboxUiScope.js', () => sandboxUi)
+
+describe('external RPC token live membership', () => {
+  const internalToken = 'dev-external-rest-api-token'
+  const staleSessionToken = signExternalSessionToken({
+    userId: 'u1',
+    email: 'u1@example.com',
+    teamId: 'team-removed',
+    role: 'admin',
+  })
+
+  function app() {
+    const instance = express()
+    instance.use(express.json())
+    instance.use(requireInternalToken)
+    instance.use(createExternalAuthRouter({} as never))
+    return instance
+  }
+
+  function issue(body: { scopes: string[]; hostRefs: string[] }) {
+    return request(app())
+      .post('/external/rpc/token')
+      .set('authorization', `Bearer ${internalToken}`)
+      .set('x-service-token', 'external-rest-api')
+      .send({ sessionToken: staleSessionToken, ...body })
+  }
+
+  beforeEach(() => {
+    Object.values(directory).forEach(mock => mock.mockReset())
+    sandboxUi.userHasUiBearingRecipeAccess.mockReset()
+    directory.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    directory.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: [] })
+    directory.getTeamAgents.mockResolvedValue({ teamId: 'team-removed', agentNames: [] })
+    sandboxUi.userHasUiBearingRecipeAccess.mockResolvedValue(false)
+  })
+
+  it('issues a user-scoped token for a directly granted Agent after team removal', async () => {
+    directory.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: ['direct-agent'] })
+
+    const response = await issue({
+      scopes: ['host:message:invoke'],
+      hostRefs: ['direct-agent'],
+    }).expect(200)
+
+    expect(response.body).toMatchObject({
+      accessScope: 'user',
+      teamId: null,
+      scopes: ['host:message:invoke'],
+      hostRefs: ['direct-agent'],
+    })
+    expect(verifyRpcAccessToken(response.body.token)).toMatchObject({
+      sub: 'u1',
+      accessScope: 'user',
+      teamId: null,
+      role: 'member',
+      scopes: ['host:message:invoke'],
+      hostRefs: ['direct-agent'],
+    })
+    expect(directory.getTeamAgents).not.toHaveBeenCalled()
+  })
+
+  it('denies a team-only Agent after team removal', async () => {
+    await issue({ scopes: ['host:message:invoke'], hostRefs: ['team-agent'] })
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+
+    expect(directory.getTeamAgents).not.toHaveBeenCalled()
+  })
+
+  it('keeps a direct Sandbox UI grant user-scoped after team removal', async () => {
+    sandboxUi.userHasUiBearingRecipeAccess.mockResolvedValue(true)
+
+    const response = await issue({
+      scopes: ['sandbox:ui:view'],
+      hostRefs: [SANDBOX_UI_RPC_HOST_REF],
+    }).expect(200)
+
+    expect(response.body).toMatchObject({
+      accessScope: 'user',
+      teamId: null,
+      scopes: ['sandbox:ui:view'],
+      hostRefs: [SANDBOX_UI_RPC_HOST_REF],
+    })
+    expect(sandboxUi.userHasUiBearingRecipeAccess).toHaveBeenCalledWith(
+      'u1',
+      expect.anything(),
+      expect.anything(),
+      null
+    )
+  })
+
+  it('atomically denies mixed direct and unavailable team HostRefs', async () => {
+    directory.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: ['direct-agent'] })
+
+    await issue({
+      scopes: ['host:message:invoke'],
+      hostRefs: ['direct-agent', 'team-agent'],
+    })
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+  })
+
+  it('does not authorize a team path when membership authority is unavailable', async () => {
+    directory.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'unavailable',
+      code: 'team_authorization_unavailable',
+    })
+
+    await issue({ scopes: ['host:message:invoke'], hostRefs: ['team-agent'] })
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
+
+    expect(directory.getTeamAgents).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/routes.externalSharedFilesystems.test.ts
+++ b/control-api/test/routes.externalSharedFilesystems.test.ts
@@ -217,6 +217,22 @@ describe('GET /external/contexts/:contextId/shared-filesystems', () => {
     expect(getResource).not.toHaveBeenCalled()
   })
 
+  it('fails closed when team context access reconciliation is unavailable', async () => {
+    validAuth()
+    mockGetUserContexts.mockResolvedValue({ userId: 'user-1', contextIds: [] })
+    mockGetTeamContexts.mockRejectedValue(new Error('directory unavailable'))
+    const getResource = vi.fn()
+    const app = buildApp({ getResource })
+
+    await request(app)
+      .get('/external/contexts/ctx-team/shared-filesystems')
+      .set('x-user-session-token', 'dummy')
+      .expect(503)
+      .expect({ error: 'context_reconciliation_unavailable' })
+
+    expect(getResource).not.toHaveBeenCalled()
+  })
+
   it('returns 403 when caller has no access to the context', async () => {
     validAuth()
     mockGetUserContexts.mockResolvedValue({ userId: 'user-1', contextIds: ['ctx-other'] })

--- a/control-api/test/routes.externalSharedFilesystems.test.ts
+++ b/control-api/test/routes.externalSharedFilesystems.test.ts
@@ -7,6 +7,7 @@ import { K8sNotFoundError } from '../src/services/resourceService.js'
 const mockVerifyExternalSessionToken = vi.fn()
 const mockGetUserContexts = vi.fn()
 const mockGetTeamContexts = vi.fn()
+const mockAuthorizeLiveTeamMembership = vi.fn()
 const mockSignWfcBrowsingCredential = vi.hoisted(() => vi.fn())
 
 vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
@@ -14,6 +15,7 @@ vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
 }))
 
 vi.mock('../src/services/directory/index.js', () => ({
+  authorizeLiveTeamMembership: (...args: unknown[]) => mockAuthorizeLiveTeamMembership(...args),
   getUserContexts: (...args: unknown[]) => mockGetUserContexts(...args),
   getTeamContexts: (...args: unknown[]) => mockGetTeamContexts(...args),
 }))
@@ -69,6 +71,11 @@ beforeEach(() => {
   mockVerifyExternalSessionToken.mockReset()
   mockGetUserContexts.mockReset()
   mockGetTeamContexts.mockReset()
+  mockAuthorizeLiveTeamMembership.mockReset()
+  mockAuthorizeLiveTeamMembership.mockResolvedValue({
+    status: 'active',
+    membership: { team_id: 'team-1', role: 'member', team_name: 'Team One' },
+  })
   mockSignWfcBrowsingCredential.mockReset()
   mockSignWfcBrowsingCredential.mockReturnValue({ token: 'browsing-token', expiresInSeconds: 60 })
 })
@@ -145,6 +152,69 @@ describe('GET /external/contexts/:contextId/shared-filesystems', () => {
       .set('x-user-session-token', 'dummy')
     expect(res.status).toBe(200)
     expect(res.body.items).toEqual([])
+  })
+
+  it('denies a team-only context after the claimed membership is removed', async () => {
+    validAuth()
+    mockGetUserContexts.mockResolvedValue({ userId: 'user-1', contextIds: [] })
+    mockAuthorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    mockGetTeamContexts.mockResolvedValue({ teamId: 'team-1', contextIds: ['ctx-team'] })
+    const getResource = vi.fn().mockResolvedValue({ spec: { sharedFileSystems: [] } })
+    const app = buildApp({ getResource })
+
+    await request(app)
+      .get('/external/contexts/ctx-team/shared-filesystems')
+      .set('x-user-session-token', 'dummy')
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+
+    expect(mockGetTeamContexts).not.toHaveBeenCalled()
+    expect(getResource).not.toHaveBeenCalled()
+  })
+
+  it('keeps a directly granted context available after final-team removal', async () => {
+    validAuth()
+    mockGetUserContexts.mockResolvedValue({ userId: 'user-1', contextIds: ['ctx-a'] })
+    mockAuthorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    mockGetTeamContexts.mockResolvedValue({ teamId: 'team-1', contextIds: [] })
+    const getResource = vi.fn().mockResolvedValue({ spec: { sharedFileSystems: [] } })
+    const app = buildApp({ getResource })
+
+    await request(app)
+      .get('/external/contexts/ctx-a/shared-filesystems')
+      .set('x-user-session-token', 'dummy')
+      .expect(200)
+      .expect({ items: [] })
+
+    expect(mockAuthorizeLiveTeamMembership).not.toHaveBeenCalled()
+    expect(mockGetTeamContexts).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when team membership reconciliation is unavailable', async () => {
+    validAuth()
+    mockGetUserContexts.mockResolvedValue({ userId: 'user-1', contextIds: [] })
+    mockAuthorizeLiveTeamMembership.mockResolvedValue({
+      status: 'unavailable',
+      code: 'team_authorization_unavailable',
+    })
+    mockGetTeamContexts.mockResolvedValue({ teamId: 'team-1', contextIds: ['ctx-team'] })
+    const getResource = vi.fn().mockResolvedValue({ spec: { sharedFileSystems: [] } })
+    const app = buildApp({ getResource })
+
+    await request(app)
+      .get('/external/contexts/ctx-team/shared-filesystems')
+      .set('x-user-session-token', 'dummy')
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
+
+    expect(mockGetTeamContexts).not.toHaveBeenCalled()
+    expect(getResource).not.toHaveBeenCalled()
   })
 
   it('returns 403 when caller has no access to the context', async () => {

--- a/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
+++ b/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
-import { requireExternalWorkflowCaller } from '../src/routes/workflows/shared/auth.js'
+import { createExternalWorkflowsRouter } from '../src/routes/external/workflows/index.js'
+import { MockGateway } from './mockGateway.js'
 
 const dbMocks = vi.hoisted(() => ({ query: vi.fn() }))
 const tokenMocks = vi.hoisted(() => ({ verify: vi.fn() }))
@@ -17,15 +18,7 @@ vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
 
 function buildApp() {
   const app = express()
-  app.get('/external/workflows', async (req, res) => {
-    const caller = await requireExternalWorkflowCaller(req, res)
-    if (!caller) return
-    res.status(200).json({
-      userId: caller.claims.userId,
-      teamId: caller.claims.teamId,
-      role: caller.claims.role,
-    })
-  })
+  app.use(createExternalWorkflowsRouter(new MockGateway('sandbox-recipes') as never))
   return app
 }
 
@@ -41,30 +34,7 @@ describe('external workflow live team context', () => {
     })
   })
 
-  it('strips a removed team while preserving the authenticated user for direct grants', async () => {
-    dbMocks.query.mockResolvedValue({ rows: [], rowCount: 0 })
-
-    await request(buildApp())
-      .get('/external/workflows')
-      .set('x-user-session-token', 'session-token')
-      .expect(200)
-      .expect({ userId: 'user-1', teamId: null, role: 'member' })
-  })
-
-  it('replaces a stale claimed role with the current active role', async () => {
-    dbMocks.query.mockResolvedValue({
-      rows: [{ team_id: 'team-1', role: 'member', team_name: 'Team One' }],
-      rowCount: 1,
-    })
-
-    await request(buildApp())
-      .get('/external/workflows')
-      .set('x-user-session-token', 'session-token')
-      .expect(200)
-      .expect({ userId: 'user-1', teamId: 'team-1', role: 'member' })
-  })
-
-  it('fails closed when workflow team-context reconciliation is unavailable', async () => {
+  it('returns 503 from the real workflow router when membership authority is unavailable', async () => {
     dbMocks.query.mockRejectedValue(new Error('database unavailable'))
 
     await request(buildApp())

--- a/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
+++ b/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { createExternalWorkflowsRouter } from '../src/routes/external/workflows/index.js'

--- a/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
+++ b/control-api/test/routes.externalWorkflowAuth.liveMembership.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { requireExternalWorkflowCaller } from '../src/routes/workflows/shared/auth.js'
+
+const dbMocks = vi.hoisted(() => ({ query: vi.fn() }))
+const tokenMocks = vi.hoisted(() => ({ verify: vi.fn() }))
+
+vi.mock('../src/db.js', () => ({
+  pool: { query: dbMocks.query },
+  withTransaction: vi.fn(),
+}))
+
+vi.mock('../src/utils/auth/externalSessionAuthToken.js', () => ({
+  verifyExternalSessionToken: tokenMocks.verify,
+}))
+
+function buildApp() {
+  const app = express()
+  app.get('/external/workflows', async (req, res) => {
+    const caller = await requireExternalWorkflowCaller(req, res)
+    if (!caller) return
+    res.status(200).json({
+      userId: caller.claims.userId,
+      teamId: caller.claims.teamId,
+      role: caller.claims.role,
+    })
+  })
+  return app
+}
+
+describe('external workflow live team context', () => {
+  beforeEach(() => {
+    dbMocks.query.mockReset()
+    tokenMocks.verify.mockReset()
+    tokenMocks.verify.mockReturnValue({
+      userId: 'user-1',
+      email: 'user@example.com',
+      teamId: 'team-1',
+      role: 'admin',
+    })
+  })
+
+  it('strips a removed team while preserving the authenticated user for direct grants', async () => {
+    dbMocks.query.mockResolvedValue({ rows: [], rowCount: 0 })
+
+    await request(buildApp())
+      .get('/external/workflows')
+      .set('x-user-session-token', 'session-token')
+      .expect(200)
+      .expect({ userId: 'user-1', teamId: null, role: 'member' })
+  })
+
+  it('replaces a stale claimed role with the current active role', async () => {
+    dbMocks.query.mockResolvedValue({
+      rows: [{ team_id: 'team-1', role: 'member', team_name: 'Team One' }],
+      rowCount: 1,
+    })
+
+    await request(buildApp())
+      .get('/external/workflows')
+      .set('x-user-session-token', 'session-token')
+      .expect(200)
+      .expect({ userId: 'user-1', teamId: 'team-1', role: 'member' })
+  })
+
+  it('fails closed when workflow team-context reconciliation is unavailable', async () => {
+    dbMocks.query.mockRejectedValue(new Error('database unavailable'))
+
+    await request(buildApp())
+      .get('/external/workflows')
+      .set('x-user-session-token', 'session-token')
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
+  })
+})

--- a/control-api/test/routes.externalWorkflows.test.ts
+++ b/control-api/test/routes.externalWorkflows.test.ts
@@ -7,6 +7,7 @@ import { MockGateway } from './mockGateway.js'
 const RECIPE_NS = 'sandbox-recipes'
 
 const mockPoolQuery = vi.fn()
+const mockLiveMembershipQuery = vi.fn()
 const mockWithTransaction = vi.fn()
 const mockIssueWorkflowControlToken = vi.fn()
 const mockVerifyWorkflowControlToken = vi.fn()
@@ -18,7 +19,10 @@ const mockIsAdminTokenRevoked = vi.fn()
 
 vi.mock('../src/db.js', () => ({
   pool: {
-    query: (...args: unknown[]) => mockPoolQuery(...args),
+    query: (text: unknown, ...args: unknown[]) =>
+      String(text).includes('SELECT tm.team_id, tm.role, t.name AS team_name')
+        ? mockLiveMembershipQuery(text, ...args)
+        : mockPoolQuery(text, ...args),
   },
   withTransaction: (...args: unknown[]) => mockWithTransaction(...args),
 }))
@@ -115,6 +119,11 @@ describe('routes/external/workflows', () => {
 
   beforeEach(() => {
     mockPoolQuery.mockReset()
+    mockLiveMembershipQuery.mockReset()
+    mockLiveMembershipQuery.mockResolvedValue({
+      rows: [{ team_id: 'team-1', role: 'member', team_name: 'Team One' }],
+      rowCount: 1,
+    })
     mockWithTransaction.mockReset()
     mockIssueWorkflowControlToken.mockReset()
     mockVerifyWorkflowControlToken.mockReset()

--- a/control-api/test/routes.externalWorkflows.test.ts
+++ b/control-api/test/routes.externalWorkflows.test.ts
@@ -214,6 +214,113 @@ describe('routes/external/workflows', () => {
       const app = makeApp(gateway)
       await request(app).get('/external/workflows').expect(401)
     })
+
+    it('keeps direct workflow routes usable and hides team-only routes after team removal', async () => {
+      const directRecipe = {
+        ...VALID_RECIPE,
+        metadata: { ...VALID_RECIPE.metadata, name: 'direct-recipe', uid: 'uid-direct' },
+      }
+      const teamRecipe = {
+        ...VALID_RECIPE,
+        metadata: { ...VALID_RECIPE.metadata, name: 'team-recipe', uid: 'uid-team' },
+      }
+      await gateway.createResource('workflowrecipes', directRecipe as never, RECIPE_NS)
+      await gateway.createResource('workflowrecipes', teamRecipe as never, RECIPE_NS)
+      mockLiveMembershipQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ recipe_namespace: RECIPE_NS, recipe_name: 'direct-recipe' }],
+        rowCount: 1,
+      })
+      const app = makeApp(gateway)
+      const list = await request(app)
+        .get('/external/workflows')
+        .set('x-user-session-token', 'user-session-token')
+        .expect(200)
+      expect(
+        list.body.items.map((item: { metadata: { name: string } }) => item.metadata.name)
+      ).toEqual(['direct-recipe'])
+
+      mockPoolQuery.mockResolvedValueOnce({ rows: [{ '1': 1 }], rowCount: 1 })
+      await request(app)
+        .get(`/external/workflows/${RECIPE_NS}/direct-recipe`)
+        .set('x-user-session-token', 'user-session-token')
+        .expect(200)
+
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [{ '1': 1 }], rowCount: 1 })
+      await request(app)
+        .get(`/external/workflows/${RECIPE_NS}/team-recipe`)
+        .set('x-user-session-token', 'user-session-token')
+        .expect(403)
+      mockPoolQuery.mockReset()
+
+      const runRow = {
+        run_id: 'direct-run-id',
+        recipe_namespace: RECIPE_NS,
+        recipe_name: 'direct-recipe',
+        phase: 'Pending',
+        actor_type: 'user',
+        actor_id: USER_SESSION_CLAIMS.userId,
+        team_id: null,
+        usage_team_id: null,
+        idempotency_key: 'direct-after-removal',
+        trigger_source: 'onDemand',
+        inputs: {},
+        intermediate_parameters: null,
+        output_overrides: null,
+        child_recipe_name: null,
+        child_recipe_namespace: null,
+        owner_instance_id: null,
+        max_duration_seconds: null,
+        ttl_seconds_after_finished: null,
+        started_at: null,
+        completed_at: null,
+        last_reconciled_at: null,
+        created_at: '2026-08-07T00:00:00.000Z',
+        updated_at: '2026-08-07T00:00:00.000Z',
+      }
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [{ count: 1 }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ '1': 1 }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [runRow], rowCount: 1 })
+      await request(app)
+        .post(`/external/workflows/${RECIPE_NS}/direct-recipe/trigger`)
+        .set('x-user-session-token', 'user-session-token')
+        .set('Idempotency-Key', 'direct-after-removal')
+        .send({ inputs: {} })
+        .expect(201)
+        .expect(({ body }) => {
+          expect(body.id).toBe('direct-run-id')
+        })
+
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [{ count: 1 }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      await request(app)
+        .post(`/external/workflows/${RECIPE_NS}/team-recipe/trigger`)
+        .set('x-user-session-token', 'user-session-token')
+        .set('Idempotency-Key', 'team-after-removal')
+        .send({ inputs: {} })
+        .expect(403)
+
+      mockPoolQuery
+        .mockResolvedValueOnce({ rows: [{ '1': 1 }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      await request(app)
+        .get(`/external/workflows/${RECIPE_NS}/direct-recipe/runs`)
+        .set('x-user-session-token', 'user-session-token')
+        .expect(200)
+        .expect({ items: [], count: 0 })
+
+      mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      await request(app)
+        .get(`/external/workflows/${RECIPE_NS}/team-recipe/runs`)
+        .set('x-user-session-token', 'user-session-token')
+        .expect(403)
+    })
   })
 
   describe('runtime token issuance isolation', () => {

--- a/control-api/test/routes.profile.test.ts
+++ b/control-api/test/routes.profile.test.ts
@@ -414,6 +414,61 @@ describe('routes/profile', () => {
     ).expect(200)
   })
 
+  it('requires the current live admin role to rename a team', async () => {
+    svc.renameTeam.mockResolvedValue({ id: 't1', name: 'Renamed Team' })
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(request(app).put('/external/teams/t1/name'))
+      .send({ userId: 'u1', name: 'Renamed Team' })
+      .expect(403)
+      .expect({ error: 'team_role_insufficient' })
+
+    expect(svc.renameTeam).not.toHaveBeenCalled()
+
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'active',
+      membership: { team_id: 't1', role: 'admin', team_name: 'Team One' },
+    })
+
+    await withInternalServiceAuthAndUserSession(request(app).put('/external/teams/t1/name'))
+      .send({ userId: 'u1', name: 'Renamed Team' })
+      .expect(200)
+      .expect({ id: 't1', name: 'Renamed Team' })
+
+    expect(svc.renameTeam).toHaveBeenCalledOnce()
+    expect(svc.renameTeam).toHaveBeenCalledWith('t1', 'Renamed Team')
+  })
+
+  it('keeps current-role guards on representative team mutations', async () => {
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).patch('/external/teams/t1/members/u2/role')
+    )
+      .send({ userId: 'u1', role: 'admin' })
+      .expect(403)
+      .expect({ error: 'team_role_insufficient' })
+
+    await withInternalServiceAuthAndUserSession(request(app).post('/external/teams/t1/invitations'))
+      .send({ userId: 'u1', name: 'Invitee', email: 'invitee@example.com', role: 'member' })
+      .expect(403)
+      .expect({ error: 'team_role_insufficient' })
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).delete('/external/teams/t1/members/u2')
+    )
+      .expect(403)
+      .expect({ error: 'team_role_insufficient' })
+
+    expect(svc.updateMemberRole).not.toHaveBeenCalled()
+    expect(svc.createInvitation).not.toHaveBeenCalled()
+    expect(svc.softDeleteMember).not.toHaveBeenCalled()
+  })
+
   it('live-authorizes the directory query team without changing its response shape', async () => {
     svc.searchDirectory.mockResolvedValue([{ id: 'u2', email: 'two@example.com' }])
     const app = express()

--- a/control-api/test/routes.profile.test.ts
+++ b/control-api/test/routes.profile.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
+import { pool } from '../src/db.js'
 import { requireInternalToken } from '../src/middleware/internalServiceAuth.js'
 import { createExternalRouter } from '../src/routes/external/index.js'
 import { createRpcAccessRouter } from '../src/routes/rpc-access/index.js'
@@ -373,6 +374,22 @@ describe('routes/profile', () => {
     ).expect(403)
   })
 
+  it('returns unavailable when replacement session membership validation fails', async () => {
+    const query = vi.spyOn(pool, 'query').mockRejectedValue(new Error('database unavailable'))
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    try {
+      await withInternalServiceAuth(request(app).post('/external/auth/session-token'))
+        .send({ userId: 'u1', email: 'u@example.com', teamId: 't1', role: 'member' })
+        .expect(503)
+        .expect({ error: 'team_authorization_unavailable' })
+    } finally {
+      query.mockRestore()
+    }
+  })
+
   it('denies a removed team while direct Agent and Context endpoints remain available', async () => {
     svc.authorizeLiveTeamMembership.mockResolvedValue({
       status: 'denied',
@@ -418,6 +435,10 @@ describe('routes/profile', () => {
       role: 'member',
       team_name: 'best team',
     })
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'active',
+      membership: { team_id: 't2', role: 'member', team_name: 'best team' },
+    })
 
     const app = express()
     app.use(express.json())
@@ -426,6 +447,40 @@ describe('routes/profile', () => {
     await withInternalServiceAuthAndUserSession(
       request(app).get('/external/users/u1/memberships/t2')
     ).expect(200)
+  })
+
+  it('returns a stable denial when a requested replacement team is no longer active', async () => {
+    svc.findMembership.mockResolvedValue(null)
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).get('/external/users/u1/memberships/t2')
+    )
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+  })
+
+  it('returns unavailable when replacement-team membership lookup fails', async () => {
+    svc.findMembership.mockRejectedValue(new Error('database unavailable'))
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'unavailable',
+      code: 'team_authorization_unavailable',
+    })
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).get('/external/users/u1/memberships/t2')
+    )
+      .expect(503)
+      .expect({ error: 'team_authorization_unavailable' })
   })
 
   it('returns initial team directory for all user memberships without switching team claims', async () => {

--- a/control-api/test/routes.profile.test.ts
+++ b/control-api/test/routes.profile.test.ts
@@ -10,6 +10,7 @@ import { signRpcAccessToken } from '../src/utils/auth/rpcAuthToken.js'
 const svc = vi.hoisted(() => ({
   acceptInvitation: vi.fn(),
   acceptInvitationForEmail: vi.fn(),
+  authorizeLiveTeamMembership: vi.fn(),
   createInvitation: vi.fn(),
   createTeamForUser: vi.fn(),
   findMemberRole: vi.fn(),
@@ -113,6 +114,10 @@ describe('routes/profile', () => {
       resetMs: Date.now() + 60_000,
       windowStartMs: Date.now(),
       count: 1,
+    })
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'active',
+      membership: { team_id: 't1', role: 'member', team_name: 'Team One' },
     })
   })
 
@@ -366,6 +371,45 @@ describe('routes/profile', () => {
     await withInternalServiceAuthAndUserSession(
       request(app).get('/external/teams/t2/agents')
     ).expect(403)
+  })
+
+  it('denies a removed team while direct Agent and Context endpoints remain available', async () => {
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    svc.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: ['agent-a'] })
+    svc.getUserContexts.mockResolvedValue({ userId: 'u1', contextIds: ['ctx-a'] })
+
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(request(app).get('/external/teams/t1/members'))
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).get('/external/users/u1/agents')
+    ).expect(200)
+    await withInternalServiceAuthAndUserSession(
+      request(app).get('/external/users/u1/contexts')
+    ).expect(200)
+  })
+
+  it('live-authorizes the directory query team without changing its response shape', async () => {
+    svc.searchDirectory.mockResolvedValue([{ id: 'u2', email: 'two@example.com' }])
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, accessCatalogGateway())
+
+    await withInternalServiceAuthAndUserSession(
+      request(app).get('/external/directory/search?teamId=t1&q=two')
+    )
+      .expect(200)
+      .expect({ items: [{ id: 'u2', email: 'two@example.com' }] })
+
+    expect(svc.authorizeLiveTeamMembership).toHaveBeenCalledWith('u1', 't1')
   })
 
   it('allows membership lookup for another team when user claim matches', async () => {
@@ -652,6 +696,81 @@ describe('routes/profile', () => {
       ['mcp:servers:list'],
       ['host-a'],
       [] // extraGrantedScopes — no UI-bearing recipe in this mock
+    )
+  })
+
+  it('denies team-derived RPC issuance after the claimed membership is removed', async () => {
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'denied',
+      code: 'team_membership_inactive',
+    })
+    svc.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: [] })
+    svc.getTeamAgents.mockResolvedValue({ teamId: 't1', agentNames: ['team-agent'] })
+    rpcMock.issueRpcAccessToken.mockReturnValue({
+      token: 'stale-team-rpc-token',
+      accessScope: 'team',
+      teamId: 't1',
+      scopes: ['host:message:invoke'],
+      hostRefs: ['team-agent'],
+      expiresInSeconds: 300,
+    })
+
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, { listResource: vi.fn() })
+
+    await withInternalServiceAuth(request(app).post('/external/rpc/token'))
+      .send({
+        sessionToken: userSessionToken,
+        scopes: ['host:message:invoke'],
+        hostRefs: ['team-agent'],
+      })
+      .expect(403)
+      .expect({ error: 'team_membership_inactive' })
+
+    expect(svc.getTeamAgents).not.toHaveBeenCalled()
+    expect(rpcMock.issueRpcAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('uses the current membership role for RPC token attribution', async () => {
+    const adminSessionToken = signExternalSessionToken({
+      userId: 'u1',
+      email: 'u@example.com',
+      teamId: 't1',
+      role: 'admin',
+    })
+    svc.authorizeLiveTeamMembership.mockResolvedValue({
+      status: 'active',
+      membership: { team_id: 't1', role: 'member', team_name: 'Team One' },
+    })
+    svc.getUserAgents.mockResolvedValue({ userId: 'u1', agentNames: [] })
+    svc.getTeamAgents.mockResolvedValue({ teamId: 't1', agentNames: ['team-agent'] })
+    rpcMock.issueRpcAccessToken.mockReturnValue({
+      token: 'rpc-token',
+      accessScope: 'team',
+      teamId: 't1',
+      scopes: ['host:message:invoke'],
+      hostRefs: ['team-agent'],
+      expiresInSeconds: 300,
+    })
+
+    const app = express()
+    app.use(express.json())
+    mountInternalRoutes(app, { listResource: vi.fn() })
+
+    await withInternalServiceAuth(request(app).post('/external/rpc/token'))
+      .send({
+        sessionToken: adminSessionToken,
+        scopes: ['host:message:invoke'],
+        hostRefs: ['team-agent'],
+      })
+      .expect(200)
+
+    expect(rpcMock.issueRpcAccessToken).toHaveBeenCalledWith(
+      { userId: 'u1', teamId: 't1', role: 'member' },
+      ['host:message:invoke'],
+      ['team-agent'],
+      []
     )
   })
 

--- a/control-api/test/services.directory.channels.test.ts
+++ b/control-api/test/services.directory.channels.test.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { searchDirectory } from '../src/services/directory/index.js'
 import { normalizeChannels } from '../src/services/directory/types.js'
 
+const dbMocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  txQuery: vi.fn(),
+}))
+
+vi.mock('../src/db.js', () => ({
+  pool: { query: dbMocks.poolQuery },
+  withTransaction: async (work: (db: { query: typeof dbMocks.txQuery }) => Promise<unknown>) =>
+    work({ query: dbMocks.txQuery }),
+}))
+
 describe('directory channel mappings', () => {
+  beforeEach(() => {
+    dbMocks.poolQuery.mockReset()
+    dbMocks.txQuery.mockReset()
+  })
+
   it('normalizes all supported profile social channels', () => {
     expect(
       normalizeChannels({
@@ -31,5 +48,35 @@ describe('directory channel mappings', () => {
       discordUserNames: [],
       whatsappNumbers: [],
     })
+  })
+
+  it('searches literal text and returns only supported directory fields', async () => {
+    dbMocks.poolQuery.mockResolvedValue({
+      rows: [
+        {
+          id: 'user-1',
+          email: 'user@example.com',
+          name: 'User',
+          display_name: 'Display',
+        },
+      ],
+      rowCount: 1,
+    })
+
+    await expect(searchDirectory('team-1', String.raw`100%_name\value`)).resolves.toEqual([
+      {
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User',
+        display_name: 'Display',
+      },
+    ])
+
+    expect(dbMocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT u\.id, u\.email, u\.name, p\.display_name\s+FROM/),
+      ['team-1', String.raw`%100\%\_name\\value%`]
+    )
+    expect(dbMocks.poolQuery.mock.calls[0]?.[0]).toContain("ESCAPE '\\'")
+    expect(dbMocks.poolQuery.mock.calls[0]?.[0]).not.toContain('p.channels')
   })
 })

--- a/control-api/test/services.directory.login.passwordBackstop.test.ts
+++ b/control-api/test/services.directory.login.passwordBackstop.test.ts
@@ -129,6 +129,32 @@ describe('directory login without team memberships', () => {
     )
   })
 
+  it('does not select a pending invitation as the Google session team', async () => {
+    dbMocks.txQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: 'u1', email: 'a@b.com', name: 'Ada', picture: null }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: 'u1', email: 'a@b.com', name: 'Ada', picture: null }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({
+        rows: [{ team_id: 'pending-team', role: 'admin', team_name: 'Pending Team' }],
+        rowCount: 1,
+      })
+
+    const result = await googleLoginData({ email: 'a@b.com', name: 'Ada' })
+
+    expect(result).toMatchObject({
+      membership: { team_id: null, role: 'member', team_name: null },
+    })
+  })
+
   it('does NOT self-heal (no team created) when the password is wrong', async () => {
     bcryptMock.compare.mockResolvedValue(false)
     dbMocks.txQuery.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Harden Control API team-session authorization so pending or stale team state
cannot authorize team data or actions.

## Changes

- Stop selecting pending invitations as the Google login session team.
- Revalidate active membership and current role on team-sensitive routes.
- Deny stale team-derived RPC issuance.
- Sanitize stale workflow team context while retaining direct-user grants.
- Make Shared FileSystem Context authorization direct-first and team-live.
- Remove claimed-team fallback from GFS subject expansion.
- Return stable 403 and 503 authorization outcomes.
- Preserve authentication and direct Agents and Contexts after final-team removal.

## Compatibility

- Team-scoped session and RPC token formats are unchanged.
- Existing successful endpoint response shapes are unchanged.
- No aggregate catalog, Desktop token broker, or later initiative work is included.

## Validation

- Control API build passed.
- Full Control API suite passed:
  - 311 test files passed, 12 skipped.
  - 3,912 tests passed, 61 skipped.
- Code review passed after addressing all Must-fix findings.
- Security review passed with no open high-severity or must-fix findings.