### PR TITLE
chore(deploy): enable LLM catalog sync cron 

### DIFF
--- a/deploy/base/control-plane/configmaps.yaml
+++ b/deploy/base/control-plane/configmaps.yaml
@@ -90,6 +90,9 @@ data:
   # prefixes for their own registry.
   CONTROL_API_ALLOWED_IMAGE_PREFIXES: "ghcr.io/evenfire-ai/,mongodb/,mcr.microsoft.com/,clerum/"
   CONTROL_API_ENFORCE_IMAGE_ALLOWLIST: "false"
+  # LLM catalog discovery sync cron (spec 09 Fase 4). Non-destructive; code
+  # default off. Interval + plausibility floors keep their code defaults.
+  LLM_CATALOG_SYNC_CRON_ENABLED: "true"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
## What
Enable `LLM_CATALOG_SYNC_CRON_ENABLED=true` in the control-api base ConfigMap (`deploy/base/control-plane/configmaps.yaml`). Code default is off; this is the deliberate opt-in.

## Why
The scheduled catalog-sync cron (spec 09 Fase 4) ships default-off. Its stale alert drives an operator remediation (disable a vanished model, then Host PUT) that depends on the mcp-host ModelNotAvailable classification (#338) to avoid a silent cross-provider failover, and on the attention feed (#339) to be actionable. Both are merged, so it is safe to turn on.

## How
One key added to the base ConfigMap, which is the single cluster-wide definition (the minikube overlay inherits it). Interval and plausibility floors stay at their code defaults. The cron is non-destructive: it marks vanished models stale, never disables or deletes, and its per-provider and global plausibility floors skip stale-marking when the live catalog looks flappy or truncated.

## Testing
YAML parses. ConfigMap mirror tests green (config.pluginSdkRateLimits, network.workflowApprovalMediumGateway); the new key is additive and does not perturb the pinned keys.

## Risks / Follow-ups
Draft on purpose: merge only after #338 and #339 land, since this activates code that ships in them. No DB migration needed; the stale/source columns already exist on dev.