### PR TITLE
fix(hcc): bind MCP discovery and auth to Host Context

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.470",
+  "version": "0.1.471",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.470",
+      "version": "0.1.471",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.470",
+  "version": "0.1.471",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/test/network.gateway.intent.test.ts
+++ b/control-api/test/network.gateway.intent.test.ts
@@ -693,10 +693,37 @@ describe('network/gateway intent (manifest-level)', () => {
       'name: host-context-controller-api-gateway'
     )
     expect(hccGatewayConf).toContain('location = /health')
+    expect(hccGatewayConf).toContain('location = /api/v1/mcpservers')
     expect(hccGatewayConf).toContain('location ~ ^/api/v1/mcpservers/context/[^/]+$')
     expect(hccGatewayConf).toContain('location ~ ^/api/v1/mcpservers/[^/]+/auth$')
+    const contextBlock = locationBlock(
+      hccGatewayConf,
+      'location ~ ^/api/v1/mcpservers/context/[^/]+$'
+    )
+    const authBlock = locationBlock(hccGatewayConf, 'location ~ ^/api/v1/mcpservers/[^/]+/auth$')
+    expect(contextBlock).toContain('proxy_set_header Authorization $http_authorization')
+    expect(authBlock).toContain('proxy_set_header Authorization $http_authorization')
     expect(hccGatewayConf).toContain('location / {')
     expect(hccGatewayConf).toContain('return 403;')
+  })
+
+  it('grants host-context-controller TokenReview so MCP discovery can bind Host Context', () => {
+    const clusterRoles = read(`${BASE}/cluster-wide/clusterroles.yaml`)
+    const bindings = read(`${BASE}/cluster-wide/clusterrolebindings.yaml`)
+    const tokenReviewRole = docContaining(
+      yamlDocs(clusterRoles),
+      'name: host-context-controller-tokenreview'
+    )
+    const tokenReviewBinding = docContaining(
+      yamlDocs(bindings),
+      'name: host-context-controller-tokenreview'
+    )
+
+    expect(tokenReviewRole).toContain('authentication.k8s.io')
+    expect(tokenReviewRole).toContain('tokenreviews')
+    expect(tokenReviewRole).toContain('- create')
+    expect(tokenReviewBinding).toContain('name: host-context-controller')
+    expect(tokenReviewBinding).toContain('namespace: control-plane')
   })
 
   it('routes runtime workflow broker traffic through workflow gateway and not admin routes', () => {

--- a/deploy/base/cluster-wide/clusterrolebindings.yaml
+++ b/deploy/base/cluster-wide/clusterrolebindings.yaml
@@ -86,3 +86,19 @@ subjects:
 - kind: ServiceAccount
   name: control-api
   namespace: control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: host-context-controller-tokenreview
+  labels:
+    app.kubernetes.io/part-of: clerum
+    app.kubernetes.io/name: host-context-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: host-context-controller-tokenreview
+subjects:
+- kind: ServiceAccount
+  name: host-context-controller
+  namespace: control-plane

--- a/deploy/base/cluster-wide/clusterroles.yaml
+++ b/deploy/base/cluster-wide/clusterroles.yaml
@@ -138,3 +138,21 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list"]
+---
+# host-context-controller-tokenreview — bind MCP discovery/auth to the
+# calling Host's current Context. HCC TokenReviews the per-Host
+# ServiceAccount bearer; path Context and unsigned headers are not authority.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: host-context-controller-tokenreview
+  labels:
+    app.kubernetes.io/part-of: clerum
+    app.kubernetes.io/name: host-context-controller
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create

--- a/deploy/base/control-plane/configmaps.yaml
+++ b/deploy/base/control-plane/configmaps.yaml
@@ -835,6 +835,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Authorization $http_authorization;
         }
 
         location ~ ^/api/v1/mcpservers/context/[^/]+$ {
@@ -843,6 +844,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Authorization $http_authorization;
         }
 
         location ~ ^/api/v1/mcpservers/[^/]+/auth$ {
@@ -851,6 +853,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Authorization $http_authorization;
         }
 
         location ~ ^/api/v1/desktop/[^/]+$ {
@@ -859,6 +862,7 @@ data:
           proxy_set_header X-Real-IP $remote_addr;
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Authorization $http_authorization;
         }
 
         location / {

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.228",
+  "version": "0.1.229",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.228",
+      "version": "0.1.229",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.228",
+  "version": "0.1.229",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -9,6 +9,7 @@ import { HOST_LABEL, MANAGED_BY_LABEL, MANAGED_BY_VALUE } from './constants'
 import { mintHostGfsToken } from './gfsHostBinding'
 import { GFS_HOST_SCOPES } from './gfsHostPolicy'
 import { makeExpectedHostGfsSubject } from './gfsHostSubject'
+import { hostServiceAccountName } from './hostServiceAccount'
 import type {
   HccInfrastructureTelemetryPayload,
   InfrastructureTelemetryReporter,
@@ -816,7 +817,7 @@ export class HostReconciler {
 
   /** Per-Host ServiceAccount name. */
   private hostSaName(host: HostCRD): string {
-    return `host-${host.name}-sa`
+    return hostServiceAccountName(host.name)
   }
 
   /** Per-Host RBAC Role + RoleBinding name (shared between the two). */
@@ -2715,6 +2716,9 @@ export class HostReconciler {
             // mcp-host watch only its own Host CRD, env CM/Secret, and LLM
             // Secret.
             serviceAccountName: this.hostSaName(host),
+            // Discovery TokenReview needs the projected SA token in the pod.
+            // Pin true so a later hardening pass cannot silently drop it.
+            automountServiceAccountToken: true,
             // A stateless Host may be recreated after a user interaction.
             // Give only that on-demand workload the interactive class so its
             // wake can preempt explicitly lower-priority batch work. Keep

--- a/host-context-controller/src/hostServiceAccount.ts
+++ b/host-context-controller/src/hostServiceAccount.ts
@@ -1,0 +1,8 @@
+/**
+ * Per-Host ServiceAccount naming. HCC discovery TokenReview maps
+ * `system:serviceaccount:<hostNamespace>:<this>` back to the Host name.
+ * Keep in lockstep with HostReconciler.ensureHostServiceAccount.
+ */
+export function hostServiceAccountName(hostName: string): string {
+  return `host-${hostName}-sa`
+}

--- a/host-context-controller/src/main.ts
+++ b/host-context-controller/src/main.ts
@@ -18,6 +18,7 @@ import {
   createMcpServerProvider,
   getKubeConfig,
 } from './k8sClient'
+import { buildMcpCallerResolver, reviewKubernetesToken } from './mcpCallerAuth'
 import { resolveHostAuthoritativeFn, resolveProviderAuthoritativeFn } from './readinessGate'
 import { ContextMapperServer } from './server'
 import { StatelessLifecycleTracker } from './statelessLifecycleTracker'
@@ -126,6 +127,17 @@ async function main(): Promise<void> {
   // server's fail-closed default would pin /api/v1/desktop/* at 503 forever in
   // dev (R2-M1). See resolveHostAuthoritativeFn.
   const hostAuthoritativeFn = resolveHostAuthoritativeFn(watcher)
+  // MCP discovery is TokenReview-bound. Apply TokenReview RBAC and restart
+  // the HCC gateway, roll Hosts onto an mcp-host that sends the SA bearer,
+  // then this HCC image. Recreate HCC first 401s discovery until Hosts roll
+  // (running Hosts keep last fleet; cold start waits on 401 after /ready).
+  const resolveMcpCaller = buildMcpCallerResolver({
+    devMode: config.devMode,
+    hostNamespace: config.hostNamespace,
+    getHost: name => watcher?.getHost(name),
+    reviewToken: reviewKubernetesToken,
+    devContextRef: config.devContexts[0]?.name ?? 'dev-context',
+  })
 
   // Stateless heartbeat consumption — mcp-host pods authenticate their
   // heartbeats toward control-api's /mcp-host facade (control-api is the
@@ -164,7 +176,8 @@ async function main(): Promise<void> {
     hostReconciler,
     hasDesktopFn,
     providerAuthoritativeFn,
-    hostAuthoritativeFn
+    hostAuthoritativeFn,
+    { resolveMcpCaller }
   )
   await server.start()
 

--- a/host-context-controller/src/mcpCallerAuth.test.ts
+++ b/host-context-controller/src/mcpCallerAuth.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest'
+import { hostServiceAccountName } from './hostServiceAccount'
+import {
+  buildMcpCallerResolver,
+  createTokenReviewMcpCallerResolver,
+  hostRefFromServiceAccountUser,
+  parseBearerToken,
+  tokenReviewResultFromResponse,
+} from './mcpCallerAuth'
+import type { HostCRD } from './types'
+
+describe('parseBearerToken', () => {
+  it('returns the token from a Bearer header', () => {
+    expect(parseBearerToken('Bearer abc.def')).toBe('abc.def')
+  })
+
+  it('accepts a case-insensitive Bearer scheme', () => {
+    expect(parseBearerToken('bearer abc')).toBe('abc')
+  })
+
+  it('rejects missing, empty, or non-Bearer credentials', () => {
+    expect(parseBearerToken(undefined)).toBeNull()
+    expect(parseBearerToken('')).toBeNull()
+    expect(parseBearerToken('Bearer')).toBeNull()
+    expect(parseBearerToken('Bearer ')).toBeNull()
+    expect(parseBearerToken('Basic abc')).toBeNull()
+    expect(parseBearerToken(['Bearer a', 'Bearer b'])).toBeNull()
+  })
+})
+
+describe('hostRefFromServiceAccountUser', () => {
+  it('maps a per-Host ServiceAccount username to the Host name', () => {
+    expect(
+      hostRefFromServiceAccountUser('system:serviceaccount:mcp-host:host-chatllm-sa', 'mcp-host')
+    ).toBe('chatllm')
+    expect(
+      hostRefFromServiceAccountUser(
+        'system:serviceaccount:mcp-host:host-chatllm-stateless-sa',
+        'mcp-host'
+      )
+    ).toBe('chatllm-stateless')
+  })
+
+  it('rejects ServiceAccounts from another namespace or a non-Host name', () => {
+    expect(
+      hostRefFromServiceAccountUser('system:serviceaccount:default:host-chatllm-sa', 'mcp-host')
+    ).toBeNull()
+    expect(
+      hostRefFromServiceAccountUser('system:serviceaccount:mcp-host:default', 'mcp-host')
+    ).toBeNull()
+    expect(
+      hostRefFromServiceAccountUser('system:serviceaccount:mcp-host:host-sa', 'mcp-host')
+    ).toBe(null)
+  })
+
+  it('round-trips the HostReconciler ServiceAccount name', () => {
+    expect(hostServiceAccountName('chatllm')).toBe('host-chatllm-sa')
+    expect(
+      hostRefFromServiceAccountUser(
+        `system:serviceaccount:mcp-host:${hostServiceAccountName('alpha')}`,
+        'mcp-host'
+      )
+    ).toBe('alpha')
+  })
+})
+
+describe('tokenReviewResultFromResponse', () => {
+  it('reads client-node createTokenReview body shape', () => {
+    expect(
+      tokenReviewResultFromResponse({
+        status: {
+          authenticated: true,
+          user: { username: 'system:serviceaccount:mcp-host:host-chatllm-sa' },
+        },
+      })
+    ).toEqual({
+      authenticated: true,
+      username: 'system:serviceaccount:mcp-host:host-chatllm-sa',
+    })
+  })
+
+  it('reads HttpInfo.data wrapping and rejects unauthenticated or empty username', () => {
+    expect(
+      tokenReviewResultFromResponse({
+        data: {
+          status: {
+            authenticated: true,
+            user: { username: 'system:serviceaccount:mcp-host:host-chatllm-sa' },
+          },
+        },
+      })
+    ).toEqual({
+      authenticated: true,
+      username: 'system:serviceaccount:mcp-host:host-chatllm-sa',
+    })
+    expect(tokenReviewResultFromResponse({ status: { authenticated: false } })).toEqual({
+      authenticated: false,
+    })
+    expect(tokenReviewResultFromResponse({ status: { authenticated: true, user: {} } })).toEqual({
+      authenticated: false,
+    })
+    expect(tokenReviewResultFromResponse(null)).toEqual({ authenticated: false })
+  })
+})
+
+describe('createTokenReviewMcpCallerResolver', () => {
+  const hosts = new Map<string, HostCRD>([
+    [
+      'chatllm',
+      {
+        name: 'chatllm',
+        namespace: 'mcp-host',
+        spec: { host: 'chatllm', contextRef: 'context1', secretRef: 'llm' },
+      },
+    ],
+  ])
+
+  it('returns the Host current Context from TokenReview, ignoring forged headers', async () => {
+    const resolve = createTokenReviewMcpCallerResolver({
+      hostNamespace: 'mcp-host',
+      getHost: name => hosts.get(name),
+      reviewToken: async token =>
+        token === 'sa-token'
+          ? {
+              authenticated: true,
+              username: 'system:serviceaccount:mcp-host:host-chatllm-sa',
+            }
+          : { authenticated: false },
+    })
+
+    const caller = await resolve({
+      headers: {
+        authorization: 'Bearer sa-token',
+        'x-clerum-host-ref': 'other-host',
+        'x-clerum-context': 'context2',
+      },
+    } as never)
+
+    expect(caller).toEqual({ hostRef: 'chatllm', contextRef: 'context1' })
+  })
+
+  it('returns null when the bearer is missing, junk, or does not map to a live Host', async () => {
+    const resolve = createTokenReviewMcpCallerResolver({
+      hostNamespace: 'mcp-host',
+      getHost: name => hosts.get(name),
+      reviewToken: async () => ({ authenticated: false }),
+    })
+
+    expect(await resolve({ headers: {} } as never)).toBeNull()
+    expect(await resolve({ headers: { authorization: 'Bearer junk' } } as never)).toBeNull()
+  })
+
+  it('returns null when TokenReview succeeds but the Host is gone from cache', async () => {
+    const resolve = createTokenReviewMcpCallerResolver({
+      hostNamespace: 'mcp-host',
+      getHost: () => undefined,
+      reviewToken: async () => ({
+        authenticated: true,
+        username: 'system:serviceaccount:mcp-host:host-chatllm-sa',
+      }),
+    })
+
+    expect(await resolve({ headers: { authorization: 'Bearer sa-token' } } as never)).toBeNull()
+  })
+
+  it('does not fall back to forged headers when TokenReview fails', async () => {
+    const resolve = createTokenReviewMcpCallerResolver({
+      hostNamespace: 'mcp-host',
+      getHost: name => hosts.get(name),
+      reviewToken: async () => ({ authenticated: false }),
+    })
+
+    expect(
+      await resolve({
+        headers: {
+          authorization: 'Bearer junk',
+          'x-clerum-host-ref': 'chatllm',
+          'x-clerum-context': 'context1',
+        },
+      } as never)
+    ).toBeNull()
+  })
+
+  it('returns null when TokenReview throws', async () => {
+    const resolve = createTokenReviewMcpCallerResolver({
+      hostNamespace: 'mcp-host',
+      getHost: name => hosts.get(name),
+      reviewToken: async () => {
+        throw new Error('apiserver unavailable')
+      },
+    })
+
+    expect(await resolve({ headers: { authorization: 'Bearer sa-token' } } as never)).toBeNull()
+  })
+})
+
+describe('buildMcpCallerResolver', () => {
+  const hosts = new Map<string, HostCRD>([
+    [
+      'chatllm',
+      {
+        name: 'chatllm',
+        namespace: 'mcp-host',
+        spec: { host: 'chatllm', contextRef: 'context1', secretRef: 'llm' },
+      },
+    ],
+  ])
+
+  it('uses TokenReview in production and ignores forged headers', async () => {
+    const resolve = buildMcpCallerResolver({
+      devMode: false,
+      hostNamespace: 'mcp-host',
+      getHost: name => hosts.get(name),
+      reviewToken: async token =>
+        token === 'sa-token'
+          ? {
+              authenticated: true,
+              username: 'system:serviceaccount:mcp-host:host-chatllm-sa',
+            }
+          : { authenticated: false },
+      devContextRef: 'dev-context',
+    })
+
+    expect(
+      await resolve({
+        headers: {
+          authorization: 'Bearer sa-token',
+          'x-clerum-context': 'context2',
+        },
+      } as never)
+    ).toEqual({ hostRef: 'chatllm', contextRef: 'context1' })
+    expect(
+      await resolve({
+        headers: { authorization: 'Bearer junk', 'x-clerum-context': 'context1' },
+      } as never)
+    ).toBeNull()
+  })
+
+  it('binds to the configured Context only in devMode', async () => {
+    const resolve = buildMcpCallerResolver({
+      devMode: true,
+      hostNamespace: 'mcp-host',
+      getHost: () => undefined,
+      reviewToken: async () => ({ authenticated: false }),
+      devContextRef: 'dev-context',
+    })
+
+    expect(await resolve({ headers: {} } as never)).toEqual({
+      hostRef: 'dev',
+      contextRef: 'dev-context',
+    })
+  })
+})

--- a/host-context-controller/src/mcpCallerAuth.ts
+++ b/host-context-controller/src/mcpCallerAuth.ts
@@ -1,0 +1,130 @@
+/**
+ * Host identity for HCC MCP discovery/auth routes.
+ *
+ * Caller-supplied Context, Host name, or unsigned headers are not authority.
+ * Production maps a Kubernetes TokenReview of the per-Host ServiceAccount
+ * onto Host.spec.contextRef from HCC's own cache.
+ */
+import * as k8s from '@kubernetes/client-node'
+import type * as http from 'http'
+import { hostServiceAccountName } from './hostServiceAccount'
+import { getKubeConfig } from './k8sClient'
+import type { HostCRD } from './types'
+
+export type McpCaller = {
+  hostRef: string
+  contextRef: string
+}
+
+export type McpCallerResolver = (req: http.IncomingMessage) => Promise<McpCaller | null>
+
+export type TokenReviewResult = {
+  authenticated: boolean
+  username?: string
+}
+
+export function parseBearerToken(authorization: string | string[] | undefined): string | null {
+  if (typeof authorization !== 'string') return null
+  const match = /^(?:Bearer)\s+(\S+)$/i.exec(authorization.trim())
+  return match?.[1] ?? null
+}
+
+export function hostRefFromServiceAccountUser(
+  username: string,
+  hostNamespace: string
+): string | null {
+  const prefix = `system:serviceaccount:${hostNamespace}:`
+  if (!username.startsWith(prefix)) return null
+  const saName = username.slice(prefix.length)
+  const expectedPrefix = 'host-'
+  const expectedSuffix = '-sa'
+  if (!saName.startsWith(expectedPrefix) || !saName.endsWith(expectedSuffix)) return null
+  const hostRef = saName.slice(expectedPrefix.length, saName.length - expectedSuffix.length)
+  if (!hostRef || hostServiceAccountName(hostRef) !== saName) return null
+  return hostRef
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null
+}
+
+/**
+ * Normalize TokenReview API shapes to an authentication result.
+ * client-node `createTokenReview` returns the V1TokenReview body (`apiResponse.data`).
+ */
+export function tokenReviewResultFromResponse(review: unknown): TokenReviewResult {
+  const obj = asRecord(review)
+  if (!obj) return { authenticated: false }
+  const status = asRecord(obj.status) ?? asRecord(asRecord(obj.data)?.status)
+  if (!status?.authenticated) return { authenticated: false }
+  const user = asRecord(status.user)
+  const username = typeof user?.username === 'string' ? user.username : undefined
+  if (!username) return { authenticated: false }
+  return { authenticated: true, username }
+}
+
+export function createTokenReviewMcpCallerResolver(options: {
+  hostNamespace: string
+  getHost: (name: string) => HostCRD | undefined
+  reviewToken: (token: string) => Promise<TokenReviewResult>
+}): McpCallerResolver {
+  return async req => {
+    try {
+      const token = parseBearerToken(req.headers.authorization)
+      if (!token) return null
+      const review = await options.reviewToken(token)
+      if (!review.authenticated || !review.username) return null
+      const hostRef = hostRefFromServiceAccountUser(review.username, options.hostNamespace)
+      if (!hostRef) return null
+      const host = options.getHost(hostRef)
+      const contextRef = host?.spec.contextRef?.trim()
+      if (!host || !contextRef) return null
+      return { hostRef, contextRef }
+    } catch (err) {
+      console.error('[Server] MCP caller resolution failed:', err)
+      return null
+    }
+  }
+}
+
+export function buildMcpCallerResolver(options: {
+  devMode: boolean
+  hostNamespace: string
+  getHost: (name: string) => HostCRD | undefined
+  reviewToken: (token: string) => Promise<TokenReviewResult>
+  devContextRef: string
+}): McpCallerResolver {
+  if (options.devMode) {
+    return async () => ({
+      hostRef: 'dev',
+      contextRef: options.devContextRef,
+    })
+  }
+  return createTokenReviewMcpCallerResolver({
+    hostNamespace: options.hostNamespace,
+    getHost: options.getHost,
+    reviewToken: options.reviewToken,
+  })
+}
+
+/**
+ * TokenReview of a presented bearer. Fail-closed on missing kube config or API errors.
+ */
+export async function reviewKubernetesToken(token: string): Promise<TokenReviewResult> {
+  const kubeConfig = getKubeConfig()
+  if (!kubeConfig) return { authenticated: false }
+  try {
+    const api = kubeConfig.makeApiClient(k8s.AuthenticationV1Api)
+    const review = await api.createTokenReview({
+      body: {
+        apiVersion: 'authentication.k8s.io/v1',
+        kind: 'TokenReview',
+        spec: { token },
+      },
+    })
+    return tokenReviewResultFromResponse(review)
+  } catch (err) {
+    console.error('[Server] TokenReview failed:', err)
+    return { authenticated: false }
+  }
+}

--- a/host-context-controller/src/server.test.ts
+++ b/host-context-controller/src/server.test.ts
@@ -52,11 +52,15 @@ class MockResponse {
   }
 }
 
-async function invoke(server: ContextMapperServer, path: string) {
+async function invoke(
+  server: ContextMapperServer,
+  path: string,
+  headers: Record<string, string> = {}
+) {
   const req = {
     method: 'GET',
     url: path,
-    headers: {},
+    headers,
   }
   const res = new MockResponse()
   await (
@@ -119,10 +123,10 @@ describe('ContextMapperServer readiness', () => {
     expect(JSON.parse(response.body)).toEqual({ status: 'ready', ready: true })
 
     response = await invoke(server, '/api/v1/mcpservers')
-    expect(response.statusCode).toBe(200)
-    expect(JSON.parse(response.body)).toMatchObject({
-      servers: [],
-      contextRef: '*',
+    expect(response.statusCode).toBe(401)
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'Unauthorized',
+      message: 'Invalid or missing Host identity',
     })
   })
 
@@ -173,7 +177,7 @@ describe('ContextMapperServer readiness', () => {
     expect(JSON.parse(response.body)).toEqual({ status: 'ready', ready: true })
 
     response = await invoke(server, '/api/v1/mcpservers')
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(401)
   })
 
   it('fails readiness closed when the provider authority check throws', async () => {
@@ -308,5 +312,200 @@ describe('ContextMapperServer desktop status authority', () => {
       error: 'Service Unavailable',
       message: 'Host inventory is not authoritative',
     })
+  })
+})
+
+class InventoryProvider implements McpServerProvider {
+  getAuthTokenCalls: string[] = []
+
+  constructor(
+    private readonly servers: Array<{
+      name: string
+      contextRef: string
+      auth?: { type: 'none' | 'bearer'; secretRef?: string; secretKey?: string }
+      token?: string
+    }>
+  ) {}
+
+  getAllServers() {
+    return []
+  }
+
+  getAllServerInfos() {
+    return this.servers.map(server => ({
+      name: server.name,
+      contextRef: server.contextRef,
+      transport: { type: 'streamableHttp' as const, url: `http://${server.name}` },
+      auth: server.auth,
+      enabled: true,
+      status: { deployed: true, ready: true },
+    }))
+  }
+
+  async getServerInfosByContext(contextRef: string) {
+    return this.getAllServerInfos().filter(server => server.contextRef === contextRef)
+  }
+
+  async getAuthToken(serverName: string) {
+    this.getAuthTokenCalls.push(serverName)
+    return this.servers.find(server => server.name === serverName)?.token
+  }
+
+  onChange() {}
+
+  async start() {}
+
+  async stop() {}
+}
+
+describe('ContextMapperServer MCP Host Context bind', () => {
+  let server: ContextMapperServer | null = null
+
+  const provider = () =>
+    new InventoryProvider([
+      { name: 'airtable-server', contextRef: 'context1' },
+      {
+        name: 'foreign-server',
+        contextRef: 'context2',
+        auth: { type: 'bearer', secretRef: 'foreign-creds', secretKey: 'token' },
+        token: 'foreign-secret',
+      },
+    ])
+
+  const hostA = async (req: { headers: Record<string, string> }) => {
+    const authorization = req.headers.authorization
+    if (authorization === 'Bearer host-a') {
+      return { hostRef: 'chatllm', contextRef: 'context1' }
+    }
+    return null
+  }
+
+  afterEach(async () => {
+    await server?.stop()
+    server = null
+  })
+
+  it('rejects unauthenticated MCP inventory and auth once ready', async () => {
+    const inventory = provider()
+    server = new ContextMapperServer(
+      inventory,
+      0,
+      undefined,
+      undefined,
+      () => true,
+      () => false,
+      { resolveMcpCaller: hostA as never }
+    )
+    server.setReady(true)
+
+    for (const path of [
+      '/api/v1/mcpservers',
+      '/api/v1/mcpservers/context/context1',
+      '/api/v1/mcpservers/foreign-server/auth',
+    ]) {
+      const response = await invoke(server, path)
+      expect(response.statusCode).toBe(401)
+      expect(JSON.parse(response.body)).toEqual({
+        error: 'Unauthorized',
+        message: 'Invalid or missing Host identity',
+      })
+    }
+    expect(inventory.getAuthTokenCalls).toEqual([])
+  })
+
+  it('lists only the caller Host current Context and ignores path Context and forged headers', async () => {
+    server = new ContextMapperServer(
+      provider(),
+      0,
+      undefined,
+      undefined,
+      () => true,
+      () => false,
+      { resolveMcpCaller: hostA as never }
+    )
+    server.setReady(true)
+
+    const list = await invoke(server, '/api/v1/mcpservers', { authorization: 'Bearer host-a' })
+    expect(list.statusCode).toBe(200)
+    expect(JSON.parse(list.body)).toMatchObject({
+      contextRef: 'context1',
+      servers: [{ name: 'airtable-server', contextRef: 'context1' }],
+    })
+    expect(JSON.parse(list.body).servers.map((s: { name: string }) => s.name)).not.toContain(
+      'foreign-server'
+    )
+
+    const ownContext = await invoke(server, '/api/v1/mcpservers/context/context1', {
+      authorization: 'Bearer host-a',
+    })
+    expect(ownContext.statusCode).toBe(200)
+    expect(JSON.parse(ownContext.body).servers.map((s: { name: string }) => s.name)).toEqual([
+      'airtable-server',
+    ])
+
+    const foreignContext = await invoke(server, '/api/v1/mcpservers/context/context2', {
+      authorization: 'Bearer host-a',
+      'x-clerum-context': 'context2',
+      'x-clerum-host-ref': 'other-host',
+    })
+    expect(foreignContext.statusCode).toBe(403)
+    expect(JSON.parse(foreignContext.body)).toEqual({
+      error: 'Forbidden',
+      message: 'Host is not bound to this Context',
+    })
+  })
+
+  it('fails closed with 401 when caller resolution throws', async () => {
+    server = new ContextMapperServer(
+      provider(),
+      0,
+      undefined,
+      undefined,
+      () => true,
+      () => false,
+      {
+        resolveMcpCaller: async () => {
+          throw new Error('resolver exploded')
+        },
+      }
+    )
+    server.setReady(true)
+
+    const response = await invoke(server, '/api/v1/mcpservers', { authorization: 'Bearer host-a' })
+    expect(response.statusCode).toBe(401)
+  })
+
+  it('does not read a Secret for a server outside the caller Host current Context', async () => {
+    const inventory = provider()
+    server = new ContextMapperServer(
+      inventory,
+      0,
+      undefined,
+      undefined,
+      () => true,
+      () => false,
+      { resolveMcpCaller: hostA as never }
+    )
+    server.setReady(true)
+
+    const foreignAuth = await invoke(server, '/api/v1/mcpservers/foreign-server/auth', {
+      authorization: 'Bearer host-a',
+    })
+    expect(foreignAuth.statusCode).toBe(404)
+    expect(JSON.parse(foreignAuth.body)).toEqual({
+      error: 'Not Found',
+      message: 'McpServer foreign-server not found',
+    })
+    expect(inventory.getAuthTokenCalls).toEqual([])
+
+    const ownAuth = await invoke(server, '/api/v1/mcpservers/airtable-server/auth', {
+      authorization: 'Bearer host-a',
+    })
+    expect(ownAuth.statusCode).toBe(200)
+    expect(JSON.parse(ownAuth.body)).toEqual({
+      token: null,
+      message: 'No auth configured for this server',
+    })
+    expect(inventory.getAuthTokenCalls).toEqual(['airtable-server'])
   })
 })

--- a/host-context-controller/src/server.ts
+++ b/host-context-controller/src/server.ts
@@ -5,6 +5,7 @@ import * as http from 'http'
 import { config } from './config'
 import { HostReconciler } from './hostReconciler'
 import { McpServerProvider } from './k8sClient'
+import { type McpCaller, type McpCallerResolver } from './mcpCallerAuth'
 import { registry } from './metrics'
 import { ErrorResponse, McpServersResponse } from './types'
 
@@ -20,6 +21,7 @@ export class ContextMapperServer {
   private hasDesktopFn: ((hostRef: string) => boolean) | null
   private providerAuthoritativeFn: () => boolean
   private hostAuthoritativeFn: () => boolean
+  private resolveMcpCaller: McpCallerResolver
   private ready = false
 
   constructor(
@@ -34,7 +36,10 @@ export class ContextMapperServer {
     // Desktop status needs ONLY Host inventory authority, not the full
     // readiness inventory. Fails closed like providerAuthoritativeFn: a caller
     // that omits it gets a 503 on desktop rather than a wrong 200 'inactive'.
-    hostAuthoritativeFn: () => boolean = () => false
+    hostAuthoritativeFn: () => boolean = () => false,
+    // MCP discovery/auth: omit the resolver and every inventory/auth GET 401s.
+    // Path Context and unsigned headers are not authority.
+    options: { resolveMcpCaller?: McpCallerResolver } = {}
   ) {
     this.provider = provider
     this.port = port
@@ -42,6 +47,7 @@ export class ContextMapperServer {
     this.hasDesktopFn = hasDesktopFn ?? null
     this.providerAuthoritativeFn = providerAuthoritativeFn
     this.hostAuthoritativeFn = hostAuthoritativeFn
+    this.resolveMcpCaller = options.resolveMcpCaller ?? (async () => null)
   }
 
   /**
@@ -211,6 +217,31 @@ export class ContextMapperServer {
   }
 
   /**
+   * Bind MCP inventory/auth to the caller's current Host Context.
+   * TokenReview (or a test double) is the only identity source.
+   */
+  private async requireMcpCaller(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<McpCaller | null> {
+    let caller: McpCaller | null
+    try {
+      caller = await this.resolveMcpCaller(req)
+    } catch (err) {
+      console.error('[Server] MCP caller resolution failed:', err)
+      caller = null
+    }
+    if (!caller) {
+      this.sendJson(res, 401, {
+        error: 'Unauthorized',
+        message: 'Invalid or missing Host identity',
+      })
+      return null
+    }
+    return caller
+  }
+
+  /**
    * Start the server.
    */
   start(): Promise<void> {
@@ -294,14 +325,17 @@ export class ContextMapperServer {
   private async handleListAll(
     req: http.IncomingMessage,
     res: http.ServerResponse,
-    url: URL
+    _url: URL
   ): Promise<void> {
     console.log(`[Server] GET /api/v1/mcpservers`)
 
-    const servers = this.provider.getAllServerInfos()
+    const caller = await this.requireMcpCaller(req, res)
+    if (!caller) return
+
+    const servers = await this.provider.getServerInfosByContext(caller.contextRef)
     const response: McpServersResponse = {
       servers,
-      contextRef: '*',
+      contextRef: caller.contextRef,
       timestamp: new Date().toISOString(),
     }
 
@@ -323,7 +357,17 @@ export class ContextMapperServer {
       return
     }
 
-    const servers = await this.provider.getServerInfosByContext(contextRef)
+    const caller = await this.requireMcpCaller(req, res)
+    if (!caller) return
+    if (contextRef !== caller.contextRef) {
+      this.sendJson(res, 403, {
+        error: 'Forbidden',
+        message: 'Host is not bound to this Context',
+      })
+      return
+    }
+
+    const servers = await this.provider.getServerInfosByContext(caller.contextRef)
     const response: McpServersResponse = {
       servers,
       contextRef,
@@ -348,16 +392,17 @@ export class ContextMapperServer {
       return
     }
 
-    // Find the server
-    const servers = this.provider.getAllServerInfos()
-    const server = servers.find(s => s.name === serverName)
+    const caller = await this.requireMcpCaller(req, res)
+    if (!caller) return
+
+    const allowed = await this.provider.getServerInfosByContext(caller.contextRef)
+    const server = allowed.find(s => s.name === serverName)
 
     if (!server) {
       this.sendJson(res, 404, { error: 'Not Found', message: `McpServer ${serverName} not found` })
       return
     }
 
-    // Get the auth token via provider
     const token = await this.provider.getAuthToken(serverName)
 
     if (!token) {

--- a/host-context-controller/test/hostReconciler.test.ts
+++ b/host-context-controller/test/hostReconciler.test.ts
@@ -1005,6 +1005,7 @@ describe('HostReconciler — per-Host RBAC scaffolding', () => {
 
     const deployment = appsApi.createNamespacedDeployment.mock.calls[0][0].body
     expect(deployment.spec.template.spec.serviceAccountName).toBe('host-alpha-host-sa')
+    expect(deployment.spec.template.spec.automountServiceAccountToken).toBe(true)
   })
 
   it('injects CLERUM_LLM_SECRET_REF into the Deployment env from spec.secretRef', async () => {

--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.269",
+  "version": "0.1.270",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-mcp-host",
-      "version": "0.1.269",
+      "version": "0.1.270",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.269",
+  "version": "0.1.270",
   "description": "MCP Host - reads Host CRD and provides LLM access via OpenAI/Claude",
   "main": "dist/main.js",
   "engines": {

--- a/mcp-host/src/contextMapperClient.test.ts
+++ b/mcp-host/src/contextMapperClient.test.ts
@@ -167,6 +167,54 @@ describe('ContextMapperClient.pollServers', () => {
   })
 })
 
+describe('ContextMapperClient Host identity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('sends the Host ServiceAccount bearer on discovery and auth, not on ready', async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            servers: [],
+            contextRef: 'production',
+            timestamp: '2026-07-29T10:00:00.000Z',
+            token: null,
+          }),
+          { status: 200 }
+        )
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new ContextMapperClient(
+      'http://context-mapper.test',
+      10_000,
+      async () => 'Bearer sa-token'
+    )
+
+    await expect(client.healthCheck()).resolves.toBe(true)
+    await expect(client.listServersByContext('production')).resolves.toEqual([])
+    await expect(client.getAuthToken('open-server')).resolves.toBeUndefined()
+    await expect(client.pollServers('production')).resolves.toEqual({
+      servers: [],
+      timestamp: '2026-07-29T10:00:00.000Z',
+    })
+
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ headers: {} }))
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({ headers: { Authorization: 'Bearer sa-token' } })
+    )
+    expect(fetchMock.mock.calls[2]?.[1]).toEqual(
+      expect.objectContaining({ headers: { Authorization: 'Bearer sa-token' } })
+    )
+    expect(fetchMock.mock.calls[3]?.[1]).toEqual(
+      expect.objectContaining({ headers: { Authorization: 'Bearer sa-token' } })
+    )
+  })
+})
+
 describe('ContextMapperClient.getAuthToken', () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/mcp-host/src/contextMapperClient.ts
+++ b/mcp-host/src/contextMapperClient.ts
@@ -4,6 +4,7 @@
  * The Context Mapper provides McpServer CRDs via REST API, so mcp-host
  * doesn't need direct K8s access to McpServer resources.
  */
+import { readFile } from 'node:fs/promises'
 import { config } from './config'
 import { McpServerInfo } from './types'
 
@@ -19,6 +20,24 @@ export interface AuthTokenResponse {
 }
 
 const DEFAULT_CONTEXT_MAPPER_REQUEST_TIMEOUT_MS = 10_000
+export const DEFAULT_HCC_DISCOVERY_TOKEN_FILE =
+  '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+async function readServiceAccountBearer(tokenFile: string): Promise<string | undefined> {
+  try {
+    const token = (await readFile(tokenFile, 'utf8')).trim()
+    return token ? `Bearer ${token}` : undefined
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      console.warn(
+        `[ContextMapper] Host ServiceAccount token not readable at ${tokenFile}:`,
+        err instanceof Error ? err.message : err
+      )
+    }
+    return undefined
+  }
+}
 
 /**
  * Context Mapper client.
@@ -26,15 +45,30 @@ const DEFAULT_CONTEXT_MAPPER_REQUEST_TIMEOUT_MS = 10_000
 export class ContextMapperClient {
   private baseUrl: string
   private requestTimeoutMs: number
+  private getAuthorization: () => Promise<string | undefined>
 
-  constructor(baseUrl: string, requestTimeoutMs = DEFAULT_CONTEXT_MAPPER_REQUEST_TIMEOUT_MS) {
+  constructor(
+    baseUrl: string,
+    requestTimeoutMs = DEFAULT_CONTEXT_MAPPER_REQUEST_TIMEOUT_MS,
+    getAuthorization: () => Promise<string | undefined> = () =>
+      readServiceAccountBearer(
+        process.env.CLERUM_HCC_DISCOVERY_TOKEN_FILE || DEFAULT_HCC_DISCOVERY_TOKEN_FILE
+      )
+  ) {
     this.baseUrl = baseUrl.replace(/\/$/, '') // Remove trailing slash
     this.requestTimeoutMs = requestTimeoutMs
+    this.getAuthorization = getAuthorization
   }
 
-  private fetch(input: string): Promise<Response> {
+  private async fetch(input: string, withAuth = true): Promise<Response> {
+    const headers: Record<string, string> = {}
+    if (withAuth) {
+      const authorization = await this.getAuthorization()
+      if (authorization) headers.Authorization = authorization
+    }
     return fetch(input, {
       signal: AbortSignal.timeout(this.requestTimeoutMs),
+      headers,
     })
   }
 
@@ -43,7 +77,7 @@ export class ContextMapperClient {
    */
   async healthCheck(): Promise<boolean> {
     try {
-      const response = await this.fetch(`${this.baseUrl}/ready`)
+      const response = await this.fetch(`${this.baseUrl}/ready`, false)
       return response.ok
     } catch (error) {
       console.error('[ContextMapper] Health check failed:', error)

--- a/scripts/e2e/e2e-agentic-stdio-baseline.sh
+++ b/scripts/e2e/e2e-agentic-stdio-baseline.sh
@@ -61,24 +61,9 @@ wait_for_hcc_server_ready() {
   local server_name=$1 timeout=$2 elapsed=0
   while [ $elapsed -lt "$timeout" ]; do
     local ready
-    ready=$(kctl exec -n "$RECIPE_NS" deploy/mcp-proxy -- node -e "
-const http = require('http');
-const target = process.argv[1];
-http.get('http://host-context-controller-api-gateway.control-plane.svc.cluster.local:8081/api/v1/mcpservers', res => {
-  let body = '';
-  res.on('data', chunk => body += chunk);
-  res.on('end', () => {
-    try {
-      const data = JSON.parse(body);
-      const server = (data.servers || []).find(s => s.name === target);
-      process.stdout.write(server?.status?.deployed && server?.status?.ready ? 'ready' : 'not-ready');
-    } catch {
-      process.stdout.write('not-ready');
-    }
-  });
-}).on('error', () => process.stdout.write('not-ready'));
-" "$server_name" 2>/dev/null || echo "not-ready")
-    if [ "$ready" = "ready" ]; then
+    ready=$(kctl get mcpserver "$server_name" -n "$RECIPE_NS" \
+      -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+    if [ "$ready" = "True" ]; then
       return 0
     fi
     sleep "$POLL_INTERVAL"

--- a/scripts/e2e/e2e-hcc-mcp-context-readiness.sh
+++ b/scripts/e2e/e2e-hcc-mcp-context-readiness.sh
@@ -693,17 +693,26 @@ fixture_converged() {
 }
 
 probe_hcc_final_context() {
-  local probe_script
+  local probe_script host_pod token=""
+  host_pod="$(kctl get pod -n mcp-host -l "clerum.io/context=${CONTEXT_NAME}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+  if [ -n "$host_pod" ]; then
+    token="$(kctl exec -n mcp-host "pod/${host_pod}" -- \
+      cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null || true)"
+  fi
   probe_script="$(cat <<'NODE'
 const http = require('http');
 const context = process.argv[1];
 const expected = process.argv[2];
-function get(path) {
+function get(path, token) {
   return new Promise((resolve, reject) => {
+    const headers = token ? {Authorization: 'Bearer ' + token} : {};
     const request = http.get({
       host: '127.0.0.1',
       port: Number(process.env.HCC_E2E_PORT),
-      path
+      path,
+      headers
     }, response => {
       let body = '';
       response.setEncoding('utf8');
@@ -715,18 +724,27 @@ function get(path) {
   });
 }
 (async () => {
+  const token = process.env.HCC_DISCOVERY_TOKEN || '';
   const ready = await get('/ready');
-  const scoped = await get('/api/v1/mcpservers/context/' + encodeURIComponent(context));
-  const body = JSON.parse(scoped.body);
-  const fixture = body.servers?.find(server => server.name === expected);
+  const unauth = await get('/api/v1/mcpservers/context/' + encodeURIComponent(context));
   if (ready.status !== 200 || JSON.parse(ready.body).ready !== true) {
     throw new Error('readiness regressed: ' + ready.status + ' ' + ready.body);
   }
+  if (unauth.status !== 401) {
+    throw new Error('unauthenticated discovery must be 401: ' + unauth.status + ' ' + unauth.body);
+  }
+  if (!token) {
+    throw new Error('no Host ServiceAccount token for context ' + context);
+  }
+  const scoped = await get('/api/v1/mcpservers/context/' + encodeURIComponent(context), token);
+  const body = JSON.parse(scoped.body);
+  const fixture = body.servers?.find(server => server.name === expected);
   if (scoped.status !== 200 || !fixture || fixture.status?.ready !== true) {
     throw new Error('latest Context did not converge in discovery: ' + scoped.status + ' ' + scoped.body);
   }
   console.log(JSON.stringify({
     readyStatus: ready.status,
+    unauthenticatedStatus: unauth.status,
     scopedDiscoveryStatus: scoped.status,
     contextRef: body.contextRef,
     fixture: fixture.name,
@@ -736,7 +754,7 @@ function get(path) {
 NODE
 )"
   kctl exec "pod/${NEW_HCC_POD}" -n "$HCC_NS" -c host-context-controller -- \
-    env "HCC_E2E_PORT=${HCC_PORT}" \
+    env "HCC_E2E_PORT=${HCC_PORT}" "HCC_DISCOVERY_TOKEN=${token}" \
     node -e "$probe_script" "$CONTEXT_NAME" "$MCP_NAME"
 }
 

--- a/scripts/e2e/e2e-hcc-readiness-bootstrap.sh
+++ b/scripts/e2e/e2e-hcc-readiness-bootstrap.sh
@@ -754,15 +754,15 @@ function get(path) {
     throw new Error('unexpected readiness response: ' + ready.status + ' ' + ready.body);
   }
   const discovery = await get('/api/v1/mcpservers');
-  if (discovery.status !== 200) {
+  if (discovery.status !== 401) {
     throw new Error('unexpected discovery response: ' + discovery.status);
   }
   const discoveryBody = JSON.parse(discovery.body);
-  if (!Array.isArray(discoveryBody.servers) || discoveryBody.contextRef !== '*') {
+  if (discoveryBody.error !== 'Unauthorized') {
     throw new Error('discovery response does not match the live API contract');
   }
   console.log(JSON.stringify({readyStatus: ready.status, discoveryStatus: discovery.status,
-    discoveredServers: discoveryBody.servers.length}));
+    discoveryError: discoveryBody.error}));
 })().catch(error => { console.error(error.message); process.exit(1); });
 NODE
 )"
@@ -770,7 +770,7 @@ probe_result="$(kctl exec "pod/${new_hcc_pod}" -n "$HCC_NS" -c host-context-cont
   env "HCC_E2E_PORT=${HCC_PORT}" node -e "$probe_script")" ||
   die "real HCC readiness/discovery HTTP probe failed while the fleet pass was active"
 echo "$probe_result" | jq -e \
-  '.readyStatus == 200 and .discoveryStatus == 200 and (.discoveredServers | type == "number")' \
+  '.readyStatus == 200 and .discoveryStatus == 401 and .discoveryError == "Unauthorized"' \
   >/dev/null ||
   die "HCC HTTP probe returned an invalid result: ${probe_result}"
 hcc_gateway_ready_proxy_recovers ||
@@ -779,7 +779,7 @@ initial_host_pass_is_active "$new_hcc_pod" ||
   die "initial Host reconciliation failed or completed before the HTTP assertions finished"
 ok "/ready returned 200 while the initial Host fleet pass remained active"
 ok "API gateway /ready recovered without changing its local readiness"
-ok "/api/v1/mcpservers returned a valid live discovery response during that same pass"
+ok "/api/v1/mcpservers rejected unauthenticated inventory during that same pass"
 
 header "HCC readiness assertions passed; restoring branch-owned runtime"
 echo "$probe_result"

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -206,7 +206,12 @@ export async function waitForTasksProcessed(minCount: number, timeoutMs = 60_000
 
 /** Query host-context-controller for MCP servers in a context. */
 export async function getMcpServers(contextRef: string): Promise<any> {
-  const { data } = await fetchJson(`${CTX_MAPPER_URL}/api/v1/mcpservers/context/${contextRef}`)
+  const headers: Record<string, string> = {}
+  const token = process.env.HCC_DISCOVERY_TOKEN
+  if (token) headers.Authorization = `Bearer ${token}`
+  const { data } = await fetchJson(`${CTX_MAPPER_URL}/api/v1/mcpservers/context/${contextRef}`, {
+    headers,
+  })
   return data
 }
 

--- a/tests/e2e/mcp-host/context-mapper.test.ts
+++ b/tests/e2e/mcp-host/context-mapper.test.ts
@@ -16,8 +16,18 @@ beforeAll(async () => {
 })
 
 describe('Context Mapper', () => {
-  it('GET /api/v1/mcpservers/context/context1 returns servers', async () => {
+  it('rejects unauthenticated MCP inventory from a laptop port-forward', async () => {
     if (!contextMapperUp) return
+    const res = await fetch(`${CTX_MAPPER_URL}/api/v1/mcpservers/context/context1`)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({
+      error: 'Unauthorized',
+      message: 'Invalid or missing Host identity',
+    })
+  })
+
+  it('GET /api/v1/mcpservers/context/context1 returns servers', async () => {
+    if (!contextMapperUp || !process.env.HCC_DISCOVERY_TOKEN) return
     const data = await getMcpServers('context1')
     expect(data.servers).toBeDefined()
     expect(Array.isArray(data.servers)).toBe(true)
@@ -25,7 +35,7 @@ describe('Context Mapper', () => {
   })
 
   it('context1 includes at least one ready MCP server with transport metadata', async () => {
-    if (!contextMapperUp) return
+    if (!contextMapperUp || !process.env.HCC_DISCOVERY_TOKEN) return
     const data = await getMcpServers('context1')
     const readyServer = data.servers.find((s: any) => s.status?.ready === true)
     expect(readyServer).toBeDefined()
@@ -33,10 +43,9 @@ describe('Context Mapper', () => {
     expect(readyServer.transport.type).toBeDefined()
   })
 
-  it('non-existent context returns empty server list', async () => {
+  it('non-existent context is not caller-chosen from an unauthenticated laptop', async () => {
     if (!contextMapperUp) return
     const res = await fetch(`${CTX_MAPPER_URL}/api/v1/mcpservers/context/does-not-exist`)
-    const data = await res.json()
-    expect(data.servers).toEqual([])
+    expect(res.status).toBe(401)
   })
 })

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-e2e-tests",
-      "version": "0.1.67",
+      "version": "0.1.68",
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^22.0.0",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-e2e-tests",
-  "version": "0.1.67",
+  "version": "0.1.68",
   "private": true,
   "type": "module",
   "scripts": {

--- a/workflow-recipes/tests/e2e/hcc-wrc-integration.test.ts
+++ b/workflow-recipes/tests/e2e/hcc-wrc-integration.test.ts
@@ -17,7 +17,6 @@ import { ChildProcess } from 'node:child_process'
 import {
   MCP_SERVER_NAMESPACE,
   RECIPE_NAMESPACE,
-  fetchJson,
   kubectl,
   kubectlJson,
   sleep,
@@ -122,36 +121,30 @@ describe('HCC-WRC Integration E2E', () => {
   // 2. Patch the Context to add the server to mcpServers[]
   // 3. HCC watches Context change → caches the server → serves via API
   // We wait for Context to be patched first, then poll the Discovery API.
-  it('E6.10 — HCC Discovery API lists delegated McpServer', { timeout: 60_000 }, async () => {
-    // Wait for WRC to patch Context (may take a reconciliation cycle)
-    const ctxStart = Date.now()
-    while (Date.now() - ctxStart < 30_000) {
-      const ctx = kubectlJson<{ spec: { mcpServers?: string[] } }>(
-        `get contexts.clerum.io default -n ${MCP_SERVER_NAMESPACE}`
-      )
-      if (ctx.spec.mcpServers?.includes(MCP_SERVER_NAME)) break
-      await sleep(2_000)
-    }
+  it(
+    'E6.10 — HCC Discovery API rejects unauthenticated laptop inventory',
+    { timeout: 60_000 },
+    async () => {
+      // Wait for WRC to patch Context (may take a reconciliation cycle)
+      const ctxStart = Date.now()
+      while (Date.now() - ctxStart < 30_000) {
+        const ctx = kubectlJson<{ spec: { mcpServers?: string[] } }>(
+          `get contexts.clerum.io default -n ${MCP_SERVER_NAMESPACE}`
+        )
+        if (ctx.spec.mcpServers?.includes(MCP_SERVER_NAME)) break
+        await sleep(2_000)
+      }
 
-    // Now poll the Discovery API (HCC needs to process the Context watch event)
-    const start = Date.now()
-    let found: { name: string; transport?: { type: string } } | undefined
-
-    while (Date.now() - start < 20_000) {
-      const { data } = await fetchJson(
+      const res = await fetch(
         `http://localhost:${HCC_LOCAL_PORT}/api/v1/mcpservers/context/default`
       )
-      const response = data as { servers: Array<{ name: string; transport?: { type: string } }> }
-      if (response.servers) {
-        found = response.servers.find(s => s.name === MCP_SERVER_NAME)
-        if (found) break
-      }
-      await sleep(2_000)
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({
+        error: 'Unauthorized',
+        message: 'Invalid or missing Host identity',
+      })
     }
-
-    expect(found).toBeDefined()
-    expect(found!.transport?.type).toBe('streamableHttp')
-  })
+  )
 
   // E6.11: Context patch triggers L2 context-allow NetworkPolicy from HCC
   // HCC watches Context changes and creates L2 NetworkPolicies.
@@ -229,13 +222,8 @@ describe('HCC-WRC Integration E2E', () => {
   })
 
   // E6.14: HCC Discovery API no longer serves the deleted McpServer
-  it('E6.14 — HCC Discovery API no longer lists deleted McpServer', async () => {
-    const { data } = await fetchJson(
-      `http://localhost:${HCC_LOCAL_PORT}/api/v1/mcpservers/context/default`
-    )
-
-    const response = data as { servers: Array<{ name: string }> }
-    const found = (response.servers ?? []).find(s => s.name === MCP_SERVER_NAME)
-    expect(found).toBeUndefined()
+  it('E6.14 — HCC Discovery API still requires Host identity after delete', async () => {
+    const res = await fetch(`http://localhost:${HCC_LOCAL_PORT}/api/v1/mcpservers/context/default`)
+    expect(res.status).toBe(401)
   })
 })

--- a/workflow-recipes/tests/e2e/package-lock.json
+++ b/workflow-recipes/tests/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workflow-recipes-e2e",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workflow-recipes-e2e",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "typescript": "^5.3.0",

--- a/workflow-recipes/tests/e2e/package.json
+++ b/workflow-recipes/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-recipes-e2e",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "description": "E2E tests for Workload Recipes Controller (minikube)",
   "scripts": {


### PR DESCRIPTION
## Summary

Bind HCC MCP inventory and `/auth` to the calling Host's current Context so a compromised first-party mcp-host cannot list or pull credentials for another Context (NP-08).

Production identity is Kubernetes TokenReview of the per-Host ServiceAccount (`host-<name>-sa`). HCC then uses `Host.spec.contextRef` from its own cache. Path Context and unsigned `x-clerum-*` headers are not authority. `/auth` does not read a Secret until the server is on that Host's Context allowlist.

mcp-host sends the projected ServiceAccount bearer on discovery/auth (not `/ready`). Hosts pin `automountServiceAccountToken: true`. The HCC gateway forwards `Authorization`. ClusterRole `host-context-controller-tokenreview` grants HCC `tokenreviews/create` only.

**Deploy order:** apply TokenReview RBAC → restart the HCC api-gateway → roll Hosts onto the mcp-host image that sends the SA bearer → then this HCC image. HCC is `Recreate`; applying HCC first 401s discovery until Hosts roll (running Hosts keep last fleet; cold start can sit on `/ready` 200 then 401).

`MCP_PROXY_ENABLED` remains false by default. mcp-proxy still polls unauthenticated global list-all and will 401 if that flag is enabled — follow-up, not a Host Context bypass.

## Testing

- [x] `npm test` passes for changed services
- [x] `npx tsc --noEmit` clean

- host-context-controller: `npx vitest run` **1624 passed** (70 files); `npx tsc -p tsconfig.build.json --noEmit` **exit 0**
- mcp-host: `npx vitest run src/contextMapperClient.test.ts` **15 passed**; `npx tsc --noEmit` **exit 0**
- control-api: `npx vitest run test/network.gateway.intent.test.ts` **41 passed / 1 skipped**

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)