### PR TITLE
fix(desktop-app): stop the GFS browser test harness from leaking an unhandled rejection

### DIFF
--- a/desktop-app/ui/src/hooks/domain/__tests__/useGfsBrowserController.test.tsx
+++ b/desktop-app/ui/src/hooks/domain/__tests__/useGfsBrowserController.test.tsx
@@ -119,7 +119,10 @@ function Probe({ grantsListEnabled = false }: { grantsListEnabled?: boolean }) {
       <button type="button" onClick={() => ctrl.retryAccess()}>
         retry access
       </button>
-      <button type="button" onClick={() => void ctrl.createFolder('Root docs')}>
+      <button
+        type="button"
+        onClick={() => (ctrl.current ? void ctrl.createFolder('Root docs') : undefined)}
+      >
         create folder current
       </button>
       <button


### PR DESCRIPTION
## What
Guard the "create folder current" button in the `useGfsBrowserController` test
harness on `ctrl.current`, matching the sibling upload/rename/replace buttons.
Single test file, no production code touched.

## Why
On a full desktop-app test run, Vitest reported an unhandled promise rejection
(`Error: No folder selected`) originating in `useGfsBrowserController.ts:513`,
which fails CI with a non-zero exit even though every test "passes". The harness
button fired `void ctrl.createFolder('Root docs')` unconditionally. `createFolder`
is exposed as `mutateAsync`, so when no folder is `current` the mutationFn throws
and the promise — discarded by `void` — surfaces as a suite-level unhandled
rejection. It only leaks in the full run (the file passes 35/35 in isolation)
because the async mutationFn settles after its test has torn down, so the failure
is order-dependent and reads as flaky.

## How
The three sibling buttons in the same harness (upload, rename, replace) already
gate their click on `ctrl.current ? … : undefined`; the create-folder button was
the only one missing that guard. Applied the same guard so the button is a no-op
when there is no current folder, exactly the precondition under which the tests
that assert on it already click it.

The production hook is intentionally left unchanged: `mutationFn` throwing
`No folder selected` when `current` is absent is a correct defensive guard.

## Testing
- `useGfsBrowserController.test.tsx` in isolation: 35/35 pass, no rejection noise.
- Full desktop-app suite: 172 files / 1794 tests pass, exit 0, zero
  "Unhandled Rejection / No folder selected" lines.

## Risks / Follow-ups
- No behavior change for the assertions: the two clicks that exercise the button
  run after a `waitFor` that `current` is truthy, so `createFolder` still fires
  and its `toHaveBeenCalledWith` assertions stay meaningful.
- Unrelated pre-existing noise seen during the full run (out of scope here):
  `[PluginSDK] audit append failed: EEXIST … plugin-audit-…/file-not-dir`.