### PR TITLE
fix(#408): generation-aware network-ready handshake between WRC and HCC

### DIFF
--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -875,7 +875,7 @@ WRC                                    McpServer CRD                          HC
 | Annotation                                   | Set by | Value                  | Meaning                                                                                                              |
 | -------------------------------------------- | ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `clerum.io/pre-deploy`                       | WRC    | `"true"`               | McpServer CRD created before workload pods exist; HCC should apply NPs proactively                                   |
-| `clerum.io/network-ready`                    | HCC    | `"true"`               | L2/L3 NetworkPolicies applied; safe to start workload pods. Valid only together with a matching generation stamp     |
+| `clerum.io/network-ready`                    | HCC    | `"true"`               | L2/L3 NetworkPolicies applied; safe to start workload pods. Honored only when the generation stamp matches the current generation (a non-numeric generation is tolerated as fresh without a stamp — defensive; `metadata.generation` is always numeric in a real cluster) |
 | `clerum.io/network-ready-observed-generation` | HCC    | `"<metadata.generation>"` | Generation HCC observed when acking (Issue #408). WRC honors `network-ready` only when this equals the current generation, so a stale ack from a prior generation cannot satisfy the gate. HCC re-acks (re-stamps) when the generation advances |
 
 #### 11.4.4 Timeout and Graceful Degradation

--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -840,7 +840,7 @@ Three approaches were evaluated:
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **A — ReadinessGate**                   | HCC patches `pod.status.conditions` with `clerum.io/network-isolated: True` after applying NPs                                                    | Standard K8s pattern, Service won't route until ready                                                    | HCC must watch pods in all namespaces, direct pod patching violates Invariant #1 (CRD-only communication), adds Pod RBAC to HCC, complex lifecycle (pod restart = re-patch) |
 | **B — Init container**                  | Sidecar init container blocks until NetworkPolicy exists                                                                                          | No HCC changes needed                                                                                    | Requires shared ServiceAccount, polling from within pod is fragile, no guarantee NP is _applied_ vs just _created_                                                          |
-| **C — Pre-deploy annotation handshake** | WRC creates McpServer CRD with `clerum.io/pre-deploy: true` → HCC applies NPs → HCC sets `clerum.io/network-ready: true` → WRC creates Deployment | 100% CRD-based (Invariant #1 preserved), no pod patching, no RBAC expansion, reuses existing watch loops | Adds ~1-5s latency to first deployment, requires timeout handling for HCC unavailability                                                                                    |
+| **C — Pre-deploy annotation handshake** | WRC creates McpServer CRD with `clerum.io/pre-deploy: true` → HCC applies NPs → HCC sets `clerum.io/network-ready: true` (+ `network-ready-observed-generation`, Issue #408) → WRC creates Deployment | 100% CRD-based (Invariant #1 preserved), no pod patching, no RBAC expansion, reuses existing watch loops | Adds ~1-5s latency to first deployment, requires timeout handling for HCC unavailability                                                                                    |
 
 **Decision**: **Option C** — the annotation handshake preserves the CRD-only communication invariant while closing the vulnerability window. ReadinessGate (Option A) is deferred indefinitely as Option C provides equivalent security guarantees with simpler implementation.
 
@@ -857,7 +857,7 @@ WRC                                    McpServer CRD                          HC
  │                                           ├── watch triggers ───────────────►│
  │                                           │                                  │
  │                                           │◄── HCC applies L2/L3 NPs ───────┤
- │                                           │    + sets annotation:            │
+ │                                           │    + sets ack + generation:      │
  │                                           │    clerum.io/network-ready: true │
  │                                           │                                  │
  │◄── Step 7c: Poll for network-ready ──────┤                                  │
@@ -872,10 +872,11 @@ WRC                                    McpServer CRD                          HC
 
 #### 11.4.3 Annotations
 
-| Annotation                | Set by | Value    | Meaning                                                                            |
-| ------------------------- | ------ | -------- | ---------------------------------------------------------------------------------- |
-| `clerum.io/pre-deploy`    | WRC    | `"true"` | McpServer CRD created before workload pods exist; HCC should apply NPs proactively |
-| `clerum.io/network-ready` | HCC    | `"true"` | L2/L3 NetworkPolicies applied; safe to start workload pods                         |
+| Annotation                                   | Set by | Value                  | Meaning                                                                                                              |
+| -------------------------------------------- | ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `clerum.io/pre-deploy`                       | WRC    | `"true"`               | McpServer CRD created before workload pods exist; HCC should apply NPs proactively                                   |
+| `clerum.io/network-ready`                    | HCC    | `"true"`               | L2/L3 NetworkPolicies applied; safe to start workload pods. Valid only together with a matching generation stamp     |
+| `clerum.io/network-ready-observed-generation` | HCC    | `"<metadata.generation>"` | Generation HCC observed when acking (Issue #408). WRC honors `network-ready` only when this equals the current generation, so a stale ack from a prior generation cannot satisfy the gate. HCC re-acks (re-stamps) when the generation advances |
 
 #### 11.4.4 Timeout and Graceful Degradation
 

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.171",
+  "version": "0.1.172",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.171",
+      "version": "0.1.172",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.170",
+  "version": "0.1.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.170",
+      "version": "0.1.171",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.172",
+      "version": "0.1.173",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.171",
+  "version": "0.1.172",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.170",
+  "version": "0.1.171",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.172",
+  "version": "0.1.173",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/reconciler.test.ts
+++ b/host-context-controller/src/reconciler.test.ts
@@ -149,6 +149,89 @@ describe('Reconciler managed:false guard (Risk 1.7)', () => {
     )
   })
 
+  it('Issue #408: stamps the observed generation alongside the network-ready ack', async () => {
+    const server = {
+      ...makeServer({ name: 'stdio-mcp', managed: true }),
+      generation: 3,
+      annotations: { 'clerum.io/pre-deploy': 'true' },
+    }
+
+    await reconciler.reconcile(server)
+
+    expect(customApi.patchNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plural: 'mcpservers',
+        name: 'stdio-mcp',
+        body: {
+          metadata: {
+            annotations: {
+              'clerum.io/network-ready': 'true',
+              'clerum.io/network-ready-observed-generation': '3',
+            },
+          },
+        },
+      }),
+      expect.objectContaining({ middleware: expect.any(Array) })
+    )
+  })
+
+  it('Issue #408: re-acks when the stamped generation is stale (spec changed since last ack)', async () => {
+    const server = {
+      ...makeServer({ name: 'stdio-mcp', managed: true }),
+      generation: 3,
+      annotations: {
+        'clerum.io/pre-deploy': 'true',
+        'clerum.io/network-ready': 'true',
+        'clerum.io/network-ready-observed-generation': '2',
+      },
+    }
+
+    await reconciler.reconcile(server)
+
+    // Old guard (network-ready !== 'true') would skip the patch; the fix must re-ack
+    // for the current generation, re-stamping observed-generation to '3'.
+    expect(customApi.patchNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plural: 'mcpservers',
+        name: 'stdio-mcp',
+        body: {
+          metadata: {
+            annotations: {
+              'clerum.io/network-ready': 'true',
+              'clerum.io/network-ready-observed-generation': '3',
+            },
+          },
+        },
+      }),
+      expect.objectContaining({ middleware: expect.any(Array) })
+    )
+  })
+
+  it('Issue #408: does NOT re-ack when the stamped generation already matches (no write storm)', async () => {
+    const server = {
+      ...makeServer({ name: 'stdio-mcp', managed: true }),
+      generation: 3,
+      annotations: {
+        'clerum.io/pre-deploy': 'true',
+        'clerum.io/network-ready': 'true',
+        'clerum.io/network-ready-observed-generation': '3',
+      },
+    }
+
+    await reconciler.reconcile(server)
+
+    expect(customApi.patchNamespacedCustomObject).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          metadata: expect.objectContaining({
+            annotations: expect.objectContaining({ 'clerum.io/network-ready': 'true' }),
+          }),
+        }),
+      }),
+      expect.anything()
+    )
+  })
+
   it('should create Deployment when managed: undefined (default: true)', async () => {
     const server = makeServer({ name: 'mongo-mcp' })
     await reconciler.reconcile(server)

--- a/host-context-controller/src/reconciler.test.ts
+++ b/host-context-controller/src/reconciler.test.ts
@@ -232,6 +232,39 @@ describe('Reconciler managed:false guard (Risk 1.7)', () => {
     )
   })
 
+  it('Issue #408: re-acks when the ack predates the stamp (upgrade path: stamp absent)', async () => {
+    // A pre-#408 HCC set network-ready:'true' without an observed-generation stamp.
+    // The re-ack guard's stale-generation branch (typeof gen === 'number' && stamp !==
+    // String(gen), i.e. undefined !== '3') must fire so the ack gains a generation.
+    const server = {
+      ...makeServer({ name: 'stdio-mcp', managed: true }),
+      generation: 3,
+      annotations: {
+        'clerum.io/pre-deploy': 'true',
+        'clerum.io/network-ready': 'true',
+        // no clerum.io/network-ready-observed-generation
+      },
+    }
+
+    await reconciler.reconcile(server)
+
+    expect(customApi.patchNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plural: 'mcpservers',
+        name: 'stdio-mcp',
+        body: {
+          metadata: {
+            annotations: {
+              'clerum.io/network-ready': 'true',
+              'clerum.io/network-ready-observed-generation': '3',
+            },
+          },
+        },
+      }),
+      expect.objectContaining({ middleware: expect.any(Array) })
+    )
+  })
+
   it('should create Deployment when managed: undefined (default: true)', async () => {
     const server = makeServer({ name: 'mongo-mcp' })
     await reconciler.reconcile(server)

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -74,6 +74,9 @@ type McpServerReconcilerDeps = {
 // G2: Pre-deploy handshake constants
 const PRE_DEPLOY_ANNOTATION = 'clerum.io/pre-deploy'
 const NETWORK_READY_ANNOTATION = 'clerum.io/network-ready'
+// Issue #408: stamp the generation observed when acking so WRC can reject a stale
+// ack carried over from a previous generation.
+const NETWORK_READY_GENERATION_ANNOTATION = 'clerum.io/network-ready-observed-generation'
 
 // Issue #223: sha256 of the envSecret content, carried on the POD TEMPLATE (not
 // the Deployment object) so that changing it changes the pod template hash and
@@ -1499,6 +1502,11 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
           metadata: {
             annotations: {
               [NETWORK_READY_ANNOTATION]: 'true',
+              // Issue #408: stamp the acked generation so WRC's waitForNetworkReady
+              // can reject a stale ack from a previous generation.
+              ...(typeof server.generation === 'number'
+                ? { [NETWORK_READY_GENERATION_ANNOTATION]: String(server.generation) }
+                : {}),
             },
           },
         },
@@ -1930,7 +1938,11 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
     // NetworkPolicies are in place and workload can proceed.
     if (
       server.annotations?.[PRE_DEPLOY_ANNOTATION] === 'true' &&
-      server.annotations?.[NETWORK_READY_ANNOTATION] !== 'true'
+      (server.annotations?.[NETWORK_READY_ANNOTATION] !== 'true' ||
+        // Issue #408: re-ack when the stamped generation is stale (spec changed since
+        // the last ack). A non-numeric generation keeps the legacy behavior.
+        (typeof server.generation === 'number' &&
+          server.annotations?.[NETWORK_READY_GENERATION_ANNOTATION] !== String(server.generation)))
     ) {
       try {
         await this.setNetworkReadyAnnotation(server)

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -13,6 +13,11 @@ import * as k8s from '@kubernetes/client-node'
 import { IntOrString } from '@kubernetes/client-node/dist/types.js'
 import { createHash } from 'crypto'
 import { classifyPluginImage } from '@clerum/image-policy'
+import {
+  NETWORK_READY_ANNOTATION,
+  NETWORK_READY_GENERATION_ANNOTATION,
+  PRE_DEPLOY_ANNOTATION,
+} from '@clerum/network-policy-core'
 import { isWorkflowRecipeDefaultAllowedCapability } from '@clerum/workflow-recipe-capability-policy'
 import { config } from './config'
 import { MANAGED_BY_LABEL, MANAGED_BY_VALUE, MCPSERVER_LABEL } from './constants'
@@ -71,12 +76,10 @@ type McpServerReconcilerDeps = {
   networkingApi?: k8s.NetworkingV1Api
 }
 
-// G2: Pre-deploy handshake constants
-const PRE_DEPLOY_ANNOTATION = 'clerum.io/pre-deploy'
-const NETWORK_READY_ANNOTATION = 'clerum.io/network-ready'
-// Issue #408: stamp the generation observed when acking so WRC can reject a stale
-// ack carried over from a previous generation.
-const NETWORK_READY_GENERATION_ANNOTATION = 'clerum.io/network-ready-observed-generation'
+// G2: Pre-deploy handshake constants — imported from @clerum/network-policy-core
+// (single source of truth shared with WRC; a divergence is a compile error rather
+// than a silent 30s fail-open timeout). clerum.io/network-ready-observed-generation
+// (Issue #408) is the generation HCC stamps when acking, so WRC can reject a stale ack.
 
 // Issue #223: sha256 of the envSecret content, carried on the POD TEMPLATE (not
 // the Deployment object) so that changing it changes the pod template hash and

--- a/packages/network-policy-core/index.cjs
+++ b/packages/network-policy-core/index.cjs
@@ -9,6 +9,14 @@ const STATE_ANNOTATION = 'clerum.io/egress-fqdn-state'
 const TARGETS_ANNOTATION = 'clerum.io/egress-fqdn-targets'
 const RESOLVED_AT_ANNOTATION = 'clerum.io/egress-fqdn-resolved-at'
 
+// Pre-deploy network-readiness handshake keys (WRC producer/consumer, HCC producer).
+// Shared here so WRC (workflow-recipes) and HCC (host-context-controller) derive the
+// exact same literals — a divergence becomes a compile error, not a silent 30s
+// fail-open timeout. Consumed by both services' reconcilers.
+const PRE_DEPLOY_ANNOTATION = 'clerum.io/pre-deploy'
+const NETWORK_READY_ANNOTATION = 'clerum.io/network-ready'
+const NETWORK_READY_GENERATION_ANNOTATION = 'clerum.io/network-ready-observed-generation'
+
 const DEFAULT_PROTOCOL = 'TCP'
 const LEGACY_PORT = 443
 // Upper bound on a DNS TTL (ms) folded into the window (audit M2). A hostile or
@@ -400,6 +408,9 @@ module.exports = {
   STATE_ANNOTATION,
   TARGETS_ANNOTATION,
   RESOLVED_AT_ANNOTATION,
+  PRE_DEPLOY_ANNOTATION,
+  NETWORK_READY_ANNOTATION,
+  NETWORK_READY_GENERATION_ANNOTATION,
   emptyState,
   reconcileEgressState,
   stateHash,

--- a/packages/network-policy-core/index.d.ts
+++ b/packages/network-policy-core/index.d.ts
@@ -130,6 +130,11 @@ export declare const STATE_ANNOTATION: string
 export declare const TARGETS_ANNOTATION: string
 export declare const RESOLVED_AT_ANNOTATION: string
 
+/** Pre-deploy network-readiness handshake annotation keys (shared by WRC and HCC). */
+export declare const PRE_DEPLOY_ANNOTATION: string
+export declare const NETWORK_READY_ANNOTATION: string
+export declare const NETWORK_READY_GENERATION_ANNOTATION: string
+
 /**
  * Classify a DNS failure as 'transient' (resolver/upstream temporarily
  * unavailable → fail-static freeze, H1) or 'permanent' (genuine no-records →

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.296",
+  "version": "0.1.297",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.296",
+      "version": "0.1.297",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.297",
+  "version": "0.1.298",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.297",
+      "version": "0.1.298",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.295",
+  "version": "0.1.296",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.295",
+      "version": "0.1.296",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package-lock.json
+++ b/workflow-recipes/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.294",
+  "version": "0.1.295",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-recipes-controller",
-      "version": "0.1.294",
+      "version": "0.1.295",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1009.0",

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.296",
+  "version": "0.1.297",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.294",
+  "version": "0.1.295",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.297",
+  "version": "0.1.298",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/package.json
+++ b/workflow-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-recipes-controller",
-  "version": "0.1.295",
+  "version": "0.1.296",
   "description": "Workload Recipes Controller (WRC) - WorkloadRecipe lifecycle management and MCP server interface",
   "main": "dist/main.js",
   "engines": {

--- a/workflow-recipes/src/reconciler/mcpDelegation.test.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.test.ts
@@ -18,6 +18,7 @@ import {
   preDeployMcpServers,
   transportWorkloadSecretDenied,
   waitForExternalEgressReady,
+  waitForNetworkReady,
 } from './mcpDelegation'
 import type { SecretAccess } from './resourceBuilder'
 import { privateWorkflowContextName } from './workflowContext'
@@ -1347,6 +1348,70 @@ describe('delegateTransportWorkloads', () => {
     expect(mcpServerReplaceCalls.length).toBeGreaterThanOrEqual(1)
   })
 
+  it('Issue #408: drops the carried-over network-ready ack pair from the replace on a spec change', async () => {
+    const MCPSERVER_PLURAL = 'mcpservers'
+    const SPEC_HASH = 'clerum.io/spec-hash'
+    const NETWORK_READY = 'clerum.io/network-ready'
+    const NETWORK_READY_GEN = 'clerum.io/network-ready-observed-generation'
+    const recipe = makeRecipe()
+    let storedMcpServer:
+      | { metadata?: { annotations?: Record<string, string> }; spec?: Record<string, unknown> }
+      | undefined
+
+    const mockCustomApi = {
+      getNamespacedCustomObject: vi.fn().mockImplementation((args: { plural: string }) => {
+        if (args.plural === MCPSERVER_PLURAL && storedMcpServer) {
+          return Promise.resolve(storedMcpServer)
+        }
+        return Promise.reject({ code: 404 })
+      }),
+      createNamespacedCustomObject: vi
+        .fn()
+        .mockImplementation((args: { plural: string; body: unknown }) => {
+          if (args.plural === MCPSERVER_PLURAL) {
+            storedMcpServer = args.body as typeof storedMcpServer
+          }
+          return Promise.resolve({})
+        }),
+      replaceNamespacedCustomObject: vi.fn().mockResolvedValue({}),
+    }
+    const mockCoreApi = { createNamespacedService: vi.fn().mockResolvedValue({}) }
+    const deps: DelegationDeps = {
+      customApi: mockCustomApi as unknown as DelegationDeps['customApi'],
+      coreApi: mockCoreApi as unknown as DelegationDeps['coreApi'],
+    }
+
+    await delegateTransportWorkloads(deps, recipe, 'mcp-server', new Map())
+    expect(storedMcpServer).toBeDefined()
+
+    // Simulate a prior-generation HCC ack carried on the live object, plus a stale
+    // spec-hash so the desired manifest differs and the replace path is taken.
+    storedMcpServer!.metadata = {
+      ...(storedMcpServer!.metadata ?? {}),
+      annotations: {
+        ...(storedMcpServer!.metadata?.annotations ?? {}),
+        [SPEC_HASH]: 'stale-hash',
+        [NETWORK_READY]: 'true',
+        [NETWORK_READY_GEN]: '1',
+      },
+    }
+    mockCustomApi.replaceNamespacedCustomObject.mockClear()
+    await delegateTransportWorkloads(deps, recipe, 'mcp-server', new Map())
+
+    const replaceCall = mockCustomApi.replaceNamespacedCustomObject.mock.calls.find(
+      (call: unknown[]) => (call[0] as { plural?: string } | undefined)?.plural === MCPSERVER_PLURAL
+    ) as [{ body: { metadata: { annotations: Record<string, string> } } }] | undefined
+    expect(replaceCall).toBeDefined()
+
+    const replacedAnnotations = replaceCall![0].body.metadata.annotations
+    // The stale network ack pair must NOT be carried forward into the new generation.
+    expect(replacedAnnotations[NETWORK_READY]).toBeUndefined()
+    expect(replacedAnnotations[NETWORK_READY_GEN]).toBeUndefined()
+    // Non-network annotations (the freshly stamped spec-hash from the manifest) survive.
+    expect(replacedAnnotations[SPEC_HASH]).toBeDefined()
+    expect(replacedAnnotations[SPEC_HASH]).not.toBe('stale-hash')
+  })
+
   it('does NOT patch shared Context (H-04 isolation — no patchNamespacedCustomObject)', async () => {
     const mockCustomApi = {
       createNamespacedCustomObject: vi.fn().mockResolvedValue({}),
@@ -1996,6 +2061,106 @@ describe('waitForExternalEgressReady', () => {
     expect(result.ready).toBe(false)
     expect(result.pending).toEqual(['web-search'])
     expect(result.failed).toEqual([])
+  })
+})
+
+// ─── Issue #408 — waitForNetworkReady must be generation-aware ─────────────────
+// The flat `clerum.io/network-ready: "true"` ack carries no generation. A stale
+// ack carried over from a previous generation must NOT satisfy the gate for the
+// current generation. Mirrors waitForExternalEgressReady's observedGeneration
+// freshness check, but for the annotation pair.
+describe('waitForNetworkReady (Issue #408 generation-aware gate)', () => {
+  it('rejects a network-ready ack stamped for an older generation', async () => {
+    const deps: DelegationDeps = {
+      customApi: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue({
+          metadata: {
+            generation: 2,
+            annotations: {
+              'clerum.io/network-ready': 'true',
+              'clerum.io/network-ready-observed-generation': '1',
+            },
+          },
+        }),
+      } as any,
+      coreApi: {} as any,
+    }
+
+    const result = await waitForNetworkReady(deps, ['srv-a'], 'mcp-server', 25)
+
+    expect(result.ready).toBe(false)
+    expect(result.pending).toEqual(['srv-a'])
+  })
+
+  it('rejects a network-ready ack that lacks the generation stamp', async () => {
+    const deps: DelegationDeps = {
+      customApi: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue({
+          metadata: {
+            generation: 2,
+            annotations: { 'clerum.io/network-ready': 'true' },
+          },
+        }),
+      } as any,
+      coreApi: {} as any,
+    }
+
+    const result = await waitForNetworkReady(deps, ['srv-a'], 'mcp-server', 25)
+
+    expect(result.ready).toBe(false)
+    expect(result.pending).toEqual(['srv-a'])
+  })
+
+  it('accepts a network-ready ack stamped for the current generation', async () => {
+    const deps: DelegationDeps = {
+      customApi: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue({
+          metadata: {
+            generation: 2,
+            annotations: {
+              'clerum.io/network-ready': 'true',
+              'clerum.io/network-ready-observed-generation': '2',
+            },
+          },
+        }),
+      } as any,
+      coreApi: {} as any,
+    }
+
+    await expect(waitForNetworkReady(deps, ['srv-a'], 'mcp-server', 25)).resolves.toEqual({
+      ready: true,
+      pending: [],
+    })
+  })
+
+  it('tolerates a missing (non-numeric) generation and accepts the flat ack', async () => {
+    const deps: DelegationDeps = {
+      customApi: {
+        getNamespacedCustomObject: vi.fn().mockResolvedValue({
+          metadata: { annotations: { 'clerum.io/network-ready': 'true' } },
+        }),
+      } as any,
+      coreApi: {} as any,
+    }
+
+    await expect(waitForNetworkReady(deps, ['srv-a'], 'mcp-server', 25)).resolves.toEqual({
+      ready: true,
+      pending: [],
+    })
+  })
+
+  it('treats a 404 (McpServer deleted) as resolved', async () => {
+    const deps: DelegationDeps = {
+      customApi: {
+        getNamespacedCustomObject: vi.fn().mockRejectedValue({ code: 404 }),
+      } as any,
+      coreApi: {} as any,
+    }
+
+    await expect(waitForNetworkReady(deps, ['srv-a'], 'mcp-server', 25)).resolves.toEqual({
+      ready: true,
+      pending: [],
+    })
   })
 })
 

--- a/workflow-recipes/src/reconciler/mcpDelegation.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.ts
@@ -439,9 +439,18 @@ async function ensureMcpServer(
       }
 
       // Recipe-owned: safe to replace (idempotent update path).
-      // Merge annotations: existing annotations (e.g. HCC's "network-ready: true") are preserved
-      // as the base; WRC manifest annotations override only the keys they specify.
-      // This prevents WRC updates from erasing HCC-managed annotations during concurrent reconciles.
+      // Merge annotations: existing annotations are preserved as the base; WRC manifest
+      // annotations override only the keys they specify. This prevents WRC updates from
+      // erasing HCC-managed annotations during concurrent reconciles.
+      // EXCEPTION (Issue #408): the pre-deploy network ack pair
+      // (clerum.io/network-ready + clerum.io/network-ready-observed-generation) is dropped
+      // from the carry-over here. This branch runs only when the DESIRED manifest's
+      // spec-hash differs from the stored one (the idempotency gate below returns false and
+      // skips the replace when they match), so a byte-identical desired object is never
+      // rewritten by this path. Dropping the ack is idempotent: HCC re-acks after
+      // re-applying NetworkPolicies for the current generation via its
+      // (annotation !== 'true' || stamped-generation !== current) guard, so a stale ack
+      // cannot satisfy the gate for the new generation.
       const rv = existing.metadata?.resourceVersion
       const existingAnnotations = existing.metadata?.annotations ?? {}
       const manifestAnnotations =
@@ -465,7 +474,10 @@ async function ensureMcpServer(
         return false
       }
 
-      const mergedAnnotations = { ...existingAnnotations, ...manifestAnnotations }
+      const carriedAnnotations: Record<string, string> = { ...existingAnnotations }
+      delete carriedAnnotations[NETWORK_READY_ANNOTATION]
+      delete carriedAnnotations[NETWORK_READY_GENERATION_ANNOTATION]
+      const mergedAnnotations = { ...carriedAnnotations, ...manifestAnnotations }
       const updatedManifest = {
         ...manifest,
         metadata: {
@@ -773,6 +785,9 @@ export async function ensureRecipeContext(
  */
 export const PRE_DEPLOY_ANNOTATION = 'clerum.io/pre-deploy'
 export const NETWORK_READY_ANNOTATION = 'clerum.io/network-ready'
+// Issue #408: HCC stamps the McpServer generation it observed when acking network
+// readiness, so WRC can reject a stale ack carried over from a prior generation.
+export const NETWORK_READY_GENERATION_ANNOTATION = 'clerum.io/network-ready-observed-generation'
 const NETWORK_READY_POLL_INTERVAL_MS = 1_000
 const NETWORK_READY_TIMEOUT_MS = 30_000
 
@@ -916,10 +931,21 @@ export async function waitForNetworkReady(
             namespace,
             plural: MCPSERVER_PLURAL,
             name,
-          })) as { metadata?: { annotations?: Record<string, string> } }
+          })) as {
+            metadata?: { generation?: number; annotations?: Record<string, string> }
+          }
+          // Issue #408: mirror waitForExternalEgressReady's freshness check. The flat
+          // 'true' ack carries no generation, so trust it only when HCC's stamped
+          // generation matches the current one. A non-numeric generation is tolerated
+          // as fresh (same tolerance as the condition-based gate).
+          const annotations = mcpServer.metadata?.annotations
+          const currentGeneration = mcpServer.metadata?.generation
+          const ackFresh =
+            typeof currentGeneration !== 'number' ||
+            annotations?.[NETWORK_READY_GENERATION_ANNOTATION] === String(currentGeneration)
           return {
             name,
-            ready: mcpServer.metadata?.annotations?.[NETWORK_READY_ANNOTATION] === 'true',
+            ready: annotations?.[NETWORK_READY_ANNOTATION] === 'true' && ackFresh,
           }
         } catch (error) {
           // 404 = McpServer deleted externally — treat as resolved

--- a/workflow-recipes/src/reconciler/mcpDelegation.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.ts
@@ -11,6 +11,11 @@
  */
 import * as k8s from '@kubernetes/client-node'
 import {
+  NETWORK_READY_ANNOTATION,
+  NETWORK_READY_GENERATION_ANNOTATION,
+  PRE_DEPLOY_ANNOTATION,
+} from '@clerum/network-policy-core'
+import {
   EVENFIRE_REGISTRY_PULL_SECRET_NAME,
   isPlatformRegistryImage,
 } from '@clerum/workflow-runtime-core'
@@ -787,11 +792,12 @@ export async function ensureRecipeContext(
  *
  * See: PHASE-9-PRE-PRODUCTION-HARDENING.md §GAP 14, Option C
  */
-export const PRE_DEPLOY_ANNOTATION = 'clerum.io/pre-deploy'
-export const NETWORK_READY_ANNOTATION = 'clerum.io/network-ready'
-// Issue #408: HCC stamps the McpServer generation it observed when acking network
-// readiness, so WRC can reject a stale ack carried over from a prior generation.
-export const NETWORK_READY_GENERATION_ANNOTATION = 'clerum.io/network-ready-observed-generation'
+// Handshake annotation keys now live in @clerum/network-policy-core (single source of
+// truth shared with HCC — a divergence is a compile error, not a silent 30s timeout).
+// Re-exported here so existing WRC consumers keep importing them from this module.
+// clerum.io/network-ready-observed-generation (Issue #408) is the generation HCC
+// stamps when acking, so WRC can reject a stale ack from a prior generation.
+export { PRE_DEPLOY_ANNOTATION, NETWORK_READY_ANNOTATION, NETWORK_READY_GENERATION_ANNOTATION }
 const NETWORK_READY_POLL_INTERVAL_MS = 1_000
 const NETWORK_READY_TIMEOUT_MS = 30_000
 

--- a/workflow-recipes/src/reconciler/mcpDelegation.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.ts
@@ -475,6 +475,10 @@ async function ensureMcpServer(
       }
 
       const carriedAnnotations: Record<string, string> = { ...existingAnnotations }
+      // Only the network ack pair is dropped. Other HCC-relevant handshake keys
+      // (notably clerum.io/pre-deploy) intentionally carry over from `existing`, even
+      // on the delegate path that does not re-specify them — HCC's re-ack guard keys
+      // off pre-deploy, so this is not the full set of handshake keys, just the ack.
       delete carriedAnnotations[NETWORK_READY_ANNOTATION]
       delete carriedAnnotations[NETWORK_READY_GENERATION_ANNOTATION]
       const mergedAnnotations = { ...carriedAnnotations, ...manifestAnnotations }

--- a/workflow-recipes/src/reconciler/mcpDelegation.ts
+++ b/workflow-recipes/src/reconciler/mcpDelegation.ts
@@ -908,6 +908,10 @@ export async function preDeployMcpServers(
  * pre-deployed McpServer CRDs.
  *
  * Polls each McpServer CR until the annotation appears or timeout.
+ * The ack is honored only when HCC's stamped
+ * `clerum.io/network-ready-observed-generation` matches the current
+ * `metadata.generation` (Issue #408) — a stale ack from a prior generation
+ * does not satisfy the gate. A non-numeric generation is tolerated as fresh.
  * Returns true if all are ready, false if timeout.
  */
 export async function waitForNetworkReady(

--- a/workflow-recipes/src/reconciler/specHash.test.ts
+++ b/workflow-recipes/src/reconciler/specHash.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { SPEC_HASH_ANNOTATION, computeSpecHash, specHashUnchanged, stampSpecHash } from './specHash'
+import { PRE_DEPLOY_ANNOTATION } from './mcpDelegation'
+import {
+  HASH_EXCLUDED_ANNOTATIONS,
+  SPEC_HASH_ANNOTATION,
+  computeSpecHash,
+  specHashUnchanged,
+  stampSpecHash,
+} from './specHash'
 
 describe('computeSpecHash', () => {
   it('is stable across object key ordering (canonical)', () => {
@@ -49,6 +56,31 @@ describe('computeSpecHash', () => {
     const a = { metadata: { labels: { 'clerum.io/recipe': 'r1' } }, spec: { replicas: 1 } }
     const b = { metadata: { labels: { 'clerum.io/recipe': 'r2' } }, spec: { replicas: 1 } }
     expect(computeSpecHash(a)).not.toBe(computeSpecHash(b))
+  })
+
+  // Issue #413: WRC step 7b injects `pre-deploy: "true"` and step 9a omits it, for
+  // the SAME McpServer in the SAME pass. If the hash counted this annotation the two
+  // manifests would never converge and the idempotency gate would fire a replace
+  // twice every pass forever. Excluding it makes 7b and 9a hash identically.
+  it('ignores the pre-deploy handshake annotation (7b/9a convergence)', () => {
+    const nineA = {
+      metadata: { name: 'srv', namespace: 'mcp-server', labels: { 'clerum.io/recipe': 'r1' } },
+      spec: { transport: 'stdio' },
+    }
+    const sevenB = {
+      metadata: {
+        name: 'srv',
+        namespace: 'mcp-server',
+        labels: { 'clerum.io/recipe': 'r1' },
+        annotations: { [PRE_DEPLOY_ANNOTATION]: 'true' },
+      },
+      spec: { transport: 'stdio' },
+    }
+    expect(computeSpecHash(sevenB)).toBe(computeSpecHash(nineA))
+  })
+
+  it('keeps HASH_EXCLUDED_ANNOTATIONS in sync with PRE_DEPLOY_ANNOTATION', () => {
+    expect(HASH_EXCLUDED_ANNOTATIONS).toContain(PRE_DEPLOY_ANNOTATION)
   })
 })
 

--- a/workflow-recipes/src/reconciler/specHash.ts
+++ b/workflow-recipes/src/reconciler/specHash.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto'
+import { PRE_DEPLOY_ANNOTATION } from '@clerum/network-policy-core'
 
 /**
  * Annotation that records a hash of the recipe-derived manifest WRC last applied
@@ -34,10 +35,11 @@ export const SPEC_HASH_ANNOTATION = 'clerum.io/spec-hash'
  * The annotation intentionally PERSISTS on the live object (the replace merge
  * keeps it): HCC's network-ready re-ack guard keys off `pre-deploy === "true"`
  * (host-context-controller/src/reconciler.ts), so it must not be stripped from
- * the object — only from the hash. Keep this in sync with
- * `PRE_DEPLOY_ANNOTATION` in ./mcpDelegation (asserted by specHash.test.ts).
+ * the object — only from the hash. The key comes from the shared
+ * `@clerum/network-policy-core` constant (the same one WRC and HCC use), so it
+ * cannot drift; specHash.test.ts still pins the exclusion-list membership.
  */
-export const HASH_EXCLUDED_ANNOTATIONS = ['clerum.io/pre-deploy'] as const
+export const HASH_EXCLUDED_ANNOTATIONS = [PRE_DEPLOY_ANNOTATION] as const
 
 // Loose, class-compatible shape: K8s client model classes (V1Deployment, …) have
 // `metadata?: V1ObjectMeta` with `annotations?: { [k]: string }`, so they satisfy

--- a/workflow-recipes/src/reconciler/specHash.ts
+++ b/workflow-recipes/src/reconciler/specHash.ts
@@ -17,6 +17,28 @@ import { createHash } from 'node:crypto'
  */
 export const SPEC_HASH_ANNOTATION = 'clerum.io/spec-hash'
 
+/**
+ * Annotations that record cross-controller handshake state rather than the
+ * recipe-derived desired spec, and therefore MUST be excluded from the hash.
+ *
+ * `clerum.io/pre-deploy` is the load-bearing case: WRC builds two desired
+ * manifests for the SAME McpServer in a single reconcile pass — step 7b
+ * (`preDeployMcpServers`) injects `pre-deploy: "true"` before `ensureMcpServer`,
+ * while step 9a (`delegateTransportWorkloads`) builds the manifest via
+ * `buildMcpServerManifest` WITHOUT it. If the hash counted this annotation the
+ * two manifests would hash differently and the idempotency gate would fire a
+ * `replace` twice every pass forever (never converging, because the replace
+ * carries `pre-deploy` over via the annotation merge). Excluding it lets both
+ * paths hash identically so the gate holds (zero PUTs in steady state).
+ *
+ * The annotation intentionally PERSISTS on the live object (the replace merge
+ * keeps it): HCC's network-ready re-ack guard keys off `pre-deploy === "true"`
+ * (host-context-controller/src/reconciler.ts), so it must not be stripped from
+ * the object — only from the hash. Keep this in sync with
+ * `PRE_DEPLOY_ANNOTATION` in ./mcpDelegation (asserted by specHash.test.ts).
+ */
+export const HASH_EXCLUDED_ANNOTATIONS = ['clerum.io/pre-deploy'] as const
+
 // Loose, class-compatible shape: K8s client model classes (V1Deployment, …) have
 // `metadata?: V1ObjectMeta` with `annotations?: { [k]: string }`, so they satisfy
 // this without needing an index signature.
@@ -63,6 +85,12 @@ export function computeSpecHash(manifest: object): string {
     }
     if (clone.metadata.annotations && typeof clone.metadata.annotations === 'object') {
       delete clone.metadata.annotations[SPEC_HASH_ANNOTATION]
+      // Handshake-state annotations (e.g. pre-deploy) are cross-controller signals,
+      // not desired spec: excluding them lets WRC's 7b (with pre-deploy) and 9a
+      // (without) manifests hash identically so the idempotency gate converges.
+      for (const key of HASH_EXCLUDED_ANNOTATIONS) {
+        delete clone.metadata.annotations[key]
+      }
       // An empty annotations object must hash identically to an absent one, so that
       // a freshly-built (unstamped) manifest and the same manifest after stamping
       // produce the same hash (the gate's idempotency guarantee).

--- a/workflow-recipes/src/reconciler/workflowRecipeReconciler.ts
+++ b/workflow-recipes/src/reconciler/workflowRecipeReconciler.ts
@@ -2424,10 +2424,17 @@ export class WorkflowRecipeReconciler {
         }
       }
 
-      // Step 9a: MCP delegation — finalize (Context patch + remove pre-deploy annotation)
+      // Step 9a: MCP delegation — finalize (Context patch + ensure McpServer CRDs).
       // McpServer CRDs were already created in Step 7b (pre-deploy handshake).
       // This step patches the Context allowlist and ensures McpServer CRDs are up-to-date.
       // Same namespace invariant as Step 7b: MCP children live in mcp-server.
+      //
+      // NOTE: `pre-deploy` is deliberately NOT removed here. `buildMcpServerManifest`
+      // omits it, but the replace merge in `ensureMcpServer` carries the live object's
+      // `pre-deploy: "true"` over, so it persists — by design. HCC's network-ready
+      // re-ack guard keys off `pre-deploy === "true"`, so stripping it would break the
+      // stdio readiness handshake. The spec-hash gate excludes `pre-deploy` from the
+      // hash (see HASH_EXCLUDED_ANNOTATIONS) so 7b and 9a converge to a no-op write.
       if (hasTransportWorkloads) {
         if (!(await this.recipeStillActive(recipe))) {
           return this.staleRecipeResult(recipe, 'MCP delegation finalization')


### PR DESCRIPTION
## Summary

Fixes #408. The WRC readiness gate `waitForNetworkReady` trusted a flat
`clerum.io/network-ready: "true"` annotation with **no `observedGeneration`
check**, and the annotation was **never cleared on a spec change**. A stale ack
left over from a previous generation could therefore satisfy the gate, letting a
recipe proceed before the **current** generation's network was actually ready.

This mirrors the freshness discipline already used by `waitForExternalEgressReady`
(`condition.observedGeneration === currentGeneration`), applied minimally to the
network handshake — **without** introducing a new status condition.

## Root cause (verified against the code)

- HCC `setNetworkReadyAnnotation` wrote only the flat `network-ready: "true"`
  (`host-context-controller/src/reconciler.ts`), and its re-ack guard
  (`network-ready !== 'true'`) never re-acked once the flag was set — even across a
  generation change.
- WRC `waitForNetworkReady` treated `annotations['network-ready'] === 'true'` as
  ready, with no generation comparison (`workflow-recipes/src/reconciler/mcpDelegation.ts`).
- On a spec change, WRC `replaceFromExisting` merged existing annotations as the
  base (`{ ...existingAnnotations, ...manifest }`), carrying a stale
  `network-ready: "true"` from generation N-1 into generation N. The manifest never
  re-specifies it, so it was never cleared.

## The fix (the two points from the issue)

**#1 — generation-aware ack (defense in depth):**
- HCC now stamps `clerum.io/network-ready-observed-generation: "<metadata.generation>"`
  alongside the ack, and the re-ack guard re-acknowledges when the stamped
  generation is stale (spec changed since the last ack). Non-numeric generation
  keeps the legacy behavior.
- WRC `waitForNetworkReady` trusts `network-ready` only when the stamped generation
  equals `metadata.generation` (non-numeric generation tolerated as fresh, same as
  the mirror). The 404 = resolved path is unchanged.

**#2 — clear the stale ack on a spec change:**
- WRC `replaceFromExisting` drops the network ack pair
  (`network-ready` + `network-ready-observed-generation`) from the carry-over. This
  branch runs only when the desired manifest's spec-hash differs from the stored one
  (the idempotency gate skips the replace when they match), so a byte-identical
  desired object is never rewritten.

**Complementarity:** #2 removes the carry-over path; #1 makes the gate reject any
stale ack regardless of how it arrived.

## Behavior note (fail-open, not fail-closed)

The gate remains **fail-open**: `waitForNetworkReady`'s result only feeds a
`console.warn` in `workflowRecipeReconciler.ts` and the recipe proceeds after the
30s timeout regardless. This fix removes the **stale-ack false positive** (the gate
no longer returns `ready:true` for a prior generation); it does **not** turn the
gate into a hard block. The security posture ("proceed after 30s") is unchanged.

## Rollout / version skew

WRC and HCC are separate images from the same release. In the skew window
**WRC-new + HCC-old** (no stamp), the gate is never fresh → it waits 30s → warns →
proceeds: only +30s of latency per pass on stdio servers, identical posture to
pre-fix. **WRC-old + HCC-new** is inert (old WRC ignores the stamp). Recommended
deploy order: **HCC first, then WRC** (the apply order is controlled by
evenfire-infra and not enforced here).

## Out of scope

- Variant 2b (a full `NetworkReady` status condition) — intentionally not done; the
  annotation pair closes the hole with a minimal change.
- The pre-existing 7b/9a spec-hash ping-pong (see "Follow-up") is **not** fixed here.

## Tests (TDD, red → green)

Five tests written red-first (fail against old code), then green after the fix; no
regressions.

- WRC `mcpDelegation.test.ts`:
  - gate rejects an ack stamped for an older generation
  - gate rejects an ack that lacks the generation stamp
  - replace drops the carried-over ack pair on a spec change
  - (+ regression pins: current-gen stamp accepted, non-numeric tolerated, 404 resolved)
- HCC `reconciler.test.ts`:
  - stamps the observed generation alongside the ack
  - re-acks when the stamped generation is stale
  - (+ pin: does not re-ack when the stamp already matches — no write storm)

Results: **WRC 2478 passed / 0 failed** (29 skipped), **HCC 1088 passed / 0 failed**.
`tsc` build green for both packages.

## Docs

`docs/architecture/platform-topology.md` — annotation table (§11.4.3), Option C row,
and the handshake diagram updated for the ack + generation pair.

## Follow-up (not in this PR)

A pre-existing spec-hash divergence between step 7b (`preDeployMcpServers`, stamps
`pre-deploy: true`) and step 9a (`delegateTransportWorkloads`, does not) makes the
replace path recur on each reconcile pass, so the ack drop can recur too. This is
pre-existing churn (not introduced here) and is safe (the re-ack does not bump
`generation` — the CRD has a status subresource). It should be verified in a T1 live
run and, if confirmed, unified in a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also fixes #413 — WRC 7b/9a spec-hash convergence

Surfaced by the @claude review of this PR: the ack-drop introduced here interacts with a pre-existing structural divergence. WRC step 7b (`preDeployMcpServers`) stamps `clerum.io/pre-deploy: "true"` on the manifest; step 9a (`delegateTransportWorkloads`) builds the manifest without it. Because `computeSpecHash` hashed `metadata.annotations`, the two manifests for the same McpServer hashed differently → the idempotency gate fired a `replace` twice every pass forever, and (post-this-PR) that dropped the `network-ready` ack pair each pass, flapping it across WRC↔HCC.

**Fix (cherry-picked from @claude's #413 branch, verified here):** exclude `clerum.io/pre-deploy` from `computeSpecHash` (`HASH_EXCLUDED_ANNOTATIONS`) so 7b and 9a hash identically → the gate converges to **zero PUTs in steady state**, which also makes this PR's ack-drop a steady-state no-op (it only runs on a real spec change, as intended). `pre-deploy` still persists on the live object via the replace merge (HCC's re-ack guard requires it); only the hash excludes it. The misleading Step 9a "remove pre-deploy annotation" comment is corrected, and a drift-guard test ties `HASH_EXCLUDED_ANNOTATIONS` back to `PRE_DEPLOY_ANNOTATION`.

**Verification (locally, this branch):** `tsc` build green; `specHash.test.ts` 12/12 (convergence + drift-guard); full `workflow-recipes` suite **2480 passed / 0 failed**.

### Correction to the R1 evidence (from the @claude review)

The earlier R1 note ("recipe converges, zero write-churn") was measured on a `streamableHttp` / `managed:false` McpServer, which never enters `waitForNetworkReady` (generic gate is `stdio`-only) and never receives the `network-ready` ack (HCC diverts `managed:false` before the ack block). So that observation did **not** exercise the ack-drop path — its stable `resourceVersion` shows the 7b/9a path simply didn't run in that window. The real severity is: fail-open, +1–3s typical / +30s ceiling per pass on generic-stdio readiness — now resolved by the #413 convergence above.

## Note on the diff

The `package.json` / `package-lock.json` version bumps in both packages are automatic from the repo's `.githooks/pre-commit` `version:staged` step (one patch increment per commit that touches each package), not manual changes.

Fixes #413


## Also fixes #414 — shared handshake annotation keys

Following @zach88's R1-L2, the three handshake keys (`pre-deploy`, `network-ready`, `network-ready-observed-generation`) were duplicated as independent string literals in WRC and HCC, so a typo on one side degraded silently (never fresh → 30s fail-open → nothing red). Moved them into `@clerum/network-policy-core` (already the home of the egress-fqdn annotation contract, already a dependency of both services); WRC re-exports them for existing consumers, HCC imports them, and `specHash`'s `HASH_EXCLUDED_ANNOTATIONS` uses the shared constant too. **A divergence is now a compile error, not a silent runtime drift** — a stronger guarantee than any cross-service test, which is why the "cross-controller coverage" residual is closed here. Verified: `tsc` green (WRC+HCC), WRC suite 2480/0, HCC #408 green, `network-policy-core` self-test 42/0.

Fixes #414
