### PR TITLE
feat(control-ui): offer the Slack app manifest on the create page

### DIFF
--- a/control-ui/app/communication-channels/new/page.tsx
+++ b/control-ui/app/communication-channels/new/page.tsx
@@ -28,9 +28,11 @@ import {
 } from '@lib/communicationChannelProviders'
 import {
   type CommunicationChannelItem,
+  slackWebhookUrlForChannelName,
   teamsWebhookPathForChannelName,
   teamsWebhookUrlForChannelName,
 } from '@lib/communicationChannels'
+import { canGenerateSlackAppManifest, slackAppManifest } from '@lib/slackAppManifest'
 import { toKebabCase, toKebabInput } from '@lib/string'
 
 type HostItem = {
@@ -222,6 +224,26 @@ export default function CreateCommunicationChannelPage() {
       }),
     [draft.teamsAppName, teamsWebhookUrl]
   )
+  // Slack's order is manifest first, credentials second: the bot token only exists
+  // after the app is installed, so a manifest offered only once the channel is saved
+  // arrives after the step it describes. The Request URL encodes namespace and name
+  // only, so it is derivable here — from the NORMALIZED name, which is what the save
+  // will persist. Deriving it from the raw input would hand over a URL for a channel
+  // that never exists, which is the failure this manifest was written to remove.
+  const slackRequestUrl = useMemo(
+    () =>
+      normalizedChannelName && canUseBrowserWebhookOrigin
+        ? slackWebhookUrlForChannelName(normalizedChannelName)
+        : null,
+    [canUseBrowserWebhookOrigin, normalizedChannelName]
+  )
+  // No app name, no manifest: the name becomes display_information.name, and a
+  // placeholder would install an app under a name the operator never chose.
+  const slackManifest = useMemo(() => {
+    const appName = draft.slackBotHandle.trim()
+    if (!appName || !slackRequestUrl || !canGenerateSlackAppManifest(slackRequestUrl)) return null
+    return slackAppManifest(appName, slackRequestUrl)
+  }, [draft.slackBotHandle, slackRequestUrl])
   const teamsBotNameIsValid = isValidTeamsBotName(draft.teamsAppName)
 
   useEffect(() => {
@@ -339,6 +361,17 @@ export default function CreateCommunicationChannelPage() {
       copied
         ? 'Teams bot command copied.'
         : 'Could not copy to clipboard. Select the command and copy it manually.',
+      { tone: copied ? 'success' : 'error' }
+    )
+  }
+
+  async function copySlackAppManifest() {
+    if (!slackManifest) return
+    const copied = await copyTextToClipboard(slackManifest)
+    showToast(
+      copied
+        ? 'Slack app manifest copied.'
+        : 'Could not copy to clipboard. Select the manifest and copy it manually.',
       { tone: copied ? 'success' : 'error' }
     )
   }
@@ -604,6 +637,38 @@ export default function CreateCommunicationChannelPage() {
                           autoComplete="off"
                         />
                       </Field>
+                      {slackManifest ? (
+                        <div className="cu-field">
+                          <span className="cu-field__label">Slack App Manifest</span>
+                          <div className="cu-command-block">
+                            <div className="cu-command-block__toolbar">
+                              <span>YAML</span>
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                className="cu-command-block__copy"
+                                onClick={copySlackAppManifest}
+                                disabled={saving}
+                                aria-label="Copy Slack app manifest"
+                              >
+                                <IconCopy width={15} height={15} />
+                                Copy
+                              </Button>
+                            </div>
+                            <pre className="cu-command-block__pre cu-slack-manifest__pre">
+                              <code>{slackManifest}</code>
+                            </pre>
+                          </div>
+                          <span className="cu-field__hint">
+                            Create the Slack app from this first: in Slack, Create New App → From an
+                            app manifest → paste. It sets the scopes, the events, and both Request
+                            URLs, so the app is ready before you come back for the token below. The
+                            URLs point at <code>{normalizedChannelName}</code>, so create this
+                            channel under that name.
+                          </span>
+                        </div>
+                      ) : null}
                       <ChannelCredentialsPanel
                         ccName={channelName.trim()}
                         pending={true}

--- a/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
@@ -424,3 +424,114 @@ describe('CreateCommunicationChannelPage — provider setup', () => {
     expect(body.spec.slackSettings?.botHandle).toBe('Evenfire Test App')
   })
 })
+
+/**
+ * The cold start: a Slack channel cannot be created without a bot token, and the
+ * bot token does not exist until a Slack app has been installed — but installing
+ * one needs the scopes, the five events, and both Request URLs, none of which the
+ * create page offered. The manifest carries all of it, and the Request URL is
+ * derivable from the channel name alone, so it can be handed over here rather
+ * than only after the channel exists.
+ */
+describe('CreateCommunicationChannelPage — Slack app manifest', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function decodeSlackTarget(manifestYaml: string): unknown {
+    const match = manifestYaml.match(/\/webhooks\/slack\/slack%3A([A-Za-z0-9_-]+)/)
+    if (!match) throw new Error(`no slack target id in manifest:\n${manifestYaml}`)
+    const b64 = match[1].replace(/-/g, '+').replace(/_/g, '/')
+    return JSON.parse(Buffer.from(b64, 'base64').toString())
+  }
+
+  async function goToSlackProviderStep(rawName: string) {
+    await waitFor(() => {
+      expect(screen.queryByText('Loading agents...')).not.toBeInTheDocument()
+    })
+    fireEvent.change(screen.getByPlaceholderText(/channel-name/i), {
+      target: { value: rawName },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /agent reference/i }))
+    fireEvent.click(screen.getByRole('option', { name: 'agent-a' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    await screen.findByRole('button', { name: 'Create channel' })
+    fireEvent.click(screen.getByRole('radio', { name: 'Slack' }))
+  }
+
+  it('offers a manifest on the create page, before any channel exists', async () => {
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('support-bot')
+    fireEvent.change(document.getElementById('slack-bot-handle')!, {
+      target: { value: 'Evenfire' },
+    })
+
+    const manifest = await screen.findByText(/display_information:/)
+    // Both Request URLs, because setting only Event Subscriptions is what leaves
+    // approval buttons dead with nothing in the logs.
+    expect(manifest.textContent?.match(/request_url:/g) ?? []).toHaveLength(2)
+    expect(manifest.textContent).toContain('https://webhook.example.com/webhooks/slack/')
+  })
+
+  it('points the Request URL at the channel the create actually writes', async () => {
+    // The manifest is handed over BEFORE the channel exists, so the one thing that
+    // can silently go wrong is the URL naming a channel the save never creates —
+    // the wrong-Request-URL failure this whole manifest was written to remove.
+    // Pinning the manifest against the POST body is what makes them impossible to
+    // drift apart; asserting a hardcoded name would only restate the fixture.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('My Support Bot')
+    fireEvent.change(document.getElementById('slack-bot-handle')!, {
+      target: { value: 'Evenfire' },
+    })
+
+    const manifest = await screen.findByText(/display_information:/)
+    const encoded = decodeSlackTarget(manifest.textContent ?? '') as {
+      namespace: string
+      name: string
+    }
+
+    fireEvent.change(screen.getByLabelText('Slack Signing Secret'), {
+      target: { value: 'signing-secret' },
+    })
+    fireEvent.change(screen.getByLabelText('Slack Bot User OAuth Token'), {
+      target: { value: 'xoxb-token' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Create channel' }))
+    await waitFor(() => {
+      expect(api.apiSend).toHaveBeenCalled()
+    })
+
+    const [, , body] = vi.mocked(api.apiSend).mock.calls[0] as [
+      string,
+      string,
+      { metadata: { name: string } },
+    ]
+    expect(encoded.name).toBe(body.metadata.name)
+    expect(encoded.namespace).toBe('channels')
+  })
+
+  it('offers no manifest until the Slack App Name is set', async () => {
+    // The app name is the manifest's display_information.name. Emitting one with a
+    // placeholder would install an app under a name the operator never chose.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('support-bot')
+
+    expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
+  })
+})

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.404",
+  "version": "0.1.405",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.404",
+      "version": "0.1.405",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.404",
+  "version": "0.1.405",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
## Why

The create page asks for a Signing Secret and Bot User OAuth token, which only exist once a Slack app is installed — while offering nothing to install one with. No scopes, no events, no manifest. Slack's own order is **manifest first, credentials second**, so a manifest available only on the edit page always arrives after the step it describes.

Hit on the first real run of the from-scratch setup on dev: the only routes out were to guess the twelve scopes and five events from the docs, or create the channel with credentials you do not have yet and reopen it. #321 deferred this as product feedback on the theory it might not bite. It bit immediately.

## What

The Slack panel on `communication-channels/new` renders the same manifest the edit page does, as soon as the channel is named and the Slack App Name is set. The flow becomes: name it → pick Slack → copy manifest → build the app in Slack → paste both credentials → Save. One tab switch, no dead end, no reopening.

Because the manifest sets `event_subscriptions.request_url` **and** `interactivity.request_url`, there is no Request URL to paste by hand at all — which removes the second-Save-button trap that cost an hour, rather than documenting it.

## Why this is safe before the channel exists

The Request URL encodes namespace and name only, so it is derivable here. Three things close the gap the spec worried about:

1. **The name is already normalized.** `toKebabInput` runs on every keystroke (`new/page.tsx:489`) and `validateIdentityStep` normalizes again on Continue, so the derived URL matches what the POST writes. The test asserts the manifest's encoded name **against the create POST body**, not against a literal, so the two cannot drift apart.
2. **Gated on the Slack App Name**, which the create page already requires. It becomes `display_information.name`, so no placeholder-named app can be installed. The edit page keeps its `DEFAULT_SLACK_APP_NAME` fallback; here an unnamed app gets no manifest at all.
3. **The panel names the channel the URLs point at**, so a later rename is visible rather than silent.

Precedent on the same page: the Teams panel already derives `teamsWebhookUrlForChannelName(normalizedChannelName)` from the unsaved name, so this follows an established pattern rather than opening a new risk class.

## Reversing a spec decision, deliberately

The design spec said edit page only, reasoning that a manifest from an unsaved name could point at a channel that never exists. That risk is real and is now recorded as accepted: it is visible (the panel names the target), recoverable (the edit page shows the true URL), and self-inflicted — weighed against a cold start that blocked every operator on their first run. The spec section is marked superseded with the reasoning rather than deleted.

## Tests

Three new cases, each **mutation-verified** — breaking the URL so it names a different channel, dropping the app-name gate, and removing the block each fails exactly the test that claims to catch it.

One test was rewritten after mutation testing proved it vacuous: it asserted the URL used the normalized rather than raw name, but that distinction is unreachable because the input normalizes on every keystroke. It passed with the bug deliberately introduced. It now pins manifest-vs-POST consistency, which can actually fail.

control-ui: 139 files / 1406 passed, `tsc --noEmit` clean.

## Not done

Extracting a shared `<SlackAppManifestPanel>` for both pages. Having written both, what is genuinely shared is only the block chrome — the hint copy and the gating differ — so extraction would need props for both and buys less than it appeared to. Worth revisiting if a third caller shows up.