### PR TITLE
chore(desktop): address post-merge chat view nits

### DIFF
--- a/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
+++ b/desktop-app/ui/src/components/agents/AgentWorkspace.tsx
@@ -533,7 +533,7 @@ export function AgentWorkspace({ mode = 'agents', scrollContainerRef }: AgentWor
           {isChatMode && (
             <div className="chat-thread-container">
               <ChatThread onScrollPositionChange={handleScrollPositionChange} />
-              {activeChatId && showDelayedScrollToBottom && (
+              {showDelayedScrollToBottom && (
                 <div className="chat-scroll-to-bottom">
                   <IconButton
                     className="chat-scroll-to-bottom-button"

--- a/desktop-app/ui/src/constants/agents.ts
+++ b/desktop-app/ui/src/constants/agents.ts
@@ -1,5 +1,9 @@
 export const MAX_VISIBLE_SESSIONS = 6
 export const SESSION_PREVIEW_LIMIT = 9
+/**
+ * Distance (px) from the bottom within which a reader still follows the chat.
+ * Beyond it, appended content must not pull them away from older history.
+ */
 export const CHAT_NEAR_BOTTOM_THRESHOLD_PX = 120
 
 export const AGENT_ERROR_CODE_LABELS: Record<string, string> = {

--- a/desktop-app/ui/src/hooks/domain/useChatScroll.ts
+++ b/desktop-app/ui/src/hooks/domain/useChatScroll.ts
@@ -2,11 +2,6 @@ import { useCallback, useEffect, useRef } from 'react'
 import { CHAT_NEAR_BOTTOM_THRESHOLD_PX } from '@constants/agents'
 import type { AgentChatMessage, TaskProgress } from '../../uiTypes'
 
-/**
- * Distance (px) from the bottom of the scroll container within which we still
- * treat the user as "following" the conversation and auto-scroll on new content.
- * Beyond it, the user is reading history and we must NOT yank them down (B4-a).
- */
 interface UseChatScrollParams {
   selectedAgent: string | null
   activeChatId: string | null


### PR DESCRIPTION
## Summary

Addresses two post-merge cleanup nits from PR #332.

- Documents the shared chat near-bottom threshold at its constant declaration.
- Simplifies the scroll-to-latest render gate while preserving the active-chat safety check.

## Testing

- [x] `cd desktop-app && npm test` — 161 files, 1,658 tests
- [x] `cd desktop-app && npm run build`
- [x] `npm run style-rules -- --strict`
- [x] `git diff --check`