### PR TITLE
fix(workflow-recipes)!: default recipe isolation to standard, not minimal

### DIFF
--- a/tests/e2e/fixtures/layer3a-snippet-api-mongo-postgres-chain.yaml
+++ b/tests/e2e/fixtures/layer3a-snippet-api-mongo-postgres-chain.yaml
@@ -7,6 +7,9 @@ spec:
   triggers:
     onDemand: {}
   description: 'Layer 3A snippet runtime chain: public API -> MongoDB -> PostgreSQL -> Markdown artifact.'
+  # DB workloads need root/writable rootfs; opt out of the platform 'standard' default.
+  security:
+    isolationLevel: minimal
   runtimeEgress:
     http:
       allowedHosts:

--- a/tests/e2e/fixtures/layer3a-snippet-direct-db.yaml
+++ b/tests/e2e/fixtures/layer3a-snippet-direct-db.yaml
@@ -7,6 +7,9 @@ spec:
   triggers:
     onDemand: {}
   description: Layer 3A snippet runtime direct MongoDB and PostgreSQL SDK flow.
+  # DB workloads need root/writable rootfs; opt out of the platform 'standard' default.
+  security:
+    isolationLevel: minimal
   resources:
     - id: pg-auth
       type: secret

--- a/tests/e2e/fixtures/package-lock.json
+++ b/tests/e2e/fixtures/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clerum/e2e-test-fixtures",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clerum/e2e-test-fixtures",
-      "version": "1.0.54",
+      "version": "1.0.55",
       "dependencies": {
         "@kubernetes/client-node": "^1.0.0"
       },

--- a/tests/e2e/fixtures/package.json
+++ b/tests/e2e/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clerum/e2e-test-fixtures",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "description": "E2E test fixtures and utilities for Clerum testing",
   "type": "module",
   "main": "index.ts",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -34,7 +34,7 @@
       "engines": {
         "node": ">=24"
       },
-      "version": "0.1.280"
+      "version": "0.1.281"
     },
     "../packages/image-policy": {
       "name": "@clerum/image-policy",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.281",
+  "version": "0.1.282",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -34,7 +34,7 @@
       "engines": {
         "node": ">=24"
       },
-      "version": "0.1.281"
+      "version": "0.1.282"
     },
     "../packages/image-policy": {
       "name": "@clerum/image-policy",

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.281",
+  "version": "0.1.282",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/samples/agentic-workload-template-resolution.yaml
+++ b/workflow-recipes/samples/agentic-workload-template-resolution.yaml
@@ -4,6 +4,9 @@ metadata:
   name: agentic-workload-template-resolution
 spec:
   description: Agentic workflow sample that validates workload env/command/args template resolution.
+  # busybox/postgres need root/writable rootfs; opt out of the platform 'standard' default.
+  security:
+    isolationLevel: minimal
   agent:
     provider: zai
     model: glm-4.7

--- a/workflow-recipes/samples/webhook-hello.yaml
+++ b/workflow-recipes/samples/webhook-hello.yaml
@@ -11,6 +11,9 @@ spec:
     default config — a 200 response from the default welcome page is
     enough to prove the verify+forward pipeline. Headers sent by the
     gateway show up in the nginx access log.
+  # nginx-unprivileged needs a writable rootfs; opt out of the platform 'standard' default.
+  security:
+    isolationLevel: minimal
   workloads:
     - id: handler
       type: deployment

--- a/workflow-recipes/src/reconciler/policyEnforcer.test.ts
+++ b/workflow-recipes/src/reconciler/policyEnforcer.test.ts
@@ -130,11 +130,20 @@ describe('policyEnforcer.enforcePolicy', () => {
     expect(result[0].message).toContain('strict')
   })
 
-  it('defaults to minimal when recipe has no security config', () => {
-    const policy = makePolicy({ governance: { requiredSecurityLevel: 'standard' } })
-    const result = enforcePolicy(makeRecipe(), [policy])
-    expect(result).toHaveLength(1)
-    expect(result[0].rule).toBe('requiredSecurityLevel')
+  it('defaults to standard when recipe has no security config', () => {
+    // A recipe that omits spec.security now defaults to 'standard' (non-root +
+    // read-only rootfs), so it satisfies a 'standard' floor but not 'strict'.
+    const meetsStandard = enforcePolicy(makeRecipe(), [
+      makePolicy({ governance: { requiredSecurityLevel: 'standard' } }),
+    ])
+    expect(meetsStandard).toEqual([])
+
+    const belowStrict = enforcePolicy(makeRecipe(), [
+      makePolicy({ governance: { requiredSecurityLevel: 'strict' } }),
+    ])
+    expect(belowStrict).toHaveLength(1)
+    expect(belowStrict[0].rule).toBe('requiredSecurityLevel')
+    expect(belowStrict[0].message).toContain('standard')
   })
 
   // ── imageDenylist ────────────────────────────────────────────

--- a/workflow-recipes/src/reconciler/policyEnforcer.ts
+++ b/workflow-recipes/src/reconciler/policyEnforcer.ts
@@ -138,7 +138,7 @@ export function enforcePolicy(
     }
 
     if (gov?.requiredSecurityLevel) {
-      const recipeLevel = recipe.spec.security?.isolationLevel ?? 'minimal'
+      const recipeLevel = recipe.spec.security?.isolationLevel ?? 'standard'
       if (SECURITY_LEVELS[recipeLevel] < SECURITY_LEVELS[gov.requiredSecurityLevel]) {
         violations.push({
           policy: policyName,

--- a/workflow-recipes/src/reconciler/resourceBuilder.ts
+++ b/workflow-recipes/src/reconciler/resourceBuilder.ts
@@ -948,7 +948,7 @@ export interface WorkloadBuildOptions {
 export function buildDeployment(
   workload: DeploymentDef,
   recipe: WorkflowRecipeCRD,
-  isolationLevel: SecurityIsolationLevel = 'minimal',
+  isolationLevel: SecurityIsolationLevel = 'standard',
   secretKeys?: SecretKeysByName,
   buildOptions?: WorkloadBuildOptions
 ): k8s.V1Deployment {
@@ -1019,7 +1019,7 @@ export function buildDeployment(
 export function buildStatefulSet(
   workload: StatefulSetDef,
   recipe: WorkflowRecipeCRD,
-  isolationLevel: SecurityIsolationLevel = 'minimal',
+  isolationLevel: SecurityIsolationLevel = 'standard',
   secretKeys?: SecretKeysByName,
   buildOptions?: WorkloadBuildOptions
 ): { statefulSet: k8s.V1StatefulSet; headlessService: k8s.V1Service } {
@@ -1121,7 +1121,7 @@ export function buildStatefulSet(
 export function buildCronJob(
   workload: CronJobDef,
   recipe: WorkflowRecipeCRD,
-  isolationLevel: SecurityIsolationLevel = 'minimal',
+  isolationLevel: SecurityIsolationLevel = 'standard',
   secretKeys?: SecretKeysByName,
   buildOptions?: WorkloadBuildOptions
 ): k8s.V1CronJob {
@@ -1168,7 +1168,7 @@ export function buildCronJob(
 export function buildJob(
   workload: JobDef,
   recipe: WorkflowRecipeCRD,
-  isolationLevel: SecurityIsolationLevel = 'minimal',
+  isolationLevel: SecurityIsolationLevel = 'standard',
   secretKeys?: SecretKeysByName,
   buildOptions?: WorkloadBuildOptions
 ): k8s.V1Job {
@@ -1210,7 +1210,7 @@ export function buildJob(
 export function buildDaemonSet(
   workload: DaemonSetDef,
   recipe: WorkflowRecipeCRD,
-  isolationLevel: SecurityIsolationLevel = 'minimal',
+  isolationLevel: SecurityIsolationLevel = 'standard',
   secretKeys?: SecretKeysByName,
   buildOptions?: WorkloadBuildOptions
 ): k8s.V1DaemonSet {

--- a/workflow-recipes/src/reconciler/workflowRecipeReconciler.ts
+++ b/workflow-recipes/src/reconciler/workflowRecipeReconciler.ts
@@ -2052,7 +2052,7 @@ export class WorkflowRecipeReconciler {
       }
 
       const isolationLevel: SecurityIsolationLevel =
-        recipe.spec.security?.isolationLevel ?? 'minimal'
+        recipe.spec.security?.isolationLevel ?? 'standard'
 
       // Step 7: Create resources first (PVCs, Secrets, ConfigMaps)
       if (!(await this.hasVerifiedInheritedParentResources(recipe))) {
@@ -2932,7 +2932,8 @@ export class WorkflowRecipeReconciler {
       }
     }
 
-    const isolationLevel: SecurityIsolationLevel = recipe.spec.security?.isolationLevel ?? 'minimal'
+    const isolationLevel: SecurityIsolationLevel =
+      recipe.spec.security?.isolationLevel ?? 'standard'
     const sortOrder = sortDependencies(
       workloads.map(w => ({ id: w.id, dependsOn: w.dependsOn ?? [] }))
     )
@@ -4892,7 +4893,7 @@ export class WorkflowRecipeReconciler {
     // still rotate the (potentially compromised) Secret to fully remediate.
     if (workload.type === 'statefulset') {
       const isolationLevel: SecurityIsolationLevel =
-        recipe.spec.security?.isolationLevel ?? 'minimal'
+        recipe.spec.security?.isolationLevel ?? 'standard'
       await this.ensureStatefulSet(workload as StatefulSetDef, recipe, isolationLevel, secretKeys)
       await this.deleteStatefulSetManagedPods(workload as StatefulSetDef, recipe, ns)
       return


### PR DESCRIPTION
## What

Change the default `spec.security.isolationLevel` for WorkflowRecipes from **`minimal`** to **`standard`**. A recipe that omits the field previously ran as UID 0 with a writable root filesystem; it now gets `runAsNonRoot: true` + `readOnlyRootFilesystem: true`, while keeping the existing hard floors (no privilege escalation, drop ALL caps, seccomp `RuntimeDefault`).

The level *definitions* in `securityContext.ts` are unchanged — only the default *selection* moves. `minimal` remains available and must now be requested explicitly.

Addresses **F1** of the small-webapp / untrusted-workload security review: `minimal` (root + writable rootfs) is the wrong default floor for user/untrusted workloads.

## Changed

Every effective default was updated:
- `workflowRecipeReconciler.ts` (3 resolution sites) — the level used at deploy time.
- `policyEnforcer.ts` — the `requiredSecurityLevel` floor check now evaluates a no-security recipe as `standard`, consistent with what actually runs.
- `resourceBuilder.ts` (5 builder param fallbacks) — safety net for direct callers.

Plus fixups (2nd commit): four recipes that omit `isolationLevel` but run root/writable-fs images now declare `minimal` explicitly, preserving their prior (implicit-minimal) behavior — 2 e2e fixtures (mongodb/postgres) and 2 samples (busybox+postgres, nginx-unprivileged).

## ⚠️ Breaking (operational)

Recipes with no `isolationLevel` that rely on running as root or writing to the container root filesystem (e.g. stock mongo/nginx/redis images) will now fail to start. Fix: set `spec.security.isolationLevel: minimal`, or run non-root with a writable volume where the app needs to write.

Note: the capability floor (`drop: ALL`) is applied at *all* levels, so images whose entrypoint needs a capability (e.g. stock nginx needs `CAP_CHOWN`) require `security.addCapabilities` / `prepareVolumeOwnership` regardless of level — unrelated to this change.

## Testing

- **Unit:** full `workflow-recipes` suite green — **2355 passed, 29 skipped, 0 failures**. Updated the one test that asserted the old default.
- **Live before/after** on a minikube cluster with the rebuilt WRC, two identical busybox recipes:
  - no `isolationLevel` → applied `standard` securityContext → pod `CreateContainerConfigError` ("container has runAsNonRoot and image will run as root") → recipe `degraded`.
  - `isolationLevel: minimal` → applied `minimal` securityContext → pod **Running** → recipe **active**.
  - Confirmed no collateral damage: the pre-existing recipe on that cluster already declares `minimal` and stayed `active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)