### PR TITLE
fix(control-ui): style the block captions that were falling back to body type

### DIFF
--- a/control-ui/app/communication-channels/new/page.tsx
+++ b/control-ui/app/communication-channels/new/page.tsx
@@ -59,6 +59,9 @@ type DraftState = {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const TEAMS_BOT_NAME_RE = /^[a-z][a-z0-9-]{1,62}[a-z0-9]$/
 const LOCAL_TEAMS_ENDPOINT_ORIGIN = 'https://<public-webhook-origin>'
+
+/** Slack's "Create an app" chooser, where "From an app manifest" is one of the options. */
+const SLACK_NEW_APP_URL = 'https://api.slack.com/apps?new_app=1'
 const STEPS = ['Channel', 'Provider'] as const
 
 const STEP_DETAILS = [
@@ -661,11 +664,23 @@ export default function CreateCommunicationChannelPage() {
                             </pre>
                           </div>
                           <span className="cu-field__hint">
-                            Create the Slack app from this first: in Slack, Create New App → From an
-                            app manifest → paste. It sets the scopes, the events, and both Request
-                            URLs, so the app is ready before you come back for the token below. The
-                            URLs point at <code>{normalizedChannelName}</code>, so create this
-                            channel under that name.
+                            Copy this, then{' '}
+                            <a
+                              className="cu-link"
+                              href={SLACK_NEW_APP_URL}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              create your Slack app
+                            </a>{' '}
+                            — choose <strong>From an app manifest</strong>, pick the workspace, and
+                            paste. It sets the scopes, the events, and both Request URLs, so the app
+                            is ready before you come back here for the token below. Opens in a new
+                            tab so this form keeps what you have typed.
+                          </span>
+                          <span className="cu-field__hint">
+                            The Request URLs point at <code>{normalizedChannelName}</code>, so this
+                            channel has to be created under that name.
                           </span>
                         </div>
                       ) : null}

--- a/control-ui/app/communication-channels/new/page.tsx
+++ b/control-ui/app/communication-channels/new/page.tsx
@@ -682,6 +682,14 @@ export default function CreateCommunicationChannelPage() {
                             The Request URLs point at <code>{normalizedChannelName}</code>, so this
                             channel has to be created under that name.
                           </span>
+                          <span className="cu-field__hint">
+                            Slack checks the URL the moment you save the manifest and will report{' '}
+                            <strong>&ldquo;Your URL didn&rsquo;t respond&rdquo;</strong>. That is
+                            expected here: the URL names a channel that does not exist yet, so there
+                            are no credentials to verify the request against. Finish creating this
+                            channel, then press <strong>Retry</strong> on Slack&rsquo;s Event
+                            Subscriptions page and it turns green.
+                          </span>
                         </div>
                       ) : null}
                       <ChannelCredentialsPanel

--- a/control-ui/app/communication-channels/new/page.tsx
+++ b/control-ui/app/communication-channels/new/page.tsx
@@ -682,14 +682,6 @@ export default function CreateCommunicationChannelPage() {
                             The Request URLs point at <code>{normalizedChannelName}</code>, so this
                             channel has to be created under that name.
                           </span>
-                          <span className="cu-field__hint">
-                            Slack checks the URL the moment you save the manifest and will report{' '}
-                            <strong>&ldquo;Your URL didn&rsquo;t respond&rdquo;</strong>. That is
-                            expected here: the URL names a channel that does not exist yet, so there
-                            are no credentials to verify the request against. Finish creating this
-                            channel, then press <strong>Retry</strong> on Slack&rsquo;s Event
-                            Subscriptions page and it turns green.
-                          </span>
                         </div>
                       ) : null}
                       <ChannelCredentialsPanel

--- a/control-ui/app/communication-channels/new/page.tsx
+++ b/control-ui/app/communication-channels/new/page.tsx
@@ -17,6 +17,7 @@ import { useToast } from '@components/Toast'
 import { IconCopy } from '@components/icons'
 import { Button, Field, TextInput } from '@components/ui'
 import { CONTROL_ROUTES } from '@constants/routes'
+import { SLACK_NEW_APP_URL } from '@constants/slack'
 import { apiGet, apiSend } from '@lib/api'
 import type { ChannelType } from '@lib/channelTypes'
 import { copyTextToClipboard } from '@lib/clipboard'
@@ -59,9 +60,6 @@ type DraftState = {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 const TEAMS_BOT_NAME_RE = /^[a-z][a-z0-9-]{1,62}[a-z0-9]$/
 const LOCAL_TEAMS_ENDPOINT_ORIGIN = 'https://<public-webhook-origin>'
-
-/** Slack's "Create an app" chooser, where "From an app manifest" is one of the options. */
-const SLACK_NEW_APP_URL = 'https://api.slack.com/apps?new_app=1'
 const STEPS = ['Channel', 'Provider'] as const
 
 const STEP_DETAILS = [
@@ -682,6 +680,17 @@ export default function CreateCommunicationChannelPage() {
                             The Request URLs point at <code>{normalizedChannelName}</code>, so this
                             channel has to be created under that name.
                           </span>
+                        </div>
+                      ) : draft.slackBotHandle.trim() && normalizedChannelName ? (
+                        // Named and ready, but no absolute URL resolved: a manifest with a
+                        // relative request_url is invalid to Slack. Say so rather than render
+                        // nothing -- the operator is following a guide that promises a manifest
+                        // here, and silence gives them no cause to chase.
+                        <div className="cu-banner cu-banner--warning">
+                          No app manifest: this deployment has no public webhook address, so the
+                          Request URL would be a path Slack cannot reach. Expose the webhook proxy
+                          publicly and set NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL to that
+                          address, then reload this page.
                         </div>
                       ) : null}
                       <ChannelCredentialsPanel

--- a/control-ui/app/constants/slack.ts
+++ b/control-ui/app/constants/slack.ts
@@ -1,0 +1,7 @@
+/**
+ * Slack's "Create an app" chooser, where "From an app manifest" is one of the
+ * options. Configuration rather than copy: it is an external service address,
+ * and the edit page renders the same manifest block, so it belongs somewhere
+ * both pages can reach instead of inline in one of them.
+ */
+export const SLACK_NEW_APP_URL = 'https://api.slack.com/apps?new_app=1'

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -9648,6 +9648,14 @@ textarea.cu-input {
 .cu-channel-provider-panel,
 .cu-channel-access {
   display: grid;
+  /* minmax(0, 1fr), not the default `auto` track. An auto track is max-content
+     sized and its items keep `min-width: auto`, so the widest unbreakable line
+     in the panel sets the track width and the content paints outside the panel
+     box, which does not clip it. The Slack app manifest triggers this: its
+     `request_url` line runs ~140 monospace characters, measured here at 1088px
+     inside a 670px panel. With a 0 floor the track shrinks to the panel and the
+     manifest's own `overflow-x: auto` scrolls it instead. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--cu-space-4);
   padding: var(--cu-space-4);
   border: 1px solid var(--cu-border-subtle);

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -1199,7 +1199,13 @@ body.cu-body {
   margin-bottom: 1rem;
 }
 
-.cu-field label {
+/* `.cu-field__label` captions a block that is not a form control -- a Request URL
+   or a generated manifest sitting in a <pre>. A <label> would be the wrong element
+   there because it labels nothing, so the class carries the same treatment as a
+   real field label instead. Without it the caption falls back to body type and
+   renders larger than the inputs it sits above. */
+.cu-field label,
+.cu-field__label {
   font-size: 0.75rem;
   font-weight: 500;
   color: var(--cu-text-muted);

--- a/control-ui/components/ChannelCredentialsPanel/constants.ts
+++ b/control-ui/components/ChannelCredentialsPanel/constants.ts
@@ -20,7 +20,11 @@ export const CHANNEL_CREDENTIAL_FIELDS: CredentialField[] = [
     key: 'slack-signing-secret',
     label: 'Slack Signing Secret',
     placeholder: 'signing secret',
-    helpText: 'Required for Slack Events and Interactivity signature verification.',
+    // The one value operators cannot find. Slack never shows it during install,
+    // so the dialog that hands over the bot token looks complete when it is not.
+    // Naming the page beats describing what the secret does.
+    helpText:
+      'In your Slack app: Basic Information → App Credentials → Signing Secret, then Show. It is not in the dialog shown after you install the app — that one only carries the bot token. Used to verify that Events and Interactivity requests really came from Slack.',
   },
   {
     channelType: 'slack',
@@ -28,7 +32,7 @@ export const CHANNEL_CREDENTIAL_FIELDS: CredentialField[] = [
     label: 'Slack Bot User OAuth Token',
     placeholder: 'xoxb-…',
     helpText:
-      'Required after the app is installed in the workspace. Used to read and send messages.',
+      'In your Slack app: OAuth & Permissions → Bot User OAuth Token, and it only exists once you have installed the app to the workspace. Starts xoxb-, not xapp-. Used to read and send messages.',
   },
   {
     channelType: 'teams',

--- a/control-ui/components/ChannelCredentialsPanel/constants.ts
+++ b/control-ui/components/ChannelCredentialsPanel/constants.ts
@@ -24,7 +24,7 @@ export const CHANNEL_CREDENTIAL_FIELDS: CredentialField[] = [
     // so the dialog that hands over the bot token looks complete when it is not.
     // Naming the page beats describing what the secret does.
     helpText:
-      'In your Slack app: Basic Information → App Credentials → Signing Secret, then Show. It is not in the dialog shown after you install the app — that one only carries the bot token. Used to verify that Events and Interactivity requests really came from Slack.',
+      'In your Slack app: Settings → Basic Information → App Credentials → Signing Secret, then Show. It is not in the dialog shown after you install the app — that one only carries the bot token. Used to verify that Events and Interactivity requests really came from Slack.',
   },
   {
     channelType: 'slack',
@@ -32,7 +32,7 @@ export const CHANNEL_CREDENTIAL_FIELDS: CredentialField[] = [
     label: 'Slack Bot User OAuth Token',
     placeholder: 'xoxb-…',
     helpText:
-      'In your Slack app: OAuth & Permissions → Bot User OAuth Token, and it only exists once you have installed the app to the workspace. Starts xoxb-, not xapp-. Used to read and send messages.',
+      'In your Slack app: Features → OAuth & Permissions → Bot User OAuth Token, and it only exists once you have installed the app to the workspace. Starts xoxb-, not xapp-. Used to read and send messages.',
   },
   {
     channelType: 'teams',

--- a/control-ui/components/ChannelCredentialsPanel/index.tsx
+++ b/control-ui/components/ChannelCredentialsPanel/index.tsx
@@ -35,8 +35,13 @@ const STORED_KEYS_ERROR =
  * Secret is filed next to a Client Secret on a page the dialog never links to,
  * so both wrong values are the easy ones to grab.
  */
+/**
+ * Only the "ignore these" half. Where each value lives now sits on the field that
+ * asks for it, which is where someone hunting for it is actually looking -- this
+ * note is a paragraph under both inputs and is easy to skip.
+ */
 const SLACK_CREDENTIAL_NOTE =
-  'You do not need the App-Level Token (xapp-) or the Client Secret. Slack hands out the xapp- token beside the xoxb- one, and the Signing Secret is not in that dialog at all: find it on Basic Information, under App Credentials.'
+  'You do not need the App-Level Token (xapp-) or the Client Secret. Slack offers the xapp- token right beside the xoxb- one, so it is easy to copy the wrong value.'
 
 /**
  * Per-CommunicationChannel provider credential form.

--- a/control-ui/components/ChannelCredentialsPanel/index.tsx
+++ b/control-ui/components/ChannelCredentialsPanel/index.tsx
@@ -30,15 +30,14 @@ const UNKNOWN_PLACEHOLDER = 'Stored value unknown'
 const STORED_KEYS_ERROR =
   'Could not check which credentials are stored. You can still rotate a value; deleting one needs a successful read.'
 /**
- * Slack offers four secrets and this platform uses two of them. The "app is
- * ready" dialog puts the App-Level Token next to the bot token, and the Signing
- * Secret is filed next to a Client Secret on a page the dialog never links to,
- * so both wrong values are the easy ones to grab.
- */
-/**
- * Only the "ignore these" half. Where each value lives now sits on the field that
- * asks for it, which is where someone hunting for it is actually looking -- this
- * note is a paragraph under both inputs and is easy to skip.
+ * Slack offers four secrets and this platform uses two of them, with the "app is
+ * ready" dialog putting the App-Level Token right next to the bot token — so the
+ * wrong value is the easy one to grab.
+ *
+ * This note carries only that "ignore these" half. WHERE each value lives is on
+ * the field that asks for it (see CHANNEL_CREDENTIAL_FIELDS), because that is
+ * where someone hunting for it is looking; a paragraph under both inputs is easy
+ * to skip.
  */
 const SLACK_CREDENTIAL_NOTE =
   'You do not need the App-Level Token (xapp-) or the Client Secret. Slack offers the xapp- token right beside the xoxb- one, so it is easy to copy the wrong value.'

--- a/control-ui/components/__tests__/ChannelCredentialsPanel.test.tsx
+++ b/control-ui/components/__tests__/ChannelCredentialsPanel.test.tsx
@@ -431,10 +431,10 @@ describe('ChannelCredentialsPanel — failed stored-key read', () => {
 /** The Slack note, written out rather than imported: this copy IS the feature,
  *  so a reworded panel must fail here instead of quietly passing. */
 const SLACK_CREDENTIAL_NOTE =
-  'You do not need the App-Level Token (xapp-) or the Client Secret. Slack hands out the xapp- token beside the xoxb- one, and the Signing Secret is not in that dialog at all: find it on Basic Information, under App Credentials.'
+  'You do not need the App-Level Token (xapp-) or the Client Secret. Slack offers the xapp- token right beside the xoxb- one, so it is easy to copy the wrong value.'
 
 describe('ChannelCredentialsPanel — Slack credential note', () => {
-  it('tells the operator which Slack values are NOT needed and where the Signing Secret is', () => {
+  it('tells the operator which Slack values are NOT needed', () => {
     // Slack's "app is ready" dialog hands out xoxb- and xapp- side by side, and
     // the Signing Secret sits next to a Client Secret on another page entirely.
     // Without this note the operator pastes the wrong two values.
@@ -455,5 +455,36 @@ describe('ChannelCredentialsPanel — Slack credential note', () => {
   it('does not show the Slack note when no provider is selected', () => {
     renderPanel({ ccName: 'cc-empty', visibleChannelTypes: [] })
     expect(screen.queryByText(SLACK_CREDENTIAL_NOTE)).not.toBeInTheDocument()
+  })
+})
+
+describe('ChannelCredentialsPanel — where the Slack credentials live', () => {
+  // Both Slack values are on different pages of the Slack app, and the signing
+  // secret is the one people cannot find: it is absent from the "app is ready"
+  // dialog that hands over the bot token, so the natural assumption is that the
+  // dialog showed everything. Naming the page is the whole value of this hint --
+  // asserting on the location, not the phrasing, so copy can be reworded freely.
+  /** The hint rendered directly under a given credential input, not the panel note. */
+  function hintFor(label: string): string {
+    const input = screen.getByLabelText(label, { exact: true })
+    const row = input.closest('.cu-field') ?? input.parentElement?.parentElement
+    return row?.querySelector('.cu-field__hint')?.textContent ?? ''
+  }
+
+  it('names the Slack page holding the signing secret, on the field itself', () => {
+    renderPanel({ ccName: 'cc-slack', visibleChannelTypes: ['slack'] })
+    // Must be on the field, not only in the panel note below it: the note is a
+    // paragraph people skip, and this is the value they cannot locate.
+    expect(hintFor('Slack Signing Secret')).toMatch(/Basic Information/i)
+  })
+
+  it('warns the signing secret is absent from the post-install dialog', () => {
+    renderPanel({ ccName: 'cc-slack', visibleChannelTypes: ['slack'] })
+    expect(hintFor('Slack Signing Secret')).toMatch(/dialog|install/i)
+  })
+
+  it('names the Slack page holding the bot token, on the field itself', () => {
+    renderPanel({ ccName: 'cc-slack', visibleChannelTypes: ['slack'] })
+    expect(hintFor('Slack Bot User OAuth Token')).toMatch(/OAuth & Permissions/i)
   })
 })

--- a/control-ui/components/__tests__/ChannelCredentialsPanel.test.tsx
+++ b/control-ui/components/__tests__/ChannelCredentialsPanel.test.tsx
@@ -475,7 +475,9 @@ describe('ChannelCredentialsPanel — where the Slack credentials live', () => {
     renderPanel({ ccName: 'cc-slack', visibleChannelTypes: ['slack'] })
     // Must be on the field, not only in the panel note below it: the note is a
     // paragraph people skip, and this is the value they cannot locate.
-    expect(hintFor('Slack Signing Secret')).toMatch(/Basic Information/i)
+    // "Settings" matters: Slack's sidebar has Basic Information under Settings and
+    // a separate Features group, and the path is useless without the group name.
+    expect(hintFor('Slack Signing Secret')).toMatch(/Settings\s*(?:→|->|>)\s*Basic Information/i)
   })
 
   it('warns the signing secret is absent from the post-install dialog', () => {

--- a/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
@@ -545,6 +545,33 @@ describe('CreateCommunicationChannelPage — Slack app manifest', () => {
     expect(link.getAttribute('rel') ?? '').toMatch(/noreferrer|noopener/)
   })
 
+  it('warns that Slack will report the Request URL as unreachable until the channel exists', async () => {
+    // Inherent to handing the manifest over first: the reader authorises a Slack
+    // request by resolving the target channel's signing secret BEFORE answering
+    // the url_verification challenge, so a URL naming a channel that does not
+    // exist yet cannot verify. Slack shows "Your URL didn't respond" in orange the
+    // moment the manifest is saved, which reads as a broken setup unless the page
+    // says otherwise, and the fix is a Retry once the channel is created.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('support-bot')
+    fireEvent.change(document.getElementById('slack-bot-handle')!, {
+      target: { value: 'Evenfire' },
+    })
+    await screen.findByText(/display_information:/)
+
+    const panel = document.querySelector('.cu-channel-provider-panel')
+    const copy = panel?.textContent ?? ''
+    // Either apostrophe: the copy uses a typographic one, and which glyph it is
+    // has nothing to do with whether the warning is present.
+    expect(copy).toMatch(/did(?:n['’]t| not) respond|unreachable/i)
+    expect(copy).toMatch(/Retry/i)
+  })
+
   it('offers no manifest until the Slack App Name is set', async () => {
     // The app name is the manifest's display_information.name. Emitting one with a
     // placeholder would install an app under a name the operator never chose.

--- a/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
@@ -545,6 +545,30 @@ describe('CreateCommunicationChannelPage — Slack app manifest', () => {
     expect(link.getAttribute('rel') ?? '').toMatch(/noreferrer|noopener/)
   })
 
+  it('explains itself when the deployment has no public webhook address', async () => {
+    // Minikube and localhost: no env var and a non-app.* hostname, so
+    // webhookUrlForPath returns a bare path and no manifest can be generated. The
+    // edit page shows a warning naming the missing variable; rendering nothing
+    // here leaves the operator following a doc that promises a manifest, with no
+    // cause shown anywhere. jsdom's hostname is localhost, so simply not stubbing
+    // the env reproduces it.
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('support-bot')
+    fireEvent.change(document.getElementById('slack-bot-handle')!, {
+      target: { value: 'Evenfire' },
+    })
+
+    expect(screen.queryByText(/display_information:/)).not.toBeInTheDocument()
+    const panel = document.querySelector('.cu-channel-provider-panel')
+    expect(panel?.textContent ?? '').toMatch(
+      /NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL|no public webhook address/i
+    )
+  })
+
   it('offers no manifest until the Slack App Name is set', async () => {
     // The app name is the manifest's display_information.name. Emitting one with a
     // placeholder would install an app under a name the operator never chose.

--- a/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
@@ -521,6 +521,30 @@ describe('CreateCommunicationChannelPage — Slack app manifest', () => {
     expect(encoded.namespace).toBe('channels')
   })
 
+  it('links straight to Slack app creation, in a new tab', async () => {
+    // The manifest is only useful next to the page that consumes it, and that page
+    // is a different site. Sending the operator to find it themselves is the step
+    // this whole panel exists to remove. New tab, because the half-filled create
+    // form must survive the trip.
+    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
+    render(
+      <ToastProvider>
+        <CreateCommunicationChannelPage />
+      </ToastProvider>
+    )
+    await goToSlackProviderStep('support-bot')
+    fireEvent.change(document.getElementById('slack-bot-handle')!, {
+      target: { value: 'Evenfire' },
+    })
+    await screen.findByText(/display_information:/)
+
+    const link = screen.getByRole('link', { name: /create.*slack app/i })
+    expect(link).toHaveAttribute('href', 'https://api.slack.com/apps?new_app=1')
+    expect(link).toHaveAttribute('target', '_blank')
+    // Untrusted target: never hand it a live window.opener back to this form.
+    expect(link.getAttribute('rel') ?? '').toMatch(/noreferrer|noopener/)
+  })
+
   it('offers no manifest until the Slack App Name is set', async () => {
     // The app name is the manifest's display_information.name. Emitting one with a
     // placeholder would install an app under a name the operator never chose.

--- a/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
+++ b/control-ui/components/__tests__/CreateCommunicationChannelPage.test.tsx
@@ -545,33 +545,6 @@ describe('CreateCommunicationChannelPage — Slack app manifest', () => {
     expect(link.getAttribute('rel') ?? '').toMatch(/noreferrer|noopener/)
   })
 
-  it('warns that Slack will report the Request URL as unreachable until the channel exists', async () => {
-    // Inherent to handing the manifest over first: the reader authorises a Slack
-    // request by resolving the target channel's signing secret BEFORE answering
-    // the url_verification challenge, so a URL naming a channel that does not
-    // exist yet cannot verify. Slack shows "Your URL didn't respond" in orange the
-    // moment the manifest is saved, which reads as a broken setup unless the page
-    // says otherwise, and the fix is a Retry once the channel is created.
-    vi.stubEnv('NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL', 'https://webhook.example.com')
-    render(
-      <ToastProvider>
-        <CreateCommunicationChannelPage />
-      </ToastProvider>
-    )
-    await goToSlackProviderStep('support-bot')
-    fireEvent.change(document.getElementById('slack-bot-handle')!, {
-      target: { value: 'Evenfire' },
-    })
-    await screen.findByText(/display_information:/)
-
-    const panel = document.querySelector('.cu-channel-provider-panel')
-    const copy = panel?.textContent ?? ''
-    // Either apostrophe: the copy uses a typographic one, and which glyph it is
-    // has nothing to do with whether the warning is present.
-    expect(copy).toMatch(/did(?:n['’]t| not) respond|unreachable/i)
-    expect(copy).toMatch(/Retry/i)
-  })
-
   it('offers no manifest until the Slack App Name is set', async () => {
     // The app name is the manifest's display_information.name. Emitting one with a
     // placeholder would install an app under a name the operator never chose.

--- a/control-ui/lib/__tests__/slackAppManifest.test.ts
+++ b/control-ui/lib/__tests__/slackAppManifest.test.ts
@@ -120,6 +120,32 @@ describe('slackAppManifest', () => {
   })
 })
 
+describe('slackAppManifest — direct messages', () => {
+  const yaml = slackAppManifest('Evenfire', URL)
+
+  // Slack defaults messages_tab_enabled to false, and an app installed from a
+  // manifest that says nothing about app_home has DMs switched off: the member
+  // sees "Sending messages to this app has been turned off." That breaks the
+  // documented enrolment path, which tells people to send `verify 123456` as a
+  // DM, and it contradicts this same manifest asking for im:history and im:read.
+  it('enables the messages tab so the app can be DMed', () => {
+    expect(yaml).toContain('app_home:')
+    expect(yaml).toMatch(/messages_tab_enabled:\s*true/)
+  })
+
+  it('does not make the messages tab read-only', () => {
+    // Read-only leaves the tab visible but still refuses the member's message,
+    // which looks identical to the bug it is meant to fix.
+    expect(yaml).toMatch(/messages_tab_read_only_enabled:\s*false/)
+  })
+
+  it('keeps the DM scopes it already requests meaningful', () => {
+    const scopes = listItemsUnder(yaml, 'bot:')
+    expect(scopes).toContain('im:history')
+    expect(scopes).toContain('im:read')
+  })
+})
+
 describe('canGenerateSlackAppManifest', () => {
   it('accepts an absolute request URL', () => {
     expect(canGenerateSlackAppManifest(URL)).toBe(true)

--- a/control-ui/lib/slackAppManifest.ts
+++ b/control-ui/lib/slackAppManifest.ts
@@ -61,6 +61,10 @@ export function slackAppManifest(appName: string, requestUrl: string): string {
   return `display_information:
   name: ${name}
 features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: ${name}
     always_online: false

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.410",
+  "version": "0.1.411",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.410",
+      "version": "0.1.411",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.411",
+  "version": "0.1.412",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.411",
+      "version": "0.1.412",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.412",
+      "version": "0.1.413",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.405",
+  "version": "0.1.406",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.405",
+      "version": "0.1.406",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.407",
+  "version": "0.1.408",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.407",
+      "version": "0.1.408",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.409",
+  "version": "0.1.410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.409",
+      "version": "0.1.410",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.408",
+  "version": "0.1.409",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.408",
+      "version": "0.1.409",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.406",
+  "version": "0.1.407",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.406",
+      "version": "0.1.407",
       "dependencies": {
         "@clerum/llm-providers": "file:../packages/llm-providers",
         "@clerum/workflow-recipe-capability-policy": "file:../packages/workflow-recipe-capability-policy",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.405",
+  "version": "0.1.406",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.409",
+  "version": "0.1.410",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.410",
+  "version": "0.1.411",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.408",
+  "version": "0.1.409",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.406",
+  "version": "0.1.407",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.411",
+  "version": "0.1.412",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.412",
+  "version": "0.1.413",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.407",
+  "version": "0.1.408",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Use this index for long-form docs.
 | Doc                                                                           | Description                                                |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | [Connect Telegram](how-to/connect-telegram.md)                                | Minikube env or CRD channel path                           |
+| [Connect Slack](how-to/connect-slack.md)                                      | Slack app scopes, request URL, conversation verification   |
 | [Configure approvals](how-to/configure-approvals.md)                          | Human-in-the-loop tool gates                               |
 | [Add an MCP server](how-to/add-mcp-server.md)                                 | Dev-mode JSON or CRD allowlist path                        |
 | [LLM providers overview](llm-providers/README.md)                             | Which providers are supported and how they fit together    |

--- a/docs/how-to/configure-approvals.md
+++ b/docs/how-to/configure-approvals.md
@@ -104,7 +104,8 @@ stay approval-required by default regardless of what is set here. See
 | Control plane APIs | Automation and integration tests |
 
 Channel callbacks are signature-verified; unauthorized actors cannot mint
-approvals by replaying chat.
+approvals by replaying chat. Wiring a chat surface up:
+[Connect Telegram](connect-telegram.md), [Connect Slack](connect-slack.md).
 
 ## Verify
 

--- a/docs/how-to/connect-slack.md
+++ b/docs/how-to/connect-slack.md
@@ -10,7 +10,12 @@ as an Events API callback on `webhook-proxy`, which hands it to
 able to reach your cluster before anything works, including the setup code you
 send to link your account.
 
-## Create the Slack app
+## Create the Slack app, the long way
+
+> Start at [In the Control UI](#in-the-control-ui) instead. It hands you a
+> manifest that does every step below in one paste, including the two Request
+> URLs and the Messages Tab that are easiest to miss. This section is here for
+> repairing an existing app, or for setting one up without the Control UI.
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps), **Create New App**,
    **From scratch**, and pick the workspace.
@@ -30,20 +35,35 @@ send to link your account.
 
 3. Under **Event Subscriptions**, enable events and subscribe to these bot
    events: `app_mention`, `message.channels`, `message.groups`, `message.im`,
-   `message.mpim`. Leave the Request URL for now, you get it in the next
-   section.
-4. **Install to Workspace**, then copy the **Bot User OAuth Token** (`xoxb-…`).
-5. Under **Basic Information**, copy the **Signing Secret**.
-6. In Slack, invite the app to the channel you want it in (`/invite @YourApp`),
+   `message.mpim`, and set the Request URL from the channel's edit page.
+4. Under **Interactivity & Shortcuts**, set the **same** Request URL. Separate
+   page, separate Save button. Skipping it leaves approval buttons dead.
+5. Under **Features → App Home → Show Tabs**, enable the **Messages Tab** and
+   tick "Allow users to send Slash commands and messages from the messages tab",
+   or the app refuses DMs and `verify <code>` cannot be sent.
+6. **Install to Workspace**, then copy the **Bot User OAuth Token** (`xoxb-…`)
+   from **Features → OAuth & Permissions**.
+7. Copy the **Signing Secret** from **Settings → Basic Information → App
+   Credentials**.
+8. In Slack, invite the app to the channel you want it in (`/invite @YourApp`),
    or open a DM with it.
 
-Steps 1 and 2 are faster from a manifest. **Create New App** → **From an app
-manifest**, then paste:
+**Do not build the app by hand.** The Control UI generates a manifest carrying
+all of this, both Request URLs already filled in, and you get it before the
+channel exists. Skip to [In the Control UI](#in-the-control-ui) and come back
+here only if you want to know what the manifest contains or you are building an
+app without the Control UI.
+
+The generated manifest looks like this:
 
 ```yaml
 display_information:
   name: Evenfire
 features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: Evenfire
     always_online: false
@@ -68,54 +88,84 @@ settings:
   token_rotation_enabled: false
 ```
 
-The manifest deliberately omits `event_subscriptions` and `interactivity`.
-Slack verifies a Request URL the moment you save one, and that URL does not
-exist until the channel is created below.
+The generated manifest also sets `settings.event_subscriptions.request_url` and
+`settings.interactivity.request_url` to this channel's URL, which the block above
+omits because it depends on the channel. Those two are the reason to use the
+generated one: Slack keeps them on separate pages with separate Save buttons, and
+setting only Event Subscriptions leaves approval buttons dead with nothing in the
+logs.
+
+`app_home.messages_tab_enabled` matters more than it looks. Slack defaults it to
+**false**, and an app installed from a manifest that says nothing about
+`app_home` refuses direct messages with *"Sending messages to this app has been
+turned off."* That breaks [Confirm your Slack identity](#confirm-your-slack-identity),
+which asks you to DM the app. **If your app was created before this was added,
+switch it on by hand: Features → App Home → Show Tabs → Messages Tab, and tick
+"Allow users to send Slash commands and messages from the messages tab".**
 
 Two things to know about credentials:
 
 - The "app is ready" dialog offers a **Bot token** (`xoxb-…`) and an **App
   token** (`xapp-…`). Only the bot token is used. The `xapp-` token is for
   Socket Mode, which this platform does not use.
-- The **Signing Secret** is not in that dialog. It lives under **Basic
-  Information → App Credentials**, as a 32-character hex string. It is not the
-  Client Secret.
+- The **Signing Secret** is not in that dialog. It lives under **Settings →
+  Basic Information → App Credentials**, as a 32-character hex string. It is not
+  the Client Secret sitting directly above it. The bot token lives elsewhere
+  again, under **Features → OAuth & Permissions**.
 
 ## In the Control UI
 
 External Channels → `/external-channels` → **Create** builds the
 `CommunicationChannel` resource.
 
-> **Create a dedicated channel. Do not add Slack to an existing Telegram or
-> email channel.** Adding a Slack App Name to a channel whose Secret holds only
-> another provider's credentials is currently accepted on update, and produces a
-> channel that advertises Slack, shows a Slack Request URL, and appears in the
-> Profile UI as a target, but answers every Slack request with
-> `409 slack_signing_secret_missing`.
+> **Use a dedicated channel for Slack.** Adding Slack to a channel whose Secret
+> holds only another provider's credentials is now refused with a `400` naming
+> the missing key, so you cannot create the half-configured state that used to
+> answer every Slack request with `409 slack_signing_secret_missing`. Editing a
+> channel that already has Slack is unaffected.
 
-1. Pick the host, then the **Slack** provider.
-2. Set **Slack App Name**. It is required, and it is what users are told to
-   message, so use the app's real name.
-3. Toggles:
+Do not go to Slack first. The manifest is here, and it needs nothing from Slack:
+
+1. Name the channel and pick the host.
+2. Choose the **Slack** provider.
+3. Set **Slack App Name**. It is required, it becomes the manifest's
+   `display_information.name`, and it is what users are told to message.
+4. Toggles:
    - **Only reply when mentioned** (on by default). In a channel the app then
      only acts on `app_mention` events and messages that start with a mention.
      DMs always work, and `/approve` and `/deny` are always accepted.
    - **Reply in threads**: replies go in a thread on the triggering message.
-4. Paste the **Slack signing secret** and the **Slack Bot User OAuth token** as
-   write-only credentials. This writes a Secret in the `channels` namespace and
-   points `spec.credentialsSecretRef` at it.
-5. Grant access to the users and teams allowed on this channel.
+5. **The Slack App Manifest appears.** Copy it, follow the link to Slack, and
+   build the app from it — **Create New App** → **From an app manifest** → pick
+   the workspace → paste. It sets the scopes, the five bot events and both
+   Request URLs. Then **Install to Workspace** and collect the two credentials.
+6. Back in the still-open form, paste the **Slack signing secret** and the
+   **Slack Bot User OAuth token** as write-only credentials. This writes a Secret
+   in the `channels` namespace and points `spec.credentialsSecretRef` at it.
+7. Grant access to the users and teams allowed on this channel, and save.
+
+The Request URLs the manifest carries encode the channel **name**, so the channel
+has to be created under the name you had typed when you copied it. Rename before
+saving and the app points at a channel that never exists.
+
+Finally, invite the app to the channel you want it in (`/invite @YourApp`).
 
 `spec.slack[]` starts empty. Conversations are added when users confirm them,
-not by hand.
+not by hand — which is why an unlinked sender gets the notice described in
+[Confirm your Slack identity](#confirm-your-slack-identity) rather than silence.
 
-### Get the Request URL, from the right channel
+### If you are pasting a Request URL by hand
 
-Reopen the channel you just created and copy the **Slack Request URL** from its
-edit page. Paste it into the Slack app as both the **Event Subscriptions**
-request URL and the **Interactivity & Shortcuts** request URL. Slack's
-`url_verification` handshake is answered for you, so the URL verifies on its own
-once it is reachable.
+You should not have to. The manifest carries both Request URLs, and an app built
+from it needs no URL pasted anywhere. This section is for repairing an app that
+was set up before the manifest existed, or one pointed at the wrong channel.
+
+The **Slack Request URL** is on the channel's edit page. It goes in **two**
+places in Slack, each with its own Save button: **Event Subscriptions** and
+**Interactivity & Shortcuts**. Setting only the first is the classic failure —
+messages work, approval buttons are dead, and nothing appears in the logs.
+Slack's `url_verification` handshake is answered for you, so a reachable URL
+verifies on its own.
 
 The URL is per channel, and the page renders the URL of whichever channel you
 are looking at. Copying from the wrong channel's page is the single easiest

--- a/docs/how-to/connect-slack.md
+++ b/docs/how-to/connect-slack.md
@@ -48,24 +48,18 @@ send to link your account.
 8. In Slack, invite the app to the channel you want it in (`/invite @YourApp`),
    or open a DM with it.
 
-**Do not build the app by hand.** The Control UI generates a manifest carrying
-all of this, both Request URLs already filled in, and you get it before the
-channel exists. Skip to [In the Control UI](#in-the-control-ui) and come back
-here only if you want to know what the manifest contains or you are building an
-app without the Control UI.
-
-The generated manifest looks like this:
+For reference, the manifest the Control UI generates looks like this:
 
 ```yaml
 display_information:
-  name: Evenfire
+  name: "Evenfire"
 features:
   app_home:
     home_tab_enabled: false
     messages_tab_enabled: true
     messages_tab_read_only_enabled: false
   bot_user:
-    display_name: Evenfire
+    display_name: "Evenfire"
     always_online: false
 oauth_config:
   scopes:
@@ -187,11 +181,14 @@ Two Slack-side traps when pasting it:
 - **The field truncates on screen**, often exactly where two channels' URLs
   diverge. Press `End` in the field to see the tail before saving.
 
-Slack does not prompt for a reinstall after you subscribe to the bot events
-above, because the manifest already granted the scopes those events need. That
-is expected, not a failure. If you want one anyway: **Settings → Install App →
-Reinstall to Workspace**, then re-check the bot token, since a reinstall can
-issue a new one.
+Whether Slack prompts for a reinstall after you subscribe to the bot events
+depends on how the app was built. An app installed from the generated manifest
+already holds the scopes those events need, so no prompt appears and that is
+expected. An app built by hand **does** need the matching `*:history` scopes
+granted, and without a reinstall the subscription is accepted while no message
+event ever arrives. If you are repairing such an app, reinstall deliberately
+rather than waiting to be asked: **Settings → Install App → Reinstall to
+Workspace**, then re-check the bot token, since a reinstall can issue a new one.
 
 ## On minikube (quickstart stack)
 
@@ -199,18 +196,30 @@ Complete the [Quickstart](../get-started/quickstart.md) first so the platform
 runs.
 
 There is no `.env` shortcut for Slack. `CLERUM_SLACK_BOT_TOKEN` is read only by
-`channel-reader`'s dev-mode resolver when the process runs outside the cluster,
-and is ignored in-cluster, where credentials come from
-`spec.credentialsSecretRef` only. It changes where the token is read from and
-nothing else: Slack is webhook-driven either way, and no code path polls it.
+`channel-reader`'s `DevCredentialsResolver`, and the switch is
+**`CLERUM_DEV_MODE=true`**, not whether the process runs in a cluster
+(`channel-reader/src/credentials.ts`). Setting dev mode on an in-cluster
+deployment therefore does resolve every CommunicationChannel to the same
+env-supplied token. It also only supplies the bot token — there is no
+`CLERUM_SLACK_SIGNING_SECRET`, so the dev path cannot verify a single inbound
+Slack request, which is why real use always comes from
+`spec.credentialsSecretRef`.
 
 The bigger constraint is reachability. `webhook-proxy` runs in the
 `webhook-ingress` namespace on port 8095, and the base manifests ship no
 Ingress for it (production fronts it with cloudflared). A local minikube is not
 reachable from Slack, so expose the proxy through a public tunnel and use
-`<your-public-base>/webhooks/slack/<targetId>` as the Request URL. The Control
-UI only prints the path when `NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL` is
-unset, so prefix it with your own public base.
+`<your-public-base>/webhooks/slack/<targetId>` as the Request URL.
+
+The Control UI resolves that base in two steps: it uses
+`NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL` when set, and otherwise derives
+`webhook.<domain>` from the page's own hostname when that hostname starts with
+`app.`. Only when **neither** applies — the usual minikube and `localhost` case
+— does it fall back to a bare path, and then the Slack panel shows a warning
+instead of a manifest, because a relative `request_url` is invalid to Slack.
+That is the case where you prefix the path with your own public base by hand.
+On an `app.<domain>` deployment the URL is already absolute; prefixing it again
+produces a Request URL Slack cannot verify.
 
 Without that, the Slack app installs fine and the channel saves fine, but no
 message ever arrives.

--- a/docs/how-to/connect-slack.md
+++ b/docs/how-to/connect-slack.md
@@ -1,0 +1,376 @@
+# How to: connect Slack
+
+Reach an evenfire agent from Slack.
+
+Slack works differently from Telegram. Telegram is polled: `channel-reader`
+long-polls the bot and nothing has to reach your cluster. Slack is pushed:
+`channel-reader` skips Slack polling entirely, and every Slack message arrives
+as an Events API callback on `webhook-proxy`, which hands it to
+`workflow-approval-request-reader` and on to `channel-reader`. Slack has to be
+able to reach your cluster before anything works, including the setup code you
+send to link your account.
+
+## Create the Slack app
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps), **Create New App**,
+   **From scratch**, and pick the workspace.
+2. Under **OAuth & Permissions**, add these **Bot Token Scopes**:
+
+   | Scope                                                              | Used for                                                            |
+   | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+   | `app_mentions:read`                                                | receiving `app_mention` events                                      |
+   | `channels:history`, `groups:history`, `im:history`, `mpim:history` | receiving `message` events from channels, private channels, and DMs |
+   | `chat:write`                                                       | posting and editing replies (`chat.postMessage`, `chat.update`)     |
+   | `files:write`                                                      | delivering workflow result documents (`files.uploadV2`)             |
+   | `channels:read`, `groups:read`, `im:read`, `mpim:read`             | reading conversation metadata at link time (`conversations.info`)   |
+   | `users:read`                                                       | naming DM conversations at link time (`users.info`)                 |
+
+   Drop the `im` / `mpim` entries if the agent will only live in channels, and
+   the `groups` entries if only public channels are in play.
+
+3. Under **Event Subscriptions**, enable events and subscribe to these bot
+   events: `app_mention`, `message.channels`, `message.groups`, `message.im`,
+   `message.mpim`. Leave the Request URL for now, you get it in the next
+   section.
+4. **Install to Workspace**, then copy the **Bot User OAuth Token** (`xoxb-…`).
+5. Under **Basic Information**, copy the **Signing Secret**.
+6. In Slack, invite the app to the channel you want it in (`/invite @YourApp`),
+   or open a DM with it.
+
+Steps 1 and 2 are faster from a manifest. **Create New App** → **From an app
+manifest**, then paste:
+
+```yaml
+display_information:
+  name: Evenfire
+features:
+  bot_user:
+    display_name: Evenfire
+    always_online: false
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - groups:history
+      - im:history
+      - mpim:history
+      - channels:read
+      - groups:read
+      - im:read
+      - mpim:read
+      - chat:write
+      - files:write
+      - users:read
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false
+```
+
+The manifest deliberately omits `event_subscriptions` and `interactivity`.
+Slack verifies a Request URL the moment you save one, and that URL does not
+exist until the channel is created below.
+
+Two things to know about credentials:
+
+- The "app is ready" dialog offers a **Bot token** (`xoxb-…`) and an **App
+  token** (`xapp-…`). Only the bot token is used. The `xapp-` token is for
+  Socket Mode, which this platform does not use.
+- The **Signing Secret** is not in that dialog. It lives under **Basic
+  Information → App Credentials**, as a 32-character hex string. It is not the
+  Client Secret.
+
+## In the Control UI
+
+External Channels → `/external-channels` → **Create** builds the
+`CommunicationChannel` resource.
+
+> **Create a dedicated channel. Do not add Slack to an existing Telegram or
+> email channel.** Adding a Slack App Name to a channel whose Secret holds only
+> another provider's credentials is currently accepted on update, and produces a
+> channel that advertises Slack, shows a Slack Request URL, and appears in the
+> Profile UI as a target, but answers every Slack request with
+> `409 slack_signing_secret_missing`.
+
+1. Pick the host, then the **Slack** provider.
+2. Set **Slack App Name**. It is required, and it is what users are told to
+   message, so use the app's real name.
+3. Toggles:
+   - **Only reply when mentioned** (on by default). In a channel the app then
+     only acts on `app_mention` events and messages that start with a mention.
+     DMs always work, and `/approve` and `/deny` are always accepted.
+   - **Reply in threads**: replies go in a thread on the triggering message.
+4. Paste the **Slack signing secret** and the **Slack Bot User OAuth token** as
+   write-only credentials. This writes a Secret in the `channels` namespace and
+   points `spec.credentialsSecretRef` at it.
+5. Grant access to the users and teams allowed on this channel.
+
+`spec.slack[]` starts empty. Conversations are added when users confirm them,
+not by hand.
+
+### Get the Request URL, from the right channel
+
+Reopen the channel you just created and copy the **Slack Request URL** from its
+edit page. Paste it into the Slack app as both the **Event Subscriptions**
+request URL and the **Interactivity & Shortcuts** request URL. Slack's
+`url_verification` handshake is answered for you, so the URL verifies on its own
+once it is reachable.
+
+The URL is per channel, and the page renders the URL of whichever channel you
+are looking at. Copying from the wrong channel's page is the single easiest
+mistake to make here, and the resulting failure says nothing about which channel
+it hit. The tail of the URL is a base64url blob that decodes to the channel
+name, so you can always check what you have:
+
+```bash
+node -e 'console.log(Buffer.from(process.argv[1].replace(/-/g,"+").replace(/_/g,"/"),"base64").toString())' \
+  "<the part after slack%3A>"
+# → {"namespace":"channels","name":"slack-support"}
+```
+
+Two Slack-side traps when pasting it:
+
+- **Retry does not re-read the field.** It re-sends to the URL Slack already
+  stored, so a Retry after fixing nothing hits the old URL forever. Select the
+  field, clear it, paste the new value, and let it lose focus.
+- **The field truncates on screen**, often exactly where two channels' URLs
+  diverge. Press `End` in the field to see the tail before saving.
+
+Slack does not prompt for a reinstall after you subscribe to the bot events
+above, because the manifest already granted the scopes those events need. That
+is expected, not a failure. If you want one anyway: **Settings → Install App →
+Reinstall to Workspace**, then re-check the bot token, since a reinstall can
+issue a new one.
+
+## On minikube (quickstart stack)
+
+Complete the [Quickstart](../get-started/quickstart.md) first so the platform
+runs.
+
+There is no `.env` shortcut for Slack. `CLERUM_SLACK_BOT_TOKEN` is read only by
+`channel-reader`'s dev-mode resolver when the process runs outside the cluster,
+and is ignored in-cluster, where credentials come from
+`spec.credentialsSecretRef` only. It changes where the token is read from and
+nothing else: Slack is webhook-driven either way, and no code path polls it.
+
+The bigger constraint is reachability. `webhook-proxy` runs in the
+`webhook-ingress` namespace on port 8095, and the base manifests ship no
+Ingress for it (production fronts it with cloudflared). A local minikube is not
+reachable from Slack, so expose the proxy through a public tunnel and use
+`<your-public-base>/webhooks/slack/<targetId>` as the Request URL. The Control
+UI only prints the path when `NEXT_PUBLIC_WORKFLOW_APPROVAL_READER_BASE_URL` is
+unset, so prefix it with your own public base.
+
+Without that, the Slack app installs fine and the channel saves fine, but no
+message ever arrives.
+
+## Any cluster (CRD path)
+
+Deploy the stack ([Minikube guide](../deploy/minikube.md) for local). Slack is
+declared as a `CommunicationChannel` bound to a `Host`, with the bot token and
+signing secret in a Secret in the `channels` namespace.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cc-slack-support-credentials
+  namespace: channels
+type: Opaque
+stringData:
+  slack-bot-token: 'xoxb-…'
+  slack-signing-secret: '…'
+---
+apiVersion: clerum.io/v1alpha1
+kind: CommunicationChannel
+metadata:
+  name: slack-support
+  namespace: channels
+spec:
+  hostRef: 'chatllm'
+  credentialsSecretRef:
+    name: cc-slack-support-credentials
+  slackSettings:
+    botHandle: 'Evenfire'
+    replyOnlyWhenMentioned: true
+    replyInThreads: false
+  slack:
+    - channelId: 'C0123456789' # stable channel ID, not a display name
+      workspaceId: 'T0123456789'
+      userIds:
+        - 'U0123456789'
+```
+
+Point `Host.spec.channels` at the channel. Every `slack[]` entry needs either
+`userIds` plus `workspaceId`, or the legacy `userNames`; a bare `channelId` is
+rejected by the CRD's `anyOf`. See the
+[CRD reference](../crds/communicationchannel.md) and
+[examples](../../charts/clerum-crds/examples/channels.yaml).
+
+## Confirm your Slack identity
+
+**Do this before trying to chat.** Until a conversation is confirmed, the agent
+answers nothing. `channel-reader` calls `authorizeProviderMessage` on every
+inbound message and drops anything it cannot tie to a linked identity, logging
+`Ignoring unauthorized slack message from <user> in <channel>`. The bot looks
+dead, but the events are arriving and being refused. `verify` is the only thing
+that works in an unconfirmed conversation.
+
+Slack conversations are bound to a user rather than configured by hand. Each
+person does this once per conversation:
+
+1. In the Profile UI, open the Slack verification panel
+   (`/settings/social/slack`) and start verification. It issues a six-digit
+   code.
+2. In Slack, send the code to the app:
+
+   ```text
+   verify 123456
+   ```
+
+   Send it as a DM, or mention the app in a channel
+   (`@YourApp verify 123456`). Do not put a leading slash on `verify`: Slack
+   treats it as a slash command and never delivers it.
+
+3. The app replies `Slack identity confirmed.` control-api appends the
+   conversation to `spec.slack[]` with your Slack user ID, the workspace ID,
+   the conversation type and title, and who confirmed it, and fills in
+   `slackSettings.workspaceId` if it was empty.
+
+The `userIds` plus `workspaceId` pair recorded here is the only identity form
+valid for workflow approval decisions. Legacy `userNames` groups are a chat-only
+allowlist and are rejected as approval identity.
+
+## Talk to the agent
+
+Message the app in a confirmed conversation. In a DM any message reaches the
+agent. In a channel, with the default **Only reply when mentioned**, mention the
+app. `workflow-approval-request-reader` verifies the Slack signature, hands the
+message to `channel-reader`, and `channel-reader` forwards it to `mcp-host` and
+posts the reply back with the bot token.
+
+**Threads are not exempt from the mention rule.** With **Reply in threads** on,
+the agent answers inside a thread, but a reply you write in that thread still
+needs a mention while **Only reply when mentioned** is set. The gate
+(`workflow-approval-request-reader/src/server.ts:295-307`) accepts only
+`app_mention` events, messages whose text starts with a mention, and
+`/approve` / `/deny`. Thread identity is used to decide where to post a reply,
+never whether to accept one. If threaded back-and-forth without tagging is what
+you want, turn **Only reply when mentioned** off, and accept that the agent then
+sees every message in that conversation. DMs never need a mention either way.
+
+## Approvals over Slack
+
+**Enable Interactivity & Shortcuts with the same Request URL as Event
+Subscriptions, and press its own Save Changes button.** The reader serves both
+on one route, `POST /webhooks/{medium}/{targetId}`
+(`workflow-approval-request-reader/src/server.ts:709-721`), so the URL is
+identical. If Interactivity is unset, Slack refuses to deliver `block_actions`
+at all: the click dies in Slack, nothing reaches the cluster, and every service
+log stays silent. Slack marks the buttons with a warning tooltip reading "This
+app is not configured to handle interactive responses."
+
+A tool approval posts **three** buttons, not two
+(`channel-reader/src/main.ts:154-186`):
+
+| Button             | Value      | Effect on the conversation                                                     |
+| ------------------ | ---------- | ------------------------------------------------------------------------------ |
+| **Approve**        | `tool:a:…` | Runs the call, and auto-approves `*` plus, for MCP tools, that server's prefix |
+| **Always approve** | `tool:l:…` | Same, and additionally stores the bare tool name for future turns              |
+| **Deny**           | `tool:d:…` | Cancels the call and releases the session                                      |
+
+The value is `tool:<a|l|d>:<16-char token>`
+(`main.ts:110-121`, matched by `decisionHandler.ts:93`). Typing `/approve`,
+`/approve always`, or `/deny` works too.
+
+Three properties of that token that produce confusing failures:
+
+- It lives in `channel-reader`'s memory with a 10-minute TTL
+  (`main.ts:95`). Clicking later returns "No pending approval found".
+- Any `channel-reader` restart wipes it, and **saving an edit to the channel in
+  the Control UI restarts that pod**. Approve after such a save and the click is
+  already dead.
+- Auto-approvals are per conversation
+  (`mcp-host/src/core/conversation/conversation.ts:482-493`), so approving in
+  the desktop app does not carry to Slack. There is no cross-surface rescue
+  either: `mcp-host/src/server/routes.ts:433-435` forces `channelType='rpc'` for
+  desktop callers, so a Slack-originated approval fails binding validation
+  there.
+
+Slack is enabled as an approval medium by default
+(`WORKFLOW_APPROVAL_READER_ENABLED_MEDIA` is `telegram,slack,teams`). See
+[Configure approvals](configure-approvals.md).
+
+### An unanswered approval stalls that conversation
+
+When a tool needs approval the session is suspended, and every later message in
+that same conversation queues behind it
+(`mcp-host/src/session/sessionProcessor.ts:196-204`). The reported symptom is
+"the agent stopped responding", which sends people hunting for a connection
+fault that is not there. `channel-reader` logs the giveaway:
+`Queue: 3 pending, 1 processing`.
+
+The scope is one session, not the host. `pickNextReadySession` skips only
+suspended session keys, so other conversations keep running. Approving or
+denying releases it (`releaseSuspendedSession`). Server-side expiry of the
+approval itself is off by default (`CLERUM_APPROVAL_TIMEOUT` is `0`), so with a
+misconfigured Slack app the stall persists until the durable pending row ages
+out, 7 days by default (`CLERUM_PENDING_APPROVAL_TTL_HOURS`), or the pod
+restarts and the boot reaper clears it.
+
+To clear a stuck request without waiting, deny it from inside the
+`channel-reader` pod, the only legitimate edge caller. The image has no curl,
+so use node:
+
+```
+POST http://<host>.mcp-host.svc.cluster.local:8080/v1/runtime/approvals/deny
+  x-clerum-edge-caller: channel-reader
+  x-clerum-edge-host-ref: <host>
+  x-clerum-edge-channel-type: slack
+  x-clerum-edge-channel-id: <C…>
+  x-clerum-edge-sender: <U…>
+
+{"userId":"<U…>","requestId":"<uuid>","channelType":"slack","channelId":"<C…>"}
+```
+
+The header and body channel triple must match (`mcp-host/src/server/routes.ts:66-81`).
+A `{"success":true}` moves the task to `completed` and drains the queue.
+
+## Troubleshooting
+
+Diagnose from the two services in the path. Everything below is visible there
+before it is visible anywhere else:
+
+```bash
+# Did Slack reach us, and did the signature check pass?
+kubectl -n channels logs deploy/clerum-workflow-approval-request-reader --since=15m | grep -i slack
+
+# Did the message get accepted, or dropped at the identity gate?
+kubectl -n channels logs deploy/channel-reader-<host> --since=15m | grep -iE "New message from slack|unauthorized"
+```
+
+A silent reader log means Slack never called. The `targetId` in a reader warning
+decodes to the channel that was hit, which is how you catch a wrong Request URL.
+
+| Symptom                                          | Cause and check                                                                                                                                                                        |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Slack: "didn't respond with the challenge value" | Read the reader log. The `targetId` tells you which channel Slack actually hit, and the status tells you why it failed                                                                 |
+| `409 slack_signing_secret_missing`               | The URL points at a channel whose Secret has no `slack-signing-secret`, almost always the wrong channel's Request URL                                                                  |
+| `401 invalid_provider_signature`                 | Right channel, wrong secret. Re-copy the Signing Secret from **Basic Information**, not the Client Secret                                                                              |
+| `404` / `400 invalid_target_id`                  | Malformed or truncated URL, usually a partial paste                                                                                                                                    |
+| Retrying in Slack changes nothing                | Retry re-sends to the stored URL. Clear the field and paste the new one                                                                                                                |
+| Nothing arrives at all                           | Is the Request URL public and verified? Slack pushes, nothing is polled                                                                                                                |
+| Slack cannot verify the Request URL              | The URL must reach `webhook-proxy` (`webhook-ingress`, port 8095) from the internet                                                                                                    |
+| `Ignoring unauthorized slack message`            | The conversation is not confirmed. Run the `verify` flow first, chat is gated on a linked identity                                                                                     |
+| App answers only when tagged                     | `replyOnlyWhenMentioned` is on by default, and thread replies are not exempt                                                                                                           |
+| Missing message events                           | Subscribe to `message.channels` / `message.groups` / `message.im` / `message.mpim` and `app_mention`                                                                                   |
+| `verify` never lands                             | Sent with a leading slash (`/verify`), so Slack intercepted it. Send `verify 123456`                                                                                                   |
+| Verification fails                               | Code expired or already used; issue a new one from the Profile UI                                                                                                                      |
+| Events arrive but replies fail                   | Bot token wrong or stale. A reinstall can issue a new `xoxb-`; update it on the channel                                                                                                |
+| Two identical app names when verifying           | Two channels on the host both have Slack enabled. Only one has credentials. Clear the Slack App Name on the wrong one                                                                  |
+| Approval buttons do nothing                      | Interactivity & Shortcuts has no Request URL. Slack blocks the click itself, so the reader log is completely silent. Its tooltip says "not configured to handle interactive responses" |
+| "No pending approval found" on click             | The 10-minute token expired, or `channel-reader` restarted. Saving a channel edit in the Control UI restarts it                                                                        |
+| Agent stopped responding to Slack entirely       | An unanswered approval suspended that conversation. Look for `Queue: N pending, 1 processing`, then approve, deny, or clear it as above                                                |
+
+More FAQ: [FAQ](../faq.md).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,6 +31,7 @@
 ## How-to
 
 - Connect Telegram: how-to/connect-telegram.md
+- Connect Slack (app scopes, request URL, verify flow, approval buttons): how-to/connect-slack.md
 - Configure approvals: how-to/configure-approvals.md
 - Add MCP server: how-to/add-mcp-server.md
 - LLM providers overview (the 21 providers, mental model, support matrix): llm-providers/README.md


### PR DESCRIPTION
## What was wrong

`.cu-field__label` is used in four places and **is not defined anywhere in `globals.css`**. The `Field` primitive styles a bare `<label>` descendant (`.cu-field label`), so a `<span className="cu-field__label">` matches no rule at all and falls back to body type — larger than the inputs it sits above, wrong weight, wrong colour, and title case beside the uppercase labels of every real field.

Affected captions:

- `Slack Request URL` — edit page (pre-existing)
- `Slack App Manifest` — edit page (pre-existing)
- `Teams Request URL` — edit page (pre-existing)
- `Slack App Manifest` — create page (#331)

Not introduced by #331. It became visible there because the manifest block put the caption directly beneath a real field label, where the mismatch is impossible to miss.

## The fix

One selector, all four sites. Fixed in CSS rather than at the call sites deliberately: these caption a block that is **not a form control** — a URL or a generated manifest inside a `<pre>`. A `<label>` would be the wrong element there. It would label nothing and assert an association with a control that does not exist, which is worse for assistive tech than the visual bug it would fix.

## Not in scope

An audit of all 1004 `cu-` classes against the stylesheet found **27 undefined**, this one included. The rest are left alone — some are likely deliberately inert BEM roots whose modifiers carry the styling, and the widest ones (`cu-table__row` across 14 files, `cu-btn--secondary` across 4) deserve their own change with their own regression surface.

`cu-btn--secondary` is worth a look on its own: a `Button` primitive with a `secondary` variant already exists, so those four call sites appear to be hand-rolling a button, which the control-ui guidance explicitly says not to do.

A follow-up worth having: a test that fails when a `cu-` class used in TSX has no matching rule. Phantom classes are invisible — this one shipped three times before anyone noticed.

## Verification

control-ui 139 files / 1406 tests green, `tsc --noEmit` clean. The `max-height: 18rem` cap on the manifest `<pre>` was already correct and is untouched.