### PR TITLE
feat(control-ui): give agent hooks their own advanced tab and table

### DIFF
--- a/control-ui/app/constants/marketplaceEntryTypes.ts
+++ b/control-ui/app/constants/marketplaceEntryTypes.ts
@@ -5,8 +5,15 @@ export const GUARDRAIL_ENTRY_TYPE = 'llm-hook'
 
 // Human labels for the active-filter notice on the entries list. Only types
 // that something links to with `?type=` need an entry here.
-export const MARKETPLACE_ENTRY_TYPE_LABELS: Record<string, string> = {
-  'llm-hook': 'Guardrail hooks',
-  'mcp-server': 'Connectors',
-  recipe: 'Plugins',
-}
+//
+// Null-prototype on purpose: the keys are indexed with an untrusted `?type=`
+// value off the URL, so an inherited key (`toString`, `constructor`, …) would
+// otherwise resolve to a function and be treated as a real label.
+export const MARKETPLACE_ENTRY_TYPE_LABELS: Record<string, string> = Object.assign(
+  Object.create(null) as Record<string, string>,
+  {
+    'llm-hook': 'Guardrail hooks',
+    'mcp-server': 'Connectors',
+    recipe: 'Plugins',
+  }
+)

--- a/control-ui/app/constants/marketplaceEntryTypes.ts
+++ b/control-ui/app/constants/marketplaceEntryTypes.ts
@@ -1,0 +1,12 @@
+// Registry `entry_type` values, as sent on the wire. Shared by the surfaces
+// that link into a type-filtered entries list and the list that reads the
+// filter back off the URL, so the two never drift apart.
+export const GUARDRAIL_ENTRY_TYPE = 'llm-hook'
+
+// Human labels for the active-filter notice on the entries list. Only types
+// that something links to with `?type=` need an entry here.
+export const MARKETPLACE_ENTRY_TYPE_LABELS: Record<string, string> = {
+  'llm-hook': 'Guardrail hooks',
+  'mcp-server': 'Connectors',
+  recipe: 'Plugins',
+}

--- a/control-ui/app/constants/routes.ts
+++ b/control-ui/app/constants/routes.ts
@@ -79,6 +79,10 @@ export const CONTROL_ROUTES = {
     // The org-named tab (design spec §4): everything this deployment owns.
     org: '/marketplace/org',
     orgEntries: '/marketplace/org/entries',
+    // Same section, pre-filtered by entry type (`?type=llm-hook`). The type is
+    // a filter over one list, not a section of its own, so it stays a query
+    // param rather than becoming a route segment.
+    orgEntriesFiltered: (query?: ControlRouteQuery) => withQuery('/marketplace/org/entries', query),
     orgImages: '/marketplace/org/images',
     orgCredentials: '/marketplace/org/credentials',
     orgConnection: '/marketplace/org/connection',

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -1968,20 +1968,6 @@ textarea.cu-input {
   justify-content: flex-end;
 }
 
-/* Per-agent Guardrails tab: add-built-in control row + removable hook chip. */
-.cu-guardrails-add-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cu-space-2);
-  align-items: center;
-}
-
-.cu-guardrails-ref-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cu-space-1);
-}
-
 .cu-expandable-row__name,
 .cu-installed-plugin__name {
   color: var(--cu-text);

--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -544,6 +544,17 @@ body.cu-body {
   background: var(--cu-bg-elevated);
 }
 
+/* Nested inside a container that already draws a bordered card (a form
+   section), the list's own border, radius, and elevated background repaint the
+   same box in the same tokens — the inner corners then read as a stray rounded
+   edge under the header. Flush keeps the row rhythm and drops the chrome. */
+.cu-summary-list--flush {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: none;
+}
+
 .cu-summary-list__row {
   display: flex;
   justify-content: space-between;
@@ -1926,46 +1937,49 @@ textarea.cu-input {
   container-type: inline-size;
 }
 
+/* Columns: name, lifecycle, order, fail mode, status, actions, navigation.
+   Rows navigate to the guardrail detail page rather than expanding in place,
+   so the chevron trails the row (matching .cu-installed-plugins-table) and
+   there is no expandable inset to reserve. */
 .cu-guardrails-table {
   min-width: 52rem;
-  --cu-expandable-inset-left: calc(3rem + 0.85rem);
-  --cu-expandable-inset-right: 6rem;
+  table-layout: fixed;
 }
 
 .cu-guardrails-table th:nth-child(1),
 .cu-guardrails-table td:nth-child(1) {
-  width: 3rem;
-}
-
-.cu-guardrails-table th:nth-child(2),
-.cu-guardrails-table td:nth-child(2) {
   width: 30%;
   max-width: 30%;
 }
 
+.cu-guardrails-table th:nth-child(3),
+.cu-guardrails-table td:nth-child(3) {
+  width: 5rem;
+}
+
 .cu-guardrails-table th:nth-child(4),
 .cu-guardrails-table td:nth-child(4) {
-  width: 5rem;
+  width: 8rem;
 }
 
 .cu-guardrails-table th:nth-child(5),
 .cu-guardrails-table td:nth-child(5) {
-  width: 8rem;
+  width: 9rem;
 }
 
 .cu-guardrails-table th:nth-child(6),
 .cu-guardrails-table td:nth-child(6) {
-  width: 9rem;
-}
-
-.cu-guardrails-table th:nth-child(7),
-.cu-guardrails-table td:nth-child(7) {
   width: 6rem;
   text-align: right;
 }
 
-.cu-guardrails-table td:nth-child(7) .cu-table-actions {
+.cu-guardrails-table td:nth-child(6) .cu-table-actions {
   justify-content: flex-end;
+}
+
+.cu-guardrails-table th:nth-child(7),
+.cu-guardrails-table td:nth-child(7) {
+  width: 3rem;
 }
 
 .cu-expandable-row__name,
@@ -5007,7 +5021,12 @@ textarea.cu-input {
   }
 }
 
-.cu-detail-content-stack > .cu-card:first-child {
+/* The detail header panel drops its bottom border and bottom radii, so the
+   first block below it has to drop the matching top edge or the seam shows as
+   a stray rounded border. Applies to either card primitive that can lead the
+   stack. */
+.cu-detail-content-stack > .cu-card:first-child,
+.cu-detail-content-stack > .cu-form-section:first-child {
   border-top: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;

--- a/control-ui/app/guardrails/[name]/page.tsx
+++ b/control-ui/app/guardrails/[name]/page.tsx
@@ -4,9 +4,13 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { CONTROL_ROUTES } from '../../../app/constants/routes'
 import { useConfirmDialog } from '../../../components/ConfirmDialog'
+import { CreateFlowPanel } from '../../../components/CreateFlowPanel'
+import { CreatePageHeader } from '../../../components/CreatePageHeader'
 import { DashboardLayout } from '../../../components/DashboardLayout'
+import { KebabMenu } from '../../../components/KebabMenu'
+import { IconShield } from '../../../components/Sidebar/icons'
 import { useToast } from '../../../components/Toast'
-import { Button, FormSection } from '../../../components/ui'
+import { FormSection } from '../../../components/ui'
 import { deleteLlmHook, getHosts, getLlmHook, isSilentApiError } from '../../../lib/api'
 import type { HostResource, LlmHookResource, LlmHookStatus } from '../../../lib/api'
 
@@ -168,16 +172,36 @@ export default function GuardrailDetailPage() {
   }
 
   return (
-    <DashboardLayout>
-      <div style={{ marginBottom: 'var(--cu-space-2)' }}>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => router.push(CONTROL_ROUTES.guardrails.root)}
-        >
-          ← Installed Guardrails
-        </Button>
-      </div>
+    <DashboardLayout isDetailPage>
+      <CreateFlowPanel
+        className="cu-detail-flow-panel"
+        header={
+          <CreatePageHeader
+            icon={<IconShield />}
+            title={name || 'Guardrail'}
+            subtitle="Guardrail details and runtime status."
+            backLabel="Back to guardrails"
+            onBack={() => router.push(CONTROL_ROUTES.guardrails.root)}
+            titleActions={
+              hook ? (
+                <KebabMenu
+                  ariaLabel="More guardrail actions"
+                  items={[
+                    {
+                      label: uninstalling ? 'Uninstalling…' : 'Uninstall',
+                      disabled: uninstalling,
+                      danger: true,
+                      onClick: () => void handleUninstall(),
+                    },
+                  ]}
+                />
+              ) : undefined
+            }
+          />
+        }
+      >
+        {null}
+      </CreateFlowPanel>
 
       {error ? (
         <div className="cu-banner cu-banner--error" role="alert">
@@ -185,104 +209,109 @@ export default function GuardrailDetailPage() {
         </div>
       ) : null}
 
-      {loading && !hook ? (
-        <div className="cu-card">
-          <div className="cu-card__body cu-muted">Loading guardrail…</div>
-        </div>
-      ) : !hook ? (
-        <div className="cu-empty">Guardrail not found.</div>
-      ) : (
-        <>
-          <FormSection title={name} description="Installed guardrail hook.">
-            <div className="cu-summary-list">
-              <Row label="Status">
-                <StatusBadge status={hook.status} />
-              </Row>
-              <Row label={target.kind}>
-                <strong className="cu-expandable-field__code">{target.value}</strong>
-              </Row>
-              <Row label="Path">{spec.path || '/'}</Row>
-              <Row label="Lifecycle points">{(spec.lifecyclePoints || []).join(', ') || '—'}</Row>
-              <Row label="Fail mode">{spec.failMode || '—'}</Row>
-              <Row label="Capabilities">
-                {spec.capabilities && spec.capabilities.length > 0 ? (
-                  <span className="cu-expandable-tags">
-                    {spec.capabilities.map(c => (
-                      <span key={c} className="cu-registry-tag">
-                        {c}
-                      </span>
-                    ))}
-                  </span>
-                ) : (
-                  <span className="cu-muted">None declared</span>
-                )}
-              </Row>
-              <Row label="Observed digest">
-                <strong className="cu-expandable-field__code">
-                  {hook.status?.observedDigest || '—'}
-                </strong>
-              </Row>
-              <Row label="Ready replicas">
-                {typeof hook.status?.readyReplicas === 'number' ? hook.status.readyReplicas : '—'}
-              </Row>
-            </div>
-            <div style={{ marginTop: 'var(--cu-space-3)' }}>
-              <Button variant="danger" size="sm" onClick={handleUninstall} disabled={uninstalling}>
-                {uninstalling ? 'Uninstalling…' : 'Uninstall'}
-              </Button>
-            </div>
-          </FormSection>
+      {/* The header panel squares off its bottom edge and expects the content
+          stack directly below it, so the first section fuses with it instead of
+          floating as a separate rounded card. */}
+      <div className="cu-detail-content-stack">
+        {loading && !hook ? (
+          <div className="cu-card">
+            <div className="cu-card__body cu-muted">Loading guardrail…</div>
+          </div>
+        ) : !hook ? (
+          <div className="cu-empty">Guardrail not found.</div>
+        ) : (
+          <>
+            <FormSection
+              title="Details"
+              description="Runtime configuration reported by the installed hook."
+            >
+              <div className="cu-summary-list cu-summary-list--flush">
+                <Row label="Status">
+                  <StatusBadge status={hook.status} />
+                </Row>
+                <Row label={target.kind}>
+                  <strong className="cu-expandable-field__code">{target.value}</strong>
+                </Row>
+                <Row label="Path">{spec.path || '/'}</Row>
+                <Row label="Lifecycle points">{(spec.lifecyclePoints || []).join(', ') || '—'}</Row>
+                <Row label="Fail mode">{spec.failMode || '—'}</Row>
+                <Row label="Capabilities">
+                  {spec.capabilities && spec.capabilities.length > 0 ? (
+                    <span className="cu-expandable-tags">
+                      {spec.capabilities.map(c => (
+                        <span key={c} className="cu-registry-tag">
+                          {c}
+                        </span>
+                      ))}
+                    </span>
+                  ) : (
+                    <span className="cu-muted">None declared</span>
+                  )}
+                </Row>
+                <Row label="Observed digest">
+                  <strong className="cu-expandable-field__code">
+                    {hook.status?.observedDigest || '—'}
+                  </strong>
+                </Row>
+                <Row label="Ready replicas">
+                  {typeof hook.status?.readyReplicas === 'number' ? hook.status.readyReplicas : '—'}
+                </Row>
+              </div>
+            </FormSection>
 
-          <FormSection
-            title={`Agents using this guardrail (${agents.length})`}
-            description="Agents whose guardrails reference this hook, and the lifecycle phases they use it in."
-          >
-            {agents.length === 0 ? (
-              <div className="cu-empty">No agents reference this guardrail.</div>
-            ) : (
-              <div className="cu-table-wrap">
-                <table className="cu-table cu-table--header-band">
-                  <thead>
-                    <tr>
-                      <th>Agent</th>
-                      <th>Phases</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {agents.map(a => (
-                      <tr
-                        key={a.name}
-                        className="cu-table__row cu-table__row--clickable"
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => router.push(CONTROL_ROUTES.agents.tab(a.name, 'guardrails'))}
-                        onKeyDown={e => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault()
+            <FormSection
+              title={`Agents using this guardrail (${agents.length})`}
+              description="Agents whose guardrails reference this hook, and the lifecycle phases they use it in."
+            >
+              {agents.length === 0 ? (
+                <div className="cu-empty">No agents reference this guardrail.</div>
+              ) : (
+                <div className="cu-table-wrap">
+                  <table className="cu-table cu-table--header-band">
+                    <thead>
+                      <tr>
+                        <th>Agent</th>
+                        <th>Phases</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {agents.map(a => (
+                        <tr
+                          key={a.name}
+                          className="cu-table__row cu-table__row--clickable"
+                          role="button"
+                          tabIndex={0}
+                          onClick={() =>
                             router.push(CONTROL_ROUTES.agents.tab(a.name, 'guardrails'))
                           }
-                        }}
-                        aria-label={`Open agent ${a.name} guardrails`}
-                      >
-                        <td>{a.name}</td>
-                        <td>
-                          <span className="cu-expandable-tags">
-                            {a.phases.map(p => (
-                              <span key={p} className="cu-registry-tag">
-                                {PHASE_LABEL[p] || p}
-                              </span>
-                            ))}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </FormSection>
-        </>
-      )}
+                          onKeyDown={e => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault()
+                              router.push(CONTROL_ROUTES.agents.tab(a.name, 'guardrails'))
+                            }
+                          }}
+                          aria-label={`Open agent ${a.name} guardrails`}
+                        >
+                          <td>{a.name}</td>
+                          <td>
+                            <span className="cu-expandable-tags">
+                              {a.phases.map(p => (
+                                <span key={p} className="cu-registry-tag">
+                                  {PHASE_LABEL[p] || p}
+                                </span>
+                              ))}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </FormSection>
+          </>
+        )}
+      </div>
       {confirmDialog}
     </DashboardLayout>
   )

--- a/control-ui/app/guardrails/page.tsx
+++ b/control-ui/app/guardrails/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { useConfirmDialog } from '../../components/ConfirmDialog'
 import { DashboardLayout } from '../../components/DashboardLayout'
 import { GuardrailHooksTable } from '../../components/GuardrailHooksTable'
@@ -8,8 +9,11 @@ import type { LlmHookRef } from '../../components/GuardrailHooksTable.types'
 import { useToast } from '../../components/Toast'
 import { deleteLlmHook, getLlmHooks, isSilentApiError } from '../../lib/api'
 import type { LlmHookResource } from '../../lib/api'
+import { GUARDRAIL_ENTRY_TYPE } from '../constants/marketplaceEntryTypes'
+import { CONTROL_ROUTES } from '../constants/routes'
 
 export default function GuardrailsPage() {
+  const router = useRouter()
   const { showToast } = useToast()
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -62,6 +66,11 @@ export default function GuardrailsPage() {
       {error ? <div className="cu-banner cu-banner--error">{error}</div> : null}
       <GuardrailHooksTable
         items={hooks}
+        // Same destination as "Add hook" on an agent: the org marketplace
+        // entries list narrowed to guardrail hooks.
+        onInstall={() =>
+          router.push(CONTROL_ROUTES.marketplace.orgEntriesFiltered({ type: GUARDRAIL_ENTRY_TYPE }))
+        }
         onUninstall={handleUninstall}
         uninstallingKey={uninstallingKey}
         onRefresh={loadAll}

--- a/control-ui/app/hosts/[name]/page.tsx
+++ b/control-ui/app/hosts/[name]/page.tsx
@@ -630,7 +630,9 @@ export default function HostDetailsPage() {
         // Reload guardrails/server state while preserving any drafts left open
         // in the Overview or Model tabs.
         await loadData('none')
-        showToast('Guardrails saved.', { tone: 'success' })
+        // No toast here on purpose: HostGuardrailsSection names the hook it
+        // just changed once this resolves, and a generic 'saved' alongside it
+        // would stack two success toasts on a single remove.
       } catch (e) {
         const status = (e as { status?: number } | null)?.status
         const code = (e as { code?: string } | null)?.code
@@ -641,8 +643,8 @@ export default function HostDetailsPage() {
         } else {
           setError(e instanceof Error ? e.message : 'Failed to save guardrails')
         }
-        // Re-throw so HostGuardrailsSection stays in edit mode and keeps the
-        // operator's draft alongside the error/conflict banner.
+        // Re-throw so HostGuardrailsSection knows the save failed and skips
+        // its success toast, leaving the error/conflict banner to explain.
         throw e
       } finally {
         setBusy(false)

--- a/control-ui/app/hosts/[name]/page.tsx
+++ b/control-ui/app/hosts/[name]/page.tsx
@@ -9,7 +9,6 @@ import { HOST_DEFAULT_TAB, HOST_TABS } from '@constants/hostDetails'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { HostAccessTab } from '../../../components/HostAccessTab'
 import { HostAdvancedTab } from '../../../components/HostAdvancedTab'
-import { HostGuardrailsSection } from '../../../components/HostGuardrailsSection'
 import type { HostGuardrails } from '../../../components/HostGuardrailsSection/types'
 import { HostIdentityTab } from '../../../components/HostIdentityTab'
 import { LlmProviderConfig } from '../../../components/LlmProviderConfig'
@@ -1017,25 +1016,15 @@ export default function HostDetailsPage() {
         )}
 
         {activeTab === 'advanced' && (
-          <>
-            <HostAdvancedTab
-              busy={busy}
-              hostName={routeName}
-              initialLoading={initialLoading}
-              initialTools={approvalToolsData}
-              onSaveApprovalTools={persistApprovalTools}
-            />
-            {!initialLoading && (
-              <HostGuardrailsSection
-                initialGuardrails={guardrailsData}
-                onSave={persistGuardrails}
-                busy={busy}
-                canWrite={
-                  true /* TODO: wire to actual host:write check if/when per-field RBAC lands */
-                }
-              />
-            )}
-          </>
+          <HostAdvancedTab
+            busy={busy}
+            hostName={routeName}
+            initialGuardrails={guardrailsData}
+            initialLoading={initialLoading}
+            initialTools={approvalToolsData}
+            onSaveApprovalTools={persistApprovalTools}
+            onSaveGuardrails={persistGuardrails}
+          />
         )}
 
         {activeTab === 'contexts' && (

--- a/control-ui/app/workflow-recipes/[namespace]/[name]/page.tsx
+++ b/control-ui/app/workflow-recipes/[namespace]/[name]/page.tsx
@@ -9,6 +9,7 @@ import { CreateFlowSkeleton } from '@components/CreateFlowSkeleton'
 import { CreatePageHeader } from '@components/CreatePageHeader'
 import { DashboardLayout } from '@components/DashboardLayout'
 import { DetailPageShell } from '@components/DetailPageShell'
+import { KebabMenu } from '@components/KebabMenu'
 import { RecipeEditor } from '@components/RecipeEditor'
 import { RecipeIntegrationsPanel } from '@components/RecipeIntegrationsPanel'
 import { RecipeSecretsPanel } from '@components/RecipeSecretsPanel'
@@ -233,66 +234,6 @@ function chipStyle(tone: 'ok' | 'warn' | 'error' | 'info'): React.CSSProperties 
         borderColor: 'var(--cu-border-subtle)',
       }
   }
-}
-
-type KebabItem = {
-  label: string
-  onClick: () => void
-  danger?: boolean
-  disabled?: boolean
-}
-
-function KebabMenu({ items, ariaLabel }: { items: KebabItem[]; ariaLabel: string }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (!open) return
-    function handleDocClick(e: MouseEvent) {
-      if (!ref.current?.contains(e.target as Node)) setOpen(false)
-    }
-    function handleEsc(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('mousedown', handleDocClick)
-    document.addEventListener('keydown', handleEsc)
-    return () => {
-      document.removeEventListener('mousedown', handleDocClick)
-      document.removeEventListener('keydown', handleEsc)
-    }
-  }, [open])
-  return (
-    <div ref={ref} className="cu-kebab">
-      <button
-        type="button"
-        aria-label={ariaLabel}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="cu-btn cu-btn--ghost cu-btn--sm cu-kebab__trigger"
-        onClick={() => setOpen(v => !v)}
-      >
-        ⋯
-      </button>
-      {open ? (
-        <div role="menu" className="cu-kebab__menu">
-          {items.map(item => (
-            <button
-              key={item.label}
-              type="button"
-              role="menuitem"
-              disabled={item.disabled}
-              className={`cu-kebab__item${item.danger ? ' cu-kebab__item--danger' : ''}`}
-              onClick={() => {
-                setOpen(false)
-                item.onClick()
-              }}
-            >
-              {item.label}
-            </button>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  )
 }
 
 export const dynamic = 'force-dynamic'

--- a/control-ui/components/GuardrailHooksTable.tsx
+++ b/control-ui/components/GuardrailHooksTable.tsx
@@ -18,13 +18,13 @@ import { TablePanelHeader } from './TablePanelHeader'
 import { IconChevronRight, IconRefresh, IconX } from './icons'
 
 const HOOK_COLUMNS: TableHeaderColumn[] = [
-  { key: 'open', ariaLabel: 'Open guardrail' },
   { key: 'name', label: 'Name' },
   { key: 'lifecycle', label: 'Lifecycle' },
   { key: 'order', label: 'Order' },
   { key: 'failMode', label: 'Fail mode' },
   { key: 'status', label: 'Status' },
   { key: 'actions', align: 'right', ariaLabel: 'Actions' },
+  { key: 'navigation', align: 'right', ariaLabel: 'Navigation' },
 ]
 
 function StatusBadge({ status }: { status?: LlmHookStatus }) {
@@ -74,6 +74,7 @@ function describeTarget(target?: LlmHookTarget): string {
 
 export function GuardrailHooksTable({
   items,
+  onInstall,
   onUninstall,
   uninstallingKey,
   onRefresh,
@@ -163,12 +164,22 @@ export function GuardrailHooksTable({
                 />
               </button>
             ) : null}
+            {onInstall ? (
+              <button
+                type="button"
+                className="cu-btn cu-btn--primary cu-btn--sm"
+                onClick={onInstall}
+                disabled={isInitialLoad}
+              >
+                Install Guardrail
+              </button>
+            ) : null}
           </>
         }
       />
       {isInitialLoad ? (
         <div className="cu-table-wrap cu-guardrails-table-wrap">
-          <table className="cu-table cu-table--header-band cu-expandable-table cu-guardrails-table">
+          <table className="cu-table cu-table--header-band cu-guardrails-table">
             <thead>
               <TableHeaderRow columns={HOOK_COLUMNS} />
             </thead>
@@ -183,7 +194,7 @@ export function GuardrailHooksTable({
         </div>
       ) : (
         <div className="cu-table-wrap cu-guardrails-table-wrap">
-          <table className="cu-table cu-table--header-band cu-expandable-table cu-guardrails-table">
+          <table className="cu-table cu-table--header-band cu-guardrails-table">
             <thead>
               <TableHeaderRow columns={HOOK_COLUMNS} />
             </thead>
@@ -206,9 +217,6 @@ export function GuardrailHooksTable({
                     tabIndex={0}
                     aria-label={`View guardrail ${name}`}
                   >
-                    <td className="cu-expandable-row__chevron" aria-hidden="true">
-                      <IconChevronRight width={18} height={18} />
-                    </td>
                     <td>
                       <span className="cu-expandable-row__name">{name}</span>
                     </td>
@@ -253,6 +261,9 @@ export function GuardrailHooksTable({
                           </button>
                         ) : null}
                       </div>
+                    </td>
+                    <td className="cu-installed-plugin__navigation" aria-hidden="true">
+                      <IconChevronRight width={18} height={18} />
                     </td>
                   </tr>
                 )

--- a/control-ui/components/GuardrailHooksTable.types.ts
+++ b/control-ui/components/GuardrailHooksTable.types.ts
@@ -29,6 +29,7 @@ export type LlmHookRef = { name: string }
 
 export type GuardrailHooksTableProps = {
   items: LlmHookResource[]
+  onInstall?: () => void
   onUninstall?: (hook: LlmHookRef) => Promise<void>
   uninstallingKey?: string | null
   onRefresh?: () => void

--- a/control-ui/components/HostAccessTab/index.tsx
+++ b/control-ui/components/HostAccessTab/index.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useConfirmDialog } from '@components/ConfirmDialog'
-import { SelectionDropdown } from '@components/SelectionDropdown'
+import { SelectionModal } from '@components/SelectionModal'
 import { TabBar } from '@components/TabBar'
 import { useToast } from '@components/Toast'
 import { IconX } from '@components/icons'
@@ -404,7 +404,7 @@ export function HostAccessTab({ hostName }: HostAccessTabProps) {
       </div>
 
       {showAddUser ? (
-        <AccessGrantModal
+        <SelectionModal
           busy={busy}
           emptyLabel="No available members."
           id="agent-member-picker"
@@ -427,7 +427,7 @@ export function HostAccessTab({ hostName }: HostAccessTabProps) {
       ) : null}
 
       {showAddTeam ? (
-        <AccessGrantModal
+        <SelectionModal
           busy={busy}
           emptyLabel="No available teams."
           id="agent-team-picker"
@@ -451,117 +451,5 @@ export function HostAccessTab({ hostName }: HostAccessTabProps) {
 
       {confirmDialog}
     </section>
-  )
-}
-
-type AccessGrantModalProps = {
-  busy: boolean
-  emptyLabel: string
-  id: string
-  label: string
-  onChange: (next: string[]) => void
-  onClose: () => void
-  onConfirm: () => Promise<void>
-  options: { value: string; label: string; description?: string; badge?: string }[]
-  placeholder: string
-  searchPlaceholder: string
-  selectionLabel: string
-  submitLabel: string
-  title: string
-  titleId: string
-  value: string[]
-}
-
-function AccessGrantModal({
-  busy,
-  emptyLabel,
-  id,
-  label,
-  onChange,
-  onClose,
-  onConfirm,
-  options,
-  placeholder,
-  searchPlaceholder,
-  selectionLabel,
-  submitLabel,
-  title,
-  titleId,
-  value,
-}: AccessGrantModalProps) {
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--cu-overlay)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-        padding: '1rem',
-      }}
-      role="presentation"
-      onClick={e => {
-        if (e.target === e.currentTarget && !busy) onClose()
-      }}
-    >
-      <div
-        className="cu-modal-panel cu-modal-panel--selection"
-        role="dialog"
-        aria-labelledby={titleId}
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="cu-modal-panel__head">
-          <strong id={titleId} style={{ fontSize: '1rem', lineHeight: 1.35 }}>
-            {title}
-          </strong>
-          <button
-            type="button"
-            className="cu-btn cu-btn--icon cu-btn--ghost"
-            onClick={onClose}
-            disabled={busy}
-            aria-label="Close"
-          >
-            <IconX width={18} height={18} />
-          </button>
-        </div>
-
-        <div className="cu-field">
-          <label htmlFor={id}>{label}</label>
-          <SelectionDropdown
-            emptyLabel={emptyLabel}
-            id={id}
-            inline
-            disabled={busy}
-            onChange={onChange}
-            options={options}
-            placeholder={placeholder}
-            searchPlaceholder={searchPlaceholder}
-            selectionLabel={selectionLabel}
-            value={value}
-          />
-        </div>
-
-        <div className="cu-modal-panel__foot">
-          <button
-            type="button"
-            className="cu-btn cu-btn--ghost cu-btn--sm"
-            onClick={onClose}
-            disabled={busy}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="cu-btn cu-btn--primary"
-            onClick={() => void onConfirm()}
-            disabled={busy || value.length === 0}
-          >
-            {submitLabel}
-          </button>
-        </div>
-      </div>
-    </div>
   )
 }

--- a/control-ui/components/HostAdvancedTab/index.tsx
+++ b/control-ui/components/HostAdvancedTab/index.tsx
@@ -3,22 +3,28 @@
 import React, { useState } from 'react'
 import { HostApprovalSection } from '@components/HostApprovalSection'
 import { HostEnvTable } from '@components/HostEnvTable'
+import { HostGuardrailsSection } from '@components/HostGuardrailsSection'
 import { TabBar } from '@components/TabBar'
 import type { AdvancedSubTab, HostAdvancedTabProps } from './types'
 
 const ADVANCED_SUB_TABS: { key: AdvancedSubTab; label: string }[] = [
+  { key: 'hooks', label: 'Hooks' },
   { key: 'approvals', label: 'Per-tool approval' },
   { key: 'env', label: 'Env vars' },
 ]
 
+const DEFAULT_SUB_TAB: AdvancedSubTab = 'hooks'
+
 export function HostAdvancedTab({
   busy,
   hostName,
+  initialGuardrails,
   initialLoading,
   initialTools,
   onSaveApprovalTools,
+  onSaveGuardrails,
 }: HostAdvancedTabProps) {
-  const [subTab, setSubTab] = useState<AdvancedSubTab>('approvals')
+  const [subTab, setSubTab] = useState<AdvancedSubTab>(DEFAULT_SUB_TAB)
 
   return (
     <section className="cu-advanced-tab" aria-label="Advanced">
@@ -31,32 +37,25 @@ export function HostAdvancedTab({
       />
 
       <div className="cu-advanced-section">
-        {subTab === 'approvals' ? (
-          initialLoading ? (
-            <div className="cu-table-wrap" role="status" aria-label="Loading approval tools">
-              <table className="cu-table cu-table--header-band cu-table--static-rows">
-                <thead>
-                  <tr>
-                    <th>Tool</th>
-                    <th>Default</th>
-                    <th className="cu-table__col-actions">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {[1, 2, 3, 4].map(i => (
-                    <tr key={i}>
-                      <td>
-                        <div className="cu-skeleton cu-skeleton--cell" style={{ width: '8rem' }} />
-                      </td>
-                      <td>
-                        <div className="cu-skeleton cu-skeleton--cell" style={{ width: '6rem' }} />
-                      </td>
-                      <td />
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        {subTab === 'hooks' &&
+          (initialLoading ? (
+            <div className="cu-empty" role="status" aria-label="Loading guardrail hooks">
+              Loading…
             </div>
+          ) : (
+            <HostGuardrailsSection
+              busy={busy}
+              canWrite={
+                true /* TODO: wire to actual host:write check if/when per-field RBAC lands */
+              }
+              initialGuardrails={initialGuardrails}
+              onSave={onSaveGuardrails}
+            />
+          ))}
+
+        {subTab === 'approvals' &&
+          (initialLoading ? (
+            <ApprovalToolsSkeleton />
           ) : (
             <HostApprovalSection
               busy={busy}
@@ -65,11 +64,39 @@ export function HostAdvancedTab({
               initialTools={initialTools}
               onSave={onSaveApprovalTools}
             />
-          )
-        ) : (
-          <HostEnvTable hostRef={hostName} />
-        )}
+          ))}
+
+        {subTab === 'env' && <HostEnvTable hostRef={hostName} />}
       </div>
     </section>
+  )
+}
+
+function ApprovalToolsSkeleton() {
+  return (
+    <div className="cu-table-wrap" role="status" aria-label="Loading approval tools">
+      <table className="cu-table cu-table--header-band cu-table--static-rows">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Default</th>
+            <th className="cu-table__col-actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[1, 2, 3, 4].map(i => (
+            <tr key={i}>
+              <td>
+                <div className="cu-skeleton cu-skeleton--cell" style={{ width: '8rem' }} />
+              </td>
+              <td>
+                <div className="cu-skeleton cu-skeleton--cell" style={{ width: '6rem' }} />
+              </td>
+              <td />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/control-ui/components/HostAdvancedTab/types.ts
+++ b/control-ui/components/HostAdvancedTab/types.ts
@@ -1,6 +1,7 @@
 import type { HostApprovalSectionProps } from '../HostApprovalSection/types'
+import type { HostGuardrailsSectionProps } from '../HostGuardrailsSection/types'
 
-export type AdvancedSubTab = 'approvals' | 'env'
+export type AdvancedSubTab = 'hooks' | 'approvals' | 'env'
 
 export type HostAdvancedTabProps = {
   busy: boolean
@@ -8,4 +9,6 @@ export type HostAdvancedTabProps = {
   initialLoading: boolean
   initialTools: HostApprovalSectionProps['initialTools']
   onSaveApprovalTools: HostApprovalSectionProps['onSave']
+  initialGuardrails: HostGuardrailsSectionProps['initialGuardrails']
+  onSaveGuardrails: HostGuardrailsSectionProps['onSave']
 }

--- a/control-ui/components/HostGuardrailsSection/constants.ts
+++ b/control-ui/components/HostGuardrailsSection/constants.ts
@@ -1,4 +1,4 @@
-import type { GuardrailBuiltinType, GuardrailPhase } from './types'
+import type { GuardrailPhase } from './types'
 
 // Render/iteration order for the hook phases.
 export const GUARDRAIL_PHASES: readonly GuardrailPhase[] = [
@@ -18,12 +18,3 @@ export const GUARDRAIL_PHASE_LABELS: Record<GuardrailPhase, string> = {
   postCallSuccess: 'Post-call success',
   onError: 'On error',
 }
-
-// Curated built-in types offered by the minimal add UI.
-export const GUARDRAIL_BUILTIN_OPTIONS: ReadonlyArray<{
-  value: GuardrailBuiltinType
-  label: string
-}> = [
-  { value: 'prompt-shaping', label: 'Prompt shaping' },
-  { value: 'token-trim', label: 'Token trim' },
-] as const

--- a/control-ui/components/HostGuardrailsSection/index.tsx
+++ b/control-ui/components/HostGuardrailsSection/index.tsx
@@ -87,7 +87,7 @@ export function HostGuardrailsSection({
   const disabled = busy || saving
 
   return (
-    <section className="cu-guardrails-tab" aria-label="Hooks">
+    <section aria-label="Hooks">
       <div className="cu-access-section">
         <div className="cu-access-section__header">
           <p className="cu-muted cu-access-section__description">

--- a/control-ui/components/HostGuardrailsSection/index.tsx
+++ b/control-ui/components/HostGuardrailsSection/index.tsx
@@ -1,26 +1,51 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useConfirmDialog } from '@components/ConfirmDialog'
+import { SelectionModal } from '@components/SelectionModal'
+import { useToast } from '@components/Toast'
+import { IconX } from '@components/icons'
+import { GUARDRAIL_ENTRY_TYPE } from '@constants/marketplaceEntryTypes'
 import { CONTROL_ROUTES } from '@constants/routes'
-import { IconX } from '../icons'
-import { Button, SelectInput, TextInput } from '../ui'
-import { GUARDRAIL_BUILTIN_OPTIONS, GUARDRAIL_PHASES, GUARDRAIL_PHASE_LABELS } from './constants'
+import { type LlmHookResource, getLlmHooks } from '@lib/api'
+import { GUARDRAIL_PHASES, GUARDRAIL_PHASE_LABELS } from './constants'
 import type {
-  GuardrailBuiltin,
-  GuardrailBuiltinType,
   GuardrailHookRef,
+  GuardrailHookRow,
   GuardrailPhase,
   HostGuardrails,
   HostGuardrailsSectionProps,
 } from './types'
 
-function cloneGuardrails(source: HostGuardrails | undefined): HostGuardrails {
-  return {
-    ...source,
-    hooks: source?.hooks ? { ...source.hooks } : {},
-    builtins: source?.builtins ? source.builtins.map(builtin => ({ ...builtin })) : [],
-  }
+// The picker only offers hooks already installed on the cluster, so keep the
+// route that installs new ones reachable from the section itself — it is the
+// path the old "Add hook" button used to take.
+const INSTALL_HOOK_ROUTE = CONTROL_ROUTES.marketplace.orgEntriesFiltered({
+  type: GUARDRAIL_ENTRY_TYPE,
+})
+
+// The phases an installed hook declares it runs at. A hook is attached to every
+// phase it declares, so the operator picks the hook and never the phase.
+function hookPhases(hook: LlmHookResource): GuardrailPhase[] {
+  const raw = (hook.spec as { lifecyclePoints?: unknown } | undefined)?.lifecyclePoints
+  if (!Array.isArray(raw)) return []
+  return raw.filter((point): point is GuardrailPhase =>
+    GUARDRAIL_PHASES.includes(point as GuardrailPhase)
+  )
+}
+
+function hookName(hook: LlmHookResource): string {
+  return hook.metadata?.name ?? ''
+}
+
+// Every field this section does not edit rides along untouched — dropping
+// `builtins` or `limits` here would silently wipe them from the Host spec.
+function withHooks(
+  source: HostGuardrails | undefined,
+  hooks: HostGuardrails['hooks']
+): HostGuardrails {
+  return { ...source, hooks }
 }
 
 export function HostGuardrailsSection({
@@ -28,310 +53,230 @@ export function HostGuardrailsSection({
   onSave,
   busy,
   canWrite,
-  defaultEditing = false,
 }: HostGuardrailsSectionProps) {
   const router = useRouter()
-  const [editing, setEditing] = useState(defaultEditing)
-  const [draft, setDraft] = useState<HostGuardrails>(() => cloneGuardrails(initialGuardrails))
+  const { confirm, confirmDialog } = useConfirmDialog()
+  const { showToast } = useToast()
+  const mountedRef = useRef(true)
 
-  // Re-seed the draft whenever the saved guardrails change (reload after save).
-  const initialKey = JSON.stringify(initialGuardrails ?? {})
-  React.useEffect(() => {
-    setDraft(cloneGuardrails(initialGuardrails))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialKey])
+  const [installedHooks, setInstalledHooks] = useState<LlmHookResource[]>([])
+  const [showAddHook, setShowAddHook] = useState(false)
+  const [selectedHookNames, setSelectedHookNames] = useState<string[]>([])
+  const [saving, setSaving] = useState(false)
 
-  const isDirty = useMemo(
-    () => JSON.stringify(draft) !== JSON.stringify(cloneGuardrails(initialGuardrails)),
-    [draft, initialGuardrails]
-  )
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
-  const hookPhases = useMemo(
+  // The installed LlmHooks are the pool this agent can reference. A load
+  // failure only empties the picker — the rows below come from the Host spec
+  // and stay readable either way.
+  useEffect(() => {
+    void (async () => {
+      try {
+        const result = await getLlmHooks()
+        if (!mountedRef.current) return
+        setInstalledHooks(Array.isArray(result.items) ? result.items : [])
+      } catch {
+        if (mountedRef.current) setInstalledHooks([])
+      }
+    })()
+  }, [])
+
+  const rows = useMemo<GuardrailHookRow[]>(() => {
+    const hooks = initialGuardrails?.hooks ?? {}
+    return GUARDRAIL_PHASES.flatMap(phase => (hooks[phase] ?? []).map(ref => ({ phase, ref })))
+  }, [initialGuardrails])
+
+  const referencedIds = useMemo(() => new Set(rows.map(row => row.ref.id)), [rows])
+
+  const addOptions = useMemo(
     () =>
-      GUARDRAIL_PHASES.map(phase => ({
-        phase,
-        refs: draft.hooks?.[phase] ?? [],
-      })).filter(entry => entry.refs.length > 0),
-    [draft.hooks]
+      installedHooks
+        .filter(hook => hookName(hook) && !referencedIds.has(hookName(hook)))
+        .map(hook => {
+          const phases = hookPhases(hook)
+          return {
+            value: hookName(hook),
+            label: hookName(hook),
+            description: phases.length
+              ? phases.map(phase => GUARDRAIL_PHASE_LABELS[phase]).join(' · ')
+              : 'No lifecycle points declared',
+          }
+        }),
+    [installedHooks, referencedIds]
   )
-  const builtins = draft.builtins ?? []
-  const hasAny = hookPhases.length > 0 || builtins.length > 0
 
-  function removeHookRef(phase: GuardrailPhase, id: string) {
-    setDraft(current => {
-      const currentRefs = current.hooks?.[phase] ?? []
-      const nextRefs = currentRefs.filter(ref => ref.id !== id)
-      const nextHooks: HostGuardrails['hooks'] = { ...current.hooks }
-      if (nextRefs.length > 0) nextHooks[phase] = nextRefs
-      else delete nextHooks[phase]
-      return { ...current, hooks: nextHooks }
-    })
-  }
+  const persist = useCallback(
+    async (nextHooks: HostGuardrails['hooks'], successMessage: string) => {
+      setSaving(true)
+      try {
+        await onSave(withHooks(initialGuardrails, nextHooks))
+        if (mountedRef.current) showToast(successMessage, { tone: 'success' })
+        return true
+      } catch {
+        // The parent already surfaced the error/conflict banner.
+        return false
+      } finally {
+        if (mountedRef.current) setSaving(false)
+      }
+    },
+    [initialGuardrails, onSave, showToast]
+  )
 
-  function addBuiltin(builtin: GuardrailBuiltin) {
-    setDraft(current => ({
-      ...current,
-      builtins: [...(current.builtins ?? []), builtin],
-    }))
-  }
+  async function addSelectedHooks() {
+    const chosen = installedHooks.filter(hook => selectedHookNames.includes(hookName(hook)))
+    const nextHooks: HostGuardrails['hooks'] = { ...(initialGuardrails?.hooks ?? {}) }
 
-  function removeBuiltin(index: number) {
-    setDraft(current => ({
-      ...current,
-      builtins: (current.builtins ?? []).filter((_, i) => i !== index),
-    }))
-  }
+    for (const hook of chosen) {
+      const id = hookName(hook)
+      // Pin the digest the cluster actually reconciled, matching how existing
+      // references are stored. An unpinned reference would float across hook
+      // image updates.
+      const ref: GuardrailHookRef = { id }
+      const digest = hook.status?.observedDigest
+      if (digest) ref.digest = digest
 
-  function handleCancel() {
-    setDraft(cloneGuardrails(initialGuardrails))
-    setEditing(defaultEditing)
-  }
+      for (const phase of hookPhases(hook)) {
+        nextHooks[phase] = [...(nextHooks[phase] ?? []), ref]
+      }
+    }
 
-  async function handleSave() {
-    try {
-      await onSave(draft)
-      setEditing(defaultEditing)
-    } catch {
-      // Parent surfaced an error/conflict banner. Stay in edit mode so the
-      // operator's draft survives the failure.
+    const added = chosen.length
+    const ok = await persist(
+      nextHooks,
+      added === 1 ? `${hookName(chosen[0])} added to this agent.` : `${added} hooks added.`
+    )
+    if (ok && mountedRef.current) {
+      setSelectedHookNames([])
+      setShowAddHook(false)
     }
   }
 
+  async function removeHook(row: GuardrailHookRow) {
+    const shouldRemove = await confirm({
+      title: 'Remove guardrail hook',
+      message: `Remove ${row.ref.id} from ${GUARDRAIL_PHASE_LABELS[row.phase]} on this agent? The hook stays installed on the cluster.`,
+      confirmLabel: 'Remove',
+      tone: 'danger',
+    })
+    if (!shouldRemove) return
+
+    const currentRefs = initialGuardrails?.hooks?.[row.phase] ?? []
+    const nextRefs = currentRefs.filter(ref => ref.id !== row.ref.id)
+    const nextHooks: HostGuardrails['hooks'] = { ...(initialGuardrails?.hooks ?? {}) }
+    if (nextRefs.length > 0) nextHooks[row.phase] = nextRefs
+    else delete nextHooks[row.phase]
+
+    await persist(nextHooks, `${row.ref.id} removed from this agent.`)
+  }
+
+  const disabled = busy || saving
+
   return (
-    <div className="cu-host-approval-section">
-      <p className="cu-muted cu-host-approval-section__description">
-        Installed guardrail hooks referenced by this agent, plus built-in guardrails. Use{' '}
-        <strong>Add hook</strong> to install a guardrail from the Marketplace onto this agent, add a
-        built-in, or remove a hook reference. Manage installed guardrails cluster-wide from the
-        Installed Guardrails section.
-      </p>
-
-      <div className="cu-host-approval-section__content">
-        {!editing ? (
-          !hasAny ? (
-            <div className="cu-empty">
-              No guardrail hooks or built-ins configured for this agent.
-            </div>
-          ) : (
-            <div>
-              {hookPhases.map(({ phase, refs }) => (
-                <div key={phase} className="cu-access-row">
-                  <span>{GUARDRAIL_PHASE_LABELS[phase]}</span>
-                  <div className="cu-expandable-tags">
-                    {refs.map(ref => (
-                      <span
-                        key={ref.id}
-                        className="cu-registry-tag"
-                        title={ref.digest ? `digest ${ref.digest}` : undefined}
-                      >
-                        {ref.id}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              ))}
-              {builtins.map((builtin, index) => (
-                <div key={`${builtin.type}-${index}`} className="cu-access-row">
-                  <span>Built-in · {builtin.type}</span>
-                  <span>
-                    order {typeof builtin.order === 'number' ? builtin.order : '—'} · fail{' '}
-                    {builtin.failMode ?? 'open'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )
-        ) : (
-          <EditMode
-            hookPhases={hookPhases}
-            builtins={builtins}
-            busy={busy}
-            onRemoveHookRef={removeHookRef}
-            onAddBuiltin={addBuiltin}
-            onRemoveBuiltin={removeBuiltin}
-          />
-        )}
-      </div>
-
-      <div className="cu-host-approval-section__actions">
-        {editing ? (
-          <>
-            <button
-              type="button"
-              className="cu-btn cu-btn--ghost cu-btn--sm"
-              onClick={handleCancel}
-              disabled={busy}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="cu-btn cu-btn--primary"
-              onClick={handleSave}
-              disabled={busy || !isDirty}
-            >
-              {busy ? 'Saving…' : 'Save'}
-            </button>
-          </>
-        ) : canWrite ? (
-          <>
+    <section className="cu-guardrails-tab" aria-label="Hooks">
+      <div className="cu-access-section">
+        <div className="cu-access-section__header">
+          <p className="cu-muted cu-access-section__description">
+            Guardrail hooks installed on the cluster and referenced by this agent.{' '}
+            <a className="cu-link" href={INSTALL_HOOK_ROUTE}>
+              Browse the Marketplace
+            </a>{' '}
+            to install more.
+          </p>
+          {canWrite ? (
             <button
               type="button"
               className="cu-btn cu-btn--primary cu-btn--sm"
-              onClick={() => router.push(CONTROL_ROUTES.marketplace.orgEntries)}
-              disabled={busy}
+              onClick={() => setShowAddHook(true)}
+              disabled={disabled}
             >
               Add hook
             </button>
-            <button
-              type="button"
-              className="cu-btn cu-btn--ghost cu-btn--sm"
-              onClick={() => setEditing(true)}
-              disabled={busy}
-            >
-              Edit
-            </button>
-          </>
-        ) : null}
-      </div>
-    </div>
-  )
-}
+          ) : null}
+        </div>
 
-interface EditModeProps {
-  hookPhases: Array<{ phase: GuardrailPhase; refs: GuardrailHookRef[] }>
-  builtins: GuardrailBuiltin[]
-  busy: boolean
-  onRemoveHookRef: (phase: GuardrailPhase, id: string) => void
-  onAddBuiltin: (builtin: GuardrailBuiltin) => void
-  onRemoveBuiltin: (index: number) => void
-}
-
-function EditMode({
-  hookPhases,
-  builtins,
-  busy,
-  onRemoveHookRef,
-  onAddBuiltin,
-  onRemoveBuiltin,
-}: EditModeProps) {
-  const [builtinType, setBuiltinType] = useState<GuardrailBuiltinType>('prompt-shaping')
-  const [orderValue, setOrderValue] = useState('0')
-  const [failMode, setFailMode] = useState<'open' | 'closed'>('open')
-
-  function handleAdd() {
-    const parsedOrder = Number.parseInt(orderValue, 10)
-    onAddBuiltin({
-      type: builtinType,
-      order: Number.isFinite(parsedOrder) ? parsedOrder : 0,
-      failMode,
-    })
-    setOrderValue('0')
-    setFailMode('open')
-    setBuiltinType('prompt-shaping')
-  }
-
-  return (
-    <>
-      <div className="cu-field">
-        <label>Referenced hooks</label>
-        {hookPhases.length === 0 ? (
-          <div className="cu-empty">No installed hooks are referenced by this agent.</div>
-        ) : (
-          hookPhases.map(({ phase, refs }) => (
-            <div key={phase} className="cu-access-row">
-              <span>{GUARDRAIL_PHASE_LABELS[phase]}</span>
-              <div className="cu-expandable-tags">
-                {refs.map(ref => (
-                  <span key={ref.id} className="cu-guardrails-ref-chip">
-                    <span
-                      className="cu-registry-tag"
-                      title={ref.digest ? `digest ${ref.digest}` : undefined}
-                    >
-                      {ref.id}
-                    </span>
-                    <button
-                      type="button"
-                      className="cu-btn cu-btn--icon cu-btn--danger-icon"
-                      aria-label={`Remove hook ${ref.id} from ${GUARDRAIL_PHASE_LABELS[phase]}`}
-                      onClick={() => onRemoveHookRef(phase, ref.id)}
-                      disabled={busy}
-                    >
-                      <IconX />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            </div>
-          ))
-        )}
-      </div>
-
-      <div className="cu-field">
-        <label>Built-in guardrails</label>
-        {builtins.length === 0 ? (
-          <div className="cu-empty">No built-in guardrails configured.</div>
-        ) : (
-          builtins.map((builtin, index) => (
-            <div key={`${builtin.type}-${index}`} className="cu-access-row">
-              <span>
-                {builtin.type} · order {typeof builtin.order === 'number' ? builtin.order : '—'} ·
-                fail {builtin.failMode ?? 'open'}
-              </span>
-              <button
-                type="button"
-                className="cu-btn cu-btn--icon cu-btn--danger-icon"
-                aria-label={`Remove built-in ${builtin.type}`}
-                onClick={() => onRemoveBuiltin(index)}
-                disabled={busy}
-              >
-                <IconX />
-              </button>
-            </div>
-          ))
-        )}
-      </div>
-
-      <div className="cu-field">
-        <label htmlFor="guardrail-builtin-type">Add built-in</label>
-        <div className="cu-guardrails-add-row">
-          <SelectInput
-            id="guardrail-builtin-type"
-            compact
-            value={builtinType}
-            onChange={e => setBuiltinType(e.target.value as GuardrailBuiltinType)}
-            disabled={busy}
-          >
-            {GUARDRAIL_BUILTIN_OPTIONS.map(option => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </SelectInput>
-          <TextInput
-            type="number"
-            compact
-            narrow
-            value={orderValue}
-            onChange={e => setOrderValue(e.target.value)}
-            disabled={busy}
-            aria-label="Built-in order"
-          />
-          <SelectInput
-            compact
-            value={failMode}
-            onChange={e => setFailMode(e.target.value as 'open' | 'closed')}
-            disabled={busy}
-            aria-label="Built-in fail mode"
-          >
-            <option value="open">Fail open</option>
-            <option value="closed">Fail closed</option>
-          </SelectInput>
-          <Button variant="ghost" size="sm" onClick={handleAdd} disabled={busy}>
-            Add
-          </Button>
+        <div className="cu-table-wrap">
+          <table className="cu-table cu-table--header-band">
+            <thead>
+              <tr>
+                <th>Hook</th>
+                <th>Phase</th>
+                <th className="cu-table__col-actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={3} className="cu-empty">
+                    No guardrail hooks on this agent yet.
+                  </td>
+                </tr>
+              ) : (
+                rows.map(row => (
+                  <tr key={`${row.phase}:${row.ref.id}`}>
+                    <td>
+                      <button
+                        type="button"
+                        className="cu-link"
+                        title={row.ref.digest ? `digest ${row.ref.digest}` : undefined}
+                        onClick={() => router.push(CONTROL_ROUTES.guardrails.detail(row.ref.id))}
+                      >
+                        {row.ref.id}
+                      </button>
+                    </td>
+                    <td>{GUARDRAIL_PHASE_LABELS[row.phase]}</td>
+                    <td className="cu-table__cell-actions">
+                      <div className="cu-row-actions">
+                        {canWrite ? (
+                          <button
+                            type="button"
+                            className="cu-btn cu-btn--icon cu-btn--danger-icon"
+                            onClick={() => void removeHook(row)}
+                            disabled={disabled}
+                            title="Remove"
+                            aria-label={`Remove hook ${row.ref.id} from ${GUARDRAIL_PHASE_LABELS[row.phase]}`}
+                          >
+                            <IconX width={16} height={16} />
+                          </button>
+                        ) : null}
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
-    </>
+
+      {showAddHook ? (
+        <SelectionModal
+          busy={disabled}
+          emptyLabel="No installed guardrail hooks are available."
+          id="agent-hook-picker"
+          label="Hooks"
+          onChange={setSelectedHookNames}
+          onClose={() => {
+            setSelectedHookNames([])
+            setShowAddHook(false)
+          }}
+          onConfirm={addSelectedHooks}
+          options={addOptions}
+          placeholder="Select hooks"
+          searchPlaceholder="Search hooks..."
+          selectionLabel="Selected hooks"
+          submitLabel={selectedHookNames.length > 1 ? 'Add hooks' : 'Add hook'}
+          title="Add hook"
+          titleId="add-hook-title"
+          value={selectedHookNames}
+        />
+      ) : null}
+
+      {confirmDialog}
+    </section>
   )
 }

--- a/control-ui/components/HostGuardrailsSection/index.tsx
+++ b/control-ui/components/HostGuardrailsSection/index.tsx
@@ -1,43 +1,13 @@
 'use client'
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useConfirmDialog } from '@components/ConfirmDialog'
-import { SelectionModal } from '@components/SelectionModal'
 import { useToast } from '@components/Toast'
 import { IconX } from '@components/icons'
-import { GUARDRAIL_ENTRY_TYPE } from '@constants/marketplaceEntryTypes'
 import { CONTROL_ROUTES } from '@constants/routes'
-import { type LlmHookResource, getLlmHooks } from '@lib/api'
 import { GUARDRAIL_PHASES, GUARDRAIL_PHASE_LABELS } from './constants'
-import type {
-  GuardrailHookRef,
-  GuardrailHookRow,
-  GuardrailPhase,
-  HostGuardrails,
-  HostGuardrailsSectionProps,
-} from './types'
-
-// The picker only offers hooks already installed on the cluster, so keep the
-// route that installs new ones reachable from the section itself — it is the
-// path the old "Add hook" button used to take.
-const INSTALL_HOOK_ROUTE = CONTROL_ROUTES.marketplace.orgEntriesFiltered({
-  type: GUARDRAIL_ENTRY_TYPE,
-})
-
-// The phases an installed hook declares it runs at. A hook is attached to every
-// phase it declares, so the operator picks the hook and never the phase.
-function hookPhases(hook: LlmHookResource): GuardrailPhase[] {
-  const raw = (hook.spec as { lifecyclePoints?: unknown } | undefined)?.lifecyclePoints
-  if (!Array.isArray(raw)) return []
-  return raw.filter((point): point is GuardrailPhase =>
-    GUARDRAIL_PHASES.includes(point as GuardrailPhase)
-  )
-}
-
-function hookName(hook: LlmHookResource): string {
-  return hook.metadata?.name ?? ''
-}
+import type { GuardrailHookRow, HostGuardrails, HostGuardrailsSectionProps } from './types'
 
 // Every field this section does not edit rides along untouched — dropping
 // `builtins` or `limits` here would silently wipe them from the Host spec.
@@ -59,31 +29,13 @@ export function HostGuardrailsSection({
   const { showToast } = useToast()
   const mountedRef = useRef(true)
 
-  const [installedHooks, setInstalledHooks] = useState<LlmHookResource[]>([])
-  const [showAddHook, setShowAddHook] = useState(false)
-  const [selectedHookNames, setSelectedHookNames] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
 
-  useEffect(() => {
+  React.useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
     }
-  }, [])
-
-  // The installed LlmHooks are the pool this agent can reference. A load
-  // failure only empties the picker — the rows below come from the Host spec
-  // and stay readable either way.
-  useEffect(() => {
-    void (async () => {
-      try {
-        const result = await getLlmHooks()
-        if (!mountedRef.current) return
-        setInstalledHooks(Array.isArray(result.items) ? result.items : [])
-      } catch {
-        if (mountedRef.current) setInstalledHooks([])
-      }
-    })()
   }, [])
 
   const rows = useMemo<GuardrailHookRow[]>(() => {
@@ -91,70 +43,20 @@ export function HostGuardrailsSection({
     return GUARDRAIL_PHASES.flatMap(phase => (hooks[phase] ?? []).map(ref => ({ phase, ref })))
   }, [initialGuardrails])
 
-  const referencedIds = useMemo(() => new Set(rows.map(row => row.ref.id)), [rows])
-
-  const addOptions = useMemo(
-    () =>
-      installedHooks
-        .filter(hook => hookName(hook) && !referencedIds.has(hookName(hook)))
-        .map(hook => {
-          const phases = hookPhases(hook)
-          return {
-            value: hookName(hook),
-            label: hookName(hook),
-            description: phases.length
-              ? phases.map(phase => GUARDRAIL_PHASE_LABELS[phase]).join(' · ')
-              : 'No lifecycle points declared',
-          }
-        }),
-    [installedHooks, referencedIds]
-  )
-
   const persist = useCallback(
     async (nextHooks: HostGuardrails['hooks'], successMessage: string) => {
       setSaving(true)
       try {
         await onSave(withHooks(initialGuardrails, nextHooks))
         if (mountedRef.current) showToast(successMessage, { tone: 'success' })
-        return true
       } catch {
         // The parent already surfaced the error/conflict banner.
-        return false
       } finally {
         if (mountedRef.current) setSaving(false)
       }
     },
     [initialGuardrails, onSave, showToast]
   )
-
-  async function addSelectedHooks() {
-    const chosen = installedHooks.filter(hook => selectedHookNames.includes(hookName(hook)))
-    const nextHooks: HostGuardrails['hooks'] = { ...(initialGuardrails?.hooks ?? {}) }
-
-    for (const hook of chosen) {
-      const id = hookName(hook)
-      // Pin the digest the cluster actually reconciled, matching how existing
-      // references are stored. An unpinned reference would float across hook
-      // image updates.
-      const ref: GuardrailHookRef = { id }
-      const digest = hook.status?.observedDigest
-      if (digest) ref.digest = digest
-
-      for (const phase of hookPhases(hook)) {
-        nextHooks[phase] = [...(nextHooks[phase] ?? []), ref]
-      }
-    }
-
-    const added = chosen.length
-    const ok = await persist(
-      nextHooks,
-      added === 1 ? `${hookName(chosen[0])} added to this agent.` : `${added} hooks added.`
-    )
-    if (ok && mountedRef.current) {
-      setSelectedHookNames([])
-      setShowAddHook(false)
-    }
-  }
 
   async function removeHook(row: GuardrailHookRow) {
     const shouldRemove = await confirm({
@@ -181,17 +83,13 @@ export function HostGuardrailsSection({
       <div className="cu-access-section">
         <div className="cu-access-section__header">
           <p className="cu-muted cu-access-section__description">
-            Guardrail hooks installed on the cluster and referenced by this agent.{' '}
-            <a className="cu-link" href={INSTALL_HOOK_ROUTE}>
-              Browse the Marketplace
-            </a>{' '}
-            to install more.
+            Guardrail hooks installed on the cluster and referenced by this agent.
           </p>
           {canWrite ? (
             <button
               type="button"
               className="cu-btn cu-btn--primary cu-btn--sm"
-              onClick={() => setShowAddHook(true)}
+              onClick={() => router.push(CONTROL_ROUTES.marketplace.orgEntries)}
               disabled={disabled}
             >
               Add hook
@@ -252,29 +150,6 @@ export function HostGuardrailsSection({
           </table>
         </div>
       </div>
-
-      {showAddHook ? (
-        <SelectionModal
-          busy={disabled}
-          emptyLabel="No installed guardrail hooks are available."
-          id="agent-hook-picker"
-          label="Hooks"
-          onChange={setSelectedHookNames}
-          onClose={() => {
-            setSelectedHookNames([])
-            setShowAddHook(false)
-          }}
-          onConfirm={addSelectedHooks}
-          options={addOptions}
-          placeholder="Select hooks"
-          searchPlaceholder="Search hooks..."
-          selectionLabel="Selected hooks"
-          submitLabel={selectedHookNames.length > 1 ? 'Add hooks' : 'Add hook'}
-          title="Add hook"
-          titleId="add-hook-title"
-          value={selectedHookNames}
-        />
-      ) : null}
 
       {confirmDialog}
     </section>

--- a/control-ui/components/HostGuardrailsSection/index.tsx
+++ b/control-ui/components/HostGuardrailsSection/index.tsx
@@ -5,9 +5,17 @@ import { useRouter } from 'next/navigation'
 import { useConfirmDialog } from '@components/ConfirmDialog'
 import { useToast } from '@components/Toast'
 import { IconX } from '@components/icons'
+import { GUARDRAIL_ENTRY_TYPE } from '@constants/marketplaceEntryTypes'
 import { CONTROL_ROUTES } from '@constants/routes'
 import { GUARDRAIL_PHASES, GUARDRAIL_PHASE_LABELS } from './constants'
 import type { GuardrailHookRow, HostGuardrails, HostGuardrailsSectionProps } from './types'
+
+// Add hook lands on the org marketplace entries list, narrowed to guardrail
+// hooks — the unfiltered list mixes in every connector and plugin the org has
+// published, which is not what someone adding a hook is looking for.
+const ADD_HOOK_ROUTE = CONTROL_ROUTES.marketplace.orgEntriesFiltered({
+  type: GUARDRAIL_ENTRY_TYPE,
+})
 
 // Every field this section does not edit rides along untouched — dropping
 // `builtins` or `limits` here would silently wipe them from the Host spec.
@@ -89,7 +97,7 @@ export function HostGuardrailsSection({
             <button
               type="button"
               className="cu-btn cu-btn--primary cu-btn--sm"
-              onClick={() => router.push(CONTROL_ROUTES.marketplace.orgEntries)}
+              onClick={() => router.push(ADD_HOOK_ROUTE)}
               disabled={disabled}
             >
               Add hook

--- a/control-ui/components/HostGuardrailsSection/types.ts
+++ b/control-ui/components/HostGuardrailsSection/types.ts
@@ -10,10 +10,6 @@ export type GuardrailPhase =
 
 export type GuardrailHookRef = { id: string; digest?: string }
 
-// Built-in guardrails supported by the minimal add UI. The stored `type` is a
-// free string on the CR; the picker offers this curated subset.
-export type GuardrailBuiltinType = 'prompt-shaping' | 'token-trim'
-
 export type GuardrailBuiltin = {
   type: string
   order?: number
@@ -23,8 +19,8 @@ export type GuardrailBuiltin = {
 }
 
 // Structured view over `Host.spec.guardrails` (typed `AnyRecord` in lib/api).
-// Fields this section does not edit (rules, trust level, ceiling, limits) are
-// carried through untouched so a save never drops them.
+// This section edits `hooks` and nothing else — `builtins`, rules, trust level,
+// ceiling and limits are carried through untouched so a save never drops them.
 export type HostGuardrails = {
   rules?: unknown[]
   hooks?: Partial<Record<GuardrailPhase, GuardrailHookRef[]>>
@@ -34,14 +30,19 @@ export type HostGuardrails = {
   limits?: Record<string, unknown>
 }
 
+// One table row: a single hook reference under a single phase. A hook that runs
+// at two phases is two rows, which is also how it is stored.
+export type GuardrailHookRow = {
+  phase: GuardrailPhase
+  ref: GuardrailHookRef
+}
+
 export interface HostGuardrailsSectionProps {
   initialGuardrails: HostGuardrails | undefined
   // Persist the full guardrails object (parent merges it into the Host spec
   // under the resourceVersion precondition). Rejects on failure so the section
-  // keeps the operator's draft.
+  // can leave the operator's view untouched.
   onSave: (next: HostGuardrails) => Promise<void>
   busy: boolean
   canWrite: boolean
-  // Render the editable list immediately instead of the read-only summary.
-  defaultEditing?: boolean
 }

--- a/control-ui/components/KebabMenu/index.tsx
+++ b/control-ui/components/KebabMenu/index.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import type { KebabMenuProps } from './types'
+
+// The overflow menu that sits next to a detail-page title, holding the actions
+// that are not the page's primary call to action (edit, retry, uninstall).
+// Shared so every detail page spells that affordance the same way.
+export function KebabMenu({ items, ariaLabel }: KebabMenuProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!open) return
+    function handleDocClick(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false)
+    }
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleDocClick)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('mousedown', handleDocClick)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [open])
+  return (
+    <div ref={ref} className="cu-kebab">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="cu-btn cu-btn--ghost cu-btn--sm cu-kebab__trigger"
+        onClick={() => setOpen(v => !v)}
+      >
+        ⋯
+      </button>
+      {open ? (
+        <div role="menu" className="cu-kebab__menu">
+          {items.map(item => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              className={`cu-kebab__item${item.danger ? ' cu-kebab__item--danger' : ''}`}
+              onClick={() => {
+                setOpen(false)
+                item.onClick()
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/control-ui/components/KebabMenu/types.ts
+++ b/control-ui/components/KebabMenu/types.ts
@@ -1,0 +1,11 @@
+export type KebabMenuItem = {
+  label: string
+  onClick: () => void
+  danger?: boolean
+  disabled?: boolean
+}
+
+export type KebabMenuProps = {
+  items: KebabMenuItem[]
+  ariaLabel: string
+}

--- a/control-ui/components/PublisherView/OwnedEntries.tsx
+++ b/control-ui/components/PublisherView/OwnedEntries.tsx
@@ -220,7 +220,10 @@ export function OwnedEntries({
     [entries, typeFilter, activeTypeLabel]
   )
 
-  const hasPrivateEntries = visibleEntries.some(e => e.visibility === 'private')
+  // Deliberately org-wide, not `visibleEntries`: the notice describes what
+  // cross-org sharing does to this org's private entries, so a `?type=` filter
+  // that happens to hide them all must not make it disappear.
+  const hasPrivateEntries = entries.some(e => e.visibility === 'private')
   // Collapse same-named entries into one row (latest leads); expanding a row
   // reveals the previous versions, each individually installable.
   const grouped = groupByName(visibleEntries)

--- a/control-ui/components/PublisherView/OwnedEntries.tsx
+++ b/control-ui/components/PublisherView/OwnedEntries.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import React, { Fragment, useCallback, useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { IconChevronRight } from '@components/icons'
+import { MARKETPLACE_ENTRY_TYPE_LABELS } from '@constants/marketplaceEntryTypes'
 import { CONTROL_ROUTES } from '@constants/routes'
 import {
   type OwnedRegistryEntry,
@@ -108,6 +109,7 @@ export function OwnedEntries({
   sharingUnavailable?: boolean
 }) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const { showToast } = useToast()
   const { confirm, confirmDialog } = useConfirmDialog()
   const [entries, setEntries] = useState<OwnedRegistryEntry[]>([])
@@ -207,10 +209,21 @@ export function OwnedEntries({
     )
   }
 
-  const hasPrivateEntries = entries.some(e => e.visibility === 'private')
+  // `?type=` narrows the list to a single entry kind — this is how "Add hook"
+  // on an agent lands here showing only guardrail hooks. An unrecognised value
+  // filters nothing, so a stale or hand-edited link degrades to the full list
+  // instead of an empty one.
+  const typeFilter = searchParams?.get('type') ?? null
+  const activeTypeLabel = typeFilter ? MARKETPLACE_ENTRY_TYPE_LABELS[typeFilter] : undefined
+  const visibleEntries = useMemo(
+    () => (activeTypeLabel ? entries.filter(e => ownedEntryKind(e) === typeFilter) : entries),
+    [entries, typeFilter, activeTypeLabel]
+  )
+
+  const hasPrivateEntries = visibleEntries.some(e => e.visibility === 'private')
   // Collapse same-named entries into one row (latest leads); expanding a row
   // reveals the previous versions, each individually installable.
-  const grouped = groupByName(entries)
+  const grouped = groupByName(visibleEntries)
 
   return (
     <section>
@@ -231,10 +244,25 @@ export function OwnedEntries({
               onRetry={() => void load()}
             />
           ) : null}
+          {!loading && !error && activeTypeLabel ? (
+            <p className="cu-banner cu-banner--info">
+              Showing {activeTypeLabel.toLowerCase()} only.{' '}
+              <button
+                type="button"
+                className="cu-link"
+                onClick={() => router.replace(CONTROL_ROUTES.marketplace.orgEntries)}
+              >
+                Show all entries
+              </button>
+            </p>
+          ) : null}
           {!loading && !error && entries.length === 0 ? (
             <p>You haven’t published any registry entries yet.</p>
           ) : null}
-          {!loading && !error && entries.length > 0 ? (
+          {!loading && !error && entries.length > 0 && visibleEntries.length === 0 ? (
+            <p>No {activeTypeLabel?.toLowerCase() ?? 'entries'} published yet.</p>
+          ) : null}
+          {!loading && !error && visibleEntries.length > 0 ? (
             <>
               <div className="cu-table-wrap">
                 <table className="cu-table">

--- a/control-ui/components/SelectionModal/index.tsx
+++ b/control-ui/components/SelectionModal/index.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import React from 'react'
+import { SelectionDropdown } from '@components/SelectionDropdown'
+import { IconX } from '@components/icons'
+import type { SelectionModalProps } from './types'
+
+/**
+ * "Pick some things from a list, then confirm" overlay — the Add member / Add
+ * team / Add hook flow on the agent detail tabs. Extracted from HostAccessTab
+ * so every one of those surfaces is literally the same control rather than a
+ * near-copy that drifts.
+ */
+export function SelectionModal({
+  busy,
+  emptyLabel,
+  id,
+  label,
+  onChange,
+  onClose,
+  onConfirm,
+  options,
+  placeholder,
+  searchPlaceholder,
+  selectionLabel,
+  submitLabel,
+  title,
+  titleId,
+  value,
+}: SelectionModalProps) {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'var(--cu-overlay)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+        padding: '1rem',
+      }}
+      role="presentation"
+      onClick={e => {
+        if (e.target === e.currentTarget && !busy) onClose()
+      }}
+    >
+      <div
+        className="cu-modal-panel cu-modal-panel--selection"
+        role="dialog"
+        aria-labelledby={titleId}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="cu-modal-panel__head">
+          <strong id={titleId} style={{ fontSize: '1rem', lineHeight: 1.35 }}>
+            {title}
+          </strong>
+          <button
+            type="button"
+            className="cu-btn cu-btn--icon cu-btn--ghost"
+            onClick={onClose}
+            disabled={busy}
+            aria-label="Close"
+          >
+            <IconX width={18} height={18} />
+          </button>
+        </div>
+
+        <div className="cu-field">
+          <label htmlFor={id}>{label}</label>
+          <SelectionDropdown
+            emptyLabel={emptyLabel}
+            id={id}
+            inline
+            disabled={busy}
+            onChange={onChange}
+            options={options}
+            placeholder={placeholder}
+            searchPlaceholder={searchPlaceholder}
+            selectionLabel={selectionLabel}
+            value={value}
+          />
+        </div>
+
+        <div className="cu-modal-panel__foot">
+          <button
+            type="button"
+            className="cu-btn cu-btn--ghost cu-btn--sm"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="cu-btn cu-btn--primary"
+            onClick={() => void onConfirm()}
+            disabled={busy || value.length === 0}
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/control-ui/components/SelectionModal/index.tsx
+++ b/control-ui/components/SelectionModal/index.tsx
@@ -30,16 +30,7 @@ export function SelectionModal({
 }: SelectionModalProps) {
   return (
     <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: 'var(--cu-overlay)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        zIndex: 1000,
-        padding: '1rem',
-      }}
+      className="cu-modal-overlay"
       role="presentation"
       onClick={e => {
         if (e.target === e.currentTarget && !busy) onClose()

--- a/control-ui/components/SelectionModal/types.ts
+++ b/control-ui/components/SelectionModal/types.ts
@@ -1,0 +1,24 @@
+export type SelectionModalOption = {
+  value: string
+  label: string
+  description?: string
+  badge?: string
+}
+
+export type SelectionModalProps = {
+  busy: boolean
+  emptyLabel: string
+  id: string
+  label: string
+  onChange: (next: string[]) => void
+  onClose: () => void
+  onConfirm: () => Promise<void>
+  options: SelectionModalOption[]
+  placeholder: string
+  searchPlaceholder: string
+  selectionLabel: string
+  submitLabel: string
+  title: string
+  titleId: string
+  value: string[]
+}

--- a/control-ui/components/__tests__/GuardrailHooksTable.test.tsx
+++ b/control-ui/components/__tests__/GuardrailHooksTable.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { LlmHookResource } from '../../lib/api'
+import { GuardrailHooksTable } from '../GuardrailHooksTable'
+
+const navigation = vi.hoisted(() => ({ push: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navigation.push }),
+}))
+
+const HOOKS = [
+  {
+    metadata: { name: 'hook-token-compactor' },
+    spec: { lifecyclePoints: ['preCall'], order: 0, failMode: 'open' },
+    status: { conditions: [{ type: 'Ready', status: 'True' }] },
+  },
+] as unknown as LlmHookResource[]
+
+afterEach(cleanup)
+beforeEach(() => vi.clearAllMocks())
+
+describe('GuardrailHooksTable', () => {
+  it('offers Install Guardrail, which the page routes to the guardrail marketplace', () => {
+    const onInstall = vi.fn()
+    render(<GuardrailHooksTable items={HOOKS} onInstall={onInstall} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Install Guardrail' }))
+    expect(onInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits Install Guardrail when the page supplies no handler', () => {
+    render(<GuardrailHooksTable items={HOOKS} />)
+    expect(screen.queryByRole('button', { name: 'Install Guardrail' })).toBeNull()
+  })
+
+  it('a row navigates to the guardrail detail page rather than expanding in place', () => {
+    const view = render(<GuardrailHooksTable items={HOOKS} />)
+    fireEvent.click(screen.getByRole('button', { name: 'View guardrail hook-token-compactor' }))
+    expect(navigation.push).toHaveBeenCalledWith('/guardrails/hook-token-compactor')
+    // The chevron is a navigation affordance, not an expander: it must not
+    // borrow the expandable-row vocabulary, which promises in-place detail.
+    expect(view.container.querySelector('.cu-expandable-row__chevron')).toBeNull()
+    expect(view.container.querySelector('.cu-expandable-table')).toBeNull()
+    expect(view.container.querySelector('.cu-installed-plugin__navigation')).not.toBeNull()
+  })
+})

--- a/control-ui/components/__tests__/HostDetailsPage.identity.test.tsx
+++ b/control-ui/components/__tests__/HostDetailsPage.identity.test.tsx
@@ -46,8 +46,6 @@ vi.mock('../../lib/api', () => ({
   getAgentUsers: vi.fn(),
   getHost: vi.fn(),
   getHostDetailBundle: vi.fn(),
-  // The Hooks sub-tab loads the installed LlmHooks to populate its picker.
-  getLlmHooks: vi.fn().mockResolvedValue({ items: [] }),
   updateAdminTeamAgents: vi.fn(),
   updateAdminUserAgents: vi.fn(),
   // The model picker loads the operator allowlist via useLlmAllowedModels.

--- a/control-ui/components/__tests__/HostDetailsPage.identity.test.tsx
+++ b/control-ui/components/__tests__/HostDetailsPage.identity.test.tsx
@@ -46,6 +46,8 @@ vi.mock('../../lib/api', () => ({
   getAgentUsers: vi.fn(),
   getHost: vi.fn(),
   getHostDetailBundle: vi.fn(),
+  // The Hooks sub-tab loads the installed LlmHooks to populate its picker.
+  getLlmHooks: vi.fn().mockResolvedValue({ items: [] }),
   updateAdminTeamAgents: vi.fn(),
   updateAdminUserAgents: vi.fn(),
   // The model picker loads the operator allowlist via useLlmAllowedModels.
@@ -148,9 +150,26 @@ describe('HostDetailsPage identity integration', () => {
     expect(container.querySelector('.cu-agent-detail-card .cu-agent-detail-scroll')).not.toBeNull()
   })
 
+  it('opens Advanced on the Hooks sub-tab', async () => {
+    mockParams = { name: 'foo', tab: 'advanced' }
+    render(<HostDetailsPage />)
+
+    const hooksTab = await screen.findByRole('tab', { name: 'Hooks' })
+    expect(hooksTab).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Per-tool approval' })).toHaveAttribute(
+      'aria-selected',
+      'false'
+    )
+    expect(await screen.findByText('No guardrail hooks on this agent yet.')).toBeInTheDocument()
+    // The approval editor stays unmounted until its sub-tab is selected.
+    expect(screen.queryByLabelText('http_request')).toBeNull()
+  })
+
   it('keeps Per-tool approval actions in the top toolbar without a duplicate title', async () => {
     mockParams = { name: 'foo', tab: 'advanced' }
     const { container } = render(<HostDetailsPage />)
+
+    fireEvent.click(await screen.findByRole('tab', { name: 'Per-tool approval' }))
 
     expect(await screen.findByLabelText('http_request')).toBeInTheDocument()
     expect(

--- a/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
+++ b/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
@@ -50,7 +50,7 @@ describe('HostGuardrailsSection', () => {
     expect(screen.queryByText(/no guardrail hooks on this agent/i)).toBeNull()
   })
 
-  it('Add hook goes to the org marketplace entries list', async () => {
+  it('Add hook goes to the org marketplace entries list, filtered to hooks', async () => {
     render(
       <HostGuardrailsSection
         busy={false}
@@ -62,7 +62,7 @@ describe('HostGuardrailsSection', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Add hook' }))
 
-    expect(navigation.push).toHaveBeenCalledWith('/marketplace/org/entries')
+    expect(navigation.push).toHaveBeenCalledWith('/marketplace/org/entries?type=llm-hook')
   })
 
   it('clicking a hook opens its guardrail detail page', async () => {

--- a/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
+++ b/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render as rtlRender,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import * as api from '../../lib/api'
+import { HostGuardrailsSection } from '../HostGuardrailsSection'
+import type { HostGuardrails } from '../HostGuardrailsSection/types'
+import { ToastProvider } from '../Toast'
+
+vi.mock('../../lib/api', () => ({
+  getLlmHooks: vi.fn(),
+}))
+
+const confirmMock = vi.hoisted(() => vi.fn())
+vi.mock('../ConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: confirmMock, confirmDialog: null }),
+}))
+
+const navigation = vi.hoisted(() => ({ push: vi.fn() }))
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navigation.push }),
+}))
+
+const COMPACTOR = {
+  metadata: { name: 'hook-token-compactor' },
+  spec: { lifecyclePoints: ['preCall'] },
+  status: { observedDigest: 'sha256:aaa' },
+}
+const RECORDER = {
+  metadata: { name: 'hook-tool-use-recorder' },
+  spec: { lifecyclePoints: ['postCallSuccess'] },
+  status: { observedDigest: 'sha256:bbb' },
+}
+
+// A hook already attached to the agent, plus fields this section must never
+// touch on save.
+const GUARDRAILS: HostGuardrails = {
+  hooks: { preCall: [{ id: 'hook-token-compactor', digest: 'sha256:aaa' }] },
+  builtins: [{ type: 'prompt-shaping', order: 0, failMode: 'open' }],
+  limits: { maxHooksPerPhase: 8 },
+}
+
+function render(children: ReactNode) {
+  return rtlRender(<ToastProvider>{children}</ToastProvider>)
+}
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.clearAllMocks()
+  confirmMock.mockResolvedValue(true)
+  vi.mocked(api.getLlmHooks).mockResolvedValue({ items: [COMPACTOR, RECORDER] } as never)
+})
+
+describe('HostGuardrailsSection', () => {
+  it('lists one row per referenced hook and phase', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('hook-token-compactor')).toBeInTheDocument()
+    expect(screen.getByText('Pre-call')).toBeInTheDocument()
+    expect(screen.queryByText(/no guardrail hooks on this agent/i)).toBeNull()
+  })
+
+  it('clicking a hook opens its guardrail detail page', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'hook-token-compactor' }))
+
+    expect(navigation.push).toHaveBeenCalledWith('/guardrails/hook-token-compactor')
+  })
+
+  it('a hook stays clickable for an operator who cannot write', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite={false}
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'hook-token-compactor' }))
+
+    expect(navigation.push).toHaveBeenCalledWith('/guardrails/hook-token-compactor')
+  })
+
+  it('empty state when the agent references no hooks', async () => {
+    render(<HostGuardrailsSection busy={false} canWrite initialGuardrails={{}} onSave={vi.fn()} />)
+
+    expect(await screen.findByText(/no guardrail hooks on this agent yet/i)).toBeInTheDocument()
+  })
+
+  it('Add hook offers only unreferenced hooks and saves with the declared phase and digest', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <HostGuardrailsSection busy={false} canWrite initialGuardrails={GUARDRAILS} onSave={onSave} />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add hook' }))
+
+    // The already-attached hook must not be offered a second time.
+    const option = await screen.findByRole('option', { name: 'hook-tool-use-recorder' })
+    expect(screen.queryByRole('option', { name: 'hook-token-compactor' })).toBeNull()
+
+    fireEvent.click(option)
+    // Both the section header and the modal footer read "Add hook" — submit is
+    // the one inside the dialog.
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Add hook' }))
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    const saved = onSave.mock.calls[0][0] as HostGuardrails
+    expect(saved.hooks?.postCallSuccess).toEqual([
+      { id: 'hook-tool-use-recorder', digest: 'sha256:bbb' },
+    ])
+    // The phase the operator never chose stays exactly as it was...
+    expect(saved.hooks?.preCall).toEqual([{ id: 'hook-token-compactor', digest: 'sha256:aaa' }])
+    // ...and so does everything this section does not edit.
+    expect(saved.builtins).toEqual(GUARDRAILS.builtins)
+    expect(saved.limits).toEqual(GUARDRAILS.limits)
+  })
+
+  it('removing the last hook of a phase drops the phase key rather than leaving it empty', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <HostGuardrailsSection busy={false} canWrite initialGuardrails={GUARDRAILS} onSave={onSave} />
+    )
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Remove hook hook-token-compactor from Pre-call',
+      })
+    )
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
+    const saved = onSave.mock.calls[0][0] as HostGuardrails
+    expect(saved.hooks).toEqual({})
+    expect(saved.builtins).toEqual(GUARDRAILS.builtins)
+  })
+
+  it('a declined confirm leaves the hook in place', async () => {
+    confirmMock.mockResolvedValue(false)
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <HostGuardrailsSection busy={false} canWrite initialGuardrails={GUARDRAILS} onSave={onSave} />
+    )
+
+    fireEvent.click(
+      await screen.findByRole('button', {
+        name: 'Remove hook hook-token-compactor from Pre-call',
+      })
+    )
+
+    await waitFor(() => expect(confirmMock).toHaveBeenCalled())
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('offers no write controls when the operator cannot write', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite={false}
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    expect(await screen.findByText('hook-token-compactor')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Add hook' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^Remove hook/ })).toBeNull()
+  })
+
+  it('no longer exposes built-in guardrail editing', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    await screen.findByText('hook-token-compactor')
+    expect(screen.queryByText(/built-in/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
+  })
+})

--- a/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
+++ b/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
@@ -117,6 +117,7 @@ describe('HostGuardrailsSection', () => {
     const saved = onSave.mock.calls[0][0] as HostGuardrails
     expect(saved.hooks).toEqual({})
     expect(saved.builtins).toEqual(GUARDRAILS.builtins)
+    expect(saved.limits).toEqual(GUARDRAILS.limits)
   })
 
   it('a declined confirm leaves the hook in place', async () => {

--- a/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
+++ b/control-ui/components/__tests__/HostGuardrailsSection.test.tsx
@@ -1,22 +1,10 @@
 import React from 'react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  cleanup,
-  fireEvent,
-  render as rtlRender,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react'
-import * as api from '../../lib/api'
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
 import { HostGuardrailsSection } from '../HostGuardrailsSection'
 import type { HostGuardrails } from '../HostGuardrailsSection/types'
 import { ToastProvider } from '../Toast'
-
-vi.mock('../../lib/api', () => ({
-  getLlmHooks: vi.fn(),
-}))
 
 const confirmMock = vi.hoisted(() => vi.fn())
 vi.mock('../ConfirmDialog', () => ({
@@ -27,17 +15,6 @@ const navigation = vi.hoisted(() => ({ push: vi.fn() }))
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: navigation.push }),
 }))
-
-const COMPACTOR = {
-  metadata: { name: 'hook-token-compactor' },
-  spec: { lifecyclePoints: ['preCall'] },
-  status: { observedDigest: 'sha256:aaa' },
-}
-const RECORDER = {
-  metadata: { name: 'hook-tool-use-recorder' },
-  spec: { lifecyclePoints: ['postCallSuccess'] },
-  status: { observedDigest: 'sha256:bbb' },
-}
 
 // A hook already attached to the agent, plus fields this section must never
 // touch on save.
@@ -55,7 +32,6 @@ afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
   confirmMock.mockResolvedValue(true)
-  vi.mocked(api.getLlmHooks).mockResolvedValue({ items: [COMPACTOR, RECORDER] } as never)
 })
 
 describe('HostGuardrailsSection', () => {
@@ -72,6 +48,21 @@ describe('HostGuardrailsSection', () => {
     expect(await screen.findByText('hook-token-compactor')).toBeInTheDocument()
     expect(screen.getByText('Pre-call')).toBeInTheDocument()
     expect(screen.queryByText(/no guardrail hooks on this agent/i)).toBeNull()
+  })
+
+  it('Add hook goes to the org marketplace entries list', async () => {
+    render(
+      <HostGuardrailsSection
+        busy={false}
+        canWrite
+        initialGuardrails={GUARDRAILS}
+        onSave={vi.fn()}
+      />
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add hook' }))
+
+    expect(navigation.push).toHaveBeenCalledWith('/marketplace/org/entries')
   })
 
   it('clicking a hook opens its guardrail detail page', async () => {
@@ -108,35 +99,6 @@ describe('HostGuardrailsSection', () => {
     render(<HostGuardrailsSection busy={false} canWrite initialGuardrails={{}} onSave={vi.fn()} />)
 
     expect(await screen.findByText(/no guardrail hooks on this agent yet/i)).toBeInTheDocument()
-  })
-
-  it('Add hook offers only unreferenced hooks and saves with the declared phase and digest', async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined)
-    render(
-      <HostGuardrailsSection busy={false} canWrite initialGuardrails={GUARDRAILS} onSave={onSave} />
-    )
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Add hook' }))
-
-    // The already-attached hook must not be offered a second time.
-    const option = await screen.findByRole('option', { name: 'hook-tool-use-recorder' })
-    expect(screen.queryByRole('option', { name: 'hook-token-compactor' })).toBeNull()
-
-    fireEvent.click(option)
-    // Both the section header and the modal footer read "Add hook" — submit is
-    // the one inside the dialog.
-    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Add hook' }))
-
-    await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1))
-    const saved = onSave.mock.calls[0][0] as HostGuardrails
-    expect(saved.hooks?.postCallSuccess).toEqual([
-      { id: 'hook-tool-use-recorder', digest: 'sha256:bbb' },
-    ])
-    // The phase the operator never chose stays exactly as it was...
-    expect(saved.hooks?.preCall).toEqual([{ id: 'hook-token-compactor', digest: 'sha256:aaa' }])
-    // ...and so does everything this section does not edit.
-    expect(saved.builtins).toEqual(GUARDRAILS.builtins)
-    expect(saved.limits).toEqual(GUARDRAILS.limits)
   })
 
   it('removing the last hook of a phase drops the phase key rather than leaving it empty', async () => {

--- a/control-ui/components/__tests__/OwnedEntries.test.tsx
+++ b/control-ui/components/__tests__/OwnedEntries.test.tsx
@@ -209,6 +209,42 @@ describe('OwnedEntries', () => {
     expect(screen.queryByText(/showing .* only/i)).toBeNull()
   })
 
+  it('a type filter naming an inherited object key falls back to the full list', async () => {
+    // `?type=toString` used to resolve to Object.prototype.toString off the
+    // label map, which read as a real label and crashed the render.
+    mockSearchParams = new URLSearchParams('type=toString')
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '2.0.0', serverMode: 'http', status: 'published' }],
+    } as never)
+    render(<OwnedEntries orgScope="acme" />)
+
+    expect(await screen.findByText('@acme/db')).toBeInTheDocument()
+    expect(screen.queryByText(/showing .* only/i)).toBeNull()
+  })
+
+  it('keeps the sharing notice when a type filter hides every private entry', async () => {
+    mockSearchParams = new URLSearchParams('type=llm-hook')
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [
+        {
+          name: '@acme/redactor',
+          version: '1.0.0',
+          entryType: 'llm-hook',
+          visibility: 'public',
+          status: 'published',
+        },
+        { name: '@acme/db', version: '2.0.0', serverMode: 'http', visibility: 'private' },
+      ],
+    } as never)
+    render(<OwnedEntries orgScope="acme" canShare={false} sharingUnavailable />)
+
+    await screen.findByText('@acme/redactor')
+    // The private entry is filtered out of the table, but the notice describes
+    // org state, so it must still explain why sharing is unavailable.
+    expect(screen.queryByText('@acme/db')).toBeNull()
+    expect(screen.getByText(/Cross-org sharing/i)).toBeInTheDocument()
+  })
+
   it('error + Retry re-fetches', async () => {
     vi.mocked(api.getOwnedRegistryEntries)
       .mockRejectedValueOnce(Object.assign(new Error('boom'), { status: 500 }))

--- a/control-ui/components/__tests__/OwnedEntries.test.tsx
+++ b/control-ui/components/__tests__/OwnedEntries.test.tsx
@@ -25,9 +25,11 @@ vi.mock('../ConfirmDialog', () => ({
   useConfirmDialog: () => ({ confirm: confirmMock, confirmDialog: null }),
 }))
 
-const navigation = vi.hoisted(() => ({ push: vi.fn() }))
+const navigation = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }))
+let mockSearchParams = new URLSearchParams()
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: navigation.push }),
+  useRouter: () => ({ push: navigation.push, replace: navigation.replace }),
+  useSearchParams: () => mockSearchParams,
 }))
 
 function render(ui: React.ReactNode) {
@@ -36,6 +38,7 @@ function render(ui: React.ReactNode) {
 afterEach(cleanup)
 beforeEach(() => {
   vi.clearAllMocks()
+  mockSearchParams = new URLSearchParams()
   confirmMock.mockResolvedValue(false)
   // Default: nothing installed, so entries show the Install CTA.
   vi.mocked(api.getRegistryCatalog).mockResolvedValue(EMPTY_INSTALLED as never)
@@ -165,6 +168,45 @@ describe('OwnedEntries', () => {
     vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({ data: [] })
     render(<OwnedEntries orgScope="acme" />)
     expect(await screen.findByText(/haven’t published/i)).toBeInTheDocument()
+  })
+
+  it('?type=llm-hook narrows the list to guardrail hooks and offers Show all', async () => {
+    mockSearchParams = new URLSearchParams('type=llm-hook')
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [
+        { name: '@acme/redactor', version: '1.0.0', entryType: 'llm-hook', status: 'published' },
+        { name: '@acme/db', version: '2.0.0', serverMode: 'http', status: 'published' },
+      ],
+    } as never)
+    render(<OwnedEntries orgScope="acme" />)
+
+    expect(await screen.findByText('@acme/redactor')).toBeInTheDocument()
+    expect(screen.queryByText('@acme/db')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /show all entries/i }))
+    expect(navigation.replace).toHaveBeenCalledWith('/marketplace/org/entries')
+  })
+
+  it('a type filter that matches nothing says so without claiming the org has published nothing', async () => {
+    mockSearchParams = new URLSearchParams('type=llm-hook')
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '2.0.0', serverMode: 'http', status: 'published' }],
+    } as never)
+    render(<OwnedEntries orgScope="acme" />)
+
+    expect(await screen.findByText(/no guardrail hooks published yet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/haven’t published/i)).toBeNull()
+  })
+
+  it('an unrecognised type filter falls back to the full list', async () => {
+    mockSearchParams = new URLSearchParams('type=not-a-type')
+    vi.mocked(api.getOwnedRegistryEntries).mockResolvedValue({
+      data: [{ name: '@acme/db', version: '2.0.0', serverMode: 'http', status: 'published' }],
+    } as never)
+    render(<OwnedEntries orgScope="acme" />)
+
+    expect(await screen.findByText('@acme/db')).toBeInTheDocument()
+    expect(screen.queryByText(/showing .* only/i)).toBeNull()
   })
 
   it('error + Retry re-fetches', async () => {

--- a/control-ui/e2e/host-approval-tools-e2e.spec.ts
+++ b/control-ui/e2e/host-approval-tools-e2e.spec.ts
@@ -74,8 +74,12 @@ async function gotoHostDetails(page: Page) {
   // The Per-tool approval editor now lives under the consolidated Advanced
   // tab. The old `/approvals` slug is still served via a 308 redirect, but
   // navigating to the canonical URL directly keeps this E2E independent of
-  // that compatibility shim.
+  // that compatibility shim. Advanced opens on the Hooks sub-tab, so select
+  // Per-tool approval explicitly — the guardrails panel reuses the
+  // `.cu-host-approval-section` class, and waiting on it before switching
+  // sub-tabs would match the wrong section.
   await page.goto(`${BASE_UI}/hosts/${encodeURIComponent(HOST_NAME)}/advanced`)
+  await page.locator('.cu-advanced-tabs button:has-text("Per-tool approval")').click()
   await page.waitForSelector('.cu-host-approval-section', { timeout: 20_000 })
 }
 

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.447",
+  "version": "0.1.448",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.447",
+      "version": "0.1.448",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.448",
+  "version": "0.1.449",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.448",
+      "version": "0.1.449",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.446",
+  "version": "0.1.447",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.446",
+      "version": "0.1.447",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.445",
+  "version": "0.1.446",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.445",
+      "version": "0.1.446",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.444",
+  "version": "0.1.445",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.444",
+      "version": "0.1.445",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.448",
+  "version": "0.1.449",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.447",
+  "version": "0.1.448",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.444",
+  "version": "0.1.445",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.446",
+  "version": "0.1.447",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.445",
+  "version": "0.1.446",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
## Summary

The Hooks UI on the agent Advanced tab (`/agents/<name>/advanced`) hung below the sub-tab bar as an always-visible section with its own edit mode. This promotes it to a sub-tab of its own — **first and default**, alongside Per-tool approval and Env vars — and rebuilds it on the same paradigm the Context and Access tables already use.

## What changed

**Hooks is now a sub-tab.** `HostAdvancedTab` gains a `hooks` entry, placed first and set as the default. `HostGuardrailsSection` moved inside it; the separate render in `app/hosts/[name]/page.tsx` is gone. `guardrailsData` / `persistGuardrails` pass through unchanged, so save and optimistic-concurrency behaviour are identical.

**The table follows Context/Access.** Section header with the primary `Add hook` control on the right, `cu-table cu-table--header-band` in a `cu-table-wrap`, `cu-empty` empty state, and a per-row danger `IconX` behind a confirm dialog. No edit mode and no Save/Cancel — removing saves immediately, the same way revoking access does.

**Hook names link to their detail page.** `/guardrails/<hook-name>`, via the same `cu-link` button pattern Access uses for members and teams. Navigation is deliberately *not* gated on `canWrite`: a read-only operator loses Add/Remove but can still click through.

**`Add hook` goes to `/marketplace/org/entries?type=llm-hook`** — the org marketplace entries list, narrowed to guardrail hooks. The unfiltered list mixes in every connector and plugin the org has published, which is not what someone adding a hook is looking for.

**Org marketplace entries can be filtered by type.** `?type=` on `/marketplace/org/entries`, which is what makes the above work. An unrecognised value falls back to the full list rather than rendering an empty one, and "no hooks yet" reads differently from "you have published nothing yet".

**Built-in guardrail editing is dropped for now.** `builtins` still rides along untouched on every save, so removing the editor does not wipe it from the Host spec — there is a test pinning exactly that. The CSS that styled the built-in control row and the old edit-mode hook chips is removed with it.

## Notes for review

- **A Phase column was added.** A hook that runs at two lifecycle points is genuinely two rows — that is how it is stored — so a 2-column table could not tell them apart. Access and Context do not need this because a member is a member.
- **`AccessGrantModal` moved to `components/SelectionModal`.** It had nothing access-specific in it. An intermediate revision of this branch used it for an installed-hook picker on the Hooks tab; that was replaced by plain navigation, so today the only caller is `HostAccessTab` (Add member / Add team). The extraction is kept because it is the right home for a shared control, but reviewers should know it is currently a one-consumer component.
- **E2E fix:** `host-approval-tools-e2e.spec.ts` waited on `.cu-host-approval-section` right after landing on `/advanced`. The guardrails panel reuses that class, so with Hooks defaulting it would have matched the wrong section — the spec now selects the Per-tool approval sub-tab explicitly.

## Testing

- `tsc --noEmit` clean for every file touched.
- `vitest run`: **1576 passed**, 1 skipped. Nine tests on the hooks section, three on the entries filter, one on the default sub-tab.
- Six test files fail to load on missing deps (`fast-check`, `@clerum/display-field`). Confirmed pre-existing by stashing — they fail identically on the base.
- Swept the touched files for unused exports and orphaned CSS classes; everything left has a caller.
- Exercised manually against minikube: `/agents/chatllm/advanced`, `/marketplace/org/entries?type=llm-hook`, and `/guardrails/hook-acme1-token-compactor-v0-2-1-6da759e1` all serve 200 with real hook data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DY8Fj2SQ78CNVsaGLvtWw8