### PR TITLE
chore(release): promote v0.7.0 to main

### DIFF
--- a/deploy/components/ghcr-images/kustomization.yaml
+++ b/deploy/components/ghcr-images/kustomization.yaml
@@ -31,70 +31,70 @@ configurations:
 images:
   - name: clerum/channel-reader
     newName: ghcr.io/evenfire-ai/channel-reader
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/workflow-approval-request-reader
     newName: ghcr.io/evenfire-ai/workflow-approval-request-reader
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/control-api
     newName: ghcr.io/evenfire-ai/control-api
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/control-ui
     newName: ghcr.io/evenfire-ai/control-ui
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/external-rest-api
     newName: ghcr.io/evenfire-ai/external-rest-api
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/host-context-controller
     newName: ghcr.io/evenfire-ai/host-context-controller
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mcp-host
     newName: ghcr.io/evenfire-ai/mcp-host
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mcp-host-slim
     newName: ghcr.io/evenfire-ai/mcp-host-slim
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mcp-host-full
     newName: ghcr.io/evenfire-ai/mcp-host-full
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mcp-proxy
     newName: ghcr.io/evenfire-ai/mcp-proxy
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/gfs-controller
     newName: ghcr.io/evenfire-ai/gfs-controller
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/nginx-egress-proxy
     newName: ghcr.io/evenfire-ai/nginx-egress-proxy
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/profile-ui
     newName: ghcr.io/evenfire-ai/profile-ui
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/rpc-proxy
     newName: ghcr.io/evenfire-ai/rpc-proxy
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/workflow-recipes
     newName: ghcr.io/evenfire-ai/workflow-recipes
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/workflow-coordinator
     newName: ghcr.io/evenfire-ai/workflow-coordinator
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/workflow-snippet-runner
     newName: ghcr.io/evenfire-ai/workflow-snippet-runner
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/stdio-bridge
     newName: ghcr.io/evenfire-ai/stdio-bridge
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/workspace-files-controller
     newName: ghcr.io/evenfire-ai/workspace-files-controller
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mock-mcp-server
     newName: ghcr.io/evenfire-ai/mock-mcp-server
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/mock-stdio-mcp-server
     newName: ghcr.io/evenfire-ai/mock-stdio-mcp-server
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/webhook-gateway
     newName: ghcr.io/evenfire-ai/webhook-gateway
-    newTag: v0.6.0
+    newTag: v0.7.0
   - name: clerum/webhook-proxy
     newName: ghcr.io/evenfire-ai/webhook-proxy
-    newTag: v0.6.0
+    newTag: v0.7.0

--- a/desktop-app/package-lock.json
+++ b/desktop-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "evenfire",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "evenfire",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@clerum/desktop-app-links": "file:../packages/desktop-app-links",

--- a/desktop-app/package.json
+++ b/desktop-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "evenfire",
   "productName": "Evenfire",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "license": "MPL-2.0",
   "description": "Evenfire desktop client for secure agent and workflow access",

--- a/external-rest-api/src/releaseManifest.ts
+++ b/external-rest-api/src/releaseManifest.ts
@@ -7,9 +7,9 @@ export type ReleaseManifest = {
 }
 
 export const releaseManifest: ReleaseManifest = {
-  releaseId: 'v0.6.0',
+  releaseId: 'v0.7.0',
   externalRestApiVersion: '0.1.64',
   rpcProxyVersion: '0.1.64',
-  desktopVersion: '0.6.0',
+  desktopVersion: '0.7.0',
   minimumDesktopVersion: '0.1.252',
 }

--- a/scripts/tests/test-minikube-pull-images.sh
+++ b/scripts/tests/test-minikube-pull-images.sh
@@ -278,20 +278,25 @@ assert_it_never_pulls_a_registry_distributed_mcp_server() {
 # of main can pin a tag that is not promoted yet). A raw MANIFEST_UNKNOWN gives
 # a new contributor nothing to act on.
 assert_a_missing_tag_names_the_tag_and_the_override() {
-  local d out rc
+  local d out rc pin
   d="$(mktemp -d)"
+  # The tag has to be the one the puller will actually ask for, which is the
+  # committed pin. Hardcoding the release of the day made this assertion pass
+  # vacuously the moment the next release was cut: the simulated 404 was for a
+  # tag nobody requested, the pull succeeded, and rc=0 failed the assert.
+  pin="$(committed_pin)"
   # `A=1 out="$(cmd)"` does NOT put A in cmd's environment: every assignment's
   # value is expanded BEFORE any of them takes effect. Export it instead.
-  export TEST_MISSING_TAGS="ghcr.io/evenfire-ai/control-api:v0.6.0"
+  export TEST_MISSING_TAGS="ghcr.io/evenfire-ai/control-api:${pin}"
   out="$(run_puller "$d" --only=control-api)"; rc=$?
   unset TEST_MISSING_TAGS
   if [ "$rc" -ne 0 ] \
-     && grep -q "v0.6.0" <<< "$out" \
+     && grep -q "$pin" <<< "$out" \
      && grep -q "MINIKUBE_IMAGE_TAG" <<< "$out" \
      && grep -q "control-api" <<< "$out"; then
     pass "a missing tag fails naming the image, the tag, and MINIKUBE_IMAGE_TAG"
   else
-    fail "expected a named failure mentioning control-api, v0.6.0 and MINIKUBE_IMAGE_TAG; got rc=$rc out='$out'"
+    fail "expected a named failure mentioning control-api, ${pin} and MINIKUBE_IMAGE_TAG; got rc=$rc out='$out'"
   fi
   rm -rf "$d"
 }


### PR DESCRIPTION
Promotion of `dev` → `main` carrying the **v0.7.0** release spine. This is the commit `v0.7.0` gets tagged on.

## Merge with a **merge commit** — never squash

A merge commit keeps dev's commits ancestors of `main`. Squashing diverges the branches permanently. `main` allows all three methods, so this is manual discipline.

## What promotes

`dev@6ba4eae7` → `main@1493780c`: 5 files, 3 commits. Only the release spine plus one test fix — all the feature work already promoted in #330.

| File | Change |
|---|---|
| `desktop-app/package.json` + lockfile | `0.6.0` → `0.7.0` (the desktop-app version **is** the release version) |
| `external-rest-api/src/releaseManifest.ts` | `releaseId: v0.7.0`, `desktopVersion: 0.7.0` |
| `deploy/components/ghcr-images/kustomization.yaml` | all 23 `newTag:` rows → `v0.7.0` |
| `scripts/tests/test-minikube-pull-images.sh` | stop hard-coding the release tag in the missing-tag fixture |

`minimumDesktopVersion` stays `0.1.252` — a floor, not a version. Raising it force-updates every existing client.

## Verification

- `validate-release-tag.mjs --version 0.7.0` → *all 8 coordinates agree*
- `prepare-release.mjs` refuses to re-run ("0.7.0 is not greater than the current desktop version 0.7.0") — the idempotency guard, confirming no drift
- manifest's `externalRestApiVersion` / `rpcProxyVersion` (`0.1.64`) match both packages' actual versions — not stale
- 23 `newName` rows, 23 `newTag` rows, zero unrewritten
- repo-wide sweep for stale `0.6.0`: only a comment and an unreachable `your-gcp-project` placeholder default, neither a release coordinate
- `v0.7.0` tag does not exist yet locally or on origin

## The test fix

`assert_a_missing_tag_names_the_tag_and_the_override` hard-coded `v0.6.0` as the tag to simulate a 404 for, but the puller requests the **committed pin**. Cutting v0.7.0 moved the pin, so the simulated 404 was for a tag nobody requested: the pull succeeded, `rc` was 0, and the assertion failed. It now reads `committed_pin()` — the helper this same file already uses, commented *"read from the real tree so this cannot drift the next time a release is cut."* Without it every future release cut breaks this job.

## Immediately after merging

Tag promptly. Between this merge and the tag, `main` pins `v0.7.0` images that do not exist yet, and fresh clones fail in that window. The tag fires `release-images.yml`, which `crane copy`s the digests already proven on `:latest` — promotion, never a rebuild — so the release images are byte-identical to what prod is running right now.

Then **create the GitHub Release separately**: a git tag is not a Release, and `desktop-release.yml:57` runs `gh release view` and exits 1 without the Release object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)