### PR TITLE
fix(mcp-host): stabilize dual-store summary parity test against clock jitter

### DIFF
--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.237",
+  "version": "0.1.238",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-mcp-host",
-      "version": "0.1.237",
+      "version": "0.1.238",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.237",
+  "version": "0.1.238",
   "description": "MCP Host - reads Host CRD and provides LLM access via OpenAI/Claude",
   "main": "dist/main.js",
   "engines": {

--- a/mcp-host/src/core/conversation/persistence/__tests__/dualConversationStore.test.ts
+++ b/mcp-host/src/core/conversation/persistence/__tests__/dualConversationStore.test.ts
@@ -119,11 +119,9 @@ describe('DualConversationStore — dual-write parity', () => {
       await sqlite.persistQueue.drainSessionKey('u-cold:rpc:a:chat-1')
 
       const dual = new DualConversationStore(new InMemoryConversationStore(), sqlite.store)
-      const page = await dual.getSessionMessagesByKey(
-        'u-cold:rpc:a:chat-1',
-        'u-cold:rpc:',
-        { limit: 1 }
-      )
+      const page = await dual.getSessionMessagesByKey('u-cold:rpc:a:chat-1', 'u-cold:rpc:', {
+        limit: 1,
+      })
 
       expect(page?.turns.map(turn => turn.user_input)).toEqual(['cold question'])
     } finally {
@@ -151,6 +149,16 @@ describe('DualConversationStore — dual-write parity', () => {
 
   it('records matching parity for summaries written through both stores', async () => {
     const sqlite = makeSqliteStore({ cacheSize: 4 })
+    // Memory derives lastActivityAt from `conversation.updated_at` (stamped when
+    // the turn completes) while SQLite stamps its row from `Date.now()` when the
+    // persist worker writes it — two independent clock reads. They usually land
+    // on the same millisecond, but ~2% of runs straddle a boundary and the parity
+    // probe reports a spurious mismatch (the source of this test's flake). Freeze
+    // the clock so both reads are identical; a whole-second boundary keeps the
+    // SQLite seconds↔ms round-trip exact. Only Date is faked, so the persist
+    // queue's real setImmediate/setInterval timing (and vi.waitFor) still runs.
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
     try {
       const memory = new InMemoryConversationStore()
       const parity: Array<{ op: string; match: boolean }> = []
@@ -161,14 +169,24 @@ describe('DualConversationStore — dual-write parity', () => {
       const conversation = await manager.getOrCreate('u-1:rpc:a:chat-1', { userId: 'u-1' })
       await manager.startTurn(conversation, 'question', 'task-1')
       await manager.completeTurn(conversation, 'answer')
+      // Writes reach SQLite through the async persist queue; drainPrefix waits
+      // for every in-flight write under this prefix so the durable row (stamped
+      // at the frozen instant) has landed before the parity probe reads it.
+      await sqlite.persistQueue.drainPrefix('u-1:rpc:')
+      // Timestamps are now locked into both stores; the clock can advance again.
+      vi.useRealTimers()
 
       await dual.listSessionSummariesByPrefix('u-1:rpc:', { limit: 10 })
       await dual.getSessionMessagesByKey('u-1:rpc:a:chat-1', 'u-1:rpc:', { limit: 10 })
-      await new Promise(resolve => setImmediate(resolve))
-
-      expect(parity).toContainEqual({ op: 'listSessionSummariesByPrefix', match: true })
-      expect(parity).toContainEqual({ op: 'getSessionMessagesByKey', match: true })
+      // getSessionMessagesByKey records its parity fire-and-forget (a
+      // queueMicrotask awaiting a SQLite worker round-trip), so poll until both
+      // probes have recorded instead of racing a single fixed wait.
+      await vi.waitFor(() => {
+        expect(parity).toContainEqual({ op: 'listSessionSummariesByPrefix', match: true })
+        expect(parity).toContainEqual({ op: 'getSessionMessagesByKey', match: true })
+      })
     } finally {
+      vi.useRealTimers()
       await sqlite.shutdown()
     }
   })


### PR DESCRIPTION
## What

Makes the `DualConversationStore` test **"records matching parity for summaries written through both stores"** deterministic. It flaked ~2% of runs (seen as a red `mcp-host` job on unrelated PRs, e.g. #339).

## Root cause

Not the persist race the earlier "restore/stabilize dual store parity" fixes assumed. It's a real, benign timestamp divergence between the two stores:

- **memory** derives a summary's `lastActivityAt` from `conversation.updated_at` — stamped when the turn completes;
- **SQLite** stamps its row from `Date.now()` when the persist **worker** writes it — a few ms later.

Two independent clock reads. ~2% of runs straddle a millisecond boundary, so the inline parity probe compares e.g. `...986Z` vs `...987Z`, records `match:false`, and it never converges no matter how long the test waits. Captured by instrumenting `pagesMatch`:

```
MEM lastActivityAt = 2026-08-12T23:50:11.986Z
SQL lastActivityAt = 2026-08-12T23:50:11.987Z   (all other fields identical)
```

## Fix (test-only)

- Freeze the clock (`vi.useFakeTimers({ toFake: ['Date'] })` — **Date only**, so the persist queue's real `setImmediate`/`setInterval` timing and `vi.waitFor` keep running) on a **whole-second** boundary, which keeps SQLite's seconds↔ms round-trip exact, so both stores stamp the identical instant.
- `drainPrefix` the write chain before probing, then restore real timers and poll for the fire-and-forget `getSessionMessagesByKey` parity record.

No production code changes. Verified: 60/60 isolated runs, 15/15 full-file runs, whole persistence suite 96/96, `tsc --noEmit` clean.

## Not fixed here (reported separately)

The underlying product observation stands: in production, memory and SQLite disagree on `lastActivityAt` by write latency, so the parity **metric** emits ~2% false negatives. Making SQLite copy `updated_at` instead of stamping `Date.now()` would touch cursor ordering and cold-start TTL, so it's out of scope for a flake fix and left for a separate decision.

## Notes

- Pre-existing flake on `dev` (introduced by `0159b09` via #173), unrelated to the in-flight LLM-lifecycle PRs — it just happens to redden their `mcp-host` CI job.
- Repro is probabilistic by nature (~2%, observed 1/20–1/50 locally); no deterministic single-run repro exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)