### PR TITLE
fix(slack): make the wrong Request URL impossible to paste (#312)

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.438",
+  "version": "0.1.439",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.438",
+      "version": "0.1.439",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.433",
+      "version": "0.1.434",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.434",
+      "version": "0.1.435",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.435",
+      "version": "0.1.436",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.436",
+      "version": "0.1.437",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.437",
+  "version": "0.1.438",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.437",
+      "version": "0.1.438",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.439",
+  "version": "0.1.440",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.439",
+      "version": "0.1.440",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.436",
+  "version": "0.1.437",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.433",
+  "version": "0.1.434",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.435",
+  "version": "0.1.436",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.439",
+  "version": "0.1.440",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.438",
+  "version": "0.1.439",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.437",
+  "version": "0.1.438",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.434",
+  "version": "0.1.435",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/src/routes/admin/resources.ts
+++ b/control-api/src/routes/admin/resources.ts
@@ -266,7 +266,11 @@ async function providerTransitionError(
 
   for (const provider of added) {
     for (const key of PROVIDER_REQUIRED_KEYS[provider] || []) {
-      if (!credentials?.[key] && !existingKeys.includes(key)) {
+      // Trimmed, because this reads the RAW envelope while the Secret is written
+      // from the CLEANED values: `validateCommunicationChannelCredentials` drops
+      // whitespace-only entries, so a truthy "   " here would satisfy the guard
+      // and then never reach the Secret.
+      if (!credentials?.[key]?.trim() && !existingKeys.includes(key)) {
         return `credentials["${key}"] is required to enable the ${provider} provider on this CommunicationChannel`
       }
     }

--- a/control-api/src/routes/admin/resources.ts
+++ b/control-api/src/routes/admin/resources.ts
@@ -6,6 +6,7 @@ import { validateCommunicationChannelSpec } from '../../http/validateCommunicati
 import { validateMcpServerSpecPreflight } from '../../http/validateMcpServerSpec.js'
 import { K8sGateway } from '../../k8s.js'
 import { K8sConflictError } from '../../services/resourceService.js'
+import { secretKeyNames } from '../../services/secretKeyNames.js'
 import { ClerumResourceType } from '../../types.js'
 import {
   registerCommunicationChannelCredentialsRoutes,
@@ -211,6 +212,68 @@ function missingCreateCredentialKey(
   return null
 }
 
+const PROVIDER_REQUIRED_KEYS: Record<string, string[]> = {
+  telegram: ['telegram-bot-token'],
+  slack: ['slack-bot-token', 'slack-signing-secret'],
+  teams: ['teams-app-password'],
+  email: ['email-username', 'email-password'],
+}
+
+function providersEnabled(spec: Record<string, unknown> | null): Set<string> {
+  const enabled = new Set<string>()
+  if (!spec) return enabled
+  if (ccSpecHasTelegramProvider(spec)) enabled.add('telegram')
+  if (ccSpecHasSlackProvider(spec)) enabled.add('slack')
+  if (ccSpecHasTeamsProvider(spec)) enabled.add('teams')
+  if (Array.isArray(spec.email) && spec.email.length > 0) enabled.add('email')
+  return enabled
+}
+
+/**
+ * Validate providers that go absent -> present. Returns an error message, or null.
+ *
+ * Deliberately scoped to the transition: a channel already missing keys in a
+ * cluster stays editable, and enabling a NEW provider without its credentials is
+ * refused. Presence of `credentialsSecretRef` proves nothing, which is why the
+ * pre-existing POST guard missed this entirely — the channel that motivated this
+ * (#312) already had a ref, holding only its Telegram token, and still accepted a
+ * Slack App Name.
+ *
+ * Fails CLOSED: an unreadable Secret rejects the write. Refusing a write on a
+ * read failure is safe; assuming the keys are there is how a channel ends up
+ * advertising a provider it cannot serve.
+ */
+async function providerTransitionError(
+  gateway: K8sGateway,
+  nextSpec: Record<string, unknown>,
+  previousSpec: Record<string, unknown> | null,
+  credentials: Record<string, string> | undefined,
+  namespace: string
+): Promise<string | null> {
+  const previouslyEnabled = providersEnabled(previousSpec)
+  const added = [...providersEnabled(nextSpec)].filter(p => !previouslyEnabled.has(p))
+  if (added.length === 0) return null
+
+  const secretName = (nextSpec.credentialsSecretRef as { name?: string } | undefined)?.name?.trim()
+  let existingKeys: string[] = []
+  if (secretName) {
+    try {
+      existingKeys = await secretKeyNames(gateway, secretName, namespace)
+    } catch {
+      return `Cannot read the credentials Secret "${secretName}" to validate the new provider. Fix access to that Secret, or supply the credentials with this request.`
+    }
+  }
+
+  for (const provider of added) {
+    for (const key of PROVIDER_REQUIRED_KEYS[provider] || []) {
+      if (!credentials?.[key] && !existingKeys.includes(key)) {
+        return `credentials["${key}"] is required to enable the ${provider} provider on this CommunicationChannel`
+      }
+    }
+  }
+  return null
+}
+
 // workflowrecipes is handled by recipes.ts (canonical sandbox-recipes route).
 // workflowrecipepolicies is read inline by the recipes policy-invariant
 // helper and does not need generic admin CRUD routing.
@@ -327,6 +390,21 @@ export function createAdminResourcesRouter(gateway: K8sGateway): Router {
               'credentials. Supply a "credentials" envelope on the request, or set ' +
               '"spec.credentialsSecretRef" to an existing Secret.',
           })
+          return
+        }
+
+        // Every declared provider is new on create, so the whole spec is the
+        // transition. A credentialsSecretRef satisfies the guard above without
+        // proving the Secret behind it holds this provider's keys.
+        const transitionError = await providerTransitionError(
+          gateway,
+          body.spec,
+          null,
+          body.credentials,
+          ns
+        )
+        if (transitionError) {
+          res.status(400).json({ error: transitionError })
           return
         }
       }
@@ -516,6 +594,23 @@ export function createAdminResourcesRouter(gateway: K8sGateway): Router {
             ),
           }
         : body
+      if (isCommunicationChannelUpdate) {
+        // updateBody.spec, not body.spec: the ref the write will actually carry
+        // is the preserved one, and that is the Secret whose keys decide whether
+        // a newly enabled provider can work. Reuses the snapshot already loaded
+        // above — no second fetch.
+        const transitionError = await providerTransitionError(
+          gateway,
+          updateBody.spec,
+          previousCommunicationChannelSpec?.spec ?? null,
+          undefined,
+          ns
+        )
+        if (transitionError) {
+          res.status(400).json({ error: transitionError })
+          return
+        }
+      }
       try {
         const updated = await gateway.updateResource(plural, req.params.name, updateBody, ns)
         if (plural === 'communicationchannels' && body.spec) {

--- a/control-api/src/routes/admin/resources.ts
+++ b/control-api/src/routes/admin/resources.ts
@@ -603,7 +603,12 @@ export function createAdminResourcesRouter(gateway: K8sGateway): Router {
             ),
           }
         : body
-      if (isCommunicationChannelUpdate) {
+      // A null snapshot means the channel does not exist (loadCommunicationChannelSpecSnapshot
+      // returns null only on 404). Skipping the guard here is what makes the response
+      // honest: with no previous spec every provider reads as newly added, so the guard
+      // would answer a PUT to a missing channel with `credentials[...] is required`
+      // instead of the 404 updateResource is about to produce.
+      if (isCommunicationChannelUpdate && previousCommunicationChannelSpec) {
         // updateBody.spec, not body.spec: the ref the write will actually carry
         // is the preserved one, and that is the Secret whose keys decide whether
         // a newly enabled provider can work. Reuses the snapshot already loaded

--- a/control-api/src/routes/admin/resources.ts
+++ b/control-api/src/routes/admin/resources.ts
@@ -269,8 +269,13 @@ async function providerTransitionError(
       // Trimmed, because this reads the RAW envelope while the Secret is written
       // from the CLEANED values: `validateCommunicationChannelCredentials` drops
       // whitespace-only entries, so a truthy "   " here would satisfy the guard
-      // and then never reach the Secret.
-      if (!credentials?.[key]?.trim() && !existingKeys.includes(key)) {
+      // and then never reach the Secret. A present-but-non-string value (e.g. a
+      // number) is NOT "missing" though: it's `validateCommunicationChannelCredentials`
+      // below that owns rejecting the wrong type with its own 400, so this only
+      // calls `.trim()` once `typeof` has confirmed there's a string to trim.
+      const rawValue = credentials?.[key]
+      const isMissing = rawValue === undefined || (typeof rawValue === 'string' && !rawValue.trim())
+      if (isMissing && !existingKeys.includes(key)) {
         return `credentials["${key}"] is required to enable the ${provider} provider on this CommunicationChannel`
       }
     }

--- a/control-api/src/services/secretKeyNames.ts
+++ b/control-api/src/services/secretKeyNames.ts
@@ -1,4 +1,5 @@
 import type { K8sGateway } from '../k8s.js'
+import { extractK8sStatus } from './resourceServiceHelpers.js'
 
 /**
  * Key NAMES held by a Secret. Never returns values: callers use this to decide
@@ -8,6 +9,12 @@ import type { K8sGateway } from '../k8s.js'
  * A missing Secret is "no keys" (an absent Secret and an empty one are the same
  * answer to this question). Any other read failure rethrows, so callers fail
  * closed rather than silently treating an RBAC denial as "no credentials".
+ *
+ * Status extraction goes through `extractK8sStatus` rather than a bare
+ * `.statusCode` check: the real `@kubernetes/client-node` `ApiException` (what
+ * `gateway.getSecret` actually throws) sets `.code`, not `.statusCode` — a bare
+ * `.statusCode` check would never match a genuine 404 and every missing Secret
+ * would rethrow instead of resolving to "no keys".
  */
 export async function secretKeyNames(
   gateway: K8sGateway,
@@ -18,7 +25,7 @@ export async function secretKeyNames(
     const secret = (await gateway.getSecret(name, namespace)) as { data?: Record<string, unknown> }
     return Object.keys(secret?.data || {}).sort((a, b) => a.localeCompare(b))
   } catch (error) {
-    if ((error as { statusCode?: number })?.statusCode === 404) return []
+    if (extractK8sStatus(error) === 404) return []
     throw error
   }
 }

--- a/control-api/src/services/secretKeyNames.ts
+++ b/control-api/src/services/secretKeyNames.ts
@@ -1,0 +1,24 @@
+import type { K8sGateway } from '../k8s.js'
+
+/**
+ * Key NAMES held by a Secret. Never returns values: callers use this to decide
+ * whether a provider is configured, and a value has no place in that decision
+ * or in any response derived from it.
+ *
+ * A missing Secret is "no keys" (an absent Secret and an empty one are the same
+ * answer to this question). Any other read failure rethrows, so callers fail
+ * closed rather than silently treating an RBAC denial as "no credentials".
+ */
+export async function secretKeyNames(
+  gateway: K8sGateway,
+  name: string,
+  namespace: string
+): Promise<string[]> {
+  try {
+    const secret = (await gateway.getSecret(name, namespace)) as { data?: Record<string, unknown> }
+    return Object.keys(secret?.data || {}).sort((a, b) => a.localeCompare(b))
+  } catch (error) {
+    if ((error as { statusCode?: number })?.statusCode === 404) return []
+    throw error
+  }
+}

--- a/control-api/src/services/workflowApprovalMediumSlackVerificationService.ts
+++ b/control-api/src/services/workflowApprovalMediumSlackVerificationService.ts
@@ -65,6 +65,16 @@ export type SlackIdentity = {
 
 const SLACK_WORKSPACE_ID_RE = /^T[A-Z0-9]+$/
 
+/**
+ * Keys a channel's credentials Secret must hold before it can serve Slack.
+ * Kept identical to `PROVIDER_REQUIRED_KEYS.slack` in
+ * `routes/admin/resources.ts`, which is the write-side gate: the picker must not
+ * offer a target the write path would have refused to create. Not imported from
+ * there — a service importing an admin route would invert the layering and
+ * close an import cycle.
+ */
+const SLACK_REQUIRED_SECRET_KEYS = ['slack-signing-secret', 'slack-bot-token']
+
 function optionalString(value: unknown): string | null {
   if (value === undefined || value === null) return null
   const normalized = String(value).trim()
@@ -223,17 +233,28 @@ export async function listSlackApprovalTargets(params: {
       if (!keysBySecret.has(cacheKey)) {
         // Fails OPEN, unlike the write-path validator, and deliberately so: this
         // is a read-only listing, and one channel with a broken or unreadable
-        // Secret must not blank the user's entire verification picker.
+        // Secret must not blank the user's entire verification picker. Log the
+        // cause anyway: RBAC drift is a real condition on these clusters, and a
+        // target that silently vanishes from the picker is unreportable.
         keysBySecret.set(
           cacheKey,
-          secretKeyNames(params.gateway, secretName, target.channelNamespace).catch(() => [])
+          secretKeyNames(params.gateway, secretName, target.channelNamespace).catch(error => {
+            console.warn(
+              `[WorkflowApprovalMedium] Slack target hidden: cannot read Secret "${cacheKey}": ${error instanceof Error ? error.message : String(error)}`
+            )
+            return []
+          })
         )
       }
       const keys = await keysBySecret.get(cacheKey)!
       // A channel can carry a Slack App Name while its Secret only ever held
       // another provider's credentials. It projects as ready and then 409s on
       // use, so it must not be offered as a target at all.
-      return keys.includes('slack-signing-secret') ? target : null
+      //
+      // Both keys, matching PROVIDER_REQUIRED_KEYS.slack on the write path
+      // (routes/admin/resources.ts). Signing-secret-only would list a target
+      // that accepts events and then fails when the approval message is posted.
+      return SLACK_REQUIRED_SECRET_KEYS.every(key => keys.includes(key)) ? target : null
     })
   )
 

--- a/control-api/src/services/workflowApprovalMediumSlackVerificationService.ts
+++ b/control-api/src/services/workflowApprovalMediumSlackVerificationService.ts
@@ -1,6 +1,7 @@
 import type { K8sGateway } from '../k8s.js'
 import { decodeSlackTargetId, encodeSlackTargetId } from '../utils/slackTargetId.js'
 import { getTeamAgents, getUserAgents, listTeams } from './directory/index.js'
+import { secretKeyNames } from './secretKeyNames.js'
 import type { VerifiedMediumAccount } from './workflowApprovalMediumIdentityService.js'
 
 type CommunicationChannelResource = {
@@ -200,12 +201,44 @@ export async function listSlackApprovalTargets(params: {
     'communicationchannels',
     '*'
   )) as CommunicationChannelResource[]
-  const items = channels
-    .flatMap(channel => {
-      const target = projectTarget(channel)
-      if (!target || !userCanAccessChannel(channel, params.userId, access)) return []
-      return [target]
+  // Two phases, and the order is a security property rather than a style
+  // choice. This lists communicationchannels across ALL namespaces and the
+  // route is gated only by a valid external session, so reading Secrets before
+  // the access check would let any authenticated profile user drive one request
+  // into reading the credentials Secret of every channel in the cluster. Project
+  // and access-check first; read keys only for what survived, which bounds the
+  // reads to the caller's own channels.
+  const candidates = channels.flatMap(channel => {
+    const target = projectTarget(channel)
+    if (!target || !userCanAccessChannel(channel, params.userId, access)) return []
+    return [{ channel, target }]
+  })
+
+  const keysBySecret = new Map<string, Promise<string[]>>()
+  const readable = await Promise.all(
+    candidates.map(async ({ channel, target }) => {
+      const secretName = optionalString(channel.spec?.credentialsSecretRef?.name)
+      if (!secretName) return null
+      const cacheKey = `${target.channelNamespace}/${secretName}`
+      if (!keysBySecret.has(cacheKey)) {
+        // Fails OPEN, unlike the write-path validator, and deliberately so: this
+        // is a read-only listing, and one channel with a broken or unreadable
+        // Secret must not blank the user's entire verification picker.
+        keysBySecret.set(
+          cacheKey,
+          secretKeyNames(params.gateway, secretName, target.channelNamespace).catch(() => [])
+        )
+      }
+      const keys = await keysBySecret.get(cacheKey)!
+      // A channel can carry a Slack App Name while its Secret only ever held
+      // another provider's credentials. It projects as ready and then 409s on
+      // use, so it must not be offered as a target at all.
+      return keys.includes('slack-signing-secret') ? target : null
     })
+  )
+
+  const items = readable
+    .filter((target): target is SlackApprovalTarget => target !== null)
     .sort(
       (a, b) =>
         a.agentName.localeCompare(b.agentName) ||

--- a/control-api/test/routes.adminCommunicationChannelCredentials.test.ts
+++ b/control-api/test/routes.adminCommunicationChannelCredentials.test.ts
@@ -78,6 +78,9 @@ describe('admin communicationchannels — credentials cascade', () => {
 
   it('B4: POST provider CC (telegram) WITH credentialsSecretRef already in spec → ok (no 400)', async () => {
     // A user may pre-create the Secret and supply credentialsSecretRef directly.
+    // The Secret must actually hold the provider's key: since #312 a ref alone
+    // no longer proves the provider can work (routes.providerTransition.test.ts).
+    gatewayMock.getSecret.mockResolvedValue({ data: { 'telegram-bot-token': 'dGc=' } })
     gatewayMock.createResource.mockResolvedValue({
       metadata: { name: 'bot', namespace: 'channels' },
       spec: { hostRef: 'h1', credentialsSecretRef: { name: 'my-existing-secret' } },
@@ -119,7 +122,13 @@ describe('admin communicationchannels — credentials cascade', () => {
     // BUT the conventional cc-<name>-credentials Secret EXISTS.
     const e404 = Object.assign(new Error('not found'), { statusCode: 404 })
     gatewayMock.getResource.mockRejectedValue(e404) // existing CC 404 → no existing ref
-    gatewayMock.getSecret.mockResolvedValue({ metadata: { name: 'cc-bot-credentials' } })
+    // Holds the Telegram key, so enabling telegram on a channel that had no
+    // provider before passes the #312 transition check and the assertion under
+    // test stays about ref re-injection.
+    gatewayMock.getSecret.mockResolvedValue({
+      metadata: { name: 'cc-bot-credentials' },
+      data: { 'telegram-bot-token': 'dGc=' },
+    })
     gatewayMock.updateResource.mockResolvedValue({
       metadata: { name: 'bot', namespace: 'channels' },
       spec: { hostRef: 'h1', credentialsSecretRef: { name: 'cc-bot-credentials' } },

--- a/control-api/test/routes.providerTransition.test.ts
+++ b/control-api/test/routes.providerTransition.test.ts
@@ -242,4 +242,34 @@ describe('admin communicationchannels — provider transition validation (#312)'
     expect(res.body.error).toMatch(/Cannot read the credentials Secret/)
     expect(gatewayMock.updateResource).not.toHaveBeenCalled()
   })
+
+  it('PUT to a channel that does not exist does not answer with a credentials error', async () => {
+    // The guard is scoped to an absent->present TRANSITION, and a channel that was
+    // never there has no previous spec — so without the snapshot check every provider
+    // in the body reads as newly added and the operator is told their credentials are
+    // missing for a channel that does not exist. The snapshot is null only on 404, so
+    // it is the honest signal to stand down and let the write answer.
+    //
+    // What the caller then sees is this codebase's generic k8s error surface, NOT a
+    // 404: ApiException sets `.code` and the error handler forwards `.status`. That
+    // collapse is pre-existing and applies to every route, so it is deliberately out
+    // of scope here. This test pins the part that IS in scope — the operator is no
+    // longer told to fix credentials on a channel that does not exist.
+    gatewayMock.getResource.mockRejectedValue(
+      new ApiException(404, 'Not Found', { message: 'communicationchannels "ghost" not found' }, {})
+    )
+    gatewayMock.updateResource.mockRejectedValue(
+      new ApiException(404, 'Not Found', { message: 'communicationchannels "ghost" not found' }, {})
+    )
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/ghost')
+      .send({ spec: { hostRef: 'h1', slackSettings: { botHandle: 'Jose Bot' } } })
+
+    expect(res.status).not.toBe(400)
+    expect(res.body.error ?? '').not.toMatch(/slack-bot-token|slack-signing-secret/)
+    // The write must be ATTEMPTED — that is what proves the guard stood down rather
+    // than the route inferring an answer of its own.
+    expect(gatewayMock.updateResource).toHaveBeenCalled()
+  })
 })

--- a/control-api/test/routes.providerTransition.test.ts
+++ b/control-api/test/routes.providerTransition.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import { ApiException } from '@kubernetes/client-node'
+import request from 'supertest'
+import type { K8sGateway } from '../src/k8s.js'
+import { createAdminResourcesRouter } from '../src/routes/admin/resources.js'
+
+// Same hand-crafted gateway double as routes.adminCommunicationChannelCredentials.test.ts:
+// only the K8sGateway methods the CC write paths touch.
+const gatewayMock = {
+  createResource: vi.fn(),
+  deleteResource: vi.fn(),
+  getResource: vi.fn(),
+  updateResource: vi.fn(),
+  createSecret: vi.fn(),
+  mergeSecret: vi.fn(),
+  removeSecretKey: vi.fn(),
+  deleteSecret: vi.fn(),
+  getSecret: vi.fn(),
+}
+
+function makeApp(): express.Express {
+  const app = express()
+  app.use(express.json())
+  app.use(createAdminResourcesRouter(gatewayMock as unknown as K8sGateway))
+  return app
+}
+
+/** The jose-tg channel as the cluster holds it: Telegram only, with a credentials Secret. */
+const TELEGRAM_SPEC = {
+  hostRef: 'h1',
+  telegram: [{ channelId: '-1001', chatType: 'group', userIds: ['123'] }],
+  telegramSettings: { botHandle: '@jose_tg_bot' },
+}
+
+const SECRET_REF = { credentialsSecretRef: { name: 'cc-jose-tg-credentials' } }
+
+function persistedChannel(spec: Record<string, unknown>): Record<string, unknown> {
+  return {
+    metadata: { name: 'jose-tg', namespace: 'channels', resourceVersion: 'rv-1' },
+    spec,
+  }
+}
+
+describe('admin communicationchannels — provider transition validation (#312)', () => {
+  beforeEach(() => {
+    Object.values(gatewayMock).forEach(fn => fn.mockReset())
+    // Echo the written spec back, the way the API server does when the CRD is
+    // current. Anything less trips the pruned-provider-setting 409 instead.
+    gatewayMock.updateResource.mockImplementation(
+      async (_plural: string, name: string, body: { spec: Record<string, unknown> }) => ({
+        metadata: { name, namespace: 'channels', resourceVersion: 'rv-2' },
+        spec: body.spec,
+      })
+    )
+    gatewayMock.createResource.mockImplementation(
+      async (
+        _plural: string,
+        body: { metadata: { name: string }; spec: Record<string, unknown> }
+      ) => ({
+        metadata: { name: body.metadata.name, namespace: 'channels' },
+        spec: body.spec,
+      })
+    )
+    gatewayMock.createSecret.mockResolvedValue({})
+  })
+
+  // ── BLOCKING ─────────────────────────────────────────────────────────────
+
+  it('PUT enabling Slack on a Telegram channel whose Secret holds only telegram-bot-token → 400', async () => {
+    // The #312 regression: an operator typed a Slack App Name into an existing
+    // Telegram channel. The channel already had a credentialsSecretRef, so the
+    // pre-existing "no envelope and no ref" guard never fired, and the channel
+    // went on to answer every Slack request with slack_signing_secret_missing.
+    gatewayMock.getResource.mockResolvedValue(persistedChannel({ ...TELEGRAM_SPEC, ...SECRET_REF }))
+    gatewayMock.getSecret.mockResolvedValue({ data: { 'telegram-bot-token': 'dGc=' } })
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/jose-tg')
+      .send({ spec: { ...TELEGRAM_SPEC, slackSettings: { botHandle: 'Jose Bot' } } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/slack-bot-token|slack-signing-secret/)
+    expect(gatewayMock.updateResource).not.toHaveBeenCalled()
+  })
+
+  it('POST declaring Slack with a credentialsSecretRef whose Secret lacks the Slack keys → 400', async () => {
+    // A ref proves a Secret is named, not that it holds Slack credentials.
+    gatewayMock.getSecret.mockResolvedValue({ data: { 'telegram-bot-token': 'dGc=' } })
+
+    const res = await request(makeApp())
+      .post('/admin/communicationchannels')
+      .send({
+        metadata: { name: 'jose-slack' },
+        spec: {
+          hostRef: 'h1',
+          slackSettings: { botHandle: 'Jose Bot' },
+          credentialsSecretRef: { name: 'shared-secret' },
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/slack-bot-token|slack-signing-secret/)
+    expect(gatewayMock.createResource).not.toHaveBeenCalled()
+  })
+
+  // ── ALLOWING ─────────────────────────────────────────────────────────────
+  // Without these, a validator that reads nothing at all still passes every
+  // blocking case above.
+
+  it('PUT enabling Slack where the referenced Secret ALREADY holds both Slack keys → 200', async () => {
+    gatewayMock.getResource.mockResolvedValue(persistedChannel({ ...TELEGRAM_SPEC, ...SECRET_REF }))
+    gatewayMock.getSecret.mockResolvedValue({
+      data: {
+        'telegram-bot-token': 'dGc=',
+        'slack-bot-token': 'eG94Yi0x',
+        'slack-signing-secret': 'c2ln',
+      },
+    })
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/jose-tg')
+      .send({ spec: { ...TELEGRAM_SPEC, slackSettings: { botHandle: 'Jose Bot' } } })
+
+    expect(res.status).toBe(200)
+    // The request body carries no credentialsSecretRef (the UI never sends one),
+    // so the keys can only have come from the preserved ref being read.
+    expect(gatewayMock.getSecret).toHaveBeenCalledWith('cc-jose-tg-credentials', 'channels')
+    expect(gatewayMock.updateResource).toHaveBeenCalled()
+  })
+
+  it('POST declaring Slack with both keys in the credentials envelope → 201', async () => {
+    const res = await request(makeApp())
+      .post('/admin/communicationchannels')
+      .send({
+        metadata: { name: 'jose-slack' },
+        spec: { hostRef: 'h1', slackSettings: { botHandle: 'Jose Bot' } },
+        credentials: { 'slack-bot-token': 'xoxb-1', 'slack-signing-secret': 'sig-1' },
+      })
+
+    expect(res.status).toBe(201)
+    expect(gatewayMock.createResource).toHaveBeenCalled()
+    // Envelope-supplied keys need no Secret read at all.
+    expect(gatewayMock.getSecret).not.toHaveBeenCalled()
+  })
+
+  it('PUT editing a channel whose Secret LACKS the provider keys, with no NEW provider → 200', async () => {
+    // present -> present. Validation is scoped to the transition, so a channel
+    // already missing credentials in the cluster stays editable.
+    const slackSpec = { hostRef: 'h1', slackSettings: { botHandle: 'Jose Bot' } }
+    gatewayMock.getResource.mockResolvedValue(persistedChannel({ ...slackSpec, ...SECRET_REF }))
+    gatewayMock.getSecret.mockResolvedValue({ data: {} })
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/jose-tg')
+      .send({ spec: { ...slackSpec, access: { users: ['user-1'], teams: [] } } })
+
+    expect(res.status).toBe(200)
+    expect(gatewayMock.updateResource).toHaveBeenCalled()
+  })
+
+  it('PUT REMOVING a provider from a channel with an empty Secret → 200', async () => {
+    gatewayMock.getResource.mockResolvedValue(
+      persistedChannel({
+        ...TELEGRAM_SPEC,
+        slackSettings: { botHandle: 'Jose Bot' },
+        ...SECRET_REF,
+      })
+    )
+    gatewayMock.getSecret.mockResolvedValue({ data: {} })
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/jose-tg')
+      .send({ spec: { ...TELEGRAM_SPEC } })
+
+    expect(res.status).toBe(200)
+    expect(gatewayMock.updateResource).toHaveBeenCalled()
+  })
+
+  // ── FAIL CLOSED ──────────────────────────────────────────────────────────
+
+  it('PUT enabling Slack when the Secret read fails with 403 → 400, never a silent 200', async () => {
+    // A real @kubernetes/client-node ApiException: it sets `.code`, not
+    // `.statusCode`. A hand-rolled error shape would not exercise the
+    // status extraction that decides rethrow-vs-"no keys".
+    gatewayMock.getResource.mockResolvedValue(persistedChannel({ ...TELEGRAM_SPEC, ...SECRET_REF }))
+    gatewayMock.getSecret.mockRejectedValue(
+      new ApiException(
+        403,
+        'Forbidden',
+        { message: 'secrets "cc-jose-tg-credentials" is forbidden' },
+        {}
+      )
+    )
+
+    const res = await request(makeApp())
+      .put('/admin/communicationchannels/jose-tg')
+      .send({ spec: { ...TELEGRAM_SPEC, slackSettings: { botHandle: 'Jose Bot' } } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toMatch(/Cannot read the credentials Secret/)
+    expect(gatewayMock.updateResource).not.toHaveBeenCalled()
+  })
+})

--- a/control-api/test/routes.providerTransition.test.ts
+++ b/control-api/test/routes.providerTransition.test.ts
@@ -126,6 +126,25 @@ describe('admin communicationchannels — provider transition validation (#312)'
     expect(gatewayMock.createSecret).not.toHaveBeenCalled()
   })
 
+  it('POST declaring email with a numeric (non-string) credential value → 400 from validation, not a 500', async () => {
+    // providerTransitionError runs before validateCommunicationChannelCredentials
+    // and reads the raw, untrusted body. A bare `credentials?.[key]?.trim()` call
+    // throws on a non-string value ("... .trim is not a function"), turning this
+    // into an unhandled 500 instead of the ordinary validation 400.
+    const res = await request(makeApp())
+      .post('/admin/communicationchannels')
+      .send({
+        metadata: { name: 'jose-email' },
+        spec: { hostRef: 'h1', email: [{ emails: ['ops@example.com'] }] },
+        credentials: { 'email-username': 123, 'email-password': 'pw' },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('credentials["email-username"] must be a string')
+    expect(gatewayMock.createResource).not.toHaveBeenCalled()
+    expect(gatewayMock.createSecret).not.toHaveBeenCalled()
+  })
+
   // ── ALLOWING ─────────────────────────────────────────────────────────────
   // Without these, a validator that reads nothing at all still passes every
   // blocking case above.

--- a/control-api/test/routes.providerTransition.test.ts
+++ b/control-api/test/routes.providerTransition.test.ts
@@ -104,6 +104,28 @@ describe('admin communicationchannels — provider transition validation (#312)'
     expect(gatewayMock.createResource).not.toHaveBeenCalled()
   })
 
+  it('POST declaring email with a whitespace-only credential → 400 naming the key', async () => {
+    // This guard reads the RAW envelope while the Secret is written from the
+    // CLEANED values, which drop whitespace-only entries. Untrimmed, "   " is
+    // truthy here, `missingCreateCredentialKey` has no email branch to catch it,
+    // and the channel is created 201 advertising a provider whose Secret holds
+    // only email-password: exactly the #312 state, through the API.
+    const res = await request(makeApp())
+      .post('/admin/communicationchannels')
+      .send({
+        metadata: { name: 'jose-email' },
+        spec: { hostRef: 'h1', email: [{ emails: ['ops@example.com'] }] },
+        credentials: { 'email-username': '   ', 'email-password': 'pw' },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe(
+      'credentials["email-username"] is required to enable the email provider on this CommunicationChannel'
+    )
+    expect(gatewayMock.createResource).not.toHaveBeenCalled()
+    expect(gatewayMock.createSecret).not.toHaveBeenCalled()
+  })
+
   // ── ALLOWING ─────────────────────────────────────────────────────────────
   // Without these, a validator that reads nothing at all still passes every
   // blocking case above.

--- a/control-api/test/routes.resourcesCommunicationChannelTransportUserIds.test.ts
+++ b/control-api/test/routes.resourcesCommunicationChannelTransportUserIds.test.ts
@@ -58,6 +58,12 @@ describe('routes/resources CommunicationChannel Telegram transport userIds', () 
       { metadata: { name: 'agent-a-telegram' }, spec: { hostRef: 'agent-a' } },
       'channels'
     )
+    // The PUT turns telegram on (the stored CC has no provider yet), which since
+    // #312 requires the provider's key to exist. Seeding the conventional Secret
+    // keeps this test about userIds, not credentials.
+    gateway.seedSecret('cc-agent-a-telegram-credentials', 'channels', {
+      data: { 'telegram-bot-token': 'dGc=' },
+    })
     const updateSpy = vi.spyOn(gateway, 'updateResource')
 
     const res = await request(makeApp(gateway))

--- a/control-api/test/services.secretKeyNames.test.ts
+++ b/control-api/test/services.secretKeyNames.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ApiException } from '@kubernetes/client-node'
 import { secretKeyNames } from '../src/services/secretKeyNames.js'
 
 function gatewayReturning(secret: unknown) {
@@ -24,6 +25,19 @@ describe('secretKeyNames', () => {
     const gateway = {
       getSecret: vi.fn(async () => {
         throw Object.assign(new Error('not found'), { statusCode: 404 })
+      }),
+    } as never
+    expect(await secretKeyNames(gateway, 'missing', 'channels')).toEqual([])
+  })
+
+  it('returns an empty array for a real @kubernetes/client-node 404 ApiException', async () => {
+    // The production error shape: gateway.getSecret propagates the client's
+    // ApiException, which sets `.code`, not `.statusCode`. A helper that only
+    // checked `.statusCode` would never treat a genuinely missing Secret as
+    // "no keys" and would rethrow instead.
+    const gateway = {
+      getSecret: vi.fn(async () => {
+        throw new ApiException(404, 'Not Found', { message: 'secrets "missing" not found' }, {})
       }),
     } as never
     expect(await secretKeyNames(gateway, 'missing', 'channels')).toEqual([])

--- a/control-api/test/services.secretKeyNames.test.ts
+++ b/control-api/test/services.secretKeyNames.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { secretKeyNames } from '../src/services/secretKeyNames.js'
+
+function gatewayReturning(secret: unknown) {
+  return { getSecret: vi.fn(async () => secret) } as never
+}
+
+describe('secretKeyNames', () => {
+  it('returns the key names, sorted, and never a value', async () => {
+    const gateway = gatewayReturning({
+      data: { 'slack-signing-secret': 'aHVudGVyMg==', 'slack-bot-token': 'eG94Yi0x' },
+    })
+    const keys = await secretKeyNames(gateway, 'cc-x-credentials', 'channels')
+    expect(keys).toEqual(['slack-bot-token', 'slack-signing-secret'])
+    expect(JSON.stringify(keys)).not.toContain('aHVudGVyMg==')
+    expect(JSON.stringify(keys)).not.toContain('hunter2')
+  })
+
+  it('returns an empty array when the Secret exists but has no data', async () => {
+    expect(await secretKeyNames(gatewayReturning({}), 'cc-x-credentials', 'channels')).toEqual([])
+  })
+
+  it('returns an empty array when the Secret does not exist', async () => {
+    const gateway = {
+      getSecret: vi.fn(async () => {
+        throw Object.assign(new Error('not found'), { statusCode: 404 })
+      }),
+    } as never
+    expect(await secretKeyNames(gateway, 'missing', 'channels')).toEqual([])
+  })
+
+  it('rethrows a non-404 read failure so callers can fail closed', async () => {
+    const gateway = {
+      getSecret: vi.fn(async () => {
+        throw Object.assign(new Error('forbidden'), { statusCode: 403 })
+      }),
+    } as never
+    await expect(secretKeyNames(gateway, 'cc-x-credentials', 'channels')).rejects.toThrow()
+  })
+})

--- a/control-api/test/services.slackTargetFilter.test.ts
+++ b/control-api/test/services.slackTargetFilter.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getTeamAgents, getUserAgents, listTeams } from '../src/services/directory/index.js'
+import { secretKeyNames } from '../src/services/secretKeyNames.js'
+import { listSlackApprovalTargets } from '../src/services/workflowApprovalMediumSlackVerificationService.js'
+import { MockGateway } from './mockGateway.js'
+
+vi.mock('../src/services/directory/index.js', () => ({
+  getTeamAgents: vi.fn(),
+  getUserAgents: vi.fn(),
+  listTeams: vi.fn(),
+}))
+
+vi.mock('../src/services/secretKeyNames.js', () => ({
+  secretKeyNames: vi.fn(),
+}))
+
+const mockedGetUserAgents = vi.mocked(getUserAgents)
+const mockedGetTeamAgents = vi.mocked(getTeamAgents)
+const mockedListTeams = vi.mocked(listTeams)
+const mockedSecretKeyNames = vi.mocked(secretKeyNames)
+
+/**
+ * Keys the fake cluster holds per `namespace/secretName`. The mocked
+ * `secretKeyNames` answers from this map, so a test declares Secret contents
+ * the same way it declares channels.
+ */
+const secretKeys = new Map<string, string[]>()
+
+function seedSecretKeys(namespace: string, name: string, keys: string[]): void {
+  secretKeys.set(`${namespace}/${name}`, keys)
+}
+
+async function seedSlackChannel(
+  gateway: MockGateway,
+  options: {
+    name: string
+    namespace?: string
+    hostRef?: string
+    users?: string[]
+    secretName?: string
+  }
+): Promise<void> {
+  const namespace = options.namespace ?? 'channels'
+  await gateway.createResource(
+    'communicationchannels',
+    {
+      metadata: { name: options.name },
+      spec: {
+        hostRef: options.hostRef ?? 'agent-a',
+        access: { users: options.users ?? ['user-1'], teams: [] },
+        credentialsSecretRef: { name: options.secretName ?? `${options.name}-credentials` },
+        slackSettings: { botHandle: 'Evenfire-jos' },
+      },
+    },
+    namespace
+  )
+}
+
+/** Every `namespace/secretName` the implementation actually read. */
+function readSecretRefs(): string[] {
+  return mockedSecretKeyNames.mock.calls.map(([, name, namespace]) => `${namespace}/${name}`)
+}
+
+describe('listSlackApprovalTargets Secret filtering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    secretKeys.clear()
+    mockedGetUserAgents.mockResolvedValue({ userId: 'user-1', agentNames: ['agent-a'] })
+    mockedGetTeamAgents.mockResolvedValue({ teamId: 'team-1', agentNames: [] })
+    mockedListTeams.mockResolvedValue({ currentTeamId: '', items: [] })
+    mockedSecretKeyNames.mockImplementation(async (_gateway, name, namespace) => {
+      const keys = secretKeys.get(`${namespace}/${name}`)
+      if (!keys) {
+        const error = new Error(`secrets "${name}" unreadable`) as Error & { statusCode: number }
+        error.statusCode = 403
+        throw error
+      }
+      return [...keys].sort((a, b) => a.localeCompare(b))
+    })
+  })
+
+  it('lists a channel whose Secret holds a Slack signing secret', async () => {
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack' })
+    seedSecretKeys('channels', 'agent-a-slack-credentials', [
+      'slack-bot-token',
+      'slack-signing-secret',
+    ])
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items).toHaveLength(1)
+    expect(targets.items[0]).toMatchObject({
+      agentName: 'agent-a',
+      channelName: 'agent-a-slack',
+      channelNamespace: 'channels',
+      medium: 'slack',
+    })
+  })
+
+  it('hides a channel whose Secret holds no Slack keys even though it names a Slack app', async () => {
+    // The reported duplicate "Evenfire-jos": a Telegram channel that had a Slack
+    // App Name typed into it. It projects as a ready Slack target, but its
+    // Secret only ever held Telegram credentials, so picking it 409s.
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack' })
+    await seedSlackChannel(gateway, { name: 'agent-a-impostor' })
+    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
+    seedSecretKeys('channels', 'agent-a-impostor-credentials', ['telegram-bot-token'])
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items.map(target => target.channelName)).toEqual(['agent-a-slack'])
+  })
+
+  it('never reads the Secret of a channel the caller cannot access', async () => {
+    // The ordering property. This endpoint lists communicationchannels across
+    // ALL namespaces and is gated only by a valid external session, so reading
+    // keys before the access check would let any authenticated profile user
+    // drive control-api into reading every credentials Secret in the cluster.
+    // Asserting only on `items` would not catch that: the foreign channel is
+    // absent from the result either way.
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack' })
+    await seedSlackChannel(gateway, {
+      name: 'agent-b-slack',
+      namespace: 'other-tenant',
+      hostRef: 'agent-b',
+      users: ['user-2'],
+    })
+    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
+    seedSecretKeys('other-tenant', 'agent-b-slack-credentials', ['slack-signing-secret'])
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items.map(target => target.channelName)).toEqual(['agent-a-slack'])
+    expect(mockedSecretKeyNames).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'agent-b-slack-credentials',
+      expect.anything()
+    )
+    expect(readSecretRefs()).toEqual(['channels/agent-a-slack-credentials'])
+  })
+
+  it('reads a shared Secret once when two accessible channels reference it', async () => {
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack-one', secretName: 'shared-credentials' })
+    await seedSlackChannel(gateway, { name: 'agent-a-slack-two', secretName: 'shared-credentials' })
+    seedSecretKeys('channels', 'shared-credentials', ['slack-signing-secret'])
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items).toHaveLength(2)
+    expect(readSecretRefs()).toEqual(['channels/shared-credentials'])
+  })
+
+  it('drops only the offending target when a Secret cannot be read', async () => {
+    // Fails OPEN, deliberately, and unlike the write-path validator: this is a
+    // read-only listing, and one broken channel must not blank the whole picker.
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack' })
+    await seedSlackChannel(gateway, { name: 'agent-a-unreadable' })
+    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
+    // agent-a-unreadable-credentials is intentionally unseeded: the mock throws
+    // a 403 for it, the same shape secretKeyNames rethrows on an RBAC denial.
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items.map(target => target.channelName)).toEqual(['agent-a-slack'])
+  })
+})

--- a/control-api/test/services.slackTargetFilter.test.ts
+++ b/control-api/test/services.slackTargetFilter.test.ts
@@ -30,6 +30,9 @@ function seedSecretKeys(namespace: string, name: string, keys: string[]): void {
   secretKeys.set(`${namespace}/${name}`, keys)
 }
 
+/** Both keys the write path requires before a channel may claim the Slack provider. */
+const WORKING_SLACK_KEYS = ['slack-signing-secret', 'slack-bot-token']
+
 async function seedSlackChannel(
   gateway: MockGateway,
   options: {
@@ -79,7 +82,7 @@ describe('listSlackApprovalTargets Secret filtering', () => {
     })
   })
 
-  it('lists a channel whose Secret holds a Slack signing secret', async () => {
+  it('lists a channel whose Secret holds both Slack keys', async () => {
     const gateway = new MockGateway('channels')
     await seedSlackChannel(gateway, { name: 'agent-a-slack' })
     seedSecretKeys('channels', 'agent-a-slack-credentials', [
@@ -105,8 +108,25 @@ describe('listSlackApprovalTargets Secret filtering', () => {
     const gateway = new MockGateway('channels')
     await seedSlackChannel(gateway, { name: 'agent-a-slack' })
     await seedSlackChannel(gateway, { name: 'agent-a-impostor' })
-    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
+    seedSecretKeys('channels', 'agent-a-slack-credentials', WORKING_SLACK_KEYS)
     seedSecretKeys('channels', 'agent-a-impostor-credentials', ['telegram-bot-token'])
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items.map(target => target.channelName)).toEqual(['agent-a-slack'])
+  })
+
+  it('hides a channel whose Secret holds the signing secret but no bot token', async () => {
+    // The picker filter and the write-path validator must agree on what "Slack
+    // works" means: PROVIDER_REQUIRED_KEYS.slack requires both keys. The signing
+    // secret only verifies INBOUND requests, so a half-configured channel is
+    // listed, accepts the events, and then fails when the approval message is
+    // posted through the Web API.
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-slack' })
+    await seedSlackChannel(gateway, { name: 'agent-a-half-configured' })
+    seedSecretKeys('channels', 'agent-a-slack-credentials', WORKING_SLACK_KEYS)
+    seedSecretKeys('channels', 'agent-a-half-configured-credentials', ['slack-signing-secret'])
 
     const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
 
@@ -128,8 +148,8 @@ describe('listSlackApprovalTargets Secret filtering', () => {
       hostRef: 'agent-b',
       users: ['user-2'],
     })
-    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
-    seedSecretKeys('other-tenant', 'agent-b-slack-credentials', ['slack-signing-secret'])
+    seedSecretKeys('channels', 'agent-a-slack-credentials', WORKING_SLACK_KEYS)
+    seedSecretKeys('other-tenant', 'agent-b-slack-credentials', WORKING_SLACK_KEYS)
 
     const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
 
@@ -146,7 +166,7 @@ describe('listSlackApprovalTargets Secret filtering', () => {
     const gateway = new MockGateway('channels')
     await seedSlackChannel(gateway, { name: 'agent-a-slack-one', secretName: 'shared-credentials' })
     await seedSlackChannel(gateway, { name: 'agent-a-slack-two', secretName: 'shared-credentials' })
-    seedSecretKeys('channels', 'shared-credentials', ['slack-signing-secret'])
+    seedSecretKeys('channels', 'shared-credentials', WORKING_SLACK_KEYS)
 
     const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
 
@@ -160,12 +180,31 @@ describe('listSlackApprovalTargets Secret filtering', () => {
     const gateway = new MockGateway('channels')
     await seedSlackChannel(gateway, { name: 'agent-a-slack' })
     await seedSlackChannel(gateway, { name: 'agent-a-unreadable' })
-    seedSecretKeys('channels', 'agent-a-slack-credentials', ['slack-signing-secret'])
+    seedSecretKeys('channels', 'agent-a-slack-credentials', WORKING_SLACK_KEYS)
     // agent-a-unreadable-credentials is intentionally unseeded: the mock throws
     // a 403 for it, the same shape secretKeyNames rethrows on an RBAC denial.
 
     const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
 
     expect(targets.items.map(target => target.channelName)).toEqual(['agent-a-slack'])
+  })
+
+  it('warns with the Secret ref and the cause when a target is dropped for an unreadable Secret', async () => {
+    // Failing open is right here, but silence is not: RBAC drift is a real
+    // condition on these clusters, and without this line a target disappears
+    // from the picker with nothing anywhere to say why.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const gateway = new MockGateway('channels')
+    await seedSlackChannel(gateway, { name: 'agent-a-unreadable' })
+
+    const targets = await listSlackApprovalTargets({ gateway: gateway as never, userId: 'user-1' })
+
+    expect(targets.items).toEqual([])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toBe(
+      '[WorkflowApprovalMedium] Slack target hidden: cannot read Secret ' +
+        '"channels/agent-a-unreadable-credentials": secrets "agent-a-unreadable-credentials" unreadable'
+    )
+    warn.mockRestore()
   })
 })

--- a/control-ui/app/communication-channels/[name]/edit/page.tsx
+++ b/control-ui/app/communication-channels/[name]/edit/page.tsx
@@ -16,6 +16,8 @@ import { SegmentedControl } from '@components/SegmentedControl'
 import { SelectionDropdown } from '@components/SelectionDropdown'
 import { IconBroadcast } from '@components/Sidebar/icons'
 import { useToast } from '@components/Toast'
+import { IconCopy } from '@components/icons'
+import { Button } from '@components/ui'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { apiGet, apiSend, isSilentApiError } from '@lib/api'
 import type { ChannelType } from '@lib/channelTypes'
@@ -37,9 +39,12 @@ import {
   slackWebhookUrlForChannel,
   teamsWebhookUrlForChannel,
 } from '@lib/communicationChannels'
+import { canGenerateSlackAppManifest, slackAppManifest } from '@lib/slackAppManifest'
 
 type ChannelProvider = CommunicationChannelProvider
 type DraftState = CommunicationChannelDraftState
+
+const DEFAULT_SLACK_APP_NAME = 'Evenfire'
 
 type HostItem = {
   metadata?: { name?: string; namespace?: string }
@@ -145,6 +150,13 @@ export default function EditCommunicationChannelPage() {
   const activeConversations = draft ? conversationsForProvider(activeTab, draft) : []
   const slackRequestUrl = item ? slackWebhookUrlForChannel(item) : null
   const teamsRequestUrl = item ? teamsWebhookUrlForChannel(item) : null
+  // A relative request_url is invalid to Slack, so warn instead of handing over a manifest that
+  // cannot work. slackWebhookUrlForChannel falls back to a bare path when the deployment has no
+  // public webhook address.
+  const slackManifest =
+    slackRequestUrl && canGenerateSlackAppManifest(slackRequestUrl)
+      ? slackAppManifest(draft?.slackBotHandle.trim() || DEFAULT_SLACK_APP_NAME, slackRequestUrl)
+      : null
 
   async function persistDraft(nextDraft: DraftState, successMessage: string) {
     setSaving(true)
@@ -203,6 +215,17 @@ export default function EditCommunicationChannelPage() {
       copied
         ? 'Slack Request URL copied.'
         : 'Could not copy to clipboard. Select the URL and copy it manually.',
+      { tone: copied ? 'success' : 'error' }
+    )
+  }
+
+  async function copySlackAppManifest() {
+    if (!slackManifest) return
+    const copied = await copyTextToClipboard(slackManifest)
+    showToast(
+      copied
+        ? 'Slack app manifest copied.'
+        : 'Could not copy to clipboard. Select the manifest and copy it manually.',
       { tone: copied ? 'success' : 'error' }
     )
   }
@@ -446,6 +469,46 @@ export default function EditCommunicationChannelPage() {
                         Use this URL for Slack Event Subscriptions and Interactivity.
                       </span>
                     </div>
+                    {slackRequestUrl ? (
+                      slackManifest ? (
+                        <div className="cu-field">
+                          <span className="cu-field__label">Slack App Manifest</span>
+                          <div className="cu-command-block">
+                            <div className="cu-command-block__toolbar">
+                              <span>YAML</span>
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                className="cu-command-block__copy"
+                                onClick={copySlackAppManifest}
+                                disabled={saving}
+                                aria-label="Copy Slack app manifest"
+                              >
+                                <IconCopy width={15} height={15} />
+                                Copy
+                              </Button>
+                            </div>
+                            <pre className="cu-command-block__pre cu-slack-manifest__pre">
+                              <code>{slackManifest}</code>
+                            </pre>
+                          </div>
+                          <span className="cu-field__hint">
+                            In Slack, Create New App → From an app manifest. It fills in both
+                            Request URLs, on Event Subscriptions and on Interactivity &amp;
+                            Shortcuts. Setting only Event Subscriptions leaves approval buttons dead
+                            with nothing in the logs.
+                          </span>
+                        </div>
+                      ) : (
+                        <div className="cu-banner cu-banner--warning">
+                          No app manifest: this deployment has no public webhook address, so the
+                          Request URL above is a path and Slack cannot reach it. Expose the webhook
+                          proxy publicly and set NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL to
+                          that address, or prefix the path with it by hand in Slack.
+                        </div>
+                      )
+                    ) : null}
                   </>
                 ) : (
                   <>

--- a/control-ui/app/communication-channels/[name]/edit/page.tsx
+++ b/control-ui/app/communication-channels/[name]/edit/page.tsx
@@ -27,7 +27,7 @@ import {
   buildCommunicationChannelSpec,
   communicationChannelInitialTab,
   createCommunicationChannelDraft,
-  hasSlackConfig,
+  hasSlackConfigForRequestUrl,
 } from '@lib/communicationChannelEdit'
 import {
   COMMUNICATION_CHANNEL_PROVIDERS,
@@ -156,9 +156,11 @@ export default function EditCommunicationChannelPage() {
   // The URL depends only on namespace/name, both fixed at create time, and the
   // reader resolves that id regardless of slackSettings, so a draft-derived URL
   // is already server-truthful. The guard against a copyable dead end on a
-  // non-Slack channel is kept: no Slack config in the draft, no URL.
+  // non-Slack channel is kept: no Slack config in the draft, no URL. A bot
+  // handle the draft only inherited from the clerum.io/slack-bot-label
+  // annotation is not Slack config, which is why this is not hasSlackConfig.
   const slackRequestUrl =
-    draft && hasSlackConfig(draft)
+    draft && hasSlackConfigForRequestUrl(draft)
       ? slackWebhookUrlForChannelName(
           item?.metadata?.name?.trim() || name,
           item?.metadata?.namespace
@@ -454,7 +456,14 @@ export default function EditCommunicationChannelPage() {
                         value={draft.slackBotHandle}
                         onChange={event =>
                           setDraft(current =>
-                            current ? { ...current, slackBotHandle: event.target.value } : current
+                            current
+                              ? {
+                                  ...current,
+                                  slackBotHandle: event.target.value,
+                                  // Typed, so no longer just an inherited label.
+                                  slackBotHandleFromAnnotation: false,
+                                }
+                              : current
                           )
                         }
                         placeholder="Your Slack App"

--- a/control-ui/app/communication-channels/[name]/edit/page.tsx
+++ b/control-ui/app/communication-channels/[name]/edit/page.tsx
@@ -27,6 +27,7 @@ import {
   buildCommunicationChannelSpec,
   communicationChannelInitialTab,
   createCommunicationChannelDraft,
+  hasSlackConfig,
 } from '@lib/communicationChannelEdit'
 import {
   COMMUNICATION_CHANNEL_PROVIDERS,
@@ -36,7 +37,7 @@ import {
 } from '@lib/communicationChannelProviders'
 import {
   type CommunicationChannelItem,
-  slackWebhookUrlForChannel,
+  slackWebhookUrlForChannelName,
   teamsWebhookUrlForChannel,
 } from '@lib/communicationChannels'
 import { canGenerateSlackAppManifest, slackAppManifest } from '@lib/slackAppManifest'
@@ -148,11 +149,25 @@ export default function EditCommunicationChannelPage() {
 
   const visibleChannelTypes = useMemo<ChannelType[]>(() => [activeTab], [activeTab])
   const activeConversations = draft ? conversationsForProvider(activeTab, draft) : []
-  const slackRequestUrl = item ? slackWebhookUrlForChannel(item) : null
+  // Gated on the DRAFT, not the persisted item. Slack's own order is manifest
+  // first, credentials second: the bot token only exists after the app has been
+  // created and installed, so a manifest that needed a saved Slack spec could
+  // only ever appear after the operator had already done the step it describes.
+  // The URL depends only on namespace/name, both fixed at create time, and the
+  // reader resolves that id regardless of slackSettings, so a draft-derived URL
+  // is already server-truthful. The guard against a copyable dead end on a
+  // non-Slack channel is kept: no Slack config in the draft, no URL.
+  const slackRequestUrl =
+    draft && hasSlackConfig(draft)
+      ? slackWebhookUrlForChannelName(
+          item?.metadata?.name?.trim() || name,
+          item?.metadata?.namespace
+        )
+      : null
   const teamsRequestUrl = item ? teamsWebhookUrlForChannel(item) : null
   // A relative request_url is invalid to Slack, so warn instead of handing over a manifest that
-  // cannot work. slackWebhookUrlForChannel falls back to a bare path when the deployment has no
-  // public webhook address.
+  // cannot work. slackWebhookUrlForChannelName falls back to a bare path when the deployment has
+  // no public webhook address.
   const slackManifest =
     slackRequestUrl && canGenerateSlackAppManifest(slackRequestUrl)
       ? slackAppManifest(draft?.slackBotHandle.trim() || DEFAULT_SLACK_APP_NAME, slackRequestUrl)
@@ -454,7 +469,7 @@ export default function EditCommunicationChannelPage() {
                       <span className="cu-field__label">Slack Request URL</span>
                       <div className="cu-copy-field">
                         <div className="cu-readonly-field cu-copy-field__value">
-                          {slackRequestUrl || 'Unavailable'}
+                          {slackRequestUrl || 'Available once this channel has a Slack App Name'}
                         </div>
                         <button
                           type="button"
@@ -466,7 +481,9 @@ export default function EditCommunicationChannelPage() {
                         </button>
                       </div>
                       <span className="cu-field__hint">
-                        Use this URL for Slack Event Subscriptions and Interactivity.
+                        {slackRequestUrl
+                          ? 'Use this URL for Slack Event Subscriptions and Interactivity.'
+                          : 'Enter the Slack App Name above and this channel gets its Request URL and app manifest.'}
                       </span>
                     </div>
                     {slackRequestUrl ? (
@@ -494,10 +511,11 @@ export default function EditCommunicationChannelPage() {
                             </pre>
                           </div>
                           <span className="cu-field__hint">
-                            In Slack, Create New App → From an app manifest. It fills in both
-                            Request URLs, on Event Subscriptions and on Interactivity &amp;
-                            Shortcuts. Setting only Event Subscriptions leaves approval buttons dead
-                            with nothing in the logs.
+                            Paste this into Slack, either at Create New App → From an app manifest
+                            for a new app, or in an existing app under Settings → App Manifest. It
+                            fills in both Request URLs, on Event Subscriptions and on Interactivity
+                            &amp; Shortcuts. Setting only Event Subscriptions leaves approval
+                            buttons dead with nothing in the logs.
                           </span>
                         </div>
                       ) : (

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -9778,6 +9778,13 @@ textarea.cu-input {
   white-space: pre;
 }
 
+/* The Slack app manifest runs ~25 lines. Cap it so the credentials panel below
+   stays reachable instead of being pushed off the form. */
+.cu-slack-manifest__pre {
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
 .cu-channel-conversations-table__name {
   font-weight: 600;
 }

--- a/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
@@ -144,7 +144,10 @@ describe('EditCommunicationChannelPage Slack app manifest', () => {
     expect(requestUrlLines).toHaveLength(2)
     expect(new Set(requestUrlLines).size).toBe(1)
     expect(requestUrlLines[0]).toContain('https://webhook.example.com/webhooks/slack/')
-    expect(manifest).toContain('name: Evenfire')
+    expect(manifest.split('\n').filter(line => /^\s+(name|display_name):/.test(line))).toEqual([
+      '  name: "Evenfire"',
+      '    display_name: "Evenfire"',
+    ])
   })
 
   it('warns instead of emitting a manifest when the Request URL is only a path', async () => {
@@ -170,5 +173,57 @@ describe('EditCommunicationChannelPage Slack app manifest', () => {
     expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
     expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
     expect(screen.queryByText(/no public webhook address/)).not.toBeInTheDocument()
+  })
+
+  it('names the cause and the next step instead of a bare Unavailable', async () => {
+    // With the URL guard in place this is the DEFAULT state of the Slack tab, so
+    // "Unavailable" with no cause, under a hint telling the operator to use a URL
+    // that is not there, is the copy most operators will actually see.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel('teams-channel', { teamsSettings: { appName: 'evenfire' } })
+    await renderLoadedPage()
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+
+    expect(screen.queryByText('Unavailable')).not.toBeInTheDocument()
+    expect(screen.getByText('Available once this channel has a Slack App Name')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Enter the Slack App Name above and this channel gets its Request URL and app manifest.'
+      )
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Use this URL for Slack Event Subscriptions and Interactivity.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('offers the Request URL and manifest as soon as an App Name is typed, before any save', async () => {
+    // Slack's order is manifest first, credentials second: the xoxb token only
+    // exists once the app the manifest creates has been installed. Deriving the
+    // manifest from the PERSISTED spec made it appear only after the operator had
+    // already done, by hand, the step the manifest is for.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel('teams-channel', { teamsSettings: { appName: 'evenfire' } })
+    await renderLoadedPage()
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+
+    expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/Slack App Name/), { target: { value: 'Ops Bot' } })
+
+    expect(screen.getByText('Slack App Manifest')).toBeInTheDocument()
+    const manifest = screen.getByText(/display_information:/).textContent ?? ''
+    const lines = manifest.split('\n')
+    expect(lines.filter(line => /^\s+(name|display_name):/.test(line))).toEqual([
+      '  name: "Ops Bot"',
+      '    display_name: "Ops Bot"',
+    ])
+    const requestUrlLines = lines.filter(line => line.trim().startsWith('request_url:'))
+    expect(requestUrlLines).toHaveLength(2)
+    expect(new Set(requestUrlLines).size).toBe(1)
+    expect(requestUrlLines[0]).toBe(
+      `    request_url: ${screen.getByText(/^https:\/\/webhook\.example\.com\/webhooks\/slack\//).textContent}`
+    )
+    // Nothing was persisted to get here: no PUT, and the manifest is on screen.
+    expect(vi.mocked(api.apiSend)).not.toHaveBeenCalled()
   })
 })

--- a/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
@@ -43,7 +43,7 @@ afterEach(() => {
 
 type ChannelSpec = Record<string, unknown>
 
-function mockChannel(name: string, spec: ChannelSpec) {
+function mockChannel(name: string, spec: ChannelSpec, annotations?: Record<string, string>) {
   navigation.params = { name }
   vi.mocked(api.apiGet).mockImplementation(async path => {
     if (path === '/api/v1/admin/hosts') {
@@ -52,7 +52,7 @@ function mockChannel(name: string, spec: ChannelSpec) {
     if (path === `/api/v1/admin/communication-channels/${name}`) {
       return {
         item: {
-          metadata: { name, namespace: 'channels' },
+          metadata: { name, namespace: 'channels', ...(annotations ? { annotations } : {}) },
           spec: { access: { users: [], teams: [] }, hostRef: 'agent-a', ...spec },
         },
       }
@@ -76,6 +76,21 @@ const SLACK_CHANNEL_SPEC: ChannelSpec = {
   credentialsSecretRef: { name: 'cc-slack-channel-credentials' },
   slackSettings: { botHandle: 'Evenfire', replyOnlyWhenMentioned: true },
 }
+
+/** A Telegram-only channel that still carries a leftover Slack label annotation. */
+const LABELLED_TELEGRAM_CHANNEL = 'telegram-labelled'
+const LABELLED_TELEGRAM_SPEC: ChannelSpec = {
+  telegramSettings: { botHandle: '@ops_bot', replyOnlyWhenMentioned: false },
+}
+const STALE_SLACK_LABEL = { 'clerum.io/slack-bot-label': 'Evenfire' }
+/**
+ * The Request URL that channel would get if the gate let an annotation through:
+ * base64url of {"namespace":"channels","name":"telegram-labelled"}, which is what
+ * the reader decodes. Written out rather than derived so a change to either the
+ * gate or the encoding has to be looked at.
+ */
+const LABELLED_TELEGRAM_REQUEST_URL =
+  'https://webhook.example.com/webhooks/slack/slack%3AeyJuYW1lc3BhY2UiOiJjaGFubmVscyIsIm5hbWUiOiJ0ZWxlZ3JhbS1sYWJlbGxlZCJ9'
 
 describe('EditCommunicationChannelPage', () => {
   it('renders Teams setup details and confirmed conversation metadata', async () => {
@@ -223,6 +238,55 @@ describe('EditCommunicationChannelPage Slack app manifest', () => {
     expect(requestUrlLines[0]).toBe(
       `    request_url: ${screen.getByText(/^https:\/\/webhook\.example\.com\/webhooks\/slack\//).textContent}`
     )
+    // Nothing was persisted to get here: no PUT, and the manifest is on screen.
+    expect(vi.mocked(api.apiSend)).not.toHaveBeenCalled()
+  })
+
+  it('gives a Telegram-only channel with a stale Slack label no Request URL and no manifest', async () => {
+    // clerum.io/slack-bot-label is a leftover display label, not a Slack provider.
+    // Seeding the draft from it made this channel render a full, copyable Request
+    // URL and manifest for a Slack app that does not exist, which is the paste-the-
+    // wrong-URL failure this whole page guard is for.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel(LABELLED_TELEGRAM_CHANNEL, LABELLED_TELEGRAM_SPEC, STALE_SLACK_LABEL)
+    await renderLoadedPage()
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+
+    // The annotation still fills the visible field. Only the URL and the manifest are gated.
+    expect(screen.getByLabelText(/Slack App Name/)).toHaveValue('Evenfire')
+    expect(screen.getByText('Available once this channel has a Slack App Name')).toBeInTheDocument()
+    expect(screen.queryByText(LABELLED_TELEGRAM_REQUEST_URL)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeDisabled()
+    expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
+    expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no public webhook address/)).not.toBeInTheDocument()
+  })
+
+  it('offers the Request URL and manifest once an App Name is typed over a stale Slack label', async () => {
+    // The draft gate exists so the manifest is reachable before anything is saved:
+    // Slack hands out the xoxb token only after the app the manifest creates has
+    // been installed. Excluding the annotation must not cost that.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel(LABELLED_TELEGRAM_CHANNEL, LABELLED_TELEGRAM_SPEC, STALE_SLACK_LABEL)
+    await renderLoadedPage()
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+
+    expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText(/Slack App Name/), { target: { value: 'Ops Bot' } })
+
+    expect(screen.getByText(LABELLED_TELEGRAM_REQUEST_URL)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeEnabled()
+    expect(screen.getByText('Slack App Manifest')).toBeInTheDocument()
+    const lines = (screen.getByText(/display_information:/).textContent ?? '').split('\n')
+    expect(lines.filter(line => /^\s+(name|display_name):/.test(line))).toEqual([
+      '  name: "Ops Bot"',
+      '    display_name: "Ops Bot"',
+    ])
+    expect(lines.filter(line => line.trim().startsWith('request_url:'))).toEqual([
+      `    request_url: ${LABELLED_TELEGRAM_REQUEST_URL}`,
+      `    request_url: ${LABELLED_TELEGRAM_REQUEST_URL}`,
+    ])
     // Nothing was persisted to get here: no PUT, and the manifest is on screen.
     expect(vi.mocked(api.apiSend)).not.toHaveBeenCalled()
   })

--- a/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/EditCommunicationChannelPage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { ToastProvider } from '@components/Toast'
 import EditCommunicationChannelPage from '../../app/communication-channels/[name]/edit/page'
 import * as api from '../../lib/api'
@@ -37,7 +37,45 @@ vi.mock('../../lib/api', async () => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  vi.unstubAllEnvs()
+  navigation.params = { name: 'teams-channel' }
 })
+
+type ChannelSpec = Record<string, unknown>
+
+function mockChannel(name: string, spec: ChannelSpec) {
+  navigation.params = { name }
+  vi.mocked(api.apiGet).mockImplementation(async path => {
+    if (path === '/api/v1/admin/hosts') {
+      return { items: [{ metadata: { name: 'agent-a' } }] }
+    }
+    if (path === `/api/v1/admin/communication-channels/${name}`) {
+      return {
+        item: {
+          metadata: { name, namespace: 'channels' },
+          spec: { access: { users: [], teams: [] }, hostRef: 'agent-a', ...spec },
+        },
+      }
+    }
+    return { items: [] }
+  })
+}
+
+async function renderLoadedPage() {
+  render(
+    <ToastProvider>
+      <EditCommunicationChannelPage />
+    </ToastProvider>
+  )
+  await waitFor(() => {
+    expect(screen.queryByText('Loading communication channel...')).not.toBeInTheDocument()
+  })
+}
+
+const SLACK_CHANNEL_SPEC: ChannelSpec = {
+  credentialsSecretRef: { name: 'cc-slack-channel-credentials' },
+  slackSettings: { botHandle: 'Evenfire', replyOnlyWhenMentioned: true },
+}
 
 describe('EditCommunicationChannelPage', () => {
   it('renders Teams setup details and confirmed conversation metadata', async () => {
@@ -88,5 +126,49 @@ describe('EditCommunicationChannelPage', () => {
     expect(screen.getByText(/\/webhooks\/teams\//)).toBeInTheDocument()
     expect(screen.getByText('General')).toBeInTheDocument()
     expect(screen.getByText('Channel')).toBeInTheDocument()
+  })
+})
+
+describe('EditCommunicationChannelPage Slack app manifest', () => {
+  it('renders the manifest with both request URLs when the webhook is publicly reachable', async () => {
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel('slack-channel', SLACK_CHANNEL_SPEC)
+    await renderLoadedPage()
+
+    expect(screen.getByText('Slack App Manifest')).toBeInTheDocument()
+
+    const manifest = screen.getByText(/display_information:/).textContent ?? ''
+    const requestUrlLines = manifest
+      .split('\n')
+      .filter(line => line.trim().startsWith('request_url:'))
+    expect(requestUrlLines).toHaveLength(2)
+    expect(new Set(requestUrlLines).size).toBe(1)
+    expect(requestUrlLines[0]).toContain('https://webhook.example.com/webhooks/slack/')
+    expect(manifest).toContain('name: Evenfire')
+  })
+
+  it('warns instead of emitting a manifest when the Request URL is only a path', async () => {
+    // No NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL and a non-app.* hostname, which is the
+    // minikube case. Slack rejects a relative request_url, so a manifest here would be a broken
+    // artifact and would send the operator to debug Slack's generic error.
+    mockChannel('slack-channel', SLACK_CHANNEL_SPEC)
+    await renderLoadedPage()
+
+    expect(screen.getByText(/^\/webhooks\/slack\//)).toBeInTheDocument()
+    expect(screen.getByText(/no public webhook address/)).toBeInTheDocument()
+    expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
+    expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
+  })
+
+  it('renders no manifest and no warning on a channel with no Slack provider', async () => {
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    mockChannel('teams-channel', { teamsSettings: { appName: 'evenfire' } })
+    await renderLoadedPage()
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+
+    expect(screen.getByText('Slack Request URL')).toBeInTheDocument()
+    expect(screen.queryByText('Slack App Manifest')).not.toBeInTheDocument()
+    expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no public webhook address/)).not.toBeInTheDocument()
   })
 })

--- a/control-ui/lib/__tests__/communicationChannelEdit.test.ts
+++ b/control-ui/lib/__tests__/communicationChannelEdit.test.ts
@@ -3,6 +3,7 @@ import {
   buildCommunicationChannelSpec,
   communicationChannelInitialTab,
   createCommunicationChannelDraft,
+  hasSlackConfigForRequestUrl,
 } from '../communicationChannelEdit'
 import type { CommunicationChannelItem } from '../communicationChannels'
 
@@ -67,6 +68,53 @@ describe('communication channel edit helpers', () => {
     )
 
     expect(draft.telegramBotHandle).toBe('legacy_bot')
+  })
+
+  it('keeps the Slack label annotation out of the Request URL gate and nowhere else', () => {
+    // Only the Request URL and the app manifest ignore an annotation-only bot
+    // handle. The field it fills, the tab the page opens on, and the saved spec
+    // all still honour it, so this pins the split rather than the exclusion alone.
+    const item = channel({
+      metadata: {
+        name: 'label-only',
+        namespace: 'channels',
+        annotations: { 'clerum.io/slack-bot-label': 'Evenfire' },
+      },
+      spec: { hostRef: 'chatllm', access: { users: [], teams: [] } },
+    })
+    const draft = createCommunicationChannelDraft(item)
+
+    expect(draft.slackBotHandle).toBe('Evenfire')
+    expect(draft.slackBotHandleFromAnnotation).toBe(true)
+    expect(hasSlackConfigForRequestUrl(draft)).toBe(false)
+    expect(communicationChannelInitialTab(item)).toBe('slack')
+    expect(buildCommunicationChannelSpec(draft)).toEqual({
+      hostRef: 'chatllm',
+      access: { users: [], teams: [] },
+      slack: [],
+      slackSettings: {
+        botHandle: 'Evenfire',
+        replyOnlyWhenMentioned: false,
+        replyInThreads: false,
+      },
+    })
+  })
+
+  it('counts a Slack bot handle that came from the spec, not the annotation', () => {
+    const draft = createCommunicationChannelDraft(
+      channel({
+        metadata: {
+          name: 'slack-channel',
+          namespace: 'channels',
+          annotations: { 'clerum.io/slack-bot-label': 'Stale Label' },
+        },
+        spec: { hostRef: 'chatllm', slackSettings: { botHandle: 'Evenfire' } },
+      })
+    )
+
+    expect(draft.slackBotHandle).toBe('Evenfire')
+    expect(draft.slackBotHandleFromAnnotation).toBe(false)
+    expect(hasSlackConfigForRequestUrl(draft)).toBe(true)
   })
 
   it('omits inactive provider settings from the saved spec', () => {

--- a/control-ui/lib/__tests__/communicationChannels.test.ts
+++ b/control-ui/lib/__tests__/communicationChannels.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { slackWebhookUrlForChannel } from '../communicationChannels'
+import { slackWebhookUrlForChannel, slackWebhookUrlForChannelName } from '../communicationChannels'
+
+/** The `{namespace, name}` the reader will decode back out of a target id. */
+function decodeTargetId(url: string): unknown {
+  const targetId = decodeURIComponent(url.slice(url.lastIndexOf('/') + 1))
+  const payload = targetId.slice('slack:'.length).replace(/-/g, '+').replace(/_/g, '/')
+  return JSON.parse(atob(payload))
+}
 
 const telegramOnly = {
   metadata: { name: 'jose-tg', namespace: 'channels' },
@@ -26,5 +33,30 @@ describe('slackWebhookUrlForChannel', () => {
         spec: { slack: [{ channelId: 'C1', workspaceId: 'T1', userIds: ['U1'] }] },
       })
     ).toContain('/webhooks/slack/')
+  })
+})
+
+describe('slackWebhookUrlForChannelName', () => {
+  it('encodes the same namespace and name the reader decodes', () => {
+    // What makes a draft-derived URL safe to show before anything is saved: the
+    // id carries only the channel's coordinates, and both are fixed at create
+    // time. If this encoding drifts, the URL an operator pastes into Slack
+    // resolves to nothing.
+    const url = slackWebhookUrlForChannelName('slack-jose', 'channels')
+    expect(url).not.toBeNull()
+    expect(decodeTargetId(url!)).toEqual({ namespace: 'channels', name: 'slack-jose' })
+    expect(url).toBe(slackWebhookUrlForChannel(slackConfigured))
+  })
+
+  it('defaults an absent namespace to channels', () => {
+    expect(decodeTargetId(slackWebhookUrlForChannelName('slack-jose')!)).toEqual({
+      namespace: 'channels',
+      name: 'slack-jose',
+    })
+  })
+
+  it('returns null without a channel name', () => {
+    expect(slackWebhookUrlForChannelName('')).toBeNull()
+    expect(slackWebhookUrlForChannelName('   ')).toBeNull()
   })
 })

--- a/control-ui/lib/__tests__/communicationChannels.test.ts
+++ b/control-ui/lib/__tests__/communicationChannels.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { slackWebhookUrlForChannel } from '../communicationChannels'
+
+const telegramOnly = {
+  metadata: { name: 'jose-tg', namespace: 'channels' },
+  spec: { telegram: [{ channelId: '1', chatType: 'private' as const }] },
+}
+const slackConfigured = {
+  metadata: { name: 'slack-jose', namespace: 'channels' },
+  spec: { slackSettings: { botHandle: 'Evenfire' } },
+}
+
+describe('slackWebhookUrlForChannel', () => {
+  it('returns null for a channel with no Slack provider', () => {
+    expect(slackWebhookUrlForChannel(telegramOnly)).toBeNull()
+  })
+
+  it('returns a URL for a channel with Slack configured', () => {
+    expect(slackWebhookUrlForChannel(slackConfigured)).toContain('/webhooks/slack/')
+  })
+
+  it('treats a confirmed conversation as Slack configured even with no settings', () => {
+    expect(
+      slackWebhookUrlForChannel({
+        metadata: { name: 'x', namespace: 'channels' },
+        spec: { slack: [{ channelId: 'C1', workspaceId: 'T1', userIds: ['U1'] }] },
+      })
+    ).toContain('/webhooks/slack/')
+  })
+})

--- a/control-ui/lib/__tests__/slackAppManifest.test.ts
+++ b/control-ui/lib/__tests__/slackAppManifest.test.ts
@@ -3,6 +3,25 @@ import { canGenerateSlackAppManifest, slackAppManifest } from '../slackAppManife
 
 const URL = 'https://webhook.example.com/webhooks/slack/slack%3AeyJ4IjoxfQ'
 
+/**
+ * The emitted `      - <value>` items under a list header. Matching values against the whole
+ * document instead lets one entry stand in for another: `app_mentions:read` (a scope) satisfies
+ * a search for `app_mention` (the event), and `mpim:read` satisfies `im:read`. Three of the
+ * seventeen required values were unpinned that way.
+ */
+function listItemsUnder(yaml: string, header: string): string[] {
+  const lines = yaml.split('\n')
+  const start = lines.findIndex(line => line.trim() === header)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const items: string[] = []
+  for (const line of lines.slice(start + 1)) {
+    const item = /^\s+- (.+)$/.exec(line)
+    if (!item) break
+    items.push(item[1])
+  }
+  return items
+}
+
 describe('slackAppManifest', () => {
   const yaml = slackAppManifest('Evenfire', URL)
 
@@ -19,6 +38,7 @@ describe('slackAppManifest', () => {
   })
 
   it('subscribes to every bot event the reader handles', () => {
+    const events = listItemsUnder(yaml, 'bot_events:')
     for (const event of [
       'app_mention',
       'message.channels',
@@ -26,11 +46,13 @@ describe('slackAppManifest', () => {
       'message.im',
       'message.mpim',
     ]) {
-      expect(yaml).toContain(event)
+      expect(events).toContain(event)
     }
+    expect(events).toHaveLength(5)
   })
 
   it('requests every scope the platform calls', () => {
+    const scopes = listItemsUnder(yaml, 'bot:')
     for (const scope of [
       'app_mentions:read',
       'channels:history',
@@ -45,8 +67,9 @@ describe('slackAppManifest', () => {
       'files:write',
       'users:read',
     ]) {
-      expect(yaml).toContain(scope)
+      expect(scopes).toContain(scope)
     }
+    expect(scopes).toHaveLength(12)
   })
 
   it('disables socket mode, which this platform does not use', () => {

--- a/control-ui/lib/__tests__/slackAppManifest.test.ts
+++ b/control-ui/lib/__tests__/slackAppManifest.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { canGenerateSlackAppManifest, slackAppManifest } from '../slackAppManifest'
+
+const URL = 'https://webhook.example.com/webhooks/slack/slack%3AeyJ4IjoxfQ'
+
+describe('slackAppManifest', () => {
+  const yaml = slackAppManifest('Evenfire', URL)
+
+  it('sets BOTH request URLs to the same value', () => {
+    const occurrences = yaml.split(URL).length - 1
+    expect(occurrences).toBe(2)
+    expect(yaml).toContain('event_subscriptions:')
+    expect(yaml).toContain('interactivity:')
+    // Counting occurrences alone still passes when one URL merely has something appended, so
+    // pin the whole line. Events-only setup is the mistake this manifest exists to prevent:
+    // Slack blocks the button click client-side and nothing reaches the cluster.
+    const requestUrlLines = yaml.split('\n').filter(line => line.trim().startsWith('request_url:'))
+    expect(requestUrlLines).toEqual([`    request_url: ${URL}`, `    request_url: ${URL}`])
+  })
+
+  it('subscribes to every bot event the reader handles', () => {
+    for (const event of [
+      'app_mention',
+      'message.channels',
+      'message.groups',
+      'message.im',
+      'message.mpim',
+    ]) {
+      expect(yaml).toContain(event)
+    }
+  })
+
+  it('requests every scope the platform calls', () => {
+    for (const scope of [
+      'app_mentions:read',
+      'channels:history',
+      'groups:history',
+      'im:history',
+      'mpim:history',
+      'channels:read',
+      'groups:read',
+      'im:read',
+      'mpim:read',
+      'chat:write',
+      'files:write',
+      'users:read',
+    ]) {
+      expect(yaml).toContain(scope)
+    }
+  })
+
+  it('disables socket mode, which this platform does not use', () => {
+    expect(yaml).toContain('socket_mode_enabled: false')
+  })
+
+  it('uses the app name given', () => {
+    expect(yaml).toContain('name: Evenfire')
+  })
+
+  it('quotes an app name that would otherwise break the YAML', () => {
+    const quoted = slackAppManifest('Acme: support bot', URL)
+    expect(quoted).toContain('name: "Acme: support bot"')
+    expect(quoted).not.toContain('name: Acme: support bot')
+  })
+})
+
+describe('canGenerateSlackAppManifest', () => {
+  it('accepts an absolute request URL', () => {
+    expect(canGenerateSlackAppManifest(URL)).toBe(true)
+    expect(canGenerateSlackAppManifest('http://webhook.example.com/webhooks/slack/x')).toBe(true)
+  })
+
+  it('refuses a bare path, which Slack rejects as a request_url', () => {
+    expect(canGenerateSlackAppManifest('/webhooks/slack/slack%3AeyJ4IjoxfQ')).toBe(false)
+  })
+
+  it('refuses a channel with no Slack webhook at all', () => {
+    expect(canGenerateSlackAppManifest(null)).toBe(false)
+    expect(canGenerateSlackAppManifest(undefined)).toBe(false)
+    expect(canGenerateSlackAppManifest('')).toBe(false)
+  })
+})

--- a/control-ui/lib/__tests__/slackAppManifest.test.ts
+++ b/control-ui/lib/__tests__/slackAppManifest.test.ts
@@ -22,6 +22,15 @@ function listItemsUnder(yaml: string, header: string): string[] {
   return items
 }
 
+/**
+ * The two lines that carry the app name, whole. `toContain('name: Evenfire')` is
+ * satisfied by an unquoted scalar, by a suffixed one, and by only one of the two
+ * lines being right.
+ */
+function nameLines(yaml: string): string[] {
+  return yaml.split('\n').filter(line => /^\s+(name|display_name):/.test(line))
+}
+
 describe('slackAppManifest', () => {
   const yaml = slackAppManifest('Evenfire', URL)
 
@@ -77,13 +86,37 @@ describe('slackAppManifest', () => {
   })
 
   it('uses the app name given', () => {
-    expect(yaml).toContain('name: Evenfire')
+    expect(nameLines(yaml)).toEqual(['  name: "Evenfire"', '    display_name: "Evenfire"'])
   })
 
   it('quotes an app name that would otherwise break the YAML', () => {
     const quoted = slackAppManifest('Acme: support bot', URL)
-    expect(quoted).toContain('name: "Acme: support bot"')
-    expect(quoted).not.toContain('name: Acme: support bot')
+    expect(nameLines(quoted)).toEqual([
+      '  name: "Acme: support bot"',
+      '    display_name: "Acme: support bot"',
+    ])
+  })
+
+  it('quotes an app name YAML would otherwise read as a boolean or a number', () => {
+    // Unquoted, `no` is YAML 1.1 false and `123` is an integer, so Slack receives
+    // a manifest whose app name is not a string at all.
+    expect(nameLines(slackAppManifest('no', URL))).toEqual([
+      '  name: "no"',
+      '    display_name: "no"',
+    ])
+    expect(nameLines(slackAppManifest('123', URL))).toEqual([
+      '  name: "123"',
+      '    display_name: "123"',
+    ])
+  })
+
+  it('escapes a newline in the app name instead of emitting a second line', () => {
+    // A raw newline inside a quoted scalar would split the value across lines and
+    // make the rest of the manifest unparseable.
+    expect(nameLines(slackAppManifest('Acme\nBot', URL))).toEqual([
+      '  name: "Acme\\nBot"',
+      '    display_name: "Acme\\nBot"',
+    ])
   })
 })
 

--- a/control-ui/lib/communicationChannelEdit.ts
+++ b/control-ui/lib/communicationChannelEdit.ts
@@ -8,6 +8,13 @@ export type CommunicationChannelDraftState = {
   hostRef: string
   slack: CommunicationChannelGroup[]
   slackBotHandle: string
+  /**
+   * True when `slackBotHandle` was seeded from the `clerum.io/slack-bot-label`
+   * annotation rather than from `spec.slackSettings` or from typing. Absent
+   * means "not from the annotation": a hand-built draft has no annotation
+   * history, and anything the operator types clears the flag.
+   */
+  slackBotHandleFromAnnotation?: boolean
   slackReplyOnlyWhenMentioned: boolean
   slackReplyInThreads: boolean
   slackWorkspaceId: string
@@ -56,6 +63,37 @@ export function hasSlackConfig(
   )
 }
 
+/**
+ * Gate for the Slack Request URL and app manifest, and for nothing else.
+ *
+ * `hasSlackConfig` counts a `slackBotHandle` seeded from the
+ * `clerum.io/slack-bot-label` annotation, which is how a Telegram-only channel
+ * carrying a stale label rendered a copyable Request URL and a full manifest for
+ * a Slack app that does not exist. An annotation is a leftover label, not a
+ * declaration that this channel has a Slack provider.
+ *
+ * Everything else keeps reading `hasSlackConfig`: the annotation still fills the
+ * visible App Name field, still decides which tab the edit page opens on, and
+ * still reaches the saved spec. Only the copyable URL and the manifest wait for
+ * a real Slack provider, whether persisted or typed into the open draft.
+ */
+export function hasSlackConfigForRequestUrl(
+  draft: Pick<
+    CommunicationChannelDraftState,
+    | 'slack'
+    | 'slackBotHandle'
+    | 'slackBotHandleFromAnnotation'
+    | 'slackReplyInThreads'
+    | 'slackReplyOnlyWhenMentioned'
+    | 'slackWorkspaceId'
+  >
+): boolean {
+  return hasSlackConfig({
+    ...draft,
+    slackBotHandle: draft.slackBotHandleFromAnnotation ? '' : draft.slackBotHandle,
+  })
+}
+
 export function hasTeamsConfig(
   draft: Pick<
     CommunicationChannelDraftState,
@@ -74,6 +112,8 @@ export function createCommunicationChannelDraft(
   item: CommunicationChannelItem
 ): CommunicationChannelDraftState {
   const spec = item.spec || {}
+  const slackBotHandleFromSpec = spec.slackSettings?.botHandle || ''
+  const slackBotHandleFromLabel = annotationValue(item, ['clerum.io/slack-bot-label'])
   return {
     accessTeamIds: spec.access?.teams || [],
     accessUserIds: spec.access?.users || [],
@@ -82,8 +122,8 @@ export function createCommunicationChannelDraft(
       : {}),
     hostRef: spec.hostRef || '',
     slack: spec.slack || [],
-    slackBotHandle:
-      spec.slackSettings?.botHandle || annotationValue(item, ['clerum.io/slack-bot-label']),
+    slackBotHandle: slackBotHandleFromSpec || slackBotHandleFromLabel,
+    slackBotHandleFromAnnotation: !slackBotHandleFromSpec && Boolean(slackBotHandleFromLabel),
     slackReplyOnlyWhenMentioned: spec.slackSettings?.replyOnlyWhenMentioned === true,
     slackReplyInThreads: spec.slackSettings?.replyInThreads === true,
     slackWorkspaceId: spec.slackSettings?.workspaceId || '',

--- a/control-ui/lib/communicationChannels.ts
+++ b/control-ui/lib/communicationChannels.ts
@@ -71,6 +71,12 @@ export function slackWebhookTargetIdForChannel(item: CommunicationChannelItem): 
   const namespace = item.metadata?.namespace?.trim() || 'channels'
   const name = item.metadata?.name?.trim()
   if (!name) return null
+  const spec = item.spec
+  const slackConfigured =
+    (spec?.slack?.length ?? 0) > 0 ||
+    !!spec?.slackSettings?.workspaceId?.trim() ||
+    !!spec?.slackSettings?.botHandle?.trim()
+  if (!slackConfigured) return null
   return `slack:${base64UrlEncode(JSON.stringify({ namespace, name }))}`
 }
 

--- a/control-ui/lib/communicationChannels.ts
+++ b/control-ui/lib/communicationChannels.ts
@@ -67,17 +67,61 @@ function base64UrlEncode(value: string): string {
   return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
 }
 
+/**
+ * Absolute webhook URL for a reader path, or the bare path when this deployment
+ * has no public webhook address (the minikube case).
+ */
+function webhookUrlForPath(path: string): string {
+  const base = process.env.NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL?.replace(/\/+$/, '')
+  if (base) return `${base}${path}`
+  if (typeof window !== 'undefined' && window.location.hostname.startsWith('app.')) {
+    const rootDomain = window.location.hostname.slice('app.'.length)
+    return `${window.location.protocol}//webhook.${rootDomain}${path}`
+  }
+  return path
+}
+
+/**
+ * The Slack target id depends only on the channel's namespace and name, both
+ * fixed when the channel is created, which is why callers may build this from an
+ * unsaved edit draft: the reader resolves the id whether or not `slackSettings`
+ * has been persisted yet. Deciding WHETHER a channel should show a Slack URL is
+ * the caller's job, and it is a real decision — a URL on a channel with no Slack
+ * provider is a copyable dead end.
+ */
+export function slackWebhookTargetIdForChannelName(
+  name: string,
+  namespace = 'channels'
+): string | null {
+  const trimmedName = name.trim()
+  if (!trimmedName) return null
+  return `slack:${base64UrlEncode(JSON.stringify({ namespace: namespace.trim() || 'channels', name: trimmedName }))}`
+}
+
+export function slackWebhookPathForChannelName(
+  name: string,
+  namespace = 'channels'
+): string | null {
+  const targetId = slackWebhookTargetIdForChannelName(name, namespace)
+  return targetId ? `/webhooks/slack/${encodeURIComponent(targetId)}` : null
+}
+
+export function slackWebhookUrlForChannelName(name: string, namespace = 'channels'): string | null {
+  const path = slackWebhookPathForChannelName(name, namespace)
+  return path ? webhookUrlForPath(path) : null
+}
+
 export function slackWebhookTargetIdForChannel(item: CommunicationChannelItem): string | null {
-  const namespace = item.metadata?.namespace?.trim() || 'channels'
-  const name = item.metadata?.name?.trim()
-  if (!name) return null
   const spec = item.spec
   const slackConfigured =
     (spec?.slack?.length ?? 0) > 0 ||
     !!spec?.slackSettings?.workspaceId?.trim() ||
     !!spec?.slackSettings?.botHandle?.trim()
   if (!slackConfigured) return null
-  return `slack:${base64UrlEncode(JSON.stringify({ namespace, name }))}`
+  return slackWebhookTargetIdForChannelName(
+    item.metadata?.name ?? '',
+    item.metadata?.namespace ?? 'channels'
+  )
 }
 
 export function slackWebhookPathForChannel(item: CommunicationChannelItem): string | null {
@@ -87,14 +131,7 @@ export function slackWebhookPathForChannel(item: CommunicationChannelItem): stri
 
 export function slackWebhookUrlForChannel(item: CommunicationChannelItem): string | null {
   const path = slackWebhookPathForChannel(item)
-  if (!path) return null
-  const base = process.env.NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL?.replace(/\/+$/, '')
-  if (base) return `${base}${path}`
-  if (typeof window !== 'undefined' && window.location.hostname.startsWith('app.')) {
-    const rootDomain = window.location.hostname.slice('app.'.length)
-    return `${window.location.protocol}//webhook.${rootDomain}${path}`
-  }
-  return path
+  return path ? webhookUrlForPath(path) : null
 }
 
 export function teamsWebhookTargetIdForChannel(item: CommunicationChannelItem): string | null {
@@ -123,14 +160,7 @@ export function teamsWebhookPathForChannelName(
 
 export function teamsWebhookUrlForChannel(item: CommunicationChannelItem): string | null {
   const path = teamsWebhookPathForChannel(item)
-  if (!path) return null
-  const base = process.env.NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL?.replace(/\/+$/, '')
-  if (base) return `${base}${path}`
-  if (typeof window !== 'undefined' && window.location.hostname.startsWith('app.')) {
-    const rootDomain = window.location.hostname.slice('app.'.length)
-    return `${window.location.protocol}//webhook.${rootDomain}${path}`
-  }
-  return path
+  return path ? webhookUrlForPath(path) : null
 }
 
 export function teamsWebhookUrlForChannelName(name: string, namespace = 'channels'): string | null {

--- a/control-ui/lib/slackAppManifest.ts
+++ b/control-ui/lib/slackAppManifest.ts
@@ -1,0 +1,76 @@
+const BOT_SCOPES = [
+  'app_mentions:read',
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'mpim:history',
+  'channels:read',
+  'groups:read',
+  'im:read',
+  'mpim:read',
+  'chat:write',
+  'files:write',
+  'users:read',
+]
+
+const BOT_EVENTS = [
+  'app_mention',
+  'message.channels',
+  'message.groups',
+  'message.im',
+  'message.mpim',
+]
+
+/** Plain YAML scalars cannot carry ': ', '#', quotes, or leading punctuation. */
+const YAML_PLAIN_SAFE = /^[A-Za-z0-9][A-Za-z0-9 ._-]*$/
+
+function yamlScalar(value: string): string {
+  const trimmed = value.trim()
+  if (YAML_PLAIN_SAFE.test(trimmed)) return trimmed
+  return `"${trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Slack rejects a manifest whose `request_url` is relative, and
+ * `slackWebhookUrlForChannel` falls back to a bare path when the deployment has
+ * no public webhook address (the minikube case). Callers must warn instead of
+ * handing over a manifest Slack cannot accept.
+ */
+export function canGenerateSlackAppManifest(requestUrl: string | null | undefined): boolean {
+  return /^https?:\/\//i.test(requestUrl ?? '')
+}
+
+/**
+ * Slack app manifest for this channel. Both request URLs are the same value:
+ * the reader serves events and interactivity on one route. Setting only the
+ * events URL leaves approval buttons silently dead, because Slack blocks the
+ * click client-side and nothing reaches the cluster.
+ *
+ * `requestUrl` must be absolute. Slack rejects a relative `request_url`, so
+ * callers render a warning instead of a manifest when they only have a path.
+ */
+export function slackAppManifest(appName: string, requestUrl: string): string {
+  const name = yamlScalar(appName)
+  return `display_information:
+  name: ${name}
+features:
+  bot_user:
+    display_name: ${name}
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+${BOT_SCOPES.map(scope => `      - ${scope}`).join('\n')}
+settings:
+  event_subscriptions:
+    request_url: ${requestUrl}
+    bot_events:
+${BOT_EVENTS.map(event => `      - ${event}`).join('\n')}
+  interactivity:
+    is_enabled: true
+    request_url: ${requestUrl}
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false
+`
+}

--- a/control-ui/lib/slackAppManifest.ts
+++ b/control-ui/lib/slackAppManifest.ts
@@ -21,18 +21,25 @@ const BOT_EVENTS = [
   'message.mpim',
 ]
 
-/** Plain YAML scalars cannot carry ': ', '#', quotes, or leading punctuation. */
-const YAML_PLAIN_SAFE = /^[A-Za-z0-9][A-Za-z0-9 ._-]*$/
-
+/**
+ * A double-quoted YAML scalar, always. Quoting only what looks unsafe leaves the
+ * YAML type traps behind: `123`, `no`, `true`, and `null` are all valid app
+ * names and all parse as non-strings when written plain. Double quotes also give
+ * the only style that carries escapes, which a name with a newline in it needs.
+ */
 function yamlScalar(value: string): string {
-  const trimmed = value.trim()
-  if (YAML_PLAIN_SAFE.test(trimmed)) return trimmed
-  return `"${trimmed.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  const escaped = value
+    .trim()
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n')
+  return `"${escaped}"`
 }
 
 /**
- * Slack rejects a manifest whose `request_url` is relative, and
- * `slackWebhookUrlForChannel` falls back to a bare path when the deployment has
+ * Slack rejects a manifest whose `request_url` is relative, and the
+ * `slackWebhookUrlFor*` helpers fall back to a bare path when the deployment has
  * no public webhook address (the minikube case). Callers must warn instead of
  * handing over a manifest Slack cannot accept.
  */

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.399",
+      "version": "0.1.400",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.396",
+  "version": "0.1.397",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.396",
+      "version": "0.1.397",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.397",
+  "version": "0.1.398",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.397",
+      "version": "0.1.398",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.400",
+      "version": "0.1.401",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.398",
+  "version": "0.1.399",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.398",
+      "version": "0.1.399",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.399",
+  "version": "0.1.400",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.398",
+  "version": "0.1.399",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.397",
+  "version": "0.1.398",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.396",
+  "version": "0.1.397",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.400",
+  "version": "0.1.401",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
> **Stacked on #320.** Base is `feat/slack-unresolved-sender-notice`, not `dev`. Retarget to `dev` once #320 merges. Zero file overlap between the two, so they can land in either order.

## What

Connecting a Slack app had three traps that compound into one bad afternoon. This closes all three.

1. **The Control UI rendered a copyable Slack Request URL for channels with no Slack provider.** Two channels' URLs differ only in a base64 tail encoding the channel name, and both our field and Slack's input truncate right around where they diverge. Pasting the wrong one yields `409 slack_signing_secret_missing` — an error that names no channel and is visible only in cluster logs. Slack itself reports "your request URL responded with an HTTP error."
2. **control-api accepted adding a provider to a channel whose Secret lacked that provider's credentials** (#312). That is how such a channel comes to exist in the first place.
3. **Slack needs the same URL in two config places**, Event Subscriptions and Interactivity & Shortcuts, each with its own Save button. Setting only the first leaves approval buttons silently dead: Slack blocks the click client-side, so nothing reaches the cluster and every server log stays quiet.

## Why the obvious fix for #312 is a no-op

Mirroring POST's existing guard onto PUT closes nothing. `resources.ts:323` fires only when there is **neither** a `credentials` envelope **nor** a `credentialsSecretRef`, and the channel that motivated this already had a ref for Telegram. `missingCreateCredentialKey` runs only when an envelope is present, and typing an app name sends none. Both checks miss the case on POST as well as PUT.

So validation keys on the **absent → present transition**: enabling a provider requires that provider's keys, in the envelope or already in the referenced Secret. Presence of a ref proves nothing. Channels already broken in a cluster stay editable, so this cannot fail an unrelated edit.

## Design decisions worth reviewing

**Two error directions, deliberately opposite.** The write validator fails **closed** — an unreadable Secret rejects the write. The Profile-UI target listing fails **open** — an unreadable Secret drops that one target. Refusing one write is safe; blanking a user's entire verification picker because one unrelated channel has a broken Secret is not.

**Secret reads are ordered after authorization, and that is a security property.** `listSlackApprovalTargets` lists channels across all namespaces and is gated only by a session token. Reading keys inside `projectTarget` would let any authenticated profile user trigger a read of every channel's credentials Secret cluster-wide. Reads now run only for channels that passed `userCanAccessChannel`, memoized by `namespace/secretName`, so they are O(caller's channels).

**No secret value crosses any new surface.** `secretKeyNames` returns key names only, and both consumers use it as a set-membership test.

**The URL guard lives in the target-id builder**, not the page, so every derived surface — including the manifest — inherits it.

## Reviewer notes

- **`ApiException` sets `.code`, not `.statusCode`.** The first version of `secretKeyNames` branched on `.statusCode` and therefore never detected a missing Secret; it rethrew exactly like an RBAC denial. Fixed by reusing the shared `extractK8sStatus`, and pinned by a test that constructs a **real** `ApiException` rather than a fabricated object.
- **The validator is broader than Slack.** Enabling telegram, teams or email without keys is now refused too, per the plan's key table. Three pre-existing tests needed their gateway doubles to model Secret contents; each edit is mock-setup only, with assertions byte-identical.
- **`hasSlackConfig` also reads a `clerum.io/slack-bot-label` annotation**, so a channel carrying a stale annotation shows a Slack URL. Reachable but not a reopening of the trap: nothing in this repo writes that annotation, the App Name field visibly populates from it, `projectTarget` uses a spec-only predicate so it is never offered in the picker, and the write validator still refuses a credential-less save. Worth pinning with a test.
- **A non-string credential used to 500.** The whitespace fix introduced it, because `providerTransitionError` runs before credential validation and therefore sees the raw body. A present-but-wrong-type value now falls through to the validator that owns the "must be a string" 400.

## Testing

control-api 3910 passed / 61 skipped / 324 files (baseline 3889 / 61 / 321). control-ui 1373 passed / 139 files (baseline 1351 / 137). `tsc --noEmit` clean in both.

Every guard in this PR was verified by breaking the implementation, watching the intended test fail, and reverting. That discipline caught three separate **substring-shaped assertions** that looked rigorous and could not fail: an "appears exactly twice" check defeated by a suffix; a scopes list where `app_mentions:read` satisfied `app_mention`; and `mpim:read` satisfying `im:read`. All three now assert on exact emitted lines.

## Known follow-ups, deliberately not in this PR

- `DELETE /credentials/:key` has no counterpart guard, so deleting `slack-signing-secret` from a Slack-enabled channel restores the broken state. Needs a product decision (refuse, or also disable the provider).
- A present-but-empty key value passes both new gates: `secretKeyNames` reports names, so `data['slack-signing-secret'] = ''` still yields the 409 this PR targets. Reachable via kubectl, not via `PUT /credentials`.
- The single-target resolvers still accept a keyless channel, so a stale target id can still reach a 409.
- The manifest is only reachable for a **new** Slack app via the existing-app paste path; the create page has no manifest, and creating a Slack channel requires credentials that only exist after the app is installed.
- Three now-unused item-based Slack URL exports in `control-ui/lib/communicationChannels.ts` should be deleted.
- The Slack required-key list is duplicated in four places.

## Not proven in a real deployment

Every proof here is a unit or page test. Nothing has been exercised against a real Slack workspace or a live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
