### PR TITLE
fix(deploy): copy @clerum/display-field into control-api and control-ui images

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -122,9 +122,11 @@ jobs:
               - 'packages/workflow-runtime-core/**'
               - 'packages/workflow-recipe-capability-policy/**'
               - 'packages/image-policy/**'
+              - 'packages/display-field/**'
             control-ui:
               - 'control-ui/**'
               - 'packages/workflow-recipe-capability-policy/**'
+              - 'packages/display-field/**'
             external-rest-api:
               - 'external-rest-api/**'
             host-context-controller:

--- a/control-api/Dockerfile
+++ b/control-api/Dockerfile
@@ -7,6 +7,10 @@ COPY packages/image-policy ./packages/image-policy
 # both the workflow-runtime-core build (it depends on it) and control-api's
 # npm ci (control-api validates the provider set from it, R4).
 COPY packages/llm-providers ./packages/llm-providers
+# Shared prebuilt display-field validation package (no build step). Copied
+# before control-api's npm ci so its file: dependency resolves; resourceFieldValidation
+# imports validateDisplayField from it.
+COPY packages/display-field ./packages/display-field
 
 # Build the shared @clerum/workflow-runtime-core package (TS → dist) BEFORE
 # control-api's npm ci, so its file: dependency on it resolves with the compiled

--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.449",
+  "version": "0.1.450",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.449",
+      "version": "0.1.450",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.449",
+  "version": "0.1.450",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-ui/Dockerfile
+++ b/control-ui/Dockerfile
@@ -8,6 +8,7 @@ ENV NEXT_PUBLIC_CLERUM_ENABLE_LOCAL_TEMPLATES=${NEXT_PUBLIC_CLERUM_ENABLE_LOCAL_
 
 COPY packages/workflow-recipe-capability-policy ./packages/workflow-recipe-capability-policy
 COPY packages/llm-providers ./packages/llm-providers
+COPY packages/display-field ./packages/display-field
 COPY control-ui/package*.json ./control-ui/
 WORKDIR /app/control-ui
 # Next's bundler does not follow file: symlinks reliably, so materialize the
@@ -18,7 +19,9 @@ RUN npm ci \
   && mkdir -p node_modules/@clerum \
   && cp -R ../packages/workflow-recipe-capability-policy node_modules/@clerum/workflow-recipe-capability-policy \
   && rm -rf node_modules/@clerum/llm-providers \
-  && cp -R ../packages/llm-providers node_modules/@clerum/llm-providers
+  && cp -R ../packages/llm-providers node_modules/@clerum/llm-providers \
+  && rm -rf node_modules/@clerum/display-field \
+  && cp -R ../packages/display-field node_modules/@clerum/display-field
 
 # Next type-checks the Playwright config, which imports this shared loader.
 COPY scripts/qa-recorder /app/scripts/qa-recorder

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.424",
+  "version": "0.1.425",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.424",
+      "version": "0.1.425",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.424",
+  "version": "0.1.425",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/deploy/images.json
+++ b/deploy/images.json
@@ -22,7 +22,8 @@
         "control-api/**",
         "packages/workflow-runtime-core/**",
         "packages/workflow-recipe-capability-policy/**",
-        "packages/image-policy/**"
+        "packages/image-policy/**",
+        "packages/display-field/**"
       ],
       "published": true,
       "deployed_to_minikube": true
@@ -31,7 +32,11 @@
       "name": "control-ui",
       "path": "control-ui",
       "rooted": true,
-      "source_paths": ["control-ui/**", "packages/workflow-recipe-capability-policy/**"],
+      "source_paths": [
+        "control-ui/**",
+        "packages/workflow-recipe-capability-policy/**",
+        "packages/display-field/**"
+      ],
       "published": true,
       "deployed_to_minikube": true
     },

--- a/scripts/minikube/pre-gate-incremental.sh
+++ b/scripts/minikube/pre-gate-incremental.sh
@@ -151,6 +151,17 @@ incremental_classify_path() {
     channel-reader/*) incremental_add_target channel-reader channels channel-reader-chatllm ;;
     mcp-proxy/*) incremental_add_target mcp-proxy mcp-server mcp-proxy ;;
     control-ui/*) incremental_add_target control-ui control-plane control-ui ;;
+    packages/display-field/*)
+      # display-field is consumed ONLY by the control-api and control-ui images
+      # (their Dockerfiles COPY it and their field validation runs off it), so a
+      # change here changes exactly those two image outputs. Reshadow both
+      # instead of falling into the unmapped full-build/abort path below.
+      # (llm-providers is deliberately NOT mapped here: it has five consumers,
+      # so it stays on the fail-closed full-build default rather than risk a
+      # partial, drift-prone target list — see work-tracker/issues.)
+      incremental_add_target control-api control-plane control-api
+      incremental_add_target control-ui control-plane control-ui
+      ;;
     profile-ui/*) incremental_add_target profile-ui profiles profile-ui ;;
     webhook-proxy/*) incremental_add_target webhook-proxy webhook-ingress webhook-proxy ;;
     tests/e2e/fixtures/workflow-plugin-sdk-e2e/*)

--- a/scripts/tests/test-images-manifest.sh
+++ b/scripts/tests/test-images-manifest.sh
@@ -549,6 +549,111 @@ assert_network_policy_core_change_rebuilds_all_consumers() {
   fi
 }
 
+# packages/display-field is consumed by EXACTLY the control-api and control-ui
+# images (only those two package.json declare it, and only their Dockerfiles
+# COPY it), so a change confined to it changes both image outputs and must
+# rebuild both. Like the network-policy-core case above, this is deliberately
+# more specific than the generic source_paths/filter parity guard: a
+# synchronized omission from BOTH hand-maintained copies (the exact gap that
+# left display-field untracked) stays green under the parity guard while a
+# package-only change selects no image at all. This case fails until the
+# package appears in the control-api and control-ui filters AND source_paths.
+#
+# Scoped to display-field on purpose. packages/llm-providers has FIVE consumers
+# (control-api, control-ui, mcp-host, host-context-controller, workflow-recipes)
+# and none of them track it yet -- a broader, pre-existing change-detection gap
+# tracked in work-tracker/issues, not asserted here so this test never bakes a
+# partial (2-of-5) consumer set as golden.
+assert_display_field_change_rebuilds_both_consumers() {
+  local output rc
+  output="$(node -e '
+    import("'"$REPO_ROOT"'/scripts/release/images-manifest.mjs").then(async m => {
+      const fs = await import("node:fs")
+      const wfPath = "'"$REPO_ROOT"'/.github/workflows/build-publish.yml"
+      const wf = fs.readFileSync(wfPath, "utf8")
+      const sourcePaths = ["packages/display-field/**"]
+      const expectedConsumers = ["control-api", "control-ui"]
+
+      const filtersMatch = wf.match(/filters: \|\n([\s\S]*?)\n\n {2}build-push:/)
+      if (!filtersMatch) {
+        console.log(`PARSE_ERROR: could not find the paths-filter filters block in ${wfPath}`)
+        process.exit(1)
+      }
+      const filters = {}
+      let currentKey = null
+      for (const line of filtersMatch[1].split("\n")) {
+        if (!line.trim()) continue
+        const keyMatch = line.match(/^\s*([\w.-]+):\s*$/)
+        const pathMatch = line.match(/^\s*-\s*\x27([^\x27]+)\x27\s*$/)
+        if (keyMatch) {
+          currentKey = keyMatch[1]
+          filters[currentKey] = []
+        } else if (pathMatch && currentKey) {
+          filters[currentKey].push(pathMatch[1])
+        } else {
+          console.log(`PARSE_ERROR: unrecognized line in the filters block: ${JSON.stringify(line)}`)
+          process.exit(1)
+        }
+      }
+
+      const sectionMatch = wf.match(/include:\n([\s\S]*?)\n {4}steps:/)
+      if (!sectionMatch) {
+        console.log(`PARSE_ERROR: could not find the build-push matrix section in ${wfPath}`)
+        process.exit(1)
+      }
+      const imageFilterKeys = {}
+      for (const block of sectionMatch[1].split(/\n(?=\s*- image:)/)) {
+        const image = block.match(/- image:\s*(\S+)/)?.[1]
+        if (!image) continue
+        const changedKey = block.match(/\n\s*changed:\s*\$\{\{\s*needs\.detect\.outputs\.([\w.-]+)\s*\}\}/)?.[1]
+        if (!changedKey) {
+          console.log(`PARSE_ERROR: matrix entry ${image} has no detect output mapping`)
+          process.exit(1)
+        }
+        imageFilterKeys[image] = changedKey
+      }
+
+      const manifestByName = new Map(m.IMAGES.map(image => [image.name, image]))
+      const problems = []
+      for (const sourcePath of sourcePaths) {
+        const filterKeys = Object.entries(filters)
+          .filter(([, paths]) => paths.includes(sourcePath))
+          .map(([key]) => key)
+          .sort()
+        if (filterKeys.join(",") !== expectedConsumers.join(",")) {
+          problems.push(`filters for ${sourcePath} are ${filterKeys.join(",") || "<none>"}, expected ${expectedConsumers.join(",")}`)
+        }
+        const selectedImages = Object.entries(imageFilterKeys)
+          .filter(([, filterKey]) => filterKeys.includes(filterKey))
+          .map(([image]) => image)
+          .sort()
+        if (selectedImages.join(",") !== expectedConsumers.join(",")) {
+          problems.push(`${sourcePath} selects ${selectedImages.join(",") || "<none>"}, expected ${expectedConsumers.join(",")}`)
+        }
+        for (const consumer of expectedConsumers) {
+          const image = manifestByName.get(consumer)
+          if (!image) {
+            problems.push(`${consumer} has no deploy/images.json row`)
+          } else if (!image.source_paths?.includes(sourcePath)) {
+            problems.push(`${consumer} does not mirror ${sourcePath} in source_paths`)
+          }
+        }
+      }
+      console.log(problems.join("; "))
+    }).catch(err => {
+      console.log(`PARSE_ERROR: ${err.message}`)
+      process.exit(1)
+    })' 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "display-field changed-path contract parse failed: $output"
+  elif [ -z "$output" ]; then
+    pass "a display-field-only change rebuilds control-api and control-ui"
+  else
+    fail "display-field changed-path contract failed: $output"
+  fi
+}
+
 # THREE copies of the 28-image list exist in build-publish.yml, not two:
 # build-push's `image:` matrix dimension (the array that, crossed with
 # `arch`, produces the 56 base combinations), build-push's `include:` list
@@ -1038,6 +1143,7 @@ assert_matrix_fields_match_manifest
 assert_every_matrix_image_has_a_manifest_row
 assert_source_paths_match_filters
 assert_network_policy_core_change_rebuilds_all_consumers
+assert_display_field_change_rebuilds_both_consumers
 assert_all_three_image_lists_agree
 assert_the_verify_set_splits_on_published_not_on_mode
 assert_the_default_ghcr_verify_set_omits_only_the_e2e_fixtures


### PR DESCRIPTION
## What
Copy the shared `@clerum/display-field` package into the `control-api` and
`control-ui` Docker build contexts so their image builds resolve the dependency.

## Why
PR #304 added `@clerum/display-field` (`file:../packages/display-field`) as a
dependency of both services but did not update either Dockerfile. Local builds
pass because the `file:` symlink resolves against the on-disk package; both
image builds broke on `dev`:

- **control-api**: `tsc` cannot resolve the import in
  `src/routes/admin/resourceFieldValidation.ts` (TS2307) → `npm run build`
  exits 2.
- **control-ui**: turbopack cannot resolve the import in
  `app/contexts/new/page.tsx` → `Module not found: Can't resolve
  '@clerum/display-field'`.

## How
- Both Dockerfiles now `COPY packages/display-field ./packages/display-field`
  before the service `npm ci`, so the `file:` dependency resolves. The package
  is prebuilt (`index.cjs` + `index.d.ts`), so no build step is needed.
- `control-ui` additionally materializes it as a real copy in
  `node_modules/@clerum/display-field`, because Next's bundler does not follow
  `file:` symlinks reliably — mirroring the existing `llm-providers` /
  `workflow-recipe-capability-policy` pattern in that image.

## Testing
- Reviewed both Dockerfiles against the `npm ci` / bundler stages.
- CI image builds are the real gate for this change and run on the PR.

## Notes
Touches two services, above the single-service PR guideline, because it is one
cross-cutting fix for the same missing dependency introduced in the same PR;
splitting it would leave one image broken. The `package.json` / lockfile
version bumps are the repo's automated pre-commit versioning, not manual edits.