### PR TITLE
feat(desktop): improve chat scroll behavior

### DIFF
--- a/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
+++ b/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
+import { useAgentChatActionsContext } from '@contexts/AgentChatActionsContext'
 import { useChatListContext } from '@contexts/ChatListContext'
 import { useMcpRuntimeContext } from '@contexts/McpRuntimeContext'
 import { useNavigationContext } from '@contexts/NavigationContext'
@@ -76,8 +77,10 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
   const { sessionStateByChatId, activeChatId } = useChatListContext()
   const activeSessionState = activeChatId ? sessionStateByChatId[activeChatId] : undefined
   const { hostRuntimeStatus } = useMcpRuntimeContext()
+  const { scrollChatToBottom } = useAgentChatActionsContext()
 
   const [chatScrollNavVisible, setChatScrollNavVisible] = useState(true)
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false)
   const [chatAgentRouteMenuOpen, setChatAgentRouteMenuOpen] = useState(false)
   const chatAgentRouteMenuRef = useRef<HTMLSpanElement | null>(null)
 
@@ -497,7 +500,28 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
               <ComposerPanel inline />
             </>
           )}
-          {isChatMode && <ChatThread />}
+          {isChatMode && (
+            <div className="chat-thread-container">
+              <ChatThread onScrollPositionChange={setShowScrollToBottom} />
+              {activeChatId && showScrollToBottom && (
+                <div className="chat-scroll-to-bottom">
+                  <IconButton
+                    className="chat-scroll-to-bottom-button"
+                    color="neutral"
+                    label="Scroll to latest messages"
+                    onClick={scrollChatToBottom}
+                    size="sm"
+                    variant="solid"
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path d="M12 4v14" />
+                      <path d="m6 12 6 6 6-6" />
+                    </svg>
+                  </IconButton>
+                </div>
+              )}
+            </div>
+          )}
           {isChatMode && activeChatId && (
             <div className="agent-chat-composer-dock">
               {activeSessionState?.offlineMode || activeSessionState?.syncing ? (

--- a/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
+++ b/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 import { useAgentChatActionsContext } from '@contexts/AgentChatActionsContext'
 import { useChatListContext } from '@contexts/ChatListContext'
@@ -82,29 +82,39 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
   const { scrollChatToBottom } = useAgentChatActionsContext()
 
   const [chatScrollNavVisible, setChatScrollNavVisible] = useState(true)
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false)
-  const [showDelayedScrollToBottom, setShowDelayedScrollToBottom] = useState(false)
+  const [scrollToBottomChatId, setScrollToBottomChatId] = useState<string | null>(null)
+  const [delayedScrollToBottomChatId, setDelayedScrollToBottomChatId] = useState<string | null>(
+    null
+  )
   const [chatAgentRouteMenuOpen, setChatAgentRouteMenuOpen] = useState(false)
   const chatAgentRouteMenuRef = useRef<HTMLSpanElement | null>(null)
 
   const mcpHealthNow = undefined
 
-  useEffect(() => {
-    setShowScrollToBottom(false)
-  }, [activeChatId])
+  const handleScrollPositionChange = useCallback(
+    (isScrolledAwayFromBottom: boolean) => {
+      setScrollToBottomChatId(isScrolledAwayFromBottom ? activeChatId : null)
+    },
+    [activeChatId]
+  )
+
+  const showScrollToBottom = Boolean(activeChatId) && scrollToBottomChatId === activeChatId
+  const showDelayedScrollToBottom =
+    Boolean(activeChatId) && delayedScrollToBottomChatId === activeChatId
 
   useEffect(() => {
     if (!showScrollToBottom) {
-      setShowDelayedScrollToBottom(false)
+      setDelayedScrollToBottomChatId(null)
       return
     }
 
+    const chatId = activeChatId
     const timeoutId = window.setTimeout(
-      () => setShowDelayedScrollToBottom(true),
+      () => setDelayedScrollToBottomChatId(chatId),
       CHAT_SCROLL_TO_BOTTOM_SHOW_DELAY_MS
     )
     return () => window.clearTimeout(timeoutId)
-  }, [showScrollToBottom])
+  }, [activeChatId, showScrollToBottom])
 
   useClickOutside(chatAgentRouteMenuRef, chatAgentRouteMenuOpen, () =>
     setChatAgentRouteMenuOpen(false)
@@ -522,7 +532,7 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
           )}
           {isChatMode && (
             <div className="chat-thread-container">
-              <ChatThread onScrollPositionChange={setShowScrollToBottom} />
+              <ChatThread onScrollPositionChange={handleScrollPositionChange} />
               {activeChatId && showDelayedScrollToBottom && (
                 <div className="chat-scroll-to-bottom">
                   <IconButton

--- a/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
+++ b/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
@@ -25,6 +25,8 @@ import { FallbackBadge } from './FallbackBadge'
 import { SessionTokensIndicator } from './SessionTokensIndicator'
 import { AGENT_ROUTE_LABELS, AGENT_ROUTE_OPTIONS } from './agentRoutes'
 
+const CHAT_SCROLL_TO_BOTTOM_SHOW_DELAY_MS = 250
+
 type AgentWorkspaceMode = 'agents' | 'chat'
 
 type AgentWorkspaceProps = {
@@ -81,10 +83,28 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
 
   const [chatScrollNavVisible, setChatScrollNavVisible] = useState(true)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
+  const [showDelayedScrollToBottom, setShowDelayedScrollToBottom] = useState(false)
   const [chatAgentRouteMenuOpen, setChatAgentRouteMenuOpen] = useState(false)
   const chatAgentRouteMenuRef = useRef<HTMLSpanElement | null>(null)
 
   const mcpHealthNow = undefined
+
+  useEffect(() => {
+    setShowScrollToBottom(false)
+  }, [activeChatId])
+
+  useEffect(() => {
+    if (!showScrollToBottom) {
+      setShowDelayedScrollToBottom(false)
+      return
+    }
+
+    const timeoutId = window.setTimeout(
+      () => setShowDelayedScrollToBottom(true),
+      CHAT_SCROLL_TO_BOTTOM_SHOW_DELAY_MS
+    )
+    return () => window.clearTimeout(timeoutId)
+  }, [showScrollToBottom])
 
   useClickOutside(chatAgentRouteMenuRef, chatAgentRouteMenuOpen, () =>
     setChatAgentRouteMenuOpen(false)
@@ -503,7 +523,7 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
           {isChatMode && (
             <div className="chat-thread-container">
               <ChatThread onScrollPositionChange={setShowScrollToBottom} />
-              {activeChatId && showScrollToBottom && (
+              {activeChatId && showDelayedScrollToBottom && (
                 <div className="chat-scroll-to-bottom">
                   <IconButton
                     className="chat-scroll-to-bottom-button"

--- a/desktop-app/ui/src/components/agents/ChatThread.tsx
+++ b/desktop-app/ui/src/components/agents/ChatThread.tsx
@@ -26,7 +26,11 @@ import {
   IconWorkflows,
 } from '@components/SidebarNav/icons'
 import { WorkflowRunArtifactActions } from '@components/WorkflowRunArtifactActions'
-import { AGENT_ERROR_CODE_LABELS, SESSION_PREVIEW_LIMIT } from '@constants/agents'
+import {
+  AGENT_ERROR_CODE_LABELS,
+  CHAT_NEAR_BOTTOM_THRESHOLD_PX,
+  SESSION_PREVIEW_LIMIT,
+} from '@constants/agents'
 import { HTML_PREVIEW_INLINE_MAX_BYTES } from '@constants/htmlPreview'
 import type { ChatMessageAttachment } from '../../../../src/types'
 import {
@@ -49,8 +53,8 @@ import { NudgeArea } from './NudgeArea'
 
 type ChatThreadProps = {
   showAgentLabel?: boolean
+  onScrollPositionChange?: (isScrolledAwayFromBottom: boolean) => void
 }
-
 type RenderableChatMessage = AgentChatMessage & {
   messageKey: string
 }
@@ -211,7 +215,7 @@ function MessageAttachmentList({ attachments }: { attachments: ChatMessageAttach
   )
 }
 
-export function ChatThread({ showAgentLabel = false }: ChatThreadProps) {
+export function ChatThread({ showAgentLabel = false, onScrollPositionChange }: ChatThreadProps) {
   const { selectedAgent, handleSelectChatAgent: onStartNewChat } = useNavigationContext()
   const { decideApproval } = useNotificationsContext()
   const {
@@ -252,6 +256,7 @@ export function ChatThread({ showAgentLabel = false }: ChatThreadProps) {
   } | null>(null)
   const dedicatedSessionsRef = useRef<HTMLDivElement | null>(null)
   const sessionRenameInputRef = useRef<HTMLInputElement | null>(null)
+  const chatThreadRef = useRef<HTMLDivElement | null>(null)
   const sessionRenameClosedRef = useRef(false)
   const chatListRef = useRef(chatList)
   const copyResetTimeoutRef = useRef<number | null>(null)
@@ -300,6 +305,24 @@ export function ChatThread({ showAgentLabel = false }: ChatThreadProps) {
   useEffect(() => {
     chatListRef.current = chatList
   }, [chatList])
+
+  useEffect(() => {
+    const chatThread = chatThreadRef.current
+    if (!chatThread || !activeChatId) {
+      onScrollPositionChange?.(false)
+      return
+    }
+
+    const updateScrollPosition = () => {
+      const distanceFromBottom =
+        chatThread.scrollHeight - chatThread.scrollTop - chatThread.clientHeight
+      onScrollPositionChange?.(distanceFromBottom > CHAT_NEAR_BOTTOM_THRESHOLD_PX)
+    }
+
+    updateScrollPosition()
+    chatThread.addEventListener('scroll', updateScrollPosition, { passive: true })
+    return () => chatThread.removeEventListener('scroll', updateScrollPosition)
+  }, [activeChatId, chatMessagesLoading, groupedWithKeys, onScrollPositionChange])
 
   useEffect(() => {
     if (renamingSessionId && sessionRenameInputRef.current) {
@@ -514,6 +537,7 @@ export function ChatThread({ showAgentLabel = false }: ChatThreadProps) {
 
   return (
     <div
+      ref={chatThreadRef}
       data-testid="message-list"
       className={`chat-thread ${isDedicatedAgentView ? 'chat-thread-dedicated' : ''}`}
     >

--- a/desktop-app/ui/src/components/agents/__tests__/AgentWorkspace.chatScroll.test.tsx
+++ b/desktop-app/ui/src/components/agents/__tests__/AgentWorkspace.chatScroll.test.tsx
@@ -289,4 +289,71 @@ describe('AgentWorkspace chat scroll control', () => {
 
     expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
   })
+
+  it('cancels before the delay when returning to latest and scrolls the rendered thread on click', async () => {
+    vi.useFakeTimers()
+    const view = render(<WorkspaceHarness activeChatId="chat-a" />)
+    const { thread, getScrollTop, setScrollTop } = setScrollableThread()
+
+    fireEvent.scroll(thread)
+    setScrollTop(600)
+    fireEvent.scroll(thread)
+    await advance(300)
+    expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+
+    setScrollTop(0)
+    fireEvent.scroll(thread)
+    await advance(250)
+    fireEvent.click(screen.getByRole('button', { name: 'Scroll to latest messages' }))
+    await advance(100)
+
+    expect(getScrollTop()).toBe(800)
+    view.unmount()
+  })
+
+  it('opens both cached and hydrated provider transcripts at their latest rendered message', async () => {
+    vi.useFakeTimers()
+    const cachedView = render(<WorkspaceHarness activeChatId="cached-chat" />)
+    const cachedThread = setScrollableThread()
+    await advance(100)
+    expect(cachedThread.getScrollTop()).toBe(800)
+    cachedView.unmount()
+
+    const remoteView = render(
+      <WorkspaceHarness activeChatId="remote-chat" messages={[]} chatMessagesLoading />
+    )
+    const remoteThread = setScrollableThread()
+    remoteThread.setScrollTop(0)
+    remoteView.rerender(
+      <WorkspaceHarness
+        activeChatId="remote-chat"
+        messages={baseMessages}
+        chatMessagesLoading={false}
+      />
+    )
+    await advance(100)
+
+    expect(remoteThread.getScrollTop()).toBe(800)
+  })
+
+  it('keeps a reader at older history when provider messages append', async () => {
+    vi.useFakeTimers()
+    const view = render(<WorkspaceHarness activeChatId="chat-a" />)
+    const thread = setScrollableThread()
+    await advance(200)
+    thread.setScrollTop(0)
+
+    view.rerender(
+      <WorkspaceHarness
+        activeChatId="chat-a"
+        messages={[
+          ...baseMessages,
+          { id: 'new-assistant', role: 'assistant', content: 'New reply', timestamp: 3 },
+        ]}
+      />
+    )
+    await advance(100)
+
+    expect(thread.getScrollTop()).toBe(0)
+  })
 })

--- a/desktop-app/ui/src/components/agents/__tests__/AgentWorkspace.chatScroll.test.tsx
+++ b/desktop-app/ui/src/components/agents/__tests__/AgentWorkspace.chatScroll.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { flushSync } from 'react-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentChatActionsProvider } from '@contexts/AgentChatActionsContext'
+import { ChatListProvider } from '@contexts/ChatListContext'
+import { ChatThreadStateProvider } from '@contexts/ChatThreadStateContext'
+import { McpRuntimeProvider } from '@contexts/McpRuntimeContext'
+import { NavigationContext } from '@contexts/NavigationContext'
+import { NotificationsContext } from '@contexts/NotificationsContext'
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { createRoot } from 'react-dom/client'
+import { useChatScroll } from '@hooks/domain/useChatScroll'
+import type { AgentChatMessage } from '../../../uiTypes'
+import { AgentWorkspace } from '../AgentWorkspace'
+
+vi.mock('@hooks/domain/useAgentsDataController', () => ({
+  useAgentsDataController: () => ({ agentNames: ['agent-x'] }),
+}))
+vi.mock('@hooks/domain/useContextsDataController', () => ({
+  useContextsDataController: () => ({ contextIds: [], loading: false, error: null }),
+}))
+vi.mock('@hooks/domain/useMcpServersDataController', () => ({
+  useMcpServersDataController: () => ({ agentContextByName: {}, selectedAgentMcpServers: [] }),
+}))
+vi.mock('../ComposerPanel', () => ({ ComposerPanel: () => null }))
+vi.mock('../ContextWindowIndicator', () => ({ ContextWindowIndicator: () => null }))
+vi.mock('../InFlightAssistantPlaceholder', () => ({ InFlightAssistantPlaceholder: () => null }))
+vi.mock('../NudgeArea', () => ({ NudgeArea: () => null }))
+vi.mock('../ChatStateBadge', () => ({ ChatStateBadge: () => null }))
+vi.mock('@components/MessageArtifactActions', () => ({ MessageArtifactActions: () => null }))
+
+const actEnvGlobal = globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+actEnvGlobal.IS_REACT_ACT_ENVIRONMENT = true
+
+const baseMessages: AgentChatMessage[] = [
+  { id: 'a-user', role: 'user', content: 'First message', timestamp: 1 },
+  { id: 'a-assistant', role: 'assistant', content: 'Latest message', timestamp: 2 },
+]
+
+function ChatActionsProvider({
+  activeChatId,
+  messages,
+  chatMessagesLoading,
+  children,
+}: {
+  activeChatId: string
+  messages: AgentChatMessage[]
+  chatMessagesLoading: boolean
+  children: ReactNode
+}) {
+  const { chatEndRef, scrollChatToBottom } = useChatScroll({
+    selectedAgent: 'agent-x',
+    activeChatId,
+    chatMessages: messages,
+    chatMessagesLoading,
+    agentSending: false,
+    activeChatProgress: {},
+  })
+
+  return (
+    <AgentChatActionsProvider
+      value={
+        {
+          chatEndRef,
+          scrollChatToBottom,
+          clearComposerSendError: vi.fn(),
+          handleAddComposerImageAttachments: vi.fn(),
+          handleAddComposerReferenceAttachments: vi.fn(),
+          handleCreateChat: vi.fn(),
+          handleDeleteChat: vi.fn(),
+          handleDeleteChatForAgent: vi.fn(),
+          handleRemoveComposerImageAttachment: vi.fn(),
+          handleRemoveComposerReferenceAttachment: vi.fn(),
+          handleRenameChat: vi.fn(),
+          handleRenameChatForAgent: vi.fn(),
+          handleRetryFailedAgentSend: vi.fn(),
+          handleSelectChat: vi.fn(),
+          handleSendAgentMessage: vi.fn(),
+          handleUpdateComposerImageAttachment: vi.fn(),
+        } as never
+      }
+    >
+      {children}
+    </AgentChatActionsProvider>
+  )
+}
+
+function WorkspaceHarness({
+  activeChatId,
+  messages = baseMessages,
+  chatMessagesLoading = false,
+}: {
+  activeChatId: string
+  messages?: AgentChatMessage[]
+  chatMessagesLoading?: boolean
+}) {
+  const groupedMessages = messages.reduce<
+    Array<{ role: 'user' | 'assistant' | 'system'; items: AgentChatMessage[] }>
+  >((groups, message) => {
+    const previous = groups.at(-1)
+    if (previous?.role === message.role) previous.items.push(message)
+    else groups.push({ role: message.role, items: [message] })
+    return groups
+  }, [])
+
+  return (
+    <NavigationContext.Provider
+      value={
+        {
+          navItem: 'agents',
+          selectedAgent: 'agent-x',
+          selectedAgentRoute: 'details',
+          selectedContext: null,
+          selectedTeam: null,
+          handleNavSelect: vi.fn(),
+          handleOpenAgentWorkspace: vi.fn(),
+          handleSelectChatAgent: vi.fn(),
+          handleBackToAgents: vi.fn(),
+          handleOpenContextDetails: vi.fn(),
+          handleBackToContexts: vi.fn(),
+          handleOpenTeamDetails: vi.fn(),
+          handleBackToTeams: vi.fn(),
+        } as never
+      }
+    >
+      <McpRuntimeProvider
+        value={{
+          hostRuntimeStatus: null,
+          hostRuntimeLoading: false,
+          hostRuntimeError: null,
+          hostRuntimeLastUpdatedAt: null,
+          hostRuntimeIsStale: false,
+          activeLlmModel: null,
+          activeLlmProvider: null,
+          mcpHealthRefreshing: false,
+          handleRefreshMcpHealth: vi.fn(),
+          cancelTask: vi.fn(),
+        }}
+      >
+        <NotificationsContext.Provider
+          value={
+            {
+              notifications: [],
+              unreadNotificationCount: 0,
+              notificationActionById: {},
+              pendingApprovals: [],
+              pendingApprovalsLoading: false,
+              pendingApprovalActionId: null,
+              toasts: [],
+              markNotificationsRead: vi.fn(),
+              clearNotifications: vi.fn(),
+              removeNotification: vi.fn(),
+              resolveApprovalNotification: vi.fn(),
+              decideApproval: vi.fn(),
+              handleOpenNotification: vi.fn(),
+              handleApproveNotification: vi.fn(),
+              handleDenyNotification: vi.fn(),
+              handleRefreshPendingApprovals: vi.fn(),
+              handleDecidePendingApproval: vi.fn(),
+            } as never
+          }
+        >
+          <ChatListProvider
+            value={{
+              activeChatId,
+              chatList: [],
+              chatListLoading: false,
+              latestChatSessions: [],
+              latestChatSessionsLoading: false,
+              sessionStateByChatId: {},
+              sessionStateByChatKey: {},
+            }}
+          >
+            <ChatThreadStateProvider
+              value={{
+                activeChatId,
+                activeMessages: messages,
+                groupedMessages,
+                chatMessagesLoading,
+                hasOlderMessages: false,
+                olderMessagesLoading: false,
+                handleLoadOlderMessages: vi.fn(),
+                activityByMessageId: {},
+                progressByMessageId: {},
+              }}
+            >
+              <ChatActionsProvider
+                activeChatId={activeChatId}
+                messages={messages}
+                chatMessagesLoading={chatMessagesLoading}
+              >
+                <AgentWorkspace mode="chat" scrollContainerRef={{ current: null }} />
+              </ChatActionsProvider>
+            </ChatThreadStateProvider>
+          </ChatListProvider>
+        </NotificationsContext.Provider>
+      </McpRuntimeProvider>
+    </NavigationContext.Provider>
+  )
+}
+
+function setScrollableThread(scrollTop = 0) {
+  const thread = screen.getByTestId('message-list')
+  let position = scrollTop
+  Object.defineProperties(thread, {
+    clientHeight: { configurable: true, value: 200 },
+    scrollHeight: { configurable: true, value: 800 },
+    scrollTop: {
+      configurable: true,
+      get: () => position,
+      set: (value: number) => {
+        position = value
+      },
+    },
+  })
+  return {
+    thread,
+    getScrollTop: () => position,
+    setScrollTop: (value: number) => (position = value),
+  }
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  })
+})
+
+describe('AgentWorkspace chat scroll control', () => {
+  it('delays the control for each chat and never carries A visibility into B', async () => {
+    vi.useFakeTimers()
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+    const previousActEnvironment = actEnvGlobal.IS_REACT_ACT_ENVIRONMENT
+    actEnvGlobal.IS_REACT_ACT_ENVIRONMENT = false
+    try {
+      flushSync(() => root.render(<WorkspaceHarness activeChatId="chat-a" />))
+      const { thread } = setScrollableThread()
+
+      fireEvent.scroll(thread)
+      expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+      await advance(249)
+      expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+      await advance(1)
+      expect(screen.getByRole('button', { name: 'Scroll to latest messages' })).toBeTruthy()
+
+      flushSync(() => root.render(<WorkspaceHarness activeChatId="chat-b" />))
+      expect(
+        within(container).queryByRole('button', { name: 'Scroll to latest messages' })
+      ).toBeNull()
+
+      const { thread: chatBThread } = setScrollableThread()
+      fireEvent.scroll(chatBThread)
+      await advance(249)
+      expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+      await advance(1)
+      expect(screen.getByRole('button', { name: 'Scroll to latest messages' })).toBeTruthy()
+    } finally {
+      flushSync(() => root.unmount())
+      container.remove()
+      actEnvGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment
+    }
+  })
+
+  it('cancels an A timer before it can make the control visible in B', async () => {
+    vi.useFakeTimers()
+    const view = render(<WorkspaceHarness activeChatId="chat-a" />)
+    const { thread } = setScrollableThread()
+
+    fireEvent.scroll(thread)
+    await advance(100)
+    view.rerender(<WorkspaceHarness activeChatId="chat-b" />)
+    await advance(300)
+
+    expect(screen.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+  })
+})

--- a/desktop-app/ui/src/components/agents/__tests__/chatThread.toolSteps.test.tsx
+++ b/desktop-app/ui/src/components/agents/__tests__/chatThread.toolSteps.test.tsx
@@ -10,7 +10,7 @@
  */
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { MessageToolStep } from '../../../../../src/types'
 import type { AgentChatMessage, TaskProgress } from '../../../uiTypes'
@@ -244,6 +244,32 @@ describe('ChatThread tool-steps fallback (#582)', () => {
 
     await user.click(screen.getByRole('button', { name: 'Load older messages' }))
     expect(threadStateValue.handleLoadOlderMessages).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports when the reader is away from the bottom of the conversation', () => {
+    const onScrollPositionChange = vi.fn()
+    setThreadState([{ role: 'user', items: [userMsg] }])
+
+    render(<ChatThread onScrollPositionChange={onScrollPositionChange} />)
+
+    const chatThread = screen.getByTestId('message-list')
+    Object.defineProperties(chatThread, {
+      clientHeight: { configurable: true, value: 200 },
+      scrollHeight: { configurable: true, value: 800 },
+      scrollTop: { configurable: true, value: 0, writable: true },
+    })
+
+    fireEvent.scroll(chatThread)
+    expect(onScrollPositionChange).toHaveBeenLastCalledWith(true)
+
+    Object.defineProperty(chatThread, 'scrollTop', {
+      configurable: true,
+      value: 600,
+      writable: true,
+    })
+    fireEvent.scroll(chatThread)
+
+    expect(onScrollPositionChange).toHaveBeenLastCalledWith(false)
   })
 
   it('wraps long histories in virtualized message chunks', () => {

--- a/desktop-app/ui/src/constants/agents.ts
+++ b/desktop-app/ui/src/constants/agents.ts
@@ -1,5 +1,6 @@
 export const MAX_VISIBLE_SESSIONS = 6
 export const SESSION_PREVIEW_LIMIT = 9
+export const CHAT_NEAR_BOTTOM_THRESHOLD_PX = 120
 
 export const AGENT_ERROR_CODE_LABELS: Record<string, string> = {
   LLM_INSUFFICIENT_QUOTA: 'Out of Credits',

--- a/desktop-app/ui/src/contexts/AgentChatActionsContext/types.ts
+++ b/desktop-app/ui/src/contexts/AgentChatActionsContext/types.ts
@@ -8,6 +8,7 @@ import type { ComposerImageAttachment, ComposerReferenceAttachment } from '../..
  */
 export interface AgentChatActionsContextValue {
   chatEndRef: RefObject<HTMLDivElement | null>
+  scrollChatToBottom: () => void
   handleCreateChat: () => Promise<void>
   handleRenameChat: (chatId: string, newTitle: string) => Promise<void>
   handleRenameChatForAgent: (agentRef: string, chatId: string, newTitle: string) => Promise<void>

--- a/desktop-app/ui/src/hooks/domain/__tests__/useAgentChatController.test.tsx
+++ b/desktop-app/ui/src/hooks/domain/__tests__/useAgentChatController.test.tsx
@@ -133,6 +133,82 @@ describe('useAgentChatController — characterization (D.0)', () => {
       expect(result.current.activeChatId).toBe('chat-2')
     })
 
+    it('opens a remote chat at the bottom after its empty cache hydrates', async () => {
+      vi.useFakeTimers()
+      const hydration = deferred<{
+        agent: string
+        chatId: string
+        state: 'idle'
+        turns: Array<{
+          number: number
+          user_input: string
+          response: string
+          started_at: string
+          completed_at: string
+        }>
+      }>()
+      clerum.chat.loadMessages.mockResolvedValue([])
+      clerum.rpc.loadSessionMessages.mockReturnValue(hydration.promise)
+
+      const { result } = renderController()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      const scrollContainer = document.createElement('div')
+      const anchor = document.createElement('div')
+      let scrollTop = 0
+      Object.defineProperties(scrollContainer, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, value: 800 },
+        scrollTop: {
+          configurable: true,
+          get: () => scrollTop,
+          set: (value: number) => {
+            scrollTop = value
+          },
+        },
+      })
+      Object.defineProperty(anchor, 'scrollIntoView', { configurable: true, value: vi.fn() })
+      scrollContainer.append(anchor)
+      document.body.append(scrollContainer)
+      result.current.chatEndRef.current = anchor
+
+      let switching!: Promise<void>
+      await act(async () => {
+        switching = result.current.switchToChat('agent-x', 'chat-remote')
+        await vi.advanceTimersByTimeAsync(200)
+      })
+      expect(clerum.rpc.loadSessionMessages).toHaveBeenCalledTimes(1)
+
+      // The initial cache scroll ran while the cache was empty. Model a reader
+      // at the top when the remote transcript subsequently renders.
+      scrollTop = 0
+      await act(async () => {
+        hydration.resolve({
+          agent: 'agent-x',
+          chatId: 'chat-remote',
+          state: 'idle',
+          turns: [
+            {
+              number: 1,
+              user_input: 'remote question',
+              response: 'remote answer',
+              started_at: '2026-05-28T10:00:00Z',
+              completed_at: '2026-05-28T10:00:05Z',
+            },
+          ],
+        })
+        await switching
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
+
+      expect(scrollTop).toBe(800)
+      scrollContainer.remove()
+    })
+
     it('stops delta pagination when the active chat changes during the first page', async () => {
       clerum.chat.loadMessages.mockImplementation(async (_agentRef: string, chatId: string) =>
         chatId === 'chat-a'

--- a/desktop-app/ui/src/hooks/domain/useAgentChatController.ts
+++ b/desktop-app/ui/src/hooks/domain/useAgentChatController.ts
@@ -581,7 +581,9 @@ export function useAgentChatController({
 
   const { chatEndRef, scrollChatToBottom } = useChatScroll({
     selectedAgent,
+    activeChatId,
     chatMessages,
+    chatMessagesLoading,
     agentSending,
     activeChatProgress: progressByMessageId,
   })

--- a/desktop-app/ui/src/hooks/domain/useAgentChatController.ts
+++ b/desktop-app/ui/src/hooks/domain/useAgentChatController.ts
@@ -2928,6 +2928,7 @@ export function useAgentChatController({
     agentError,
     failedAgentSend,
     chatEndRef,
+    scrollChatToBottom,
     activityByMessageId,
     progressByMessageId,
     groupedMessages,

--- a/desktop-app/ui/src/hooks/domain/useChatScroll.ts
+++ b/desktop-app/ui/src/hooks/domain/useChatScroll.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
+import { CHAT_NEAR_BOTTOM_THRESHOLD_PX } from '@constants/agents'
 import type { AgentChatMessage, TaskProgress } from '../../uiTypes'
 
 /**
@@ -6,8 +7,6 @@ import type { AgentChatMessage, TaskProgress } from '../../uiTypes'
  * treat the user as "following" the conversation and auto-scroll on new content.
  * Beyond it, the user is reading history and we must NOT yank them down (B4-a).
  */
-const NEAR_BOTTOM_THRESHOLD_PX = 120
-
 interface UseChatScrollParams {
   selectedAgent: string | null
   chatMessages: AgentChatMessage[]
@@ -125,7 +124,7 @@ export function useChatScroll({
     while (node) {
       const { scrollHeight, scrollTop, clientHeight } = node
       if (scrollHeight > clientHeight) {
-        return scrollHeight - scrollTop - clientHeight <= NEAR_BOTTOM_THRESHOLD_PX
+        return scrollHeight - scrollTop - clientHeight <= CHAT_NEAR_BOTTOM_THRESHOLD_PX
       }
       node = node.parentElement
     }

--- a/desktop-app/ui/src/hooks/domain/useChatScroll.ts
+++ b/desktop-app/ui/src/hooks/domain/useChatScroll.ts
@@ -9,7 +9,9 @@ import type { AgentChatMessage, TaskProgress } from '../../uiTypes'
  */
 interface UseChatScrollParams {
   selectedAgent: string | null
+  activeChatId: string | null
   chatMessages: AgentChatMessage[]
+  chatMessagesLoading: boolean
   agentSending: boolean
   /**
    * Progress slice for the ACTIVE view only (the selected agent's
@@ -34,13 +36,18 @@ interface UseChatScrollParams {
  */
 export function useChatScroll({
   selectedAgent,
+  activeChatId,
   chatMessages,
+  chatMessagesLoading,
   agentSending,
   activeChatProgress,
 }: UseChatScrollParams) {
   const chatEndRef = useRef<HTMLDivElement | null>(null)
   const scrollAnimationFrameIdsRef = useRef<number[]>([])
   const scrollTimeoutIdsRef = useRef<number[]>([])
+  const pendingEntryScrollChatKeyRef = useRef<string | null>(null)
+  const activeChatKey =
+    selectedAgent && activeChatId ? `${selectedAgent}\u0000${activeChatId}` : null
 
   const cancelScheduledScrolls = useCallback(() => {
     if (typeof window !== 'undefined') {
@@ -143,6 +150,28 @@ export function useChatScroll({
     isNearBottom,
     scrollChatToBottom,
   ])
+
+  // A newly selected chat must open at its latest message even when its local
+  // cache was empty and the remote transcript arrives after the first scroll.
+  // Keep the entry scroll pending until at least one message is rendered; later
+  // updates still follow the near-bottom guard above.
+  useEffect(() => {
+    pendingEntryScrollChatKeyRef.current = activeChatKey
+  }, [activeChatKey])
+
+  useEffect(() => {
+    if (
+      !activeChatKey ||
+      chatMessagesLoading ||
+      chatMessages.length === 0 ||
+      pendingEntryScrollChatKeyRef.current !== activeChatKey
+    ) {
+      return
+    }
+
+    scrollChatToBottom()
+    pendingEntryScrollChatKeyRef.current = null
+  }, [activeChatKey, chatMessages, chatMessagesLoading, scrollChatToBottom])
 
   useEffect(() => cancelScheduledScrolls, [cancelScheduledScrolls])
 

--- a/desktop-app/ui/src/hooks/useAgentChatActionsValue.ts
+++ b/desktop-app/ui/src/hooks/useAgentChatActionsValue.ts
@@ -14,6 +14,7 @@ type AppVm = ReturnType<typeof useAppController>
  */
 export function useAgentChatActionsValue(vm: AppVm): AgentChatActionsContextValue {
   const chatEndRef = vm.chatEndRef
+  const scrollChatToBottom = useStableCallback(vm.scrollChatToBottom)
   const handleCreateChat = useStableCallback(vm.handleCreateChat)
   const handleRenameChat = useStableCallback(vm.handleRenameChat)
   const handleRenameChatForAgent = useStableCallback(vm.handleRenameChatForAgent)
@@ -40,6 +41,7 @@ export function useAgentChatActionsValue(vm: AppVm): AgentChatActionsContextValu
   return useMemo(
     () => ({
       chatEndRef,
+      scrollChatToBottom,
       handleCreateChat,
       handleRenameChat,
       handleRenameChatForAgent,
@@ -57,6 +59,7 @@ export function useAgentChatActionsValue(vm: AppVm): AgentChatActionsContextValu
     }),
     [
       chatEndRef,
+      scrollChatToBottom,
       handleCreateChat,
       handleRenameChat,
       handleRenameChatForAgent,

--- a/desktop-app/ui/src/hooks/useAppController.ts
+++ b/desktop-app/ui/src/hooks/useAppController.ts
@@ -1221,6 +1221,7 @@ export function useAppController() {
     agentError: chat.agentError,
     failedAgentSend: chat.failedAgentSend,
     chatEndRef: chat.chatEndRef,
+    scrollChatToBottom: chat.scrollChatToBottom,
     activeMessages: chat.chatMessages,
     activityByMessageId: chat.activityByMessageId,
     progressByMessageId: chat.progressByMessageId,

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -6084,6 +6084,10 @@ h3 {
   pointer-events: auto;
 }
 
+.chat-scroll-to-bottom-button.ui-icon-button.ui-icon-button--solid.ui-icon-button--neutral:hover:enabled {
+  background: var(--bg-elev-2);
+}
+
 .chat-scroll-to-bottom-button.ui-icon-button svg {
   width: 18px;
   height: 18px;

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -4014,6 +4014,11 @@ h3 {
   transform: rotate(90deg);
 }
 
+.agent-workspace-shell .chat-thread-container {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .agent-workspace-shell .chat-thread {
   flex: 1 1 auto;
   min-height: 0;
@@ -6042,7 +6047,13 @@ h3 {
   color: var(--warning);
 }
 
+.chat-thread-container {
+  position: relative;
+  min-height: 0;
+}
+
 .chat-thread {
+  height: 100%;
   min-height: 280px;
   max-height: none;
   overflow: auto;
@@ -6055,6 +6066,32 @@ h3 {
   min-height: 0;
   align-content: start;
   gap: var(--space-2-5);
+}
+
+.chat-scroll-to-bottom {
+  position: absolute;
+  inset-inline: 0;
+  inset-block-end: var(--space-3);
+  z-index: var(--layer-chat-overlay);
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+}
+
+.chat-scroll-to-bottom-button.ui-icon-button {
+  border-color: rgba(var(--edge-rgb), 0.58);
+  box-shadow: var(--shadow-soft);
+  pointer-events: auto;
+}
+
+.chat-scroll-to-bottom-button.ui-icon-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
 }
 
 .chat-history-page-control {


### PR DESCRIPTION
## Summary

Improves the desktop chat reading experience for long conversations.

- Shows a centered, accessible control that returns the reader to the latest messages after scrolling away from the bottom.
- Keeps the control scoped to the active conversation, with a 250 ms delay that prevents entry flicker and cancels stale timers on chat switches.
- Opens cached and remotely hydrated conversations at their latest rendered message.
- Preserves the reader position when new messages append while they are viewing older history.
- Adds provider-backed workspace coverage for control visibility, cancellation, click-to-bottom, chat switching, and transcript hydration.

## Testing

- [x] `cd desktop-app && npm test` — 161 files, 1,658 tests
- [x] `cd desktop-app && npm run build`
- [x] `npm run style-rules -- --strict`
- [x] `git diff --check`

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe.