### PR TITLE
fix(deploy): the llm-hooks baseline netpol must not claim hcc ownership

### DIFF
--- a/deploy/base/llm-hooks/networkpolicies.yaml
+++ b/deploy/base/llm-hooks/networkpolicies.yaml
@@ -16,14 +16,25 @@
 # inbound connection (connection tracking), which needs no egress rule.
 #
 # Kubelet health/readiness probes originate from the node and are unaffected.
+#
+# OWNERSHIP: this baseline is applied by the DEPLOY, not by HCC, so it carries
+# `managed-by: llm-hooks` and a distinct name — the same convention
+# deploy/base/sandbox-ui/networkpolicies.yaml uses for its static baseline.
+# Labelling it `managed-by: host-context-controller` claimed an owner that has
+# never reconciled it, and the ValidatingAdmissionPolicy
+# `managed-networkpolicy-label-immutability` refuses CREATE of a NetworkPolicy
+# carrying a controller's label from anyone but that controller's ServiceAccount
+# or a system:masters bootstrap — so the restricted deploy identity was denied
+# and the whole apply aborted. A local (cluster-admin) apply is exempt, which is
+# why this only surfaced in CI.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny
+  name: llm-hooks-static-default-deny
   namespace: llm-hooks
   labels:
-    clerum.io/managed-by: host-context-controller
-    clerum.io/policy-type: infrastructure
+    clerum.io/managed-by: llm-hooks
+    clerum.io/policy-type: baseline
 spec:
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
The dev deploy is currently stuck. This unsticks it by fixing one mislabelled file.

## What's broken

After #372 merged, the automatic dev deploy ran and stopped partway through with this:

```
Forbidden: networkpolicies "default-deny" is forbidden:
ValidatingAdmissionPolicy 'managed-networkpolicy-label-immutability' denied request:
Only the owning controllers or cluster-admin bootstrap may create NetworkPolicies
with managed controller labels.
```

Nothing after that step got applied.

## Why it happened, in plain terms

There's a guard in the cluster that watches network rules being created. Some of those rules are meant to be written *by a program* — the host-context-controller — and by nothing else. So when a rule shows up saying "the controller made me," the guard checks who is actually submitting it. If it isn't the controller, it refuses.

That's a sensible rule. Network rules decide what can talk to what. If anything could create one wearing the controller's badge, someone could slip in a rule that the controller would then treat as its own.

The file #372 added — the rule that seals off guardrail hook containers — **claims to be made by the controller**, because it carries the controller's name as a label. But it isn't. It's an ordinary config file applied by the deploy pipeline. So the pipeline turned up wearing a badge that wasn't its own, and the guard sent it away.

It's a mislabel, not a security hole. The rule itself is correct and does what it should.

## Why nobody noticed until now

Local deploys are applied as a full administrator, and the guard waves administrators through. Every minikube deploy we ran worked fine.

The guard only objects when a restricted account does the applying — which is exactly what CI uses. This was always going to fail the first time it left someone's laptop.

## What this changes

The same repo already solves this problem twice, in two different ways. The `mcp-host` baseline wears no badge at all. The `sandbox-ui` baseline wears its own name instead of the controller's, and uses a distinctive filename so it can never be confused with a controller-made rule. Ours was the only one borrowing the controller's identity.

This follows the `sandbox-ui` approach:

| | before | after |
|---|---|---|
| name | `default-deny` | `llm-hooks-static-default-deny` |
| owner label | `host-context-controller` | `llm-hooks` |
| type label | `infrastructure` | `baseline` |

**What the rule actually does is unchanged.** It still blocks all inbound and outbound traffic for every pod in that namespace. Only the name and the "who made this" labels move. Labels don't affect enforcement.

There's a second benefit beyond unblocking CI: the old label was simply untrue. It told the cluster the controller owned a rule the controller has never heard of — the kind of thing that looks, to anyone auditing later, like a leftover from a program that stopped managing it.

Checked with a dry run against the dev cluster: the rule is now accepted rather than refused.

## One trade-off worth knowing about

The guard does more than block creation — it also freezes the labels on controller-owned rules so they can't be quietly altered later. That protection only applies to rules carrying a controller's name, so this one won't have it. From here, the only thing protecting it is normal permissions: anyone allowed to edit network rules in that namespace could weaken it.

Worth putting in proportion, though. That protection was never actually available to us — to get it, the rule would have to be created by the controller itself, and this one is a static file. The real choice was between an unprotected rule that deploys and a protected one that nobody can deploy. Right now dev has no rule at all, which is worse than either.

If we want the stronger version later, the fix is to have the controller create this baseline the way it creates the others. That's a design change rather than a hotfix, and it would leave the namespace unsealed until the controller catches up — so it shouldn't ride along with an urgent unblock.

## After this merges

On any cluster that already has the old rule, it needs deleting by hand:

```
kubectl -n llm-hooks delete networkpolicy default-deny
```

It can't simply be renamed or relabelled in place — the same guard makes the owner label unchangeable once set, so switching owners means delete and recreate.

- **clerum-test** has the old rule (it was applied there as an administrator, which is why it went in). Needs the delete.
- **clerum-dev** never got it, so there's nothing to clean up. Until this lands, hook containers there have no baseline confinement — no hooks are installed, so nothing is exposed, but the protection is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
