### PR TITLE
feat(desktop-app): first-run onboarding questionnaire

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -783,8 +783,12 @@ local-web: ## Run Control UI locally against minikube control-api port-forward
 	wait_for_port control-api 8090 "$$api_pid" http://127.0.0.1:8090/health; \
 	CONTROL_API_INTERNAL_URL=http://localhost:8090 npm --prefix control-ui run dev
 
+.PHONY: local-app-onboarding
+local-app-onboarding: ## Run Desktop App showing the first-run onboarding flow (isolated; real environments untouched)
+	@$(MAKE) --no-print-directory EVENFIRE_ONBOARDING_PREVIEW=true local-app
+
 .PHONY: local-app
-local-app: ## Run Desktop App locally against minikube API port-forwards
+local-app: ## Run Desktop App locally against minikube API port-forwards (EVENFIRE_ONBOARDING_PREVIEW=true previews onboarding)
 	@set -euo pipefail; \
 	cleanup() { \
 		local pids; \
@@ -854,7 +858,7 @@ local-app: ## Run Desktop App locally against minikube API port-forwards
 	wait_for_port control-api 8090 "$$control_api_pid" http://127.0.0.1:8090/health; \
 	wait_for_port external-rest-api 8091 "$$external_api_pid" http://127.0.0.1:8091/health; \
 	wait_for_port rpc-proxy 8094 "$$rpc_proxy_pid" http://127.0.0.1:8094/health; \
-	env -u ELECTRON_RUN_AS_NODE EXTERNAL_REST_API_BASE_URL=http://127.0.0.1:8091 RPC_PROXY_BASE_URL=http://127.0.0.1:8094 CONTROL_API_BASE_URL=http://127.0.0.1:8090 npm --prefix desktop-app run dev
+	env -u ELECTRON_RUN_AS_NODE EXTERNAL_REST_API_BASE_URL=http://127.0.0.1:8091 RPC_PROXY_BASE_URL=http://127.0.0.1:8094 CONTROL_API_BASE_URL=http://127.0.0.1:8090 EVENFIRE_ONBOARDING_PREVIEW="$(EVENFIRE_ONBOARDING_PREVIEW)" npm --prefix desktop-app run dev
 
 .PHONY: local-ui
 local-ui: ## Run Control UI, Profile UI, and Desktop App locally against minikube port-forwards

--- a/desktop-app/src/__tests__/appService.onboarding.test.ts
+++ b/desktop-app/src/__tests__/appService.onboarding.test.ts
@@ -36,6 +36,7 @@ async function makeService(healthAt: HealthByUrl) {
     authClient: { healthAt: ReturnType<typeof vi.fn> }
     probeLocalhostReachable: () => Promise<boolean>
     openDeploymentDocs: () => Promise<{ opened: true }>
+    openHostedSignup: () => Promise<{ opened: true }>
   }
   service.authClient = { healthAt: vi.fn(healthAt) } as never
   return service
@@ -117,6 +118,26 @@ describe('onboarding main-process surface', () => {
       // Self-hosting covers any cluster the user controls, so the link must not
       // land on the local-cluster quickstart (spec §5.4).
       expect(opened).not.toMatch(/minikube|quickstart/i)
+    })
+  })
+
+  describe('openHostedSignup', () => {
+    it('opens the build-time hosted URL, taking no argument', async () => {
+      const service = await makeService(healthReachableFor())
+
+      expect(await service.openHostedSignup()).toEqual({ opened: true })
+      expect(openExternal).toHaveBeenCalledTimes(1)
+      expect(String(openExternal.mock.calls[0]?.[0] || '')).toMatch(/^https:\/\//)
+    })
+
+    it('is a distinct destination from the deployment docs', async () => {
+      const service = await makeService(healthReachableFor())
+
+      await service.openHostedSignup()
+      await service.openDeploymentDocs()
+
+      const [hosted, docs] = openExternal.mock.calls.map(call => String(call[0] || ''))
+      expect(hosted).not.toBe(docs)
     })
   })
 })

--- a/desktop-app/src/__tests__/appService.onboarding.test.ts
+++ b/desktop-app/src/__tests__/appService.onboarding.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const openExternal = vi.fn(async () => undefined)
+
+// config.ts touches the Electron `app` at module load; provide a minimal mock
+// with a NON-packaged, ready app so the env-var runtime-config path is active.
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/evenfire-test-userdata'),
+    isPackaged: false,
+    isReady: vi.fn(() => true),
+    setName: vi.fn(),
+    setPath: vi.fn(),
+    getName: vi.fn(() => 'Evenfire'),
+  },
+  shell: { openExternal },
+}))
+
+// The chat store binds to the real filesystem; stub it so importing appService
+// never touches Electron userData.
+vi.mock('../chatStoreBinding.js', () => ({
+  bindChatStoreForUser: vi.fn(),
+  unbindChatStore: vi.fn(),
+}))
+
+const LOCALHOST_EXTERNAL = 'http://127.0.0.1:8091'
+const REMOTE_EXTERNAL = 'https://api.example.com'
+const REMOTE_RPC = 'https://rpc.example.com'
+
+type HealthByUrl = (baseUrl: string) => Promise<{ status: string }>
+
+async function makeService(healthAt: HealthByUrl) {
+  vi.resetModules()
+  const { AppService } = await import('../appService.js')
+  const service = new AppService() as unknown as {
+    authClient: { healthAt: ReturnType<typeof vi.fn> }
+    probeLocalhostReachable: () => Promise<boolean>
+    openDeploymentDocs: () => Promise<{ opened: true }>
+  }
+  service.authClient = { healthAt: vi.fn(healthAt) } as never
+  return service
+}
+
+function healthReachableFor(...reachableHosts: string[]): HealthByUrl {
+  return async (baseUrl: string) => {
+    if (reachableHosts.some(host => baseUrl.includes(host))) return { status: 'ok' }
+    throw new Error('ECONNREFUSED')
+  }
+}
+
+describe('onboarding main-process surface', () => {
+  const saved = {
+    external: process.env.EXTERNAL_REST_API_BASE_URL,
+    rpc: process.env.RPC_PROXY_BASE_URL,
+    docs: process.env.DEPLOYMENT_DOCS_URL,
+  }
+
+  beforeEach(() => {
+    openExternal.mockClear()
+    delete process.env.DEPLOYMENT_DOCS_URL
+  })
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ['EXTERNAL_REST_API_BASE_URL', saved.external],
+      ['RPC_PROXY_BASE_URL', saved.rpc],
+      ['DEPLOYMENT_DOCS_URL', saved.docs],
+    ] as const) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    vi.resetModules()
+  })
+
+  describe('probeLocalhostReachable', () => {
+    it('reports a reachable local cluster', async () => {
+      process.env.EXTERNAL_REST_API_BASE_URL = REMOTE_EXTERNAL
+      process.env.RPC_PROXY_BASE_URL = REMOTE_RPC
+
+      const service = await makeService(healthReachableFor('127.0.0.1'))
+
+      expect(await service.probeLocalhostReachable()).toBe(true)
+    })
+
+    it('reports false when nothing answers, rather than throwing', async () => {
+      process.env.EXTERNAL_REST_API_BASE_URL = REMOTE_EXTERNAL
+      process.env.RPC_PROXY_BASE_URL = REMOTE_RPC
+
+      const service = await makeService(healthReachableFor())
+
+      expect(await service.probeLocalhostReachable()).toBe(false)
+    })
+
+    it('only ever probes the localhost option, whatever the active environment', async () => {
+      process.env.EXTERNAL_REST_API_BASE_URL = REMOTE_EXTERNAL
+      process.env.RPC_PROXY_BASE_URL = REMOTE_RPC
+
+      const service = await makeService(healthReachableFor('127.0.0.1'))
+      await service.probeLocalhostReachable()
+
+      // The renderer cannot name a URL for the main process to fetch, so the
+      // remote environment must never be contacted by this call (spec §6.8).
+      expect(service.authClient.healthAt).toHaveBeenCalledTimes(1)
+      expect(service.authClient.healthAt.mock.calls[0]?.[0]).toBe(LOCALHOST_EXTERNAL)
+    })
+  })
+
+  describe('openDeploymentDocs', () => {
+    it('opens the build-time documentation URL, taking no argument', async () => {
+      const service = await makeService(healthReachableFor())
+
+      expect(await service.openDeploymentDocs()).toEqual({ opened: true })
+      expect(openExternal).toHaveBeenCalledTimes(1)
+
+      const opened = String(openExternal.mock.calls[0]?.[0] || '')
+      expect(opened).toMatch(/^https:\/\//)
+      // Self-hosting covers any cluster the user controls, so the link must not
+      // land on the local-cluster quickstart (spec §5.4).
+      expect(opened).not.toMatch(/minikube|quickstart/i)
+    })
+  })
+})

--- a/desktop-app/src/__tests__/appService.onboarding.test.ts
+++ b/desktop-app/src/__tests__/appService.onboarding.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const openExternal = vi.fn(async () => undefined)
+const openExternal = vi.fn(async (_url: string) => undefined)
 
 // config.ts touches the Electron `app` at module load; provide a minimal mock
 // with a NON-packaged, ready app so the env-var runtime-config path is active.

--- a/desktop-app/src/__tests__/appService.onboarding.test.ts
+++ b/desktop-app/src/__tests__/appService.onboarding.test.ts
@@ -100,7 +100,7 @@ describe('onboarding main-process surface', () => {
       await service.probeLocalhostReachable()
 
       // The renderer cannot name a URL for the main process to fetch, so the
-      // remote environment must never be contacted by this call (spec §6.8).
+      // remote environment must never be contacted by this call.
       expect(service.authClient.healthAt).toHaveBeenCalledTimes(1)
       expect(service.authClient.healthAt.mock.calls[0]?.[0]).toBe(LOCALHOST_EXTERNAL)
     })
@@ -116,7 +116,7 @@ describe('onboarding main-process surface', () => {
       const opened = String(openExternal.mock.calls[0]?.[0] || '')
       expect(opened).toMatch(/^https:\/\//)
       // Self-hosting covers any cluster the user controls, so the link must not
-      // land on the local-cluster quickstart (spec §5.4).
+      // land on the local-cluster quickstart.
       expect(opened).not.toMatch(/minikube|quickstart/i)
     })
   })

--- a/desktop-app/src/__tests__/config.onboardingPreview.test.ts
+++ b/desktop-app/src/__tests__/config.onboardingPreview.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
+
+const testUserDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'evenfire-test-userdata-'))
 
 vi.mock('electron', () => ({
   app: {
-    getPath: vi.fn(() => '/tmp/evenfire-test-userdata'),
+    getPath: vi.fn(() => testUserDataDir),
     isPackaged: false,
     isReady: vi.fn(() => true),
     setName: vi.fn(),
@@ -130,7 +133,7 @@ describe('EVENFIRE_ONBOARDING_PREVIEW', () => {
     // came up configured and went to sign-in. The switch showed onboarding
     // once and then quietly stopped working.
     const previewDir = path.join(
-      '/tmp/evenfire-test-userdata',
+      testUserDataDir,
       'runtime-configs-onboarding-preview'
     )
     fs.mkdirSync(previewDir, { recursive: true })

--- a/desktop-app/src/__tests__/config.onboardingPreview.test.ts
+++ b/desktop-app/src/__tests__/config.onboardingPreview.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/tmp/evenfire-test-userdata'),
+    isPackaged: false,
+    isReady: vi.fn(() => true),
+    setName: vi.fn(),
+    setPath: vi.fn(),
+    getName: vi.fn(() => 'Evenfire'),
+  },
+}))
+
+const LOCALHOST_EXTERNAL = 'http://127.0.0.1:8091'
+const LOCALHOST_RPC = 'http://127.0.0.1:8094'
+
+async function loadState() {
+  vi.resetModules()
+  const config = await import('../config.js')
+  // getDesktopRuntimeConfigState hydrates first, so this is the value the
+  // renderer actually receives — not the pre-hydrate one.
+  return config.getDesktopRuntimeConfigState()
+}
+
+describe('EVENFIRE_ONBOARDING_PREVIEW', () => {
+  const saved = {
+    external: process.env.EXTERNAL_REST_API_BASE_URL,
+    rpc: process.env.RPC_PROXY_BASE_URL,
+    preview: process.env.EVENFIRE_ONBOARDING_PREVIEW,
+    explicit: process.env.CLERUM_DESKTOP_CONFIG_PATH,
+  }
+
+  beforeEach(() => {
+    delete process.env.EVENFIRE_ONBOARDING_PREVIEW
+    delete process.env.CLERUM_DESKTOP_CONFIG_PATH
+  })
+
+  afterEach(() => {
+    for (const [key, value] of [
+      ['EXTERNAL_REST_API_BASE_URL', saved.external],
+      ['RPC_PROXY_BASE_URL', saved.rpc],
+      ['EVENFIRE_ONBOARDING_PREVIEW', saved.preview],
+      ['CLERUM_DESKTOP_CONFIG_PATH', saved.explicit],
+    ] as const) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    vi.resetModules()
+  })
+
+  it('defaults to off: an env-configured app stays configured', async () => {
+    process.env.EXTERNAL_REST_API_BASE_URL = LOCALHOST_EXTERNAL
+    process.env.RPC_PROXY_BASE_URL = LOCALHOST_RPC
+
+    expect((await loadState()).configured).toBe(true)
+  })
+
+  it('ignores any value other than "true"', async () => {
+    process.env.EXTERNAL_REST_API_BASE_URL = LOCALHOST_EXTERNAL
+    process.env.RPC_PROXY_BASE_URL = LOCALHOST_RPC
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = 'false'
+
+    expect((await loadState()).configured).toBe(true)
+
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = '1'
+    expect((await loadState()).configured).toBe(true)
+  })
+
+  it('starts cold when enabled, even with the make local-app runtime vars set', async () => {
+    process.env.EXTERNAL_REST_API_BASE_URL = LOCALHOST_EXTERNAL
+    process.env.RPC_PROXY_BASE_URL = LOCALHOST_RPC
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = 'true'
+
+    // configured === false is what routes the renderer to onboarding.
+    expect((await loadState()).configured).toBe(false)
+  })
+
+  it('reads and writes a separate directory, never the real runtime config', async () => {
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = 'true'
+    const previewPath = (await loadState()).storagePath
+
+    delete process.env.EVENFIRE_ONBOARDING_PREVIEW
+    const realPath = (await loadState()).storagePath
+
+    expect(previewPath).not.toBe(realPath)
+    expect(previewPath).toContain('runtime-configs-onboarding-preview')
+    expect(realPath).toMatch(/runtime-configs$/)
+  })
+
+  it('survives hydration under a real `make local-app` launch', async () => {
+    // Regression: hydrateDesktopRuntimeConfig re-pinned the Localhost option
+    // whenever the app was launched with --evenfire-desktop-dev-package AND
+    // localhost endpoints — exactly what `make local-app` does. That flipped
+    // `configured` back to true after boot, so the app opened on sign-in while
+    // the boot log still claimed onboarding.
+    process.argv.push('--evenfire-desktop-dev-package')
+    try {
+      process.env.EXTERNAL_REST_API_BASE_URL = LOCALHOST_EXTERNAL
+      process.env.RPC_PROXY_BASE_URL = LOCALHOST_RPC
+      process.env.EVENFIRE_ONBOARDING_PREVIEW = 'true'
+
+      const state = await loadState()
+
+      expect(state.configured).toBe(false)
+      expect(state.activeOptionId).not.toBe('__localhost__')
+    } finally {
+      process.argv = process.argv.filter(a => a !== '--evenfire-desktop-dev-package')
+    }
+  })
+
+  it('still pins Localhost for a dev-package launch when preview is off', async () => {
+    process.argv.push('--evenfire-desktop-dev-package')
+    try {
+      process.env.EXTERNAL_REST_API_BASE_URL = LOCALHOST_EXTERNAL
+      process.env.RPC_PROXY_BASE_URL = LOCALHOST_RPC
+
+      const state = await loadState()
+
+      expect(state.configured).toBe(true)
+    } finally {
+      process.argv = process.argv.filter(a => a !== '--evenfire-desktop-dev-package')
+    }
+  })
+
+  it('does not let an explicit config path hand the preview an environment', async () => {
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = 'true'
+    process.env.CLERUM_DESKTOP_CONFIG_PATH = '/tmp/evenfire-explicit/runtime-config.json'
+
+    const state = await loadState()
+
+    expect(state.configured).toBe(false)
+    expect(state.storagePath).toContain('runtime-configs-onboarding-preview')
+  })
+})

--- a/desktop-app/src/__tests__/config.onboardingPreview.test.ts
+++ b/desktop-app/src/__tests__/config.onboardingPreview.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
 
 vi.mock('electron', () => ({
   app: {
@@ -120,6 +122,29 @@ describe('EVENFIRE_ONBOARDING_PREVIEW', () => {
     } finally {
       process.argv = process.argv.filter(a => a !== '--evenfire-desktop-dev-package')
     }
+  })
+
+  it('starts cold again after a previous preview selected an environment', async () => {
+    // Regression: selecting Localhost (or saving) inside the preview wrote
+    // activeProfileId into the preview's own directory, so the NEXT launch
+    // came up configured and went to sign-in. The switch showed onboarding
+    // once and then quietly stopped working.
+    const previewDir = path.join(
+      '/tmp/evenfire-test-userdata',
+      'runtime-configs-onboarding-preview'
+    )
+    fs.mkdirSync(previewDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(previewDir, 'index.json'),
+      JSON.stringify({ version: 1, activeProfileId: '__localhost__', profiles: [] })
+    )
+
+    process.env.EVENFIRE_ONBOARDING_PREVIEW = 'true'
+
+    const state = await loadState()
+
+    expect(state.configured).toBe(false)
+    expect(state.activeOptionId).not.toBe('__localhost__')
   })
 
   it('does not let an explicit config path hand the preview an environment', async () => {

--- a/desktop-app/src/appService.ts
+++ b/desktop-app/src/appService.ts
@@ -1173,7 +1173,7 @@ export class AppService {
   /**
    * Monotonic per sandbox-ui mount. Carried into the SDK surface pin so a
    * request from a superseded embed can be told apart from the live one
-   * (spec §8.1), mirroring the driver's own `mountGeneration` guard.
+   *, mirroring the driver's own `mountGeneration` guard.
    */
   private sandboxUiGeneration = 0
 
@@ -1761,7 +1761,7 @@ export class AppService {
   }
 
   /**
-   * Onboarding's path-D hint (spec §5.6): is a local Evenfire answering?
+   * Onboarding's local-cluster hint: is a local Evenfire answering?
    *
    * Takes **no argument** on purpose. The renderer cannot name a URL for the
    * main process to fetch — it can only ask about the built-in Localhost
@@ -1778,8 +1778,8 @@ export class AppService {
   }
 
   /**
-   * Open the deployment documentation for onboarding's self-hosted path
-   * (spec §5.4). The URL is a build-time constant, not a renderer argument.
+   * Open the deployment documentation for onboarding's self-hosted answer
+   *. The URL is a build-time constant, not a renderer argument.
    */
   async openDeploymentDocs(): Promise<{ opened: true }> {
     const { shell } = await import('electron')
@@ -1788,7 +1788,7 @@ export class AppService {
   }
 
   /**
-   * Open the hosted Evenfire site for onboarding's hosted path (spec §5.3).
+   * Open the hosted Evenfire site for onboarding's hosted answer.
    * Also a build-time constant. No credentials, no tenant name and no nonce
    * cross this boundary — the app only opens a page.
    */
@@ -3039,7 +3039,7 @@ export class AppService {
       this.stopAllStreams()
       // Grants are keyed by userId, not by team, so they carry over — but every
       // cached org/agents/contexts answer is now about the wrong team. Drop the
-      // cache and tell mounted plugins to refetch (spec §6.2).
+      // cache and tell mounted plugins to refetch.
       tryGetPluginSdkRuntime()?.notifySessionChanged(true)
       return { authenticated: true, me: this.me }
     } finally {
@@ -3090,7 +3090,7 @@ export class AppService {
     // boundary for the desktop catalog: the `|| name` guard lives here only
     // (mirroring control-api's accessReconciliation `configuredDisplayName ||
     // name`), so renderer consumers read `agentDisplayByName[name]` directly
-    // without sprinkling `|| name` (spec Decision #6). Filled total over
+    // without sprinkling `|| name`. Filled total over
     // `agentNames` below so a lookup is never undefined.
     const agentDisplayByName: Record<string, string> = {}
     const upsertScopedServers = (
@@ -4605,7 +4605,7 @@ export class AppService {
       return
     }
     // Pin the surface so the SDK broker can derive this plugin's identity from
-    // `webContents.id` — the plugin never asserts who it is (spec §8.1).
+    // `webContents.id` — the plugin never asserts who it is.
     tryGetPluginSdkRuntime()?.pinSandboxUiSurface({
       pluginId: activeView.appRef,
       pluginTitle: String(args.title || '').trim() || recipeName,

--- a/desktop-app/src/appService.ts
+++ b/desktop-app/src/appService.ts
@@ -1787,6 +1787,17 @@ export class AppService {
     return { opened: true }
   }
 
+  /**
+   * Open the hosted Evenfire site for onboarding's hosted path (spec §5.3).
+   * Also a build-time constant. No credentials, no tenant name and no nonce
+   * cross this boundary — the app only opens a page.
+   */
+  async openHostedSignup(): Promise<{ opened: true }> {
+    const { shell } = await import('electron')
+    await shell.openExternal(config.hostedSignupUrl)
+    return { opened: true }
+  }
+
   /** True iff `<baseUrl>/health` returns `{ status: 'ok' }` within the probe bound. */
   private async probeBackendHealthy(baseUrl: string): Promise<boolean> {
     if (!baseUrl?.trim()) return false

--- a/desktop-app/src/appService.ts
+++ b/desktop-app/src/appService.ts
@@ -1760,6 +1760,33 @@ export class AppService {
     }
   }
 
+  /**
+   * Onboarding's path-D hint (spec §5.6): is a local Evenfire answering?
+   *
+   * Takes **no argument** on purpose. The renderer cannot name a URL for the
+   * main process to fetch — it can only ask about the built-in Localhost
+   * option, whose address is a constant in config. Best-effort and
+   * time-bounded, like every other use of `probeBackendHealthy`; a negative
+   * result means "show no hint", never an error.
+   */
+  async probeLocalhostReachable(): Promise<boolean> {
+    hydrateDesktopRuntimeConfig()
+    const state = getDesktopRuntimeConfigState()
+    const localhostOption = state.options.find(option => option.source === 'localhost')
+    if (!localhostOption?.externalRestApiBaseUrl) return false
+    return this.probeBackendHealthy(localhostOption.externalRestApiBaseUrl)
+  }
+
+  /**
+   * Open the deployment documentation for onboarding's self-hosted path
+   * (spec §5.4). The URL is a build-time constant, not a renderer argument.
+   */
+  async openDeploymentDocs(): Promise<{ opened: true }> {
+    const { shell } = await import('electron')
+    await shell.openExternal(config.deploymentDocsUrl)
+    return { opened: true }
+  }
+
   /** True iff `<baseUrl>/health` returns `{ status: 'ok' }` within the probe bound. */
   private async probeBackendHealthy(baseUrl: string): Promise<boolean> {
     if (!baseUrl?.trim()) return false

--- a/desktop-app/src/config.ts
+++ b/desktop-app/src/config.ts
@@ -49,14 +49,14 @@ const DEFAULT_APP_NAME = 'Evenfire'
 const LOCALHOST_OPTION_ID = '__localhost__'
 const LOCALHOST_EXTERNAL_REST_API_BASE_URL = 'http://127.0.0.1:8091'
 const LOCALHOST_RPC_PROXY_BASE_URL = 'http://127.0.0.1:8094'
-// Where onboarding's self-hosted path sends the user (spec §5.4). Self-hosting
+// Where onboarding's self-hosted path sends the user. Self-hosting
 // means any cluster the user controls — remote or local — so this must land on
 // documentation that covers both shapes, never on the minikube quickstart
 // alone. A build-time constant, overridable only where the dev env config gate
 // already allows overrides, so a packaged build cannot be pointed elsewhere.
 const DEFAULT_DEPLOYMENT_DOCS_URL =
   'https://github.com/evenfire-ai/evenfire#deploying-to-a-remote-cluster'
-// Where onboarding's hosted path sends the user (spec §5.3). Today this is the
+// Where onboarding's hosted path sends the user. Today this is the
 // marketing site, not a signup endpoint: there is no tenant provisioning and no
 // evenfire://desktop-environment handoff yet, so the hosted step links out and
 // offers the manual-address fallback for when the user returns with a server.
@@ -64,7 +64,7 @@ const DEFAULT_DEPLOYMENT_DOCS_URL =
 const DEFAULT_HOSTED_SIGNUP_URL = 'https://evenfire.ai'
 const RUNTIME_CONFIG_DIR_NAME = 'runtime-configs'
 /**
- * Dev switch for previewing the first-run onboarding flow (spec §5.1) on a
+ * Dev switch for previewing the first-run onboarding flow on a
  * machine that already has environments configured. Defaults to false; only
  * the exact string "true" enables it.
  *
@@ -791,7 +791,7 @@ export async function saveDesktopRuntimeConfig(next: DesktopRuntimeConfig): Prom
 
 /**
  * Derive the environment namespacing key from a runtime config's external-rest-api
- * and rpc-proxy base origins (spec §5.1, D1). Same REST origin + different RPC
+ * and rpc-proxy base origins. Same REST origin + different RPC
  * origin is a different runtime boundary because desktop session tokens are
  * accepted by the RPC proxy, not by external-rest-api alone.
  *

--- a/desktop-app/src/config.ts
+++ b/desktop-app/src/config.ts
@@ -15,6 +15,7 @@ type DesktopConfig = Omit<DesktopRuntimeConfig, 'appName' | 'rpcProxyBaseUrl'> &
   memberRegistrationServiceBaseUrl: string
   desktopProfileUiBaseUrl: string
   desktopProfileUiBaseUrlExplicit: boolean
+  deploymentDocsUrl: string
   requestTimeoutMs: number
   gfsUploadTimeoutMs: number
   appName: string
@@ -47,6 +48,13 @@ const DEFAULT_APP_NAME = 'Evenfire'
 const LOCALHOST_OPTION_ID = '__localhost__'
 const LOCALHOST_EXTERNAL_REST_API_BASE_URL = 'http://127.0.0.1:8091'
 const LOCALHOST_RPC_PROXY_BASE_URL = 'http://127.0.0.1:8094'
+// Where onboarding's self-hosted path sends the user (spec §5.4). Self-hosting
+// means any cluster the user controls — remote or local — so this must land on
+// documentation that covers both shapes, never on the minikube quickstart
+// alone. A build-time constant, overridable only where the dev env config gate
+// already allows overrides, so a packaged build cannot be pointed elsewhere.
+const DEFAULT_DEPLOYMENT_DOCS_URL =
+  'https://github.com/evenfire-ai/evenfire#deploying-to-a-remote-cluster'
 const RUNTIME_CONFIG_DIR_NAME = 'runtime-configs'
 const RUNTIME_CONFIG_INDEX_FILE = 'index.json'
 const PACKAGED_ENV_FILE = '.env.prod'
@@ -556,6 +564,9 @@ export const config: DesktopConfig = {
   ),
   desktopProfileUiBaseUrl: deriveProfileUiBaseUrl(initialRuntimeConfig.externalRestApiBaseUrl),
   desktopProfileUiBaseUrlExplicit: hasExplicitProfileUiBaseUrl(),
+  deploymentDocsUrl: canUseEnvRuntimeConfig
+    ? requiredOrDefault('DEPLOYMENT_DOCS_URL', DEFAULT_DEPLOYMENT_DOCS_URL)
+    : DEFAULT_DEPLOYMENT_DOCS_URL,
   requestTimeoutMs: Number(requiredOrDefault('REQUEST_TIMEOUT_MS', '60000')),
   // Generous deadline for legacy JSON GFS uploads: a 16 MiB file is a ~22.4 MiB
   // base64 body, ~60s alone on a slow uplink. v2 streams binary indexed parts and

--- a/desktop-app/src/config.ts
+++ b/desktop-app/src/config.ts
@@ -56,6 +56,25 @@ const LOCALHOST_RPC_PROXY_BASE_URL = 'http://127.0.0.1:8094'
 const DEFAULT_DEPLOYMENT_DOCS_URL =
   'https://github.com/evenfire-ai/evenfire#deploying-to-a-remote-cluster'
 const RUNTIME_CONFIG_DIR_NAME = 'runtime-configs'
+/**
+ * Dev switch for previewing the first-run onboarding flow (spec §5.1) on a
+ * machine that already has environments configured. Defaults to false; only
+ * the exact string "true" enables it.
+ *
+ * Onboarding is by definition the zero-environment state, so a developer whose
+ * app is already configured — including anyone launched by `make local-app`,
+ * which exports EXTERNAL_REST_API_BASE_URL and RPC_PROXY_BASE_URL — can never
+ * reach it. Rather than fake the view, this makes the app genuinely start cold:
+ * it reads and writes runtime config in a SEPARATE directory and ignores the
+ * env-var runtime config. The wizard is real, saving an environment works, and
+ * the developer's actual environments are neither read nor modified — unset the
+ * variable and they are all still there.
+ */
+const ONBOARDING_PREVIEW = process.env.EVENFIRE_ONBOARDING_PREVIEW?.trim().toLowerCase() === 'true'
+const ONBOARDING_PREVIEW_DIR_NAME = 'runtime-configs-onboarding-preview'
+const activeRuntimeConfigDirName = ONBOARDING_PREVIEW
+  ? ONBOARDING_PREVIEW_DIR_NAME
+  : RUNTIME_CONFIG_DIR_NAME
 const RUNTIME_CONFIG_INDEX_FILE = 'index.json'
 const PACKAGED_ENV_FILE = '.env.prod'
 const MAX_PROFILE_FILE_ATTEMPTS = 1000
@@ -143,6 +162,9 @@ loadPackagedEnv()
 
 function explicitRuntimeConfigPath(): string {
   if (app?.isPackaged) return ''
+  // The onboarding preview owns its own directory; an explicit config file
+  // would hand it a configured environment and defeat the point.
+  if (ONBOARDING_PREVIEW) return ''
   return process.env.CLERUM_DESKTOP_CONFIG_PATH?.trim() || ''
 }
 
@@ -198,11 +220,11 @@ function runtimeConfigDirectoryPath(): string {
   if (explicit) return path.dirname(explicit)
 
   if (app?.isReady()) {
-    return path.join(app.getPath('userData'), RUNTIME_CONFIG_DIR_NAME)
+    return path.join(app.getPath('userData'), activeRuntimeConfigDirName)
   }
 
   // Keep a deterministic fallback before Electron is ready.
-  return path.join(defaultUserDataDirectoryPath(), RUNTIME_CONFIG_DIR_NAME)
+  return path.join(defaultUserDataDirectoryPath(), activeRuntimeConfigDirName)
 }
 
 function runtimeConfigIndexPath(): string {
@@ -516,6 +538,9 @@ const desktopDevPackageRuntimeConfigEnabled =
   runtimeEndpointsMatch(envRuntimeConfig, localhostRuntimeConfig)
 const canUseEnvRuntimeConfig = !app?.isPackaged || desktopDevPackageRuntimeConfigEnabled
 const envRuntimeConfigured = Boolean(
+  // `make local-app` exports both of these, which would mark the app
+  // configured and skip the wizard the preview exists to show.
+  !ONBOARDING_PREVIEW &&
   canUseEnvRuntimeConfig &&
   process.env.EXTERNAL_REST_API_BASE_URL?.trim() &&
   process.env.RPC_PROXY_BASE_URL?.trim()
@@ -549,6 +574,33 @@ if (
 let desktopRuntimeConfigured = Boolean(
   activeStoredProfile || envRuntimeConfigured || activeRuntimeOptionId === LOCALHOST_OPTION_ID
 )
+
+/**
+ * Diagnostic for "why did the app open on this screen?".
+ *
+ * `configured` decides sign-in vs. the first-run onboarding wizard, and it is
+ * resolved twice: once at module load, then again by
+ * `hydrateDesktopRuntimeConfig` once Electron is ready. Only the second value
+ * reaches the renderer, so this is logged from there — logging the module-load
+ * value instead reports a screen the user never sees. No URLs, tokens or paths
+ * beyond the config directory name; nothing secret.
+ */
+function logRuntimeConfigResolution(): void {
+  if (process.env.VITEST) return
+  console.log(
+    '[evenfire] runtime config:',
+    JSON.stringify({
+      configured: desktopRuntimeConfigured,
+      screen: desktopRuntimeConfigured ? 'sign-in' : 'onboarding',
+      onboardingPreview: ONBOARDING_PREVIEW,
+      onboardingPreviewRaw: process.env.EVENFIRE_ONBOARDING_PREVIEW ?? '(unset)',
+      activeOptionId: activeRuntimeOptionId,
+      configDir: activeRuntimeConfigDirName,
+      isPackaged: Boolean(app?.isPackaged),
+      devPackageLaunch: desktopDevPackageRuntimeConfigEnabled,
+    })
+  )
+}
 
 const initialRuntimeConfig =
   activeRuntimeOptionId === LOCALHOST_OPTION_ID
@@ -602,14 +654,24 @@ export function hydrateDesktopRuntimeConfig(): void {
   if (runtimeConfigHydrated) return
   if (!app?.isReady()) return
   runtimeConfigHydrated = true
+  resolveHydratedRuntimeConfig()
+  logRuntimeConfigResolution()
+}
 
+function resolveHydratedRuntimeConfig(): void {
   const loaded = loadStoredProfilesSync()
   storedProfiles = loaded.profiles
   const preserveLocalhostRuntime =
-    preferLocalhostRuntimeByDefault ||
-    (desktopDevPackageRuntimeConfigEnabled &&
-      envMatchesLocalhostOption &&
-      isLocalhostRuntimeConfig(currentRuntimeConfig()))
+    // The onboarding preview must not be pulled back onto the Localhost
+    // option here. `make local-app` satisfies every condition below — it
+    // passes --evenfire-desktop-dev-package and points the env endpoints at
+    // 127.0.0.1 — which would re-mark the app configured after boot and land
+    // the developer on sign-in, the exact screen the preview exists to bypass.
+    !ONBOARDING_PREVIEW &&
+    (preferLocalhostRuntimeByDefault ||
+      (desktopDevPackageRuntimeConfigEnabled &&
+        envMatchesLocalhostOption &&
+        isLocalhostRuntimeConfig(currentRuntimeConfig())))
   activeRuntimeOptionId = preserveLocalhostRuntime ? LOCALHOST_OPTION_ID : loaded.activeProfileId
 
   const selectedProfile = resolveActiveProfile(storedProfiles, activeRuntimeOptionId)

--- a/desktop-app/src/config.ts
+++ b/desktop-app/src/config.ts
@@ -336,6 +336,14 @@ function loadStoredProfilesSync(): {
   profiles: StoredRuntimeProfile[]
   activeProfileId: string | null
 } {
+  // The onboarding preview starts cold on EVERY launch. Selecting Localhost or
+  // saving an environment writes to the preview directory, which would leave
+  // the next launch configured — the switch would show onboarding once and
+  // then silently stop, which is exactly the confusion it exists to prevent.
+  // Reads are dropped rather than the directory deleted: writes still work, so
+  // the wizard can be completed and used for the rest of the session.
+  if (ONBOARDING_PREVIEW) return { profiles: [], activeProfileId: null }
+
   const explicitPath = explicitRuntimeConfigPath()
   if (explicitPath) {
     const configFromFile = readRuntimeConfigFileSync(explicitPath)

--- a/desktop-app/src/config.ts
+++ b/desktop-app/src/config.ts
@@ -16,6 +16,7 @@ type DesktopConfig = Omit<DesktopRuntimeConfig, 'appName' | 'rpcProxyBaseUrl'> &
   desktopProfileUiBaseUrl: string
   desktopProfileUiBaseUrlExplicit: boolean
   deploymentDocsUrl: string
+  hostedSignupUrl: string
   requestTimeoutMs: number
   gfsUploadTimeoutMs: number
   appName: string
@@ -55,6 +56,12 @@ const LOCALHOST_RPC_PROXY_BASE_URL = 'http://127.0.0.1:8094'
 // already allows overrides, so a packaged build cannot be pointed elsewhere.
 const DEFAULT_DEPLOYMENT_DOCS_URL =
   'https://github.com/evenfire-ai/evenfire#deploying-to-a-remote-cluster'
+// Where onboarding's hosted path sends the user (spec §5.3). Today this is the
+// marketing site, not a signup endpoint: there is no tenant provisioning and no
+// evenfire://desktop-environment handoff yet, so the hosted step links out and
+// offers the manual-address fallback for when the user returns with a server.
+// Same build-time-constant rule as the docs URL.
+const DEFAULT_HOSTED_SIGNUP_URL = 'https://evenfire.ai'
 const RUNTIME_CONFIG_DIR_NAME = 'runtime-configs'
 /**
  * Dev switch for previewing the first-run onboarding flow (spec §5.1) on a
@@ -619,6 +626,9 @@ export const config: DesktopConfig = {
   deploymentDocsUrl: canUseEnvRuntimeConfig
     ? requiredOrDefault('DEPLOYMENT_DOCS_URL', DEFAULT_DEPLOYMENT_DOCS_URL)
     : DEFAULT_DEPLOYMENT_DOCS_URL,
+  hostedSignupUrl: canUseEnvRuntimeConfig
+    ? requiredOrDefault('HOSTED_SIGNUP_URL', DEFAULT_HOSTED_SIGNUP_URL)
+    : DEFAULT_HOSTED_SIGNUP_URL,
   requestTimeoutMs: Number(requiredOrDefault('REQUEST_TIMEOUT_MS', '60000')),
   // Generous deadline for legacy JSON GFS uploads: a 16 MiB file is a ~22.4 MiB
   // base64 body, ~60s alone on a slow uplink. v2 streams binary indexed parts and

--- a/desktop-app/src/ipc.ts
+++ b/desktop-app/src/ipc.ts
@@ -251,6 +251,14 @@ export function registerIpcHandlers(service: AppService): void {
     assertTrustedSender(event)
     return service.diagnoseLoginBackend()
   })
+  ipcMain.handle('auth:probeLocalhostReachable', async event => {
+    assertTrustedSender(event)
+    return service.probeLocalhostReachable()
+  })
+  ipcMain.handle('auth:openDeploymentDocs', async event => {
+    assertTrustedSender(event)
+    return service.openDeploymentDocs()
+  })
   ipcMain.handle('auth:startDesktopSetup', async (event, payload: { email: string }) => {
     assertTrustedSender(event)
     return service.startDesktopSetup(sanitizeString(payload?.email).toLowerCase())

--- a/desktop-app/src/ipc.ts
+++ b/desktop-app/src/ipc.ts
@@ -1792,7 +1792,7 @@ export function registerIpcHandlers(service: AppService): void {
   // The consent resolve channel IS trusted-sender guarded. That is what stops
   // an embed from answering its own permission prompt, and it pairs with the
   // main-generated `promptId` nonce: a resolve for an unknown or already-
-  // answered prompt is dropped inside the gate (spec §9.4).
+  // answered prompt is dropped inside the gate.
 
   ipcMain.handle(
     PLUGIN_SDK_CONSENT_RESOLVE_CHANNEL,

--- a/desktop-app/src/ipc.ts
+++ b/desktop-app/src/ipc.ts
@@ -259,6 +259,10 @@ export function registerIpcHandlers(service: AppService): void {
     assertTrustedSender(event)
     return service.openDeploymentDocs()
   })
+  ipcMain.handle('auth:openHostedSignup', async event => {
+    assertTrustedSender(event)
+    return service.openHostedSignup()
+  })
   ipcMain.handle('auth:startDesktopSetup', async (event, payload: { email: string }) => {
     assertTrustedSender(event)
     return service.startDesktopSetup(sanitizeString(payload?.email).toLowerCase())

--- a/desktop-app/src/preload.ts
+++ b/desktop-app/src/preload.ts
@@ -86,6 +86,8 @@ const clerum = Object.freeze({
     passwordLogin: (email: string, password: string) =>
       ipcRenderer.invoke('auth:passwordLogin', { email, password }),
     diagnoseLoginBackend: () => ipcRenderer.invoke('auth:diagnoseLoginBackend'),
+    probeLocalhostReachable: () => ipcRenderer.invoke('auth:probeLocalhostReachable'),
+    openDeploymentDocs: () => ipcRenderer.invoke('auth:openDeploymentDocs'),
     startDesktopSetup: (email: string) => ipcRenderer.invoke('auth:startDesktopSetup', { email }),
     openForgotPassword: (email?: string) =>
       ipcRenderer.invoke('auth:openForgotPassword', { email }),

--- a/desktop-app/src/preload.ts
+++ b/desktop-app/src/preload.ts
@@ -88,6 +88,7 @@ const clerum = Object.freeze({
     diagnoseLoginBackend: () => ipcRenderer.invoke('auth:diagnoseLoginBackend'),
     probeLocalhostReachable: () => ipcRenderer.invoke('auth:probeLocalhostReachable'),
     openDeploymentDocs: () => ipcRenderer.invoke('auth:openDeploymentDocs'),
+    openHostedSignup: () => ipcRenderer.invoke('auth:openHostedSignup'),
     startDesktopSetup: (email: string) => ipcRenderer.invoke('auth:startDesktopSetup', { email }),
     openForgotPassword: (email?: string) =>
       ipcRenderer.invoke('auth:openForgotPassword', { email }),

--- a/desktop-app/src/renderer.d.ts
+++ b/desktop-app/src/renderer.d.ts
@@ -77,6 +77,7 @@ declare global {
         diagnoseLoginBackend: () => Promise<LoginBackendHint | null>
         probeLocalhostReachable: () => Promise<boolean>
         openDeploymentDocs: () => Promise<{ opened: true }>
+        openHostedSignup: () => Promise<{ opened: true }>
         startDesktopSetup: (email: string) => Promise<{ profileUiUrl: string; appName: string }>
         openForgotPassword: (email?: string) => Promise<{ profileUiUrl: string }>
         openProfileSettings: (

--- a/desktop-app/src/renderer.d.ts
+++ b/desktop-app/src/renderer.d.ts
@@ -75,6 +75,8 @@ declare global {
         googleLogin: (idToken: string) => Promise<SessionState>
         passwordLogin: (email: string, password: string) => Promise<PasswordLoginResult>
         diagnoseLoginBackend: () => Promise<LoginBackendHint | null>
+        probeLocalhostReachable: () => Promise<boolean>
+        openDeploymentDocs: () => Promise<{ opened: true }>
         startDesktopSetup: (email: string) => Promise<{ profileUiUrl: string; appName: string }>
         openForgotPassword: (email?: string) => Promise<{ profileUiUrl: string }>
         openProfileSettings: (

--- a/desktop-app/ui/src/App.tsx
+++ b/desktop-app/ui/src/App.tsx
@@ -428,7 +428,7 @@ export function App() {
   activeConversationOriginRef.current = activeConversationOrigin
 
   /**
-   * Plugin permission prompts (spec §9). Main hides the plugin's
+   * Plugin permission prompts. Main hides the plugin's
    * `WebContentsView` before pushing the request and restores it once the user
    * answers, so the plugin can neither fake the prompt nor paint over it. The
    * prompt is centered over — and its backdrop scoped to — the plugin's embed

--- a/desktop-app/ui/src/App.tsx
+++ b/desktop-app/ui/src/App.tsx
@@ -69,6 +69,7 @@ import { ContextDetailsPage } from '@pages/ContextDetailsPage'
 import { ContextsPage } from '@pages/ContextsPage'
 import { FilesPage } from '@pages/FilesPage'
 import { McpServersPage } from '@pages/McpServersPage'
+import { OnboardingPage } from '@pages/OnboardingPage'
 import { SandboxUiPage } from '@pages/SandboxUiPage'
 import type {
   SandboxUiConversationOrigin,
@@ -1956,7 +1957,13 @@ export function App() {
           </NavigationContext.Provider>
         ) : (
           <>
-            {vm.hasDependencyOutage ? <UnavailablePage /> : <AuthPage />}
+            {vm.unauthenticatedView === 'outage' ? (
+              <UnavailablePage />
+            ) : vm.unauthenticatedView === 'onboarding' ? (
+              <OnboardingPage onboarding={vm.onboarding} />
+            ) : (
+              <AuthPage />
+            )}
             {environmentSetupConfirmationDialog}
             {environmentSetupSuccessDialog}
             <ToastStack items={vm.toasts} />

--- a/desktop-app/ui/src/components/AuthBrand/index.tsx
+++ b/desktop-app/ui/src/components/AuthBrand/index.tsx
@@ -1,0 +1,30 @@
+import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
+
+/**
+ * The brand lockup for pre-authentication cards (sign-in and onboarding).
+ *
+ * Uses the logotype SVG — one asset carrying the mark and the wordmark
+ * together — rather than the square mark beside hand-typed text, matching
+ * Control UI's login card and this app's own SidebarNav. Both themes ship as
+ * separate files and are toggled by CSS, not by reading the theme in JS, so
+ * the correct one is painted on the first frame with no flash.
+ *
+ * Only the dark variant carries alt text; the light one is aria-hidden, so
+ * assistive tech announces "Evenfire" exactly once no matter which is visible.
+ */
+export function AuthBrand() {
+  const desktopAppInfo = useDesktopAppInfo()
+  const desktopVersionTooltip = formatDesktopAppVersionTooltip(desktopAppInfo)
+
+  return (
+    <div className="auth-brand" title={desktopVersionTooltip}>
+      <img
+        className="brand-lockup brand-lockup--light"
+        src="./logotype-light.svg"
+        alt=""
+        aria-hidden="true"
+      />
+      <img className="brand-lockup brand-lockup--dark" src="./logotype-dark.svg" alt="Evenfire" />
+    </div>
+  )
+}

--- a/desktop-app/ui/src/components/BootSplash/index.tsx
+++ b/desktop-app/ui/src/components/BootSplash/index.tsx
@@ -38,11 +38,17 @@ export function BootSplash({ loading }: BootSplashProps) {
     <div className={`boot-overlay${leaving ? ' boot-overlay--leaving' : ''}`}>
       <section className="boot-screen glass-card" role="status" aria-live="polite">
         <div className="boot-brand">
-          <img className="boot-brand-mark" src="./logo.svg" alt="" aria-hidden="true" />
-          <span className="boot-brand-copy">
-            <span className="boot-brand-title">Evenfire</span>
-            <span className="boot-brand-subtitle">Desktop App</span>
-          </span>
+          <img
+            className="brand-lockup brand-lockup--light"
+            src="./logotype-light.svg"
+            alt=""
+            aria-hidden="true"
+          />
+          <img
+            className="brand-lockup brand-lockup--dark"
+            src="./logotype-dark.svg"
+            alt="Evenfire"
+          />
         </div>
         <div className="boot-progress" aria-hidden="true" />
         <p className="boot-status muted">Loading session…</p>

--- a/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
+++ b/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
@@ -6,6 +6,7 @@ import {
   LOCALHOST_RUNTIME_CONFIG_OPTION_ID,
   createLocalhostRuntimeConfigOption,
 } from '@constants/runtimeConfig'
+import { useLocalhostReachable } from '@hooks/useLocalhostReachable'
 import type { DesktopRuntimeConfigOption } from '../../../../src/types'
 
 interface RuntimeConfigDockProps {
@@ -44,8 +45,19 @@ export function RuntimeConfigDock({ onAddEnvironment }: RuntimeConfigDockProps) 
   const localhostRuntimeConfigOption = runtimeConfigOptions.find(
     option => option.source === 'localhost'
   )
+  // Offer Localhost only when a local Evenfire actually answers, so the menu
+  // never advertises a server that isn't there. The exception is a Localhost
+  // that is already the active environment: hiding the row the user is
+  // currently on would strand them with no way to see or leave it — a cluster
+  // that went down mid-session is exactly when that row matters most.
+  const localhostIsActive =
+    activeRuntimeConfigId === LOCALHOST_RUNTIME_CONFIG_OPTION_ID ||
+    selectedRuntimeConfig?.source === 'localhost'
+  const localhostReachable = useLocalhostReachable()
   const displayedLocalhostRuntimeConfigOption =
-    localhostRuntimeConfigOption || createLocalhostRuntimeConfigOption()
+    localhostReachable || localhostIsActive
+      ? localhostRuntimeConfigOption || createLocalhostRuntimeConfigOption()
+      : null
 
   const handleRuntimeOptionSelect = (optionId: string) => {
     setRuntimeMenuOpen(false)

--- a/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
+++ b/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from 'react'
+import { useAuthContext } from '@contexts/AuthContext'
+import { IconButton, MenuItem } from '@components/Common'
+import { ConfirmDialog } from '@components/ConfirmDialog'
+import {
+  LOCALHOST_RUNTIME_CONFIG_OPTION_ID,
+  createLocalhostRuntimeConfigOption,
+} from '@constants/runtimeConfig'
+import type { DesktopRuntimeConfigOption } from '../../../../src/types'
+
+interface RuntimeConfigDockProps {
+  /**
+   * Where "Add environment" goes. AuthPage opens its inline environment form;
+   * onboarding moves to its manual step. The dock itself stays identical, so
+   * the Localhost escape hatch (spec §3, path E) is reachable from both — a
+   * cold install renders onboarding, not AuthPage, and would otherwise have no
+   * way to reach it.
+   */
+  onAddEnvironment: () => void
+}
+
+export function RuntimeConfigDock({ onAddEnvironment }: RuntimeConfigDockProps) {
+  const {
+    busy,
+    authTransitioning,
+    runtimeConfigState,
+    handleDeleteRuntimeConfig,
+    handleSelectRuntimeConfig,
+    handleClearRuntimeConfigSelection,
+  } = useAuthContext()
+
+  const [runtimeMenuOpen, setRuntimeMenuOpen] = useState(false)
+  const [pendingDeleteOption, setPendingDeleteOption] = useState<DesktopRuntimeConfigOption | null>(
+    null
+  )
+  const runtimeDockRef = useRef<HTMLDivElement | null>(null)
+
+  const runtimeConfigOptions = runtimeConfigState?.options || []
+  const activeRuntimeConfigId = runtimeConfigState?.activeOptionId ?? null
+  const selectedRuntimeConfig = runtimeConfigOptions.find(
+    option => option.id === activeRuntimeConfigId
+  )
+  const savedRuntimeConfigOptions = runtimeConfigOptions.filter(option => option.source === 'file')
+  const localhostRuntimeConfigOption = runtimeConfigOptions.find(
+    option => option.source === 'localhost'
+  )
+  const displayedLocalhostRuntimeConfigOption =
+    localhostRuntimeConfigOption || createLocalhostRuntimeConfigOption()
+
+  const handleRuntimeOptionSelect = (optionId: string) => {
+    setRuntimeMenuOpen(false)
+    if (
+      optionId === activeRuntimeConfigId &&
+      (selectedRuntimeConfig?.source === 'localhost' ||
+        optionId === LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
+    ) {
+      handleClearRuntimeConfigSelection()
+      return
+    }
+    handleSelectRuntimeConfig(optionId)
+  }
+
+  const confirmDeleteRuntimeOption = () => {
+    if (!pendingDeleteOption) return
+    handleDeleteRuntimeConfig(pendingDeleteOption.id)
+    setPendingDeleteOption(null)
+  }
+
+  useEffect(() => {
+    if (!runtimeMenuOpen) {
+      return
+    }
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      if (runtimeDockRef.current?.contains(event.target as Node)) {
+        return
+      }
+
+      setRuntimeMenuOpen(false)
+    }
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setRuntimeMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('pointerdown', handleDocumentPointerDown)
+    document.addEventListener('keydown', handleEscape)
+
+    return () => {
+      document.removeEventListener('pointerdown', handleDocumentPointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
+  }, [runtimeMenuOpen])
+
+  if (!runtimeConfigState) return null
+
+  return (
+    <>
+      <aside className="auth-runtime-dock" ref={runtimeDockRef}>
+        <IconButton
+          className="auth-runtime-dock__toggle"
+          aria-label="Open environment selector"
+          aria-expanded={runtimeMenuOpen}
+          aria-controls="auth-runtime-dock-panel"
+          label="Open environment selector"
+          onClick={() => setRuntimeMenuOpen(open => !open)}
+          variant="soft"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M19.43 12.98a7.9 7.9 0 0 0 .05-.98 7.9 7.9 0 0 0-.05-.98l2.11-1.65a.48.48 0 0 0 .12-.61l-2-3.46a.49.49 0 0 0-.58-.22l-2.49 1a7.2 7.2 0 0 0-1.7-.98l-.38-2.65A.49.49 0 0 0 14 2h-4a.49.49 0 0 0-.49.41l-.38 2.65a7.2 7.2 0 0 0-1.7.98l-2.49-1a.49.49 0 0 0-.58.22l-2 3.46a.48.48 0 0 0 .12.61l2.11 1.65a7.9 7.9 0 0 0-.05.98 7.9 7.9 0 0 0 .05.98l-2.11 1.65a.48.48 0 0 0-.12.61l2 3.46a.49.49 0 0 0 .58.22l2.49-1a7.2 7.2 0 0 0 1.7.98l.38 2.65A.49.49 0 0 0 10 22h4a.49.49 0 0 0 .49-.41l.38-2.65a7.2 7.2 0 0 0 1.7-.98l2.49 1a.49.49 0 0 0 .58-.22l2-3.46a.48.48 0 0 0-.12-.61Zm-7.43 2.52A3.5 3.5 0 1 1 15.5 12 3.5 3.5 0 0 1 12 15.5Z" />
+          </svg>
+        </IconButton>
+        {runtimeMenuOpen ? (
+          <div className="auth-runtime-dock__panel glass-card" id="auth-runtime-dock-panel">
+            <div className="auth-runtime-menu__header">
+              <span className="auth-runtime-menu__label">Environment</span>
+              <IconButton
+                aria-label="Add environment"
+                disabled={busy || authTransitioning}
+                label="Add environment"
+                onClick={() => {
+                  setRuntimeMenuOpen(false)
+                  onAddEnvironment()
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M12 5v14" />
+                  <path d="M5 12h14" />
+                </svg>
+              </IconButton>
+            </div>
+            <div className="auth-runtime-menu">
+              {savedRuntimeConfigOptions.length > 0 ? (
+                <section className="auth-runtime-menu__section">
+                  {savedRuntimeConfigOptions.map(option => {
+                    const selected = option.id === activeRuntimeConfigId
+                    return (
+                      <div
+                        key={option.id}
+                        className={`auth-runtime-menu__row${selected ? ' selected' : ''}`}
+                      >
+                        <MenuItem
+                          className={`auth-runtime-menu__select${selected ? ' selected' : ''}`}
+                          active={selected}
+                          disabled={busy || authTransitioning}
+                          leadingIcon={
+                            <span className="auth-runtime-menu__check" aria-hidden="true">
+                              {selected ? (
+                                <svg viewBox="0 0 24 24" focusable="false">
+                                  <path d="M20 6 9 17l-5-5" />
+                                </svg>
+                              ) : null}
+                            </span>
+                          }
+                          onClick={() => handleRuntimeOptionSelect(option.id)}
+                        >
+                          {option.label}
+                        </MenuItem>
+                        <IconButton
+                          className="auth-runtime-menu__delete"
+                          aria-label={`Delete ${option.appName} environment`}
+                          color="danger"
+                          disabled={busy || authTransitioning}
+                          label={`Delete ${option.appName}`}
+                          onClick={() => setPendingDeleteOption(option)}
+                          size="sm"
+                          title={`Delete ${option.appName}`}
+                          variant="ghost"
+                        >
+                          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                            <path d="M3 6h18" />
+                            <path d="M8 6V4h8v2" />
+                            <path d="M6 6l1 15h10l1-15" />
+                            <path d="M10 10v7" />
+                            <path d="M14 10v7" />
+                          </svg>
+                        </IconButton>
+                      </div>
+                    )
+                  })}
+                </section>
+              ) : null}
+              {displayedLocalhostRuntimeConfigOption ? (
+                <section className="auth-runtime-menu__section">
+                  {(() => {
+                    const option = displayedLocalhostRuntimeConfigOption
+                    const selected = option.id === activeRuntimeConfigId
+                    return (
+                      <MenuItem
+                        className={`auth-runtime-menu__select auth-runtime-menu__select--standalone${
+                          selected ? ' selected' : ''
+                        }`}
+                        active={selected}
+                        disabled={busy || authTransitioning}
+                        leadingIcon={
+                          <span className="auth-runtime-menu__check" aria-hidden="true">
+                            {selected ? (
+                              <svg viewBox="0 0 24 24" focusable="false">
+                                <path d="M20 6 9 17l-5-5" />
+                              </svg>
+                            ) : null}
+                          </span>
+                        }
+                        onClick={() => handleRuntimeOptionSelect(option.id)}
+                      >
+                        Localhost
+                      </MenuItem>
+                    )
+                  })()}
+                </section>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </aside>
+      {pendingDeleteOption ? (
+        <ConfirmDialog
+          title="Delete environment?"
+          body={
+            <p>
+              Delete <strong>{pendingDeleteOption.appName}</strong>? This only removes the local
+              desktop environment configuration.
+            </p>
+          }
+          confirmLabel="Delete"
+          tone="danger"
+          onCancel={() => setPendingDeleteOption(null)}
+          onConfirm={confirmDeleteRuntimeOption}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
+++ b/desktop-app/ui/src/components/RuntimeConfigDock/index.tsx
@@ -13,7 +13,7 @@ interface RuntimeConfigDockProps {
   /**
    * Where "Add environment" goes. AuthPage opens its inline environment form;
    * onboarding moves to its manual step. The dock itself stays identical, so
-   * the Localhost escape hatch (spec §3, path E) is reachable from both — a
+   * the Localhost escape hatch is reachable from both — a
    * cold install renders onboarding, not AuthPage, and would otherwise have no
    * way to reach it.
    */

--- a/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
+++ b/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
@@ -33,13 +33,27 @@ describe('useOnboardingController', () => {
     expect(result.current.canGoBack).toBe(false)
   })
 
-  it('skips Q2 while the hosted path is unavailable', () => {
+  it('sends "just getting started" to Q2, where hosting is offered', () => {
     const { result } = renderHook(() => useOnboardingController())
 
-    expect(result.current.hostedAvailable).toBe(false)
+    expect(result.current.hostedAvailable).toBe(true)
 
     act(() => result.current.answerOrigin('gettingStarted'))
 
+    expect(result.current.step).toBe('runStyle')
+  })
+
+  it('routes each Q2 answer to its own step', () => {
+    const { result } = renderHook(() => useOnboardingController())
+
+    act(() => result.current.answerOrigin('gettingStarted'))
+    act(() => result.current.answerRunStyle('hosted'))
+    expect(result.current.step).toBe('hosted')
+
+    act(() => result.current.back())
+    expect(result.current.step).toBe('runStyle')
+
+    act(() => result.current.answerRunStyle('selfHosted'))
     expect(result.current.step).toBe('selfHosted')
   })
 
@@ -47,6 +61,7 @@ describe('useOnboardingController', () => {
     const { result } = renderHook(() => useOnboardingController())
 
     act(() => result.current.answerOrigin('gettingStarted'))
+    act(() => result.current.answerRunStyle('hosted'))
     act(() => result.current.goToManual())
     expect(result.current.canGoBack).toBe(true)
 

--- a/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
+++ b/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useOnboardingController } from '../useOnboardingController'
+
+describe('useOnboardingController', () => {
+  it('starts on Q1 with no history', () => {
+    const { result } = renderHook(() => useOnboardingController())
+
+    expect(result.current.step).toBe('origin')
+    expect(result.current.canGoBack).toBe(false)
+  })
+
+  it('ignores back at the root instead of unwinding past Q1', () => {
+    const { result } = renderHook(() => useOnboardingController())
+
+    act(() => result.current.back())
+
+    expect(result.current.step).toBe('origin')
+    expect(result.current.canGoBack).toBe(false)
+  })
+
+  it('records one history entry per transition, not two', () => {
+    // Guards the StrictMode hazard that made step and history one state value:
+    // a duplicated history entry would need two backs to leave a one-step path.
+    const { result } = renderHook(() => useOnboardingController())
+
+    act(() => result.current.answerOrigin('haveAddress'))
+    expect(result.current.step).toBe('manual')
+
+    act(() => result.current.back())
+    expect(result.current.step).toBe('origin')
+    expect(result.current.canGoBack).toBe(false)
+  })
+
+  it('skips Q2 while the hosted path is unavailable', () => {
+    const { result } = renderHook(() => useOnboardingController())
+
+    expect(result.current.hostedAvailable).toBe(false)
+
+    act(() => result.current.answerOrigin('gettingStarted'))
+
+    expect(result.current.step).toBe('selfHosted')
+  })
+
+  it('reset returns to Q1 and clears the history', () => {
+    const { result } = renderHook(() => useOnboardingController())
+
+    act(() => result.current.answerOrigin('gettingStarted'))
+    act(() => result.current.goToManual())
+    expect(result.current.canGoBack).toBe(true)
+
+    act(() => result.current.reset())
+
+    expect(result.current.step).toBe('origin')
+    expect(result.current.canGoBack).toBe(false)
+  })
+})

--- a/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
+++ b/desktop-app/ui/src/hooks/domain/__tests__/useOnboardingController.test.tsx
@@ -36,8 +36,6 @@ describe('useOnboardingController', () => {
   it('sends "just getting started" to Q2, where hosting is offered', () => {
     const { result } = renderHook(() => useOnboardingController())
 
-    expect(result.current.hostedAvailable).toBe(true)
-
     act(() => result.current.answerOrigin('gettingStarted'))
 
     expect(result.current.step).toBe('runStyle')

--- a/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
+++ b/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
@@ -7,14 +7,16 @@ import type {
 } from '@pages/OnboardingPage/types'
 
 /**
- * Whether the hosted trial path (spec §5.3) is reachable in this build.
+ * Whether the hosted path (spec §5.3) is offered in Q2.
  *
- * False until the hosted signup project exists: Q2 would otherwise offer a
- * choice with one real answer. While false, Q1's "just getting started"
- * routes straight to the self-hosted step. Flipping this to true is the only
- * change this file needs when path A ships (spec §7.1).
+ * True: hosting is the first thing someone just getting started should see,
+ * and the hosted step has somewhere real to send them — the Evenfire site.
+ * It is a link-out, not an in-app signup, because tenant provisioning and the
+ * deep-link handoff do not exist yet (see `steps/Hosted.tsx`). Setting this to
+ * false collapses Q2 and routes "just getting started" straight to
+ * self-hosting.
  */
-const HOSTED_SIGNUP_AVAILABLE = false
+const HOSTED_SIGNUP_AVAILABLE = true
 
 interface OnboardingState {
   step: OnboardingStep
@@ -52,10 +54,7 @@ export function useOnboardingController(): OnboardingViewModel {
 
   const answerRunStyle = useCallback(
     (answer: OnboardingRunStyleAnswer) => {
-      // 'hosted' gets its own waiting step in the PR that ships path A
-      // (spec §5.3). Until then Q2 is never rendered, so only 'selfHosted'
-      // can arrive here.
-      if (answer === 'selfHosted') goTo('selfHosted')
+      goTo(answer === 'hosted' ? 'hosted' : 'selfHosted')
     },
     [goTo]
   )

--- a/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
+++ b/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
@@ -1,0 +1,88 @@
+import { useCallback, useMemo, useState } from 'react'
+import type {
+  OnboardingOriginAnswer,
+  OnboardingRunStyleAnswer,
+  OnboardingStep,
+  OnboardingViewModel,
+} from '@pages/OnboardingPage/types'
+
+/**
+ * Whether the hosted trial path (spec §5.3) is reachable in this build.
+ *
+ * False until the hosted signup project exists: Q2 would otherwise offer a
+ * choice with one real answer. While false, Q1's "just getting started"
+ * routes straight to the self-hosted step. Flipping this to true is the only
+ * change this file needs when path A ships (spec §7.1).
+ */
+const HOSTED_SIGNUP_AVAILABLE = false
+
+interface OnboardingState {
+  step: OnboardingStep
+  history: OnboardingStep[]
+}
+
+const INITIAL_STATE: OnboardingState = { step: 'origin', history: [] }
+
+/**
+ * Onboarding wizard state (spec §5.1, §5.2).
+ *
+ * Memory-only by design. A cold install closed mid-questionnaire comes back to
+ * Q1: nothing was accomplished worth restoring, and persisting a half-answered
+ * wizard can strand the user on a step whose path no longer applies.
+ *
+ * Step and history are one state value so a step transition is a single
+ * update. Nesting `setHistory` inside a `setStep` updater would push a
+ * duplicate history entry under StrictMode's double invocation.
+ */
+export function useOnboardingController(): OnboardingViewModel {
+  const [state, setState] = useState<OnboardingState>(INITIAL_STATE)
+
+  const goTo = useCallback((next: OnboardingStep) => {
+    setState(current => ({ step: next, history: [...current.history, current.step] }))
+  }, [])
+
+  const answerOrigin = useCallback(
+    (answer: OnboardingOriginAnswer) => {
+      if (answer === 'invited') return goTo('invited')
+      if (answer === 'haveAddress') return goTo('manual')
+      return goTo(HOSTED_SIGNUP_AVAILABLE ? 'runStyle' : 'selfHosted')
+    },
+    [goTo]
+  )
+
+  const answerRunStyle = useCallback(
+    (answer: OnboardingRunStyleAnswer) => {
+      // 'hosted' gets its own waiting step in the PR that ships path A
+      // (spec §5.3). Until then Q2 is never rendered, so only 'selfHosted'
+      // can arrive here.
+      if (answer === 'selfHosted') goTo('selfHosted')
+    },
+    [goTo]
+  )
+
+  const goToManual = useCallback(() => goTo('manual'), [goTo])
+
+  const back = useCallback(() => {
+    setState(current => {
+      const previous = current.history[current.history.length - 1]
+      if (!previous) return current
+      return { step: previous, history: current.history.slice(0, -1) }
+    })
+  }, [])
+
+  const reset = useCallback(() => setState(INITIAL_STATE), [])
+
+  return useMemo(
+    () => ({
+      step: state.step,
+      canGoBack: state.history.length > 0,
+      hostedAvailable: HOSTED_SIGNUP_AVAILABLE,
+      answerOrigin,
+      answerRunStyle,
+      goToManual,
+      back,
+      reset,
+    }),
+    [state.step, state.history.length, answerOrigin, answerRunStyle, goToManual, back, reset]
+  )
+}

--- a/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
+++ b/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
@@ -7,7 +7,7 @@ import type {
 } from '@pages/OnboardingPage/types'
 
 /**
- * Whether the hosted path (spec §5.3) is offered in Q2.
+ * Whether the hosted path is offered in Q2.
  *
  * True: hosting is the first thing someone just getting started should see,
  * and the hosted step has somewhere real to send them — the Evenfire site.
@@ -26,7 +26,7 @@ interface OnboardingState {
 const INITIAL_STATE: OnboardingState = { step: 'origin', history: [] }
 
 /**
- * Onboarding wizard state (spec §5.1, §5.2).
+ * Onboarding wizard state.
  *
  * Memory-only by design. A cold install closed mid-questionnaire comes back to
  * Q1: nothing was accomplished worth restoring, and persisting a half-answered

--- a/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
+++ b/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
@@ -54,6 +54,7 @@ export function useOnboardingController(): OnboardingViewModel {
 
   const answerRunStyle = useCallback(
     (answer: OnboardingRunStyleAnswer) => {
+      if (answer === 'compare') return goTo('compare')
       goTo(answer === 'hosted' ? 'hosted' : 'selfHosted')
     },
     [goTo]

--- a/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
+++ b/desktop-app/ui/src/hooks/domain/useOnboardingController.ts
@@ -76,7 +76,6 @@ export function useOnboardingController(): OnboardingViewModel {
     () => ({
       step: state.step,
       canGoBack: state.history.length > 0,
-      hostedAvailable: HOSTED_SIGNUP_AVAILABLE,
       answerOrigin,
       answerRunStyle,
       goToManual,

--- a/desktop-app/ui/src/hooks/useAppController.ts
+++ b/desktop-app/ui/src/hooks/useAppController.ts
@@ -172,7 +172,7 @@ export function useAppController() {
   // ─── First-run onboarding ───
   const onboarding = useOnboardingController()
   // Onboarding owns the unauthenticated screen only while the app has no
-  // environment at all (spec §5.1). Saving one — or selecting Localhost —
+  // environment at all. Saving one — or selecting Localhost —
   // flips `configured`, which retires the wizard; deleting the last one brings
   // it back rather than leaving a sign-in form with nothing to sign in to.
   const unauthenticatedView = selectUnauthenticatedView({
@@ -552,7 +552,7 @@ export function useAppController() {
         if (!sessionState.authenticated || !sessionState.me) {
           throw new Error('Team switch ended without an authenticated session')
         }
-        // GAP-N4 (spec §4.5-3): the renderer half of a team switch. `clearActiveChat`
+        // GAP-N4: the renderer half of a team switch. `clearActiveChat`
         // only deselects — the previous team's tracker entries and FSM projection
         // survive, so a late terminal from an old-team task could run side effects
         // and stale badges leak across teams. Tear down the renderer chat state
@@ -746,7 +746,7 @@ export function useAppController() {
       teamsData.reset()
       resetWorkflowsData()
       queryClient.removeQueries({ queryKey: desktopQueryKeys.gfsRoot })
-      // Drop ALL cached queries on logout (spec §5.2 P1): the singleton
+      // Drop ALL cached queries on logout: the singleton
       // desktopQueryClient uses staleTime:Infinity, so any env-scoped data left
       // in cache would otherwise bleed into the next login (possibly a different
       // environment, since the env is chosen pre-login).

--- a/desktop-app/ui/src/hooks/useAppController.ts
+++ b/desktop-app/ui/src/hooks/useAppController.ts
@@ -180,6 +180,14 @@ export function useAppController() {
     runtimeConfigMissing: auth.runtimeConfigMissing,
     isAuthenticated: auth.isAuthenticated,
   })
+  // The controller is app-level, so wizard state outlives the wizard itself.
+  // Once an environment exists the run is finished: rewind to Q1, so deleting
+  // that environment later reopens onboarding at the first question instead of
+  // the step of a path the user already left.
+  const resetOnboarding = onboarding.reset
+  useEffect(() => {
+    if (!auth.runtimeConfigMissing) resetOnboarding()
+  }, [auth.runtimeConfigMissing, resetOnboarding])
 
   // ─── First-screen data contexts ───
   const agentsData = useAgentsDataController()

--- a/desktop-app/ui/src/hooks/useAppController.ts
+++ b/desktop-app/ui/src/hooks/useAppController.ts
@@ -11,6 +11,7 @@ import type {
 import { DESKTOP_ROUTES } from '../constants/navigation'
 import { pickLatestAgent } from '../lib/agents'
 import { toPrettyJson } from '../lib/format'
+import { selectUnauthenticatedView } from '../lib/unauthenticatedView'
 import { summarizeWorkflowResource } from '../lib/workflows'
 import type {
   AgentApprovalNotificationTarget,
@@ -39,6 +40,7 @@ import { useMcpServersDataController } from './domain/useMcpServersDataControlle
 import { useNavigationController } from './domain/useNavigationController'
 import { useNotificationSettingsController } from './domain/useNotificationSettingsController'
 import { useNotificationsController } from './domain/useNotificationsController'
+import { useOnboardingController } from './domain/useOnboardingController'
 import { useTeamsDataController } from './domain/useTeamsDataController'
 import { useToastController } from './domain/useToastController'
 import {
@@ -165,6 +167,18 @@ export function useAppController() {
   const auth = useAuthController({
     setStatus: fullSetStatus,
     onSessionNeedsLoad,
+  })
+
+  // ─── First-run onboarding ───
+  const onboarding = useOnboardingController()
+  // Onboarding owns the unauthenticated screen only while the app has no
+  // environment at all (spec §5.1). Saving one — or selecting Localhost —
+  // flips `configured`, which retires the wizard; deleting the last one brings
+  // it back rather than leaving a sign-in form with nothing to sign in to.
+  const unauthenticatedView = selectUnauthenticatedView({
+    hasDependencyOutage: auth.hasDependencyOutage,
+    runtimeConfigMissing: auth.runtimeConfigMissing,
+    isAuthenticated: auth.isAuthenticated,
   })
 
   // ─── First-screen data contexts ───
@@ -1119,6 +1133,8 @@ export function useAppController() {
     authTransitioning: auth.authTransitioning,
     runtimeConfigState: auth.runtimeConfigState,
     runtimeConfigMissing: auth.runtimeConfigMissing,
+    onboarding,
+    unauthenticatedView,
     desktopReleaseStatus: auth.desktopReleaseStatus,
     desktopEnvironmentSetupComplete: auth.desktopEnvironmentSetupComplete,
     pendingDesktopEnvironmentSetup: auth.pendingDesktopEnvironmentSetup,

--- a/desktop-app/ui/src/hooks/useLocalhostReachable.ts
+++ b/desktop-app/ui/src/hooks/useLocalhostReachable.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Whether a local Evenfire is answering on this machine (spec §5.6).
+ *
+ * One bounded probe per mount. The main process takes no URL — it only ever
+ * checks the built-in Localhost option — so the renderer cannot use this to
+ * reach an arbitrary host. A failed or slow probe resolves to `false`, which
+ * every caller renders as "show nothing": a machine with no local cluster
+ * never sees a Localhost affordance advertising a server that isn't there.
+ *
+ * Optional-chained throughout because tests and stale dev preloads can leave
+ * `window.clerum` partially defined, and a missing bridge must degrade to
+ * "not reachable" rather than throwing during render.
+ */
+export function useLocalhostReachable(): boolean {
+  const [reachable, setReachable] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const probe = window.clerum?.auth?.probeLocalhostReachable
+    if (typeof probe !== 'function') return
+
+    probe()
+      .then(result => {
+        if (!cancelled) setReachable(Boolean(result))
+      })
+      .catch(() => undefined)
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return reachable
+}

--- a/desktop-app/ui/src/hooks/useLocalhostReachable.ts
+++ b/desktop-app/ui/src/hooks/useLocalhostReachable.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Whether a local Evenfire is answering on this machine (spec §5.6).
+ * Whether a local Evenfire is answering on this machine.
  *
  * One bounded probe per mount. The main process takes no URL — it only ever
  * checks the built-in Localhost option — so the renderer cannot use this to

--- a/desktop-app/ui/src/lib/__tests__/unauthenticatedView.test.ts
+++ b/desktop-app/ui/src/lib/__tests__/unauthenticatedView.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { selectUnauthenticatedView } from '../unauthenticatedView'
+
+const input = (overrides: Partial<Parameters<typeof selectUnauthenticatedView>[0]> = {}) => ({
+  hasDependencyOutage: false,
+  runtimeConfigMissing: false,
+  isAuthenticated: false,
+  ...overrides,
+})
+
+describe('selectUnauthenticatedView', () => {
+  it('renders sign-in for a configured environment', () => {
+    expect(selectUnauthenticatedView(input())).toBe('auth')
+  })
+
+  it('renders onboarding when no environment is configured', () => {
+    expect(selectUnauthenticatedView(input({ runtimeConfigMissing: true }))).toBe('onboarding')
+  })
+
+  it('renders the outage page ahead of onboarding', () => {
+    expect(
+      selectUnauthenticatedView(input({ hasDependencyOutage: true, runtimeConfigMissing: true }))
+    ).toBe('outage')
+  })
+
+  it('never renders onboarding to a signed-in user', () => {
+    expect(
+      selectUnauthenticatedView(input({ runtimeConfigMissing: true, isAuthenticated: true }))
+    ).toBe('auth')
+  })
+})

--- a/desktop-app/ui/src/lib/unauthenticatedView.ts
+++ b/desktop-app/ui/src/lib/unauthenticatedView.ts
@@ -1,0 +1,27 @@
+export type UnauthenticatedView = 'outage' | 'onboarding' | 'auth'
+
+interface UnauthenticatedViewInput {
+  hasDependencyOutage: boolean
+  runtimeConfigMissing: boolean
+  isAuthenticated: boolean
+}
+
+/**
+ * Which screen the unauthenticated branch renders (spec §4.1).
+ *
+ * Order matters: an outage wins over everything, because neither signing in
+ * nor onboarding can succeed while a dependency is down. Onboarding comes
+ * next, so a cold install never lands on a sign-in form for an environment it
+ * does not have. `isAuthenticated` is checked even though the caller only
+ * renders this branch while signed out — the invariant that onboarding never
+ * appears to a signed-in user is worth holding in one place.
+ */
+export function selectUnauthenticatedView({
+  hasDependencyOutage,
+  runtimeConfigMissing,
+  isAuthenticated,
+}: UnauthenticatedViewInput): UnauthenticatedView {
+  if (hasDependencyOutage) return 'outage'
+  if (runtimeConfigMissing && !isAuthenticated) return 'onboarding'
+  return 'auth'
+}

--- a/desktop-app/ui/src/lib/unauthenticatedView.ts
+++ b/desktop-app/ui/src/lib/unauthenticatedView.ts
@@ -7,7 +7,7 @@ interface UnauthenticatedViewInput {
 }
 
 /**
- * Which screen the unauthenticated branch renders (spec §4.1).
+ * Which screen the unauthenticated branch renders.
  *
  * Order matters: an outage wins over everything, because neither signing in
  * nor onboarding can succeed while a dependency is down. Onboarding comes

--- a/desktop-app/ui/src/pages/AuthPage/index.tsx
+++ b/desktop-app/ui/src/pages/AuthPage/index.tsx
@@ -9,8 +9,8 @@ import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
  * Sign-in for a configured environment.
  *
  * A cold install never reaches this page — the unauthenticated branch renders
- * onboarding instead (spec §4.1), so the invitation email form that used to
- * live here now belongs to the wizard's invited step (spec §5.5). AuthPage has
+ * onboarding instead, so the invitation email form that used to
+ * live here now belongs to the wizard's invited step. AuthPage has
  * exactly one mode again: sign in, plus the environment dock and its inline
  * add-environment form.
  */

--- a/desktop-app/ui/src/pages/AuthPage/index.tsx
+++ b/desktop-app/ui/src/pages/AuthPage/index.tsx
@@ -1,9 +1,9 @@
 import type { FormEvent } from 'react'
 import { useState } from 'react'
 import { useAuthContext } from '@contexts/AuthContext'
+import { AuthBrand } from '@components/AuthBrand'
 import { Button, Field, StatusBanner, TextInput } from '@components/Common'
 import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
-import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
 
 /**
  * Sign-in for a configured environment.
@@ -39,8 +39,6 @@ export function AuthPage() {
     Boolean(runtimeConfigSetupName.trim()) &&
     Boolean(runtimeConfigSetupExternalRestApiBaseUrl.trim())
   const [forgotPasswordBusy, setForgotPasswordBusy] = useState(false)
-  const desktopAppInfo = useDesktopAppInfo()
-  const desktopVersionTooltip = formatDesktopAppVersionTooltip(desktopAppInfo)
 
   const handlePasswordSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -79,15 +77,12 @@ export function AuthPage() {
     <main className="auth-page">
       <section className="auth-card glass-card">
         <header className="auth-card__header">
-          <div className="auth-brand" title={desktopVersionTooltip}>
-            <img className="auth-brand-mark" src="./logo.svg" alt="" aria-hidden="true" />
-            <span className="auth-brand-copy">
-              <span className="auth-brand-title">Evenfire</span>
-              <span className="auth-brand-subtitle">Desktop App</span>
-            </span>
-          </div>
+          <AuthBrand />
         </header>
 
+        {/* Sign-in stays content-sized. The fixed height belongs to the
+            onboarding wizard, which needs it because its steps differ wildly
+            in length; sign-in has one short form and reads better snug. */}
         {runtimeSetupVisible ? (
           <form className="auth-form-stack" onSubmit={handleRuntimeSetupSubmit}>
             <Field

--- a/desktop-app/ui/src/pages/AuthPage/index.tsx
+++ b/desktop-app/ui/src/pages/AuthPage/index.tsx
@@ -1,26 +1,27 @@
 import type { FormEvent } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useAuthContext } from '@contexts/AuthContext'
-import { Button, Field, IconButton, MenuItem, StatusBanner, TextInput } from '@components/Common'
-import { ConfirmDialog } from '@components/ConfirmDialog'
-import {
-  LOCALHOST_RUNTIME_CONFIG_OPTION_ID,
-  createLocalhostRuntimeConfigOption,
-} from '@constants/runtimeConfig'
+import { Button, Field, StatusBanner, TextInput } from '@components/Common'
+import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
 import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
-import type { DesktopRuntimeConfigOption } from '../../../../src/types'
 
+/**
+ * Sign-in for a configured environment.
+ *
+ * A cold install never reaches this page — the unauthenticated branch renders
+ * onboarding instead (spec §4.1), so the invitation email form that used to
+ * live here now belongs to the wizard's invited step (spec §5.5). AuthPage has
+ * exactly one mode again: sign in, plus the environment dock and its inline
+ * add-environment form.
+ */
 export function AuthPage() {
   const {
     busy,
     email,
     password,
-    desktopSetupStarted,
     runtimeConfigSetupName,
     runtimeConfigSetupExternalRestApiBaseUrl,
     authTransitioning,
-    runtimeConfigState,
-    runtimeConfigMissing,
     backendSwitchHint,
     setEmail,
     setPassword,
@@ -29,35 +30,15 @@ export function AuthPage() {
     setStatus,
     handlePasswordLogin,
     handleSwitchLoginBackend,
-    handleStartDesktopSetup,
     handleSaveRuntimeConfig,
-    handleDeleteRuntimeConfig,
-    handleSelectRuntimeConfig,
-    handleClearRuntimeConfigSelection,
   } = useAuthContext()
 
-  const runtimeConfigOptions = runtimeConfigState?.options || []
-  const activeRuntimeConfigId = runtimeConfigState?.activeOptionId ?? null
-  const selectedRuntimeConfig = runtimeConfigOptions.find(
-    option => option.id === activeRuntimeConfigId
-  )
   const hasPasswordLoginCredentials = Boolean(email.trim()) && Boolean(password)
   const [runtimeSetupVisible, setRuntimeSetupVisible] = useState(false)
   const hasRuntimeSetupValues =
     Boolean(runtimeConfigSetupName.trim()) &&
     Boolean(runtimeConfigSetupExternalRestApiBaseUrl.trim())
-  const [runtimeMenuOpen, setRuntimeMenuOpen] = useState(false)
   const [forgotPasswordBusy, setForgotPasswordBusy] = useState(false)
-  const [pendingDeleteOption, setPendingDeleteOption] = useState<DesktopRuntimeConfigOption | null>(
-    null
-  )
-  const runtimeDockRef = useRef<HTMLDivElement | null>(null)
-  const savedRuntimeConfigOptions = runtimeConfigOptions.filter(option => option.source === 'file')
-  const localhostRuntimeConfigOption = runtimeConfigOptions.find(
-    option => option.source === 'localhost'
-  )
-  const displayedLocalhostRuntimeConfigOption =
-    localhostRuntimeConfigOption || createLocalhostRuntimeConfigOption()
   const desktopAppInfo = useDesktopAppInfo()
   const desktopVersionTooltip = formatDesktopAppVersionTooltip(desktopAppInfo)
 
@@ -65,13 +46,6 @@ export function AuthPage() {
     event.preventDefault()
     if (!busy && hasPasswordLoginCredentials) {
       handlePasswordLogin()
-    }
-  }
-
-  const handleInvitationSetupSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!busy && email.trim()) {
-      handleStartDesktopSetup()
     }
   }
 
@@ -100,53 +74,6 @@ export function AuthPage() {
   const handleRuntimeSetupCancel = () => {
     setRuntimeSetupVisible(false)
   }
-
-  const handleRuntimeOptionSelect = (optionId: string) => {
-    setRuntimeMenuOpen(false)
-    if (
-      optionId === activeRuntimeConfigId &&
-      (selectedRuntimeConfig?.source === 'localhost' ||
-        optionId === LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
-    ) {
-      handleClearRuntimeConfigSelection()
-      return
-    }
-    handleSelectRuntimeConfig(optionId)
-  }
-
-  const confirmDeleteRuntimeOption = () => {
-    if (!pendingDeleteOption) return
-    handleDeleteRuntimeConfig(pendingDeleteOption.id)
-    setPendingDeleteOption(null)
-  }
-
-  useEffect(() => {
-    if (!runtimeMenuOpen) {
-      return
-    }
-
-    const handleDocumentPointerDown = (event: PointerEvent) => {
-      if (runtimeDockRef.current?.contains(event.target as Node)) {
-        return
-      }
-
-      setRuntimeMenuOpen(false)
-    }
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setRuntimeMenuOpen(false)
-      }
-    }
-
-    document.addEventListener('pointerdown', handleDocumentPointerDown)
-    document.addEventListener('keydown', handleEscape)
-
-    return () => {
-      document.removeEventListener('pointerdown', handleDocumentPointerDown)
-      document.removeEventListener('keydown', handleEscape)
-    }
-  }, [runtimeMenuOpen])
 
   return (
     <main className="auth-page">
@@ -201,9 +128,7 @@ export function AuthPage() {
               Go back to login
             </button>
           </form>
-        ) : null}
-
-        {!runtimeConfigMissing && !runtimeSetupVisible ? (
+        ) : (
           <form className="auth-form-stack" onSubmit={handlePasswordSubmit}>
             <Field label="Email" htmlFor="email-input" wrapperClassName="auth-form-row">
               <TextInput
@@ -263,174 +188,9 @@ export function AuthPage() {
               </StatusBanner>
             ) : null}
           </form>
-        ) : null}
-
-        {runtimeConfigMissing && !runtimeSetupVisible ? (
-          <form className="auth-form-stack" onSubmit={handleInvitationSetupSubmit}>
-            <Field
-              label="Email"
-              htmlFor="desktop-setup-email-input"
-              wrapperClassName="auth-form-row"
-            >
-              <TextInput
-                id="desktop-setup-email-input"
-                type="email"
-                placeholder="you@evenfire.com"
-                value={email}
-                onChange={event => setEmail(event.target.value)}
-              />
-            </Field>
-            <Button block disabled={!email.trim() || busy} type="submit">
-              {authTransitioning ? (
-                <span className="auth-button-loading">
-                  <span className="auth-button-spinner" aria-hidden="true" />
-                  Opening setup...
-                </span>
-              ) : desktopSetupStarted ? (
-                'Open setup again'
-              ) : (
-                'Continue setup'
-              )}
-            </Button>
-          </form>
-        ) : null}
+        )}
       </section>
-      {runtimeConfigState ? (
-        <aside className="auth-runtime-dock" ref={runtimeDockRef}>
-          <IconButton
-            className="auth-runtime-dock__toggle"
-            aria-label="Open environment selector"
-            aria-expanded={runtimeMenuOpen}
-            aria-controls="auth-runtime-dock-panel"
-            label="Open environment selector"
-            onClick={() => setRuntimeMenuOpen(open => !open)}
-            variant="soft"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M19.43 12.98a7.9 7.9 0 0 0 .05-.98 7.9 7.9 0 0 0-.05-.98l2.11-1.65a.48.48 0 0 0 .12-.61l-2-3.46a.49.49 0 0 0-.58-.22l-2.49 1a7.2 7.2 0 0 0-1.7-.98l-.38-2.65A.49.49 0 0 0 14 2h-4a.49.49 0 0 0-.49.41l-.38 2.65a7.2 7.2 0 0 0-1.7.98l-2.49-1a.49.49 0 0 0-.58.22l-2 3.46a.48.48 0 0 0 .12.61l2.11 1.65a7.9 7.9 0 0 0-.05.98 7.9 7.9 0 0 0 .05.98l-2.11 1.65a.48.48 0 0 0-.12.61l2 3.46a.49.49 0 0 0 .58.22l2.49-1a7.2 7.2 0 0 0 1.7.98l.38 2.65A.49.49 0 0 0 10 22h4a.49.49 0 0 0 .49-.41l.38-2.65a7.2 7.2 0 0 0 1.7-.98l2.49 1a.49.49 0 0 0 .58-.22l2-3.46a.48.48 0 0 0-.12-.61Zm-7.43 2.52A3.5 3.5 0 1 1 15.5 12 3.5 3.5 0 0 1 12 15.5Z" />
-            </svg>
-          </IconButton>
-          {runtimeMenuOpen ? (
-            <div className="auth-runtime-dock__panel glass-card" id="auth-runtime-dock-panel">
-              <div className="auth-runtime-menu__header">
-                <span className="auth-runtime-menu__label">Environment</span>
-                <IconButton
-                  aria-label="Add environment"
-                  disabled={busy || authTransitioning}
-                  label="Add environment"
-                  onClick={() => {
-                    setRuntimeMenuOpen(false)
-                    setRuntimeSetupVisible(true)
-                  }}
-                  size="sm"
-                  variant="ghost"
-                >
-                  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                    <path d="M12 5v14" />
-                    <path d="M5 12h14" />
-                  </svg>
-                </IconButton>
-              </div>
-              <div className="auth-runtime-menu">
-                {savedRuntimeConfigOptions.length > 0 ? (
-                  <section className="auth-runtime-menu__section">
-                    {savedRuntimeConfigOptions.map(option => {
-                      const selected = option.id === activeRuntimeConfigId
-                      return (
-                        <div
-                          key={option.id}
-                          className={`auth-runtime-menu__row${selected ? ' selected' : ''}`}
-                        >
-                          <MenuItem
-                            className={`auth-runtime-menu__select${selected ? ' selected' : ''}`}
-                            active={selected}
-                            disabled={busy || authTransitioning}
-                            leadingIcon={
-                              <span className="auth-runtime-menu__check" aria-hidden="true">
-                                {selected ? (
-                                  <svg viewBox="0 0 24 24" focusable="false">
-                                    <path d="M20 6 9 17l-5-5" />
-                                  </svg>
-                                ) : null}
-                              </span>
-                            }
-                            onClick={() => handleRuntimeOptionSelect(option.id)}
-                          >
-                            {option.label}
-                          </MenuItem>
-                          <IconButton
-                            className="auth-runtime-menu__delete"
-                            aria-label={`Delete ${option.appName} environment`}
-                            color="danger"
-                            disabled={busy || authTransitioning}
-                            label={`Delete ${option.appName}`}
-                            onClick={() => setPendingDeleteOption(option)}
-                            size="sm"
-                            title={`Delete ${option.appName}`}
-                            variant="ghost"
-                          >
-                            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                              <path d="M3 6h18" />
-                              <path d="M8 6V4h8v2" />
-                              <path d="M6 6l1 15h10l1-15" />
-                              <path d="M10 10v7" />
-                              <path d="M14 10v7" />
-                            </svg>
-                          </IconButton>
-                        </div>
-                      )
-                    })}
-                  </section>
-                ) : null}
-                {displayedLocalhostRuntimeConfigOption ? (
-                  <section className="auth-runtime-menu__section">
-                    {(() => {
-                      const option = displayedLocalhostRuntimeConfigOption
-                      const selected = option.id === activeRuntimeConfigId
-                      return (
-                        <MenuItem
-                          className={`auth-runtime-menu__select auth-runtime-menu__select--standalone${
-                            selected ? ' selected' : ''
-                          }`}
-                          active={selected}
-                          disabled={busy || authTransitioning}
-                          leadingIcon={
-                            <span className="auth-runtime-menu__check" aria-hidden="true">
-                              {selected ? (
-                                <svg viewBox="0 0 24 24" focusable="false">
-                                  <path d="M20 6 9 17l-5-5" />
-                                </svg>
-                              ) : null}
-                            </span>
-                          }
-                          onClick={() => handleRuntimeOptionSelect(option.id)}
-                        >
-                          Localhost
-                        </MenuItem>
-                      )
-                    })()}
-                  </section>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-        </aside>
-      ) : null}
-      {pendingDeleteOption ? (
-        <ConfirmDialog
-          title="Delete environment?"
-          body={
-            <p>
-              Delete <strong>{pendingDeleteOption.appName}</strong>? This only removes the local
-              desktop environment configuration.
-            </p>
-          }
-          confirmLabel="Delete"
-          tone="danger"
-          onCancel={() => setPendingDeleteOption(null)}
-          onConfirm={confirmDeleteRuntimeOption}
-        />
-      ) : null}
+      <RuntimeConfigDock onAddEnvironment={() => setRuntimeSetupVisible(true)} />
     </main>
   )
 }

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -25,7 +25,7 @@ export function OnboardingPage({ onboarding }: OnboardingPageProps) {
 
   return (
     <main className="auth-page">
-      <section className="auth-card glass-card">
+      <section className="auth-card glass-card onboarding-card">
         <header className="auth-card__header">
           <div className="auth-brand" title={desktopVersionTooltip}>
             <img className="auth-brand-mark" src="./logo.svg" alt="" aria-hidden="true" />

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -1,5 +1,6 @@
 import { AuthBrand } from '@components/AuthBrand'
 import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
+import { CompareRunStyles } from './steps/CompareRunStyles'
 import { Hosted } from './steps/Hosted'
 import { InvitedMember } from './steps/InvitedMember'
 import { ManualEnvironment } from './steps/ManualEnvironment'
@@ -37,6 +38,12 @@ export function OnboardingPage({ onboarding }: OnboardingPageProps) {
               step={step}
               onAnswerOrigin={answerOrigin}
               onAnswerRunStyle={answerRunStyle}
+            />
+          ) : null}
+          {step === 'compare' ? (
+            <CompareRunStyles
+              onChooseHosted={() => answerRunStyle('hosted')}
+              onChooseSelfHosted={() => answerRunStyle('selfHosted')}
             />
           ) : null}
           {step === 'invited' ? <InvitedMember /> : null}

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -1,5 +1,6 @@
 import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
 import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
+import { Hosted } from './steps/Hosted'
 import { InvitedMember } from './steps/InvitedMember'
 import { ManualEnvironment } from './steps/ManualEnvironment'
 import { PathChoice } from './steps/PathChoice'
@@ -39,6 +40,7 @@ export function OnboardingPage({ onboarding }: OnboardingPageProps) {
           <PathChoice step={step} onAnswerOrigin={answerOrigin} onAnswerRunStyle={answerRunStyle} />
         ) : null}
         {step === 'invited' ? <InvitedMember /> : null}
+        {step === 'hosted' ? <Hosted onContinue={goToManual} /> : null}
         {step === 'selfHosted' ? <SelfHosted onContinue={goToManual} /> : null}
         {step === 'manual' ? <ManualEnvironment /> : null}
 

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -13,10 +13,10 @@ interface OnboardingPageProps {
 }
 
 /**
- * First-run onboarding (spec §5.2).
+ * First-run onboarding.
  *
  * Rendered instead of AuthPage when the app has no environment at all, so it
- * also carries the environment dock: the Localhost escape hatch (path E) lives
+ * also carries the environment dock: the Localhost escape hatch lives
  * there, and a cold install would otherwise have no way to reach it.
  */
 export function OnboardingPage({ onboarding }: OnboardingPageProps) {

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -1,5 +1,5 @@
+import { AuthBrand } from '@components/AuthBrand'
 import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
-import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
 import { Hosted } from './steps/Hosted'
 import { InvitedMember } from './steps/InvitedMember'
 import { ManualEnvironment } from './steps/ManualEnvironment'
@@ -20,35 +20,38 @@ interface OnboardingPageProps {
  */
 export function OnboardingPage({ onboarding }: OnboardingPageProps) {
   const { step, canGoBack, answerOrigin, answerRunStyle, goToManual, back } = onboarding
-  const desktopAppInfo = useDesktopAppInfo()
-  const desktopVersionTooltip = formatDesktopAppVersionTooltip(desktopAppInfo)
 
   return (
     <main className="auth-page">
-      <section className="auth-card glass-card onboarding-card">
+      <section className="auth-card glass-card auth-card--flow">
         <header className="auth-card__header">
-          <div className="auth-brand" title={desktopVersionTooltip}>
-            <img className="auth-brand-mark" src="./logo.svg" alt="" aria-hidden="true" />
-            <span className="auth-brand-copy">
-              <span className="auth-brand-title">Evenfire</span>
-              <span className="auth-brand-subtitle">Desktop App</span>
-            </span>
-          </div>
+          <AuthBrand />
         </header>
+        <div className="auth-card__divider" role="presentation" />
 
-        {step === 'origin' || step === 'runStyle' ? (
-          <PathChoice step={step} onAnswerOrigin={answerOrigin} onAnswerRunStyle={answerRunStyle} />
-        ) : null}
-        {step === 'invited' ? <InvitedMember /> : null}
-        {step === 'hosted' ? <Hosted onContinue={goToManual} /> : null}
-        {step === 'selfHosted' ? <SelfHosted onContinue={goToManual} /> : null}
-        {step === 'manual' ? <ManualEnvironment /> : null}
+        {/* One wrapper for every step so the card can hold a constant height
+            and scroll internally, instead of resizing as steps change. */}
+        <div className="auth-card__body">
+          {step === 'origin' || step === 'runStyle' ? (
+            <PathChoice
+              step={step}
+              onAnswerOrigin={answerOrigin}
+              onAnswerRunStyle={answerRunStyle}
+            />
+          ) : null}
+          {step === 'invited' ? <InvitedMember /> : null}
+          {step === 'hosted' ? <Hosted onContinue={goToManual} /> : null}
+          {step === 'selfHosted' ? <SelfHosted onContinue={goToManual} /> : null}
+          {step === 'manual' ? <ManualEnvironment /> : null}
+        </div>
 
-        {canGoBack ? (
-          <button type="button" className="auth-inline-link" onClick={back}>
-            Back
-          </button>
-        ) : null}
+        <div className="auth-card__footer">
+          {canGoBack ? (
+            <button type="button" className="auth-inline-link" onClick={back}>
+              Back
+            </button>
+          ) : null}
+        </div>
       </section>
       <RuntimeConfigDock onAddEnvironment={goToManual} />
     </main>

--- a/desktop-app/ui/src/pages/OnboardingPage/index.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/index.tsx
@@ -1,0 +1,54 @@
+import { RuntimeConfigDock } from '@components/RuntimeConfigDock'
+import { formatDesktopAppVersionTooltip, useDesktopAppInfo } from '@hooks/useDesktopAppInfo'
+import { InvitedMember } from './steps/InvitedMember'
+import { ManualEnvironment } from './steps/ManualEnvironment'
+import { PathChoice } from './steps/PathChoice'
+import { SelfHosted } from './steps/SelfHosted'
+import type { OnboardingViewModel } from './types'
+
+interface OnboardingPageProps {
+  onboarding: OnboardingViewModel
+}
+
+/**
+ * First-run onboarding (spec §5.2).
+ *
+ * Rendered instead of AuthPage when the app has no environment at all, so it
+ * also carries the environment dock: the Localhost escape hatch (path E) lives
+ * there, and a cold install would otherwise have no way to reach it.
+ */
+export function OnboardingPage({ onboarding }: OnboardingPageProps) {
+  const { step, canGoBack, answerOrigin, answerRunStyle, goToManual, back } = onboarding
+  const desktopAppInfo = useDesktopAppInfo()
+  const desktopVersionTooltip = formatDesktopAppVersionTooltip(desktopAppInfo)
+
+  return (
+    <main className="auth-page">
+      <section className="auth-card glass-card">
+        <header className="auth-card__header">
+          <div className="auth-brand" title={desktopVersionTooltip}>
+            <img className="auth-brand-mark" src="./logo.svg" alt="" aria-hidden="true" />
+            <span className="auth-brand-copy">
+              <span className="auth-brand-title">Evenfire</span>
+              <span className="auth-brand-subtitle">Desktop App</span>
+            </span>
+          </div>
+        </header>
+
+        {step === 'origin' || step === 'runStyle' ? (
+          <PathChoice step={step} onAnswerOrigin={answerOrigin} onAnswerRunStyle={answerRunStyle} />
+        ) : null}
+        {step === 'invited' ? <InvitedMember /> : null}
+        {step === 'selfHosted' ? <SelfHosted onContinue={goToManual} /> : null}
+        {step === 'manual' ? <ManualEnvironment /> : null}
+
+        {canGoBack ? (
+          <button type="button" className="auth-inline-link" onClick={back}>
+            Back
+          </button>
+        ) : null}
+      </section>
+      <RuntimeConfigDock onAddEnvironment={goToManual} />
+    </main>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/CompareRunStyles.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/CompareRunStyles.tsx
@@ -1,0 +1,95 @@
+import { Button } from '@components/Common'
+
+interface CompareRunStylesProps {
+  onChooseHosted: () => void
+  onChooseSelfHosted: () => void
+}
+
+interface RunStyleSummary {
+  title: string
+  lead: string
+  pros: string[]
+  cons: string[]
+}
+
+/**
+ * Q2's undecided answer: the two run styles side by side.
+ *
+ * Framed around the requirements that actually force the decision rather than
+ * generic benefits — someone who does not know which to pick is not weighing
+ * preferences, they are checking whether a constraint applies to them. So the
+ * self-hosted side reads as a checklist of those constraints, and hosting is
+ * positioned as the default when none of them do.
+ *
+ * Deliberately limited to operational trade-offs. No pricing or trial claims:
+ * hosted signup does not exist yet, so anything about cost would be a promise
+ * the product cannot keep. Self-hosting is described as "a cluster you
+ * control" rather than anything local, because it covers remote and local.
+ */
+const RUN_STYLES: RunStyleSummary[] = [
+  {
+    title: 'Evenfire hosts it',
+    lead: 'The default if none of the requirements below apply to you.',
+    pros: ['Nothing to deploy, upgrade, or monitor', 'Fastest way to a working agent'],
+    cons: ['Runs on Evenfire’s infrastructure, not yours'],
+  },
+  {
+    title: 'You run it yourself',
+    lead: 'Choose this if any of these are true:',
+    pros: [
+      'Data or model keys are not allowed to leave your own network',
+      'Agents must reach internal systems that are not on the public internet',
+      'Policy or compliance dictates where your data is processed and stored',
+      'You need to set your own network policy, egress rules, and upgrade schedule',
+    ],
+    cons: ['You deploy and maintain the cluster'],
+  },
+]
+
+export function CompareRunStyles({ onChooseHosted, onChooseSelfHosted }: CompareRunStylesProps) {
+  return (
+    <>
+      <h1>Which one is right for you?</h1>
+      <div className="onboarding-compare">
+        {RUN_STYLES.map(style => (
+          <section className="onboarding-compare__group" key={style.title}>
+            <h2 className="onboarding-compare__title">{style.title}</h2>
+            <p className="onboarding-compare__lead">{style.lead}</p>
+            <ul className="onboarding-compare__list">
+              {style.pros.map(point => (
+                <li className="onboarding-compare__item" key={point}>
+                  <span
+                    className="onboarding-compare__mark onboarding-compare__mark--pro"
+                    aria-hidden="true"
+                  >
+                    +
+                  </span>
+                  <span>{point}</span>
+                </li>
+              ))}
+              {style.cons.map(point => (
+                <li className="onboarding-compare__item" key={point}>
+                  <span
+                    className="onboarding-compare__mark onboarding-compare__mark--con"
+                    aria-hidden="true"
+                  >
+                    −
+                  </span>
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+      <div className="auth-flow-card__actions">
+        <Button block onClick={onChooseHosted}>
+          Evenfire hosts it
+        </Button>
+        <Button block variant="soft" onClick={onChooseSelfHosted}>
+          I’ll run it myself
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/Hosted.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/Hosted.tsx
@@ -1,0 +1,32 @@
+import { LinkOutStep } from './LinkOutStep'
+
+interface HostedProps {
+  /** Continue into the manual environment step, which owns the submit path. */
+  onContinue: () => void
+}
+
+/**
+ * Path A — Evenfire-hosted (spec §5.3), in its link-out form.
+ *
+ * The hosted signup project does not exist yet: there is no tenant
+ * provisioning and no `evenfire://desktop-environment` handoff back into the
+ * app. So this step links to the hosted site and offers the manual-address
+ * fallback for when the user returns with a server, rather than promising an
+ * in-app signup the product cannot complete. When hosted signup ships, this
+ * step gains the `state` nonce and the waiting screen; the questionnaire above
+ * it does not change.
+ */
+export function Hosted({ onContinue }: HostedProps) {
+  return (
+    <LinkOutStep
+      title="Evenfire hosts it for you"
+      body="We run and operate Evenfire for you — no cluster to deploy or maintain. See what's available on the Evenfire site, then come back and connect with your server's address."
+      channel="openHostedSignup"
+      linkLabel="See hosted Evenfire"
+      successMessage="Evenfire opened in your browser."
+      errorMessage="The Evenfire site could not be opened"
+      continueLabel="I have a server — enter its address"
+      onContinue={onContinue}
+    />
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/Hosted.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/Hosted.tsx
@@ -6,7 +6,7 @@ interface HostedProps {
 }
 
 /**
- * Path A — Evenfire-hosted (spec §5.3), in its link-out form.
+ * Evenfire-hosted, in its link-out form.
  *
  * The hosted signup project does not exist yet: there is no tenant
  * provisioning and no `evenfire://desktop-environment` handoff back into the

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/InvitedMember.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/InvitedMember.tsx
@@ -3,7 +3,7 @@ import { useAuthContext } from '@contexts/AuthContext'
 import { Button, Field, TextInput } from '@components/Common'
 
 /**
- * Path C — invited member (spec §5.5).
+ * Invited member: finish setup for an address a team already invited.
  *
  * Behaviour is unchanged from the form this replaces on AuthPage: the same
  * `handleStartDesktopSetup` handler, the same single email field, the same

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/InvitedMember.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/InvitedMember.tsx
@@ -1,0 +1,55 @@
+import type { FormEvent } from 'react'
+import { useAuthContext } from '@contexts/AuthContext'
+import { Button, Field, TextInput } from '@components/Common'
+
+/**
+ * Path C — invited member (spec §5.5).
+ *
+ * Behaviour is unchanged from the form this replaces on AuthPage: the same
+ * `handleStartDesktopSetup` handler, the same single email field, the same
+ * "Open setup again" affordance once setup has been started. Only its home
+ * moved. Distinct copy for a missing invitation lands in the follow-up PR.
+ */
+export function InvitedMember() {
+  const { busy, email, desktopSetupStarted, authTransitioning, setEmail, handleStartDesktopSetup } =
+    useAuthContext()
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!busy && email.trim()) {
+      handleStartDesktopSetup()
+    }
+  }
+
+  return (
+    <>
+      <h1>Connect to your team</h1>
+      <p className="muted">
+        Enter the email address your team invited. We’ll open your browser to finish setup.
+      </p>
+      <form className="auth-form-stack" onSubmit={handleSubmit}>
+        <Field label="Email" htmlFor="desktop-setup-email-input" wrapperClassName="auth-form-row">
+          <TextInput
+            id="desktop-setup-email-input"
+            type="email"
+            placeholder="you@evenfire.com"
+            value={email}
+            onChange={event => setEmail(event.target.value)}
+          />
+        </Field>
+        <Button block disabled={!email.trim() || busy} type="submit">
+          {authTransitioning ? (
+            <span className="auth-button-loading">
+              <span className="auth-button-spinner" aria-hidden="true" />
+              Opening setup...
+            </span>
+          ) : desktopSetupStarted ? (
+            'Open setup again'
+          ) : (
+            'Continue setup'
+          )}
+        </Button>
+      </form>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/LinkOutStep.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/LinkOutStep.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { useAuthContext } from '@contexts/AuthContext'
+import { Button } from '@components/Common'
+
+/** No-argument main-process calls that open a build-time URL in the browser. */
+type LinkOutChannel = 'openDeploymentDocs' | 'openHostedSignup'
+
+interface LinkOutStepProps {
+  title: string
+  body: string
+  channel: LinkOutChannel
+  linkLabel: string
+  successMessage: string
+  errorMessage: string
+  continueLabel: string
+  onContinue: () => void
+}
+
+/**
+ * Shared shell for the two onboarding steps that hand off to the browser and
+ * then wait for the user to come back with an address — self-hosted (§5.4) and
+ * hosted (§5.3). Both open a URL the main process owns and both fall back to
+ * the manual environment step, so they differ only in copy.
+ */
+export function LinkOutStep({
+  title,
+  body,
+  channel,
+  linkLabel,
+  successMessage,
+  errorMessage,
+  continueLabel,
+  onContinue,
+}: LinkOutStepProps) {
+  const { busy, setStatus } = useAuthContext()
+  const [opening, setOpening] = useState(false)
+
+  const handleOpen = async () => {
+    if (opening) return
+    setOpening(true)
+    try {
+      // Vite can hot-reload renderer code while Electron still runs an older
+      // preload script, matching the guard on the environment delete action.
+      const open = window.clerum.auth[channel]
+      if (typeof open !== 'function') {
+        throw new Error('Restart the desktop app to finish loading this link')
+      }
+      await open()
+      setStatus(successMessage, 'success', undefined, { global: false, toast: true })
+    } catch (error) {
+      setStatus(
+        `${errorMessage}: ${error instanceof Error ? error.message : String(error)}`,
+        'error'
+      )
+    } finally {
+      setOpening(false)
+    }
+  }
+
+  return (
+    <>
+      <h1>{title}</h1>
+      <p className="muted">{body}</p>
+      <div className="auth-flow-card__actions">
+        <Button block disabled={busy || opening} onClick={() => void handleOpen()}>
+          {linkLabel}
+        </Button>
+        <Button block disabled={busy} onClick={onContinue} variant="soft">
+          {continueLabel}
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
@@ -1,0 +1,114 @@
+import type { FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+import { useAuthContext } from '@contexts/AuthContext'
+import { Button, Field, StatusBanner, TextInput } from '@components/Common'
+import { LOCALHOST_RUNTIME_CONFIG_OPTION_ID } from '@constants/runtimeConfig'
+
+/**
+ * Path D — manual environment (spec §5.6).
+ *
+ * The terminal step for paths B and D alike, so it carries the local-cluster
+ * hint for both. It shares `handleSaveRuntimeConfig` with AuthPage's inline
+ * environment form: one submit path, one validation rule.
+ */
+export function ManualEnvironment() {
+  const {
+    busy,
+    runtimeConfigSetupName,
+    runtimeConfigSetupExternalRestApiBaseUrl,
+    setRuntimeConfigSetupName,
+    setRuntimeConfigSetupExternalRestApiBaseUrl,
+    handleSaveRuntimeConfig,
+    handleSelectRuntimeConfig,
+  } = useAuthContext()
+
+  const [localhostReachable, setLocalhostReachable] = useState(false)
+
+  const hasRuntimeSetupValues =
+    Boolean(runtimeConfigSetupName.trim()) &&
+    Boolean(runtimeConfigSetupExternalRestApiBaseUrl.trim())
+
+  // One bounded probe on entry (spec §9.4). It takes no URL — the main process
+  // only ever checks the built-in Localhost option — and a negative or failed
+  // result renders nothing, so a user with no local cluster sees no trace of
+  // it. The probe never fills the form or saves on its own.
+  useEffect(() => {
+    let cancelled = false
+    const probe = window.clerum.auth.probeLocalhostReachable
+    if (typeof probe !== 'function') return
+
+    probe()
+      .then(reachable => {
+        if (!cancelled) setLocalhostReachable(reachable)
+      })
+      .catch(() => undefined)
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!busy && hasRuntimeSetupValues) {
+      void handleSaveRuntimeConfig()
+    }
+  }
+
+  return (
+    <>
+      <h1>Connect to a server</h1>
+      <p className="muted">
+        Enter the address of your Evenfire server. You can add more environments later.
+      </p>
+      {localhostReachable ? (
+        <StatusBanner tone="info">
+          <span className="auth-backend-hint">
+            <span>A local Evenfire looks like it’s running on this machine.</span>
+            <Button
+              type="button"
+              size="sm"
+              variant="soft"
+              block
+              disabled={busy}
+              onClick={() => void handleSelectRuntimeConfig(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)}
+            >
+              Use Localhost
+            </Button>
+          </span>
+        </StatusBanner>
+      ) : null}
+      <form className="auth-form-stack" onSubmit={handleSubmit}>
+        <Field
+          label="Environment name"
+          htmlFor="runtime-config-name-input"
+          wrapperClassName="auth-form-row"
+        >
+          <TextInput
+            id="runtime-config-name-input"
+            type="text"
+            placeholder="Production"
+            value={runtimeConfigSetupName}
+            onChange={event => setRuntimeConfigSetupName(event.target.value)}
+          />
+        </Field>
+        <Field
+          label="External REST API"
+          htmlFor="runtime-config-external-rest-api-input"
+          wrapperClassName="auth-form-row"
+        >
+          <TextInput
+            id="runtime-config-external-rest-api-input"
+            type="url"
+            placeholder="https://evenfire.example.com"
+            value={runtimeConfigSetupExternalRestApiBaseUrl}
+            onChange={event => setRuntimeConfigSetupExternalRestApiBaseUrl(event.target.value)}
+          />
+        </Field>
+        <Button block disabled={!hasRuntimeSetupValues || busy} type="submit">
+          Save environment
+        </Button>
+      </form>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
@@ -8,9 +8,9 @@ import {
 import { useLocalhostReachable } from '@hooks/useLocalhostReachable'
 
 /**
- * Path D — manual environment (spec §5.6).
+ * Manual environment: connect to a server by address.
  *
- * The terminal step for paths B and D alike, so it carries the local-cluster
+ * The terminal step for the self-hosted and have-an-address answers alike, so it carries the local-cluster
  * hint for both. It shares `handleSaveRuntimeConfig` with AuthPage's inline
  * environment form: one submit path, one validation rule.
  */
@@ -25,7 +25,7 @@ export function ManualEnvironment() {
     handleSelectRuntimeConfig,
   } = useAuthContext()
 
-  // One bounded probe on entry (spec §9.4). A negative or failed result
+  // One bounded probe on entry. A negative or failed result
   // renders nothing, so a user with no local cluster sees no trace of it. The
   // probe never fills the form or saves on its own.
   const localhostReachable = useLocalhostReachable()

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/ManualEnvironment.tsx
@@ -1,8 +1,11 @@
 import type { FormEvent } from 'react'
-import { useEffect, useState } from 'react'
 import { useAuthContext } from '@contexts/AuthContext'
-import { Button, Field, StatusBanner, TextInput } from '@components/Common'
-import { LOCALHOST_RUNTIME_CONFIG_OPTION_ID } from '@constants/runtimeConfig'
+import { Button, Field, SelectableOption, TextInput } from '@components/Common'
+import {
+  LOCALHOST_RUNTIME_CONFIG_OPTION_ID,
+  createLocalhostRuntimeConfigOption,
+} from '@constants/runtimeConfig'
+import { useLocalhostReachable } from '@hooks/useLocalhostReachable'
 
 /**
  * Path D — manual environment (spec §5.6).
@@ -22,31 +25,15 @@ export function ManualEnvironment() {
     handleSelectRuntimeConfig,
   } = useAuthContext()
 
-  const [localhostReachable, setLocalhostReachable] = useState(false)
+  // One bounded probe on entry (spec §9.4). A negative or failed result
+  // renders nothing, so a user with no local cluster sees no trace of it. The
+  // probe never fills the form or saves on its own.
+  const localhostReachable = useLocalhostReachable()
+  const localhostOption = createLocalhostRuntimeConfigOption()
 
   const hasRuntimeSetupValues =
     Boolean(runtimeConfigSetupName.trim()) &&
     Boolean(runtimeConfigSetupExternalRestApiBaseUrl.trim())
-
-  // One bounded probe on entry (spec §9.4). It takes no URL — the main process
-  // only ever checks the built-in Localhost option — and a negative or failed
-  // result renders nothing, so a user with no local cluster sees no trace of
-  // it. The probe never fills the form or saves on its own.
-  useEffect(() => {
-    let cancelled = false
-    const probe = window.clerum.auth.probeLocalhostReachable
-    if (typeof probe !== 'function') return
-
-    probe()
-      .then(reachable => {
-        if (!cancelled) setLocalhostReachable(reachable)
-      })
-      .catch(() => undefined)
-
-    return () => {
-      cancelled = true
-    }
-  }, [])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -62,21 +49,19 @@ export function ManualEnvironment() {
         Enter the address of your Evenfire server. You can add more environments later.
       </p>
       {localhostReachable ? (
-        <StatusBanner tone="info">
-          <span className="auth-backend-hint">
-            <span>A local Evenfire looks like it’s running on this machine.</span>
-            <Button
-              type="button"
-              size="sm"
-              variant="soft"
-              block
-              disabled={busy}
-              onClick={() => void handleSelectRuntimeConfig(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)}
-            >
-              Use Localhost
-            </Button>
-          </span>
-        </StatusBanner>
+        <div className="onboarding-options">
+          <SelectableOption
+            className="onboarding-option"
+            size="lg"
+            disabled={busy}
+            onClick={() => void handleSelectRuntimeConfig(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)}
+          >
+            <span className="onboarding-option__title">Localhost</span>
+            <span className="onboarding-option__hint">
+              {localhostOption.externalRestApiBaseUrl}
+            </span>
+          </SelectableOption>
+        </div>
       ) : null}
       <form className="auth-form-stack" onSubmit={handleSubmit}>
         <Field

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
@@ -26,7 +26,7 @@ export function PathChoice({ step, onAnswerOrigin, onAnswerRunStyle }: PathChoic
           >
             <span className="onboarding-option__title">Evenfire hosts it for me</span>
             <span className="onboarding-option__hint">
-              Free for 1 week. Nothing to deploy or operate.
+              We run and operate it for you. Nothing to deploy.
             </span>
           </SelectableOption>
           <SelectableOption
@@ -75,7 +75,7 @@ export function PathChoice({ step, onAnswerOrigin, onAnswerRunStyle }: PathChoic
           onClick={() => onAnswerOrigin('gettingStarted')}
         >
           <span className="onboarding-option__title">No, I’m just getting started</span>
-          <span className="onboarding-option__hint">See what it takes to run Evenfire.</span>
+          <span className="onboarding-option__hint">See your options for running Evenfire.</span>
         </SelectableOption>
       </div>
     </>

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
@@ -39,6 +39,16 @@ export function PathChoice({ step, onAnswerOrigin, onAnswerRunStyle }: PathChoic
               Deploy Evenfire to a cluster you control.
             </span>
           </SelectableOption>
+          <SelectableOption
+            className="onboarding-option"
+            size="lg"
+            onClick={() => onAnswerRunStyle('compare')}
+          >
+            <span className="onboarding-option__title">I have no idea</span>
+            <span className="onboarding-option__hint">
+              Tell me more about the other two options.
+            </span>
+          </SelectableOption>
         </div>
       </>
     )

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
@@ -8,7 +8,7 @@ interface PathChoiceProps {
 }
 
 /**
- * The questionnaire itself — Q1, and Q2 once the hosted path ships (spec §3).
+ * The questionnaire itself — Q1, and Q2 once the hosted path ships.
  *
  * Q1's "I have a server address" doubles as the wizard's one-click skip, which
  * is why the first step needs no separate skip control.

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/PathChoice.tsx
@@ -1,0 +1,83 @@
+import { SelectableOption } from '@components/Common'
+import type { OnboardingOriginAnswer, OnboardingRunStyleAnswer } from '../types'
+
+interface PathChoiceProps {
+  step: 'origin' | 'runStyle'
+  onAnswerOrigin: (answer: OnboardingOriginAnswer) => void
+  onAnswerRunStyle: (answer: OnboardingRunStyleAnswer) => void
+}
+
+/**
+ * The questionnaire itself — Q1, and Q2 once the hosted path ships (spec §3).
+ *
+ * Q1's "I have a server address" doubles as the wizard's one-click skip, which
+ * is why the first step needs no separate skip control.
+ */
+export function PathChoice({ step, onAnswerOrigin, onAnswerRunStyle }: PathChoiceProps) {
+  if (step === 'runStyle') {
+    return (
+      <>
+        <h1>How do you want to run Evenfire?</h1>
+        <div className="onboarding-options">
+          <SelectableOption
+            className="onboarding-option"
+            size="lg"
+            onClick={() => onAnswerRunStyle('hosted')}
+          >
+            <span className="onboarding-option__title">Evenfire hosts it for me</span>
+            <span className="onboarding-option__hint">
+              Free for 1 week. Nothing to deploy or operate.
+            </span>
+          </SelectableOption>
+          <SelectableOption
+            className="onboarding-option"
+            size="lg"
+            onClick={() => onAnswerRunStyle('selfHosted')}
+          >
+            <span className="onboarding-option__title">I’ll run it myself</span>
+            <span className="onboarding-option__hint">
+              Deploy Evenfire to a cluster you control.
+            </span>
+          </SelectableOption>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h1>Do you already have an Evenfire server?</h1>
+      <p className="muted">
+        The desktop app connects to an Evenfire server. Tell us which one and we’ll get you there.
+      </p>
+      <div className="onboarding-options">
+        <SelectableOption
+          className="onboarding-option"
+          size="lg"
+          onClick={() => onAnswerOrigin('invited')}
+        >
+          <span className="onboarding-option__title">My team already uses Evenfire</span>
+          <span className="onboarding-option__hint">
+            Finish setup with the email your team invited.
+          </span>
+        </SelectableOption>
+        <SelectableOption
+          className="onboarding-option"
+          size="lg"
+          onClick={() => onAnswerOrigin('haveAddress')}
+        >
+          <span className="onboarding-option__title">I have a server address</span>
+          <span className="onboarding-option__hint">Connect to a server you already know.</span>
+        </SelectableOption>
+        <SelectableOption
+          className="onboarding-option"
+          size="lg"
+          onClick={() => onAnswerOrigin('gettingStarted')}
+        >
+          <span className="onboarding-option__title">No, I’m just getting started</span>
+          <span className="onboarding-option__hint">See what it takes to run Evenfire.</span>
+        </SelectableOption>
+      </div>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { useAuthContext } from '@contexts/AuthContext'
+import { Button } from '@components/Common'
+
+interface SelfHostedProps {
+  /** Continue into the manual environment step, which owns the submit path. */
+  onContinue: () => void
+}
+
+/**
+ * Path B — self-hosted (spec §5.4).
+ *
+ * Documentation-first: deployment shapes differ too much for a wizard to guide
+ * any of them honestly, so this step names the option, links out, and hands to
+ * path D. It deliberately shows no prerequisites, no install command and no
+ * default address — all three would assume a deployment shape, and
+ * self-hosting means any cluster the user controls, remote or local.
+ */
+export function SelfHosted({ onContinue }: SelfHostedProps) {
+  const { busy, setStatus } = useAuthContext()
+  const [openingDocs, setOpeningDocs] = useState(false)
+
+  const handleOpenDocs = async () => {
+    if (openingDocs) return
+    setOpeningDocs(true)
+    try {
+      // Vite can hot-reload renderer code while Electron still runs an older
+      // preload script, matching the guard on the environment delete action.
+      if (typeof window.clerum.auth.openDeploymentDocs !== 'function') {
+        throw new Error('Restart the desktop app to finish loading the deployment guide link')
+      }
+      await window.clerum.auth.openDeploymentDocs()
+      setStatus('Deployment guide opened in your browser.', 'success', undefined, {
+        global: false,
+        toast: true,
+      })
+    } catch (error) {
+      setStatus(
+        `The deployment guide could not be opened: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        'error'
+      )
+    } finally {
+      setOpeningDocs(false)
+    }
+  }
+
+  return (
+    <>
+      <h1>Run Evenfire yourself</h1>
+      <p className="muted">
+        Deploy Evenfire to a Kubernetes cluster you control — your own infrastructure or a local
+        one. The deployment guide covers both, including what each shape needs.
+      </p>
+      <div className="auth-flow-card__actions">
+        <Button block disabled={busy || openingDocs} onClick={() => void handleOpenDocs()}>
+          Open the deployment guide
+        </Button>
+        <Button block disabled={busy} onClick={onContinue} variant="soft">
+          I have a server — enter its address
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
@@ -6,11 +6,11 @@ interface SelfHostedProps {
 }
 
 /**
- * Path B — self-hosted (spec §5.4).
+ * Self-hosted.
  *
  * Documentation-first: deployment shapes differ too much for a wizard to guide
  * any of them honestly, so this step names the option, links out, and hands to
- * path D. It deliberately shows no prerequisites, no install command and no
+ * the manual environment step. It deliberately shows no prerequisites, no install command and no
  * default address — all three would assume a deployment shape, and
  * self-hosting means any cluster the user controls, remote or local.
  */

--- a/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
+++ b/desktop-app/ui/src/pages/OnboardingPage/steps/SelfHosted.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
-import { useAuthContext } from '@contexts/AuthContext'
-import { Button } from '@components/Common'
+import { LinkOutStep } from './LinkOutStep'
 
 interface SelfHostedProps {
   /** Continue into the manual environment step, which owns the submit path. */
@@ -17,50 +15,16 @@ interface SelfHostedProps {
  * self-hosting means any cluster the user controls, remote or local.
  */
 export function SelfHosted({ onContinue }: SelfHostedProps) {
-  const { busy, setStatus } = useAuthContext()
-  const [openingDocs, setOpeningDocs] = useState(false)
-
-  const handleOpenDocs = async () => {
-    if (openingDocs) return
-    setOpeningDocs(true)
-    try {
-      // Vite can hot-reload renderer code while Electron still runs an older
-      // preload script, matching the guard on the environment delete action.
-      if (typeof window.clerum.auth.openDeploymentDocs !== 'function') {
-        throw new Error('Restart the desktop app to finish loading the deployment guide link')
-      }
-      await window.clerum.auth.openDeploymentDocs()
-      setStatus('Deployment guide opened in your browser.', 'success', undefined, {
-        global: false,
-        toast: true,
-      })
-    } catch (error) {
-      setStatus(
-        `The deployment guide could not be opened: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-        'error'
-      )
-    } finally {
-      setOpeningDocs(false)
-    }
-  }
-
   return (
-    <>
-      <h1>Run Evenfire yourself</h1>
-      <p className="muted">
-        Deploy Evenfire to a Kubernetes cluster you control — your own infrastructure or a local
-        one. The deployment guide covers both, including what each shape needs.
-      </p>
-      <div className="auth-flow-card__actions">
-        <Button block disabled={busy || openingDocs} onClick={() => void handleOpenDocs()}>
-          Open the deployment guide
-        </Button>
-        <Button block disabled={busy} onClick={onContinue} variant="soft">
-          I have a server — enter its address
-        </Button>
-      </div>
-    </>
+    <LinkOutStep
+      title="Run Evenfire yourself"
+      body="Deploy Evenfire to a Kubernetes cluster you control — your own infrastructure or a local one. The deployment guide covers both, including what each shape needs."
+      channel="openDeploymentDocs"
+      linkLabel="Open the deployment guide"
+      successMessage="Deployment guide opened in your browser."
+      errorMessage="The deployment guide could not be opened"
+      continueLabel="I have a server — enter its address"
+      onContinue={onContinue}
+    />
   )
 }

--- a/desktop-app/ui/src/pages/OnboardingPage/types.ts
+++ b/desktop-app/ui/src/pages/OnboardingPage/types.ts
@@ -30,8 +30,6 @@ export interface OnboardingViewModel {
   step: OnboardingStep
   /** False on the first step, which uses Q1's "I have a server address" as its skip. */
   canGoBack: boolean
-  /** Whether Q2 is part of the flow. False until the hosted project exists. */
-  hostedAvailable: boolean
   answerOrigin: (answer: OnboardingOriginAnswer) => void
   answerRunStyle: (answer: OnboardingRunStyleAnswer) => void
   goToManual: () => void

--- a/desktop-app/ui/src/pages/OnboardingPage/types.ts
+++ b/desktop-app/ui/src/pages/OnboardingPage/types.ts
@@ -1,0 +1,33 @@
+/**
+ * First-run onboarding types (spec §5.2).
+ *
+ * The wizard is one page with a step model and an explicit history stack, not
+ * a set of routes. Answers live in the controller; only a path's terminal
+ * action touches disk.
+ */
+
+export type OnboardingStep = 'origin' | 'runStyle' | 'invited' | 'selfHosted' | 'manual'
+
+/** Q1 — "Do you already have an Evenfire server?" */
+export type OnboardingOriginAnswer = 'invited' | 'haveAddress' | 'gettingStarted'
+
+/**
+ * Q2 — "How do you want to run Evenfire?"
+ *
+ * Only reachable once the hosted trial path ships; until then Q1's
+ * "just getting started" goes straight to the self-hosted step (spec §7.1).
+ */
+export type OnboardingRunStyleAnswer = 'hosted' | 'selfHosted'
+
+export interface OnboardingViewModel {
+  step: OnboardingStep
+  /** False on the first step, which uses Q1's "I have a server address" as its skip. */
+  canGoBack: boolean
+  /** Whether Q2 is part of the flow. False until the hosted project exists. */
+  hostedAvailable: boolean
+  answerOrigin: (answer: OnboardingOriginAnswer) => void
+  answerRunStyle: (answer: OnboardingRunStyleAnswer) => void
+  goToManual: () => void
+  back: () => void
+  reset: () => void
+}

--- a/desktop-app/ui/src/pages/OnboardingPage/types.ts
+++ b/desktop-app/ui/src/pages/OnboardingPage/types.ts
@@ -6,17 +6,12 @@
  * action touches disk.
  */
 
-export type OnboardingStep = 'origin' | 'runStyle' | 'invited' | 'selfHosted' | 'manual'
+export type OnboardingStep = 'origin' | 'runStyle' | 'invited' | 'hosted' | 'selfHosted' | 'manual'
 
 /** Q1 — "Do you already have an Evenfire server?" */
 export type OnboardingOriginAnswer = 'invited' | 'haveAddress' | 'gettingStarted'
 
-/**
- * Q2 — "How do you want to run Evenfire?"
- *
- * Only reachable once the hosted trial path ships; until then Q1's
- * "just getting started" goes straight to the self-hosted step (spec §7.1).
- */
+/** Q2 — "How do you want to run Evenfire?" */
 export type OnboardingRunStyleAnswer = 'hosted' | 'selfHosted'
 
 export interface OnboardingViewModel {

--- a/desktop-app/ui/src/pages/OnboardingPage/types.ts
+++ b/desktop-app/ui/src/pages/OnboardingPage/types.ts
@@ -1,5 +1,5 @@
 /**
- * First-run onboarding types (spec §5.2).
+ * First-run onboarding types.
  *
  * The wizard is one page with a step model and an explicit history stack, not
  * a set of routes. Answers live in the controller; only a path's terminal

--- a/desktop-app/ui/src/pages/OnboardingPage/types.ts
+++ b/desktop-app/ui/src/pages/OnboardingPage/types.ts
@@ -6,13 +6,25 @@
  * action touches disk.
  */
 
-export type OnboardingStep = 'origin' | 'runStyle' | 'invited' | 'hosted' | 'selfHosted' | 'manual'
+export type OnboardingStep =
+  | 'origin'
+  | 'runStyle'
+  | 'compare'
+  | 'invited'
+  | 'hosted'
+  | 'selfHosted'
+  | 'manual'
 
 /** Q1 — "Do you already have an Evenfire server?" */
 export type OnboardingOriginAnswer = 'invited' | 'haveAddress' | 'gettingStarted'
 
-/** Q2 — "How do you want to run Evenfire?" */
-export type OnboardingRunStyleAnswer = 'hosted' | 'selfHosted'
+/**
+ * Q2 — "How do you want to run Evenfire?"
+ *
+ * `compare` is the undecided answer: it leads to a side-by-side of the other
+ * two rather than committing the user to either.
+ */
+export type OnboardingRunStyleAnswer = 'hosted' | 'selfHosted' | 'compare'
 
 export interface OnboardingViewModel {
   step: OnboardingStep

--- a/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
@@ -78,10 +78,12 @@ function renderAuthPage(auth?: Partial<AuthContextValue>) {
 }
 
 describe('AuthPage', () => {
-  it('asks for invitation email when no environment is configured', async () => {
-    const user = userEvent.setup()
+  // The invitation email form moved to onboarding's invited step (spec §5.5).
+  // AuthPage has one mode again, and must keep it even if it is somehow
+  // rendered without an environment — the unauthenticated branch routes that
+  // case to OnboardingPage instead.
+  it('renders sign-in only, never the invitation form, when no environment is configured', () => {
     const handleStartDesktopSetup = vi.fn()
-    const setEmail = vi.fn()
 
     renderAuthPage({
       runtimeConfigMissing: true,
@@ -95,16 +97,13 @@ describe('AuthPage', () => {
         options: [],
       },
       email: 'new-user@example.com',
-      setEmail,
       handleStartDesktopSetup,
     })
 
     expect(screen.getByLabelText('Email')).toBeTruthy()
-    expect(screen.queryByLabelText('Password')).toBeNull()
-
-    await user.click(screen.getByRole('button', { name: 'Continue setup' }))
-
-    expect(handleStartDesktopSetup).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText('Password')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Continue setup' })).toBeNull()
+    expect(handleStartDesktopSetup).not.toHaveBeenCalled()
   })
 
   it('hides login while adding an environment and can return to login', async () => {

--- a/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
@@ -87,7 +87,7 @@ function renderAuthPage(auth?: Partial<AuthContextValue>) {
 }
 
 describe('AuthPage', () => {
-  // The invitation email form moved to onboarding's invited step (spec §5.5).
+  // The invitation email form moved to onboarding's invited step.
   // AuthPage has one mode again, and must keep it even if it is somehow
   // rendered without an environment — the unauthenticated branch routes that
   // case to OnboardingPage instead.

--- a/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/AuthPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { LOCALHOST_RUNTIME_CONFIG_OPTION_ID } from '../../constants/runtimeConfig'
@@ -9,6 +9,15 @@ import { AuthPage } from '../AuthPage'
 
 afterEach(() => {
   cleanup()
+})
+
+// The environment dock probes for a local Evenfire and only lists Localhost
+// when one answers, so these tests must say whether one is running.
+let probeLocalhostReachable = vi.fn()
+
+beforeEach(() => {
+  probeLocalhostReachable = vi.fn().mockResolvedValue(false)
+  ;(window as unknown as { clerum: unknown }).clerum = { auth: { probeLocalhostReachable } }
 })
 
 const makeAuthValue = (overrides: Partial<AuthContextValue> = {}): AuthContextValue => ({
@@ -129,9 +138,10 @@ describe('AuthPage', () => {
     expect(screen.queryByLabelText('Environment name')).toBeNull()
   })
 
-  it('shows localhost in the environment menu even when no options are configured', async () => {
+  it('shows localhost in the environment menu when one is detected', async () => {
     const user = userEvent.setup()
     const handleSelectRuntimeConfig = vi.fn()
+    probeLocalhostReachable.mockResolvedValue(true)
 
     renderAuthPage({
       runtimeConfigMissing: true,
@@ -149,14 +159,44 @@ describe('AuthPage', () => {
 
     await user.click(screen.getByLabelText('Open environment selector'))
 
-    expect(screen.getByRole('button', { name: 'Localhost' })).toBeTruthy()
-    expect(
-      screen.getByRole('button', { name: 'Localhost' }).getAttribute('aria-current')
-    ).toBeNull()
+    const localhost = await screen.findByRole('button', { name: 'Localhost' })
+    expect(localhost.getAttribute('aria-current')).toBeNull()
 
-    await user.click(screen.getByRole('button', { name: 'Localhost' }))
+    await user.click(localhost)
 
     expect(handleSelectRuntimeConfig).toHaveBeenCalledWith(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
+  })
+
+  it('omits localhost from the environment menu when nothing is running', async () => {
+    const user = userEvent.setup()
+
+    renderAuthPage()
+
+    await user.click(screen.getByLabelText('Open environment selector'))
+
+    expect(screen.queryByRole('button', { name: 'Localhost' })).toBeNull()
+  })
+
+  it('keeps localhost listed while it is the active environment', async () => {
+    const user = userEvent.setup()
+
+    // A local cluster that went down mid-session must not silently vanish from
+    // the menu the user is currently pointed at.
+    renderAuthPage({
+      runtimeConfigState: {
+        configured: true,
+        isLocalhost: true,
+        selectorVisible: true,
+        activeOptionId: LOCALHOST_RUNTIME_CONFIG_OPTION_ID,
+        envKey: 'env-test-key',
+        storagePath: '/tmp/evenfire-runtime-config',
+        options: [],
+      },
+    })
+
+    await user.click(screen.getByLabelText('Open environment selector'))
+
+    expect(screen.getByRole('button', { name: 'Localhost' })).toBeTruthy()
   })
 
   it('offers a switch-and-retry action when a backend-mismatch hint is present', async () => {

--- a/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
@@ -14,12 +14,14 @@ afterEach(() => {
 
 let probeLocalhostReachable = vi.fn()
 let openDeploymentDocs = vi.fn()
+let openHostedSignup = vi.fn()
 
 beforeEach(() => {
   probeLocalhostReachable = vi.fn().mockResolvedValue(false)
   openDeploymentDocs = vi.fn().mockResolvedValue({ opened: true })
+  openHostedSignup = vi.fn().mockResolvedValue({ opened: true })
   ;(window as unknown as { clerum: unknown }).clerum = {
-    auth: { probeLocalhostReachable, openDeploymentDocs },
+    auth: { probeLocalhostReachable, openDeploymentDocs, openHostedSignup },
   }
 })
 
@@ -132,16 +134,47 @@ describe('OnboardingPage', () => {
     expect(screen.getByLabelText('External REST API')).toBeTruthy()
   })
 
-  it('sends the getting-started answer to the self-hosted step while path A is unavailable', async () => {
+  it('sends the getting-started answer to Q2, leading with the hosted option', async () => {
     const user = userEvent.setup()
 
     renderOnboarding()
 
     await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
 
-    // Q2 is skipped entirely rather than offering a choice with one real answer.
-    expect(screen.queryByText('How do you want to run Evenfire?')).toBeNull()
-    expect(screen.getByText('Run Evenfire yourself')).toBeTruthy()
+    expect(screen.getByText('How do you want to run Evenfire?')).toBeTruthy()
+    const options = screen.getAllByRole('button', { name: /Evenfire hosts it|run it myself/ })
+    // Hosting is what someone just getting started should see first.
+    expect(options[0]?.textContent).toContain('Evenfire hosts it for me')
+  })
+
+  it('does not promise a trial the hosted service cannot deliver yet', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+
+    const hosted = screen.getByRole('button', { name: /Evenfire hosts it for me/ })
+    expect(hosted.textContent).not.toMatch(/free|trial|week|\d+\s*day/i)
+  })
+
+  it('routes the hosted answer to a link-out step with a manual fallback', async () => {
+    const user = userEvent.setup()
+    const handleSaveRuntimeConfig = vi.fn()
+
+    renderOnboarding({ handleSaveRuntimeConfig })
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /Evenfire hosts it for me/ }))
+
+    expect(screen.getByText('Evenfire hosts it for you')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'See hosted Evenfire' }))
+    expect(openHostedSignup).toHaveBeenCalledTimes(1)
+    // No argument: the renderer never names a URL for the main process (spec §6.8).
+    expect(openHostedSignup).toHaveBeenCalledWith()
+    expect(handleSaveRuntimeConfig).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: /I have a server — enter its address/ }))
+    expect(screen.getByLabelText('Environment name')).toBeTruthy()
   })
 
   it('keeps the self-hosted step neutral about where the server runs', async () => {
@@ -149,6 +182,7 @@ describe('OnboardingPage', () => {
 
     renderOnboarding()
     await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I’ll run it myself/ }))
 
     const step = screen.getByText('Run Evenfire yourself').closest('section')
     const copy = step?.textContent || ''
@@ -163,6 +197,7 @@ describe('OnboardingPage', () => {
 
     renderOnboarding({ handleSaveRuntimeConfig })
     await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I’ll run it myself/ }))
     await user.click(screen.getByRole('button', { name: 'Open the deployment guide' }))
 
     expect(openDeploymentDocs).toHaveBeenCalledTimes(1)
@@ -176,22 +211,27 @@ describe('OnboardingPage', () => {
 
     renderOnboarding()
     await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I’ll run it myself/ }))
     await user.click(screen.getByRole('button', { name: /I have a server — enter its address/ }))
 
     expect(screen.getByLabelText('Environment name')).toBeTruthy()
   })
 
-  it('walks back to the previous step, and to Q1 from a two-step path', async () => {
+  it('walks back through every step of the longest path to Q1', async () => {
     const user = userEvent.setup()
 
     renderOnboarding()
     await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I’ll run it myself/ }))
     await user.click(screen.getByRole('button', { name: /I have a server — enter its address/ }))
 
     expect(screen.getByLabelText('Environment name')).toBeTruthy()
 
     await user.click(screen.getByRole('button', { name: 'Back' }))
     expect(screen.getByText('Run Evenfire yourself')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(screen.getByText('How do you want to run Evenfire?')).toBeTruthy()
 
     await user.click(screen.getByRole('button', { name: 'Back' }))
     expect(screen.getByText('Do you already have an Evenfire server?')).toBeTruthy()

--- a/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LOCALHOST_RUNTIME_CONFIG_OPTION_ID } from '../../constants/runtimeConfig'
+import { AuthContext } from '../../contexts/AuthContext'
+import type { AuthContextValue } from '../../contexts/AuthContext'
+import { useOnboardingController } from '../../hooks/domain/useOnboardingController'
+import { OnboardingPage } from '../OnboardingPage'
+
+afterEach(() => {
+  cleanup()
+})
+
+let probeLocalhostReachable = vi.fn()
+let openDeploymentDocs = vi.fn()
+
+beforeEach(() => {
+  probeLocalhostReachable = vi.fn().mockResolvedValue(false)
+  openDeploymentDocs = vi.fn().mockResolvedValue({ opened: true })
+  ;(window as unknown as { clerum: unknown }).clerum = {
+    auth: { probeLocalhostReachable, openDeploymentDocs },
+  }
+})
+
+const makeAuthValue = (overrides: Partial<AuthContextValue> = {}): AuthContextValue => ({
+  booting: false,
+  busy: false,
+  statusText: 'Ready.',
+  statusTone: 'info',
+  isAuthenticated: false,
+  me: null,
+  email: '',
+  password: '',
+  desktopSetupAuthorizationToken: '',
+  desktopSetupStarted: false,
+  desktopEnvironmentSetupComplete: false,
+  runtimeConfigSetupName: '',
+  runtimeConfigSetupExternalRestApiBaseUrl: '',
+  runtimeConfigSetupRpcProxyBaseUrl: '',
+  authTransitioning: false,
+  runtimeConfigState: {
+    configured: false,
+    isLocalhost: false,
+    selectorVisible: true,
+    activeOptionId: null,
+    envKey: 'env-test-key',
+    storagePath: '/tmp/evenfire-runtime-config',
+    options: [],
+  },
+  desktopReleaseStatus: null,
+  pendingDesktopEnvironmentSetup: null,
+  backendSwitchHint: null,
+  runtimeConfigMissing: true,
+  showRuntimeConfigSelector: false,
+  dependencyHealth: null,
+  hasDependencyOutage: false,
+  setBooting: vi.fn(),
+  setEmail: vi.fn(),
+  setPassword: vi.fn(),
+  setDesktopSetupAuthorizationToken: vi.fn(),
+  setDesktopEnvironmentSetupComplete: vi.fn(),
+  setPendingDesktopEnvironmentSetup: vi.fn(),
+  setRuntimeConfigSetupName: vi.fn(),
+  setRuntimeConfigSetupExternalRestApiBaseUrl: vi.fn(),
+  setRuntimeConfigSetupRpcProxyBaseUrl: vi.fn(),
+  setStatus: vi.fn(),
+  loadSession: vi.fn(),
+  handlePasswordLogin: vi.fn(),
+  handleSwitchLoginBackend: vi.fn(),
+  handleStartDesktopSetup: vi.fn(),
+  handleCompleteDesktopSetup: vi.fn(),
+  handleSaveRuntimeConfig: vi.fn(),
+  handleDeleteRuntimeConfig: vi.fn(),
+  handleSelectRuntimeConfig: vi.fn(),
+  handleClearRuntimeConfigSelection: vi.fn(),
+  handleCancelDesktopEnvironmentSetup: vi.fn(),
+  handleConfirmDesktopEnvironmentSetup: vi.fn(),
+  handleOpenDesktopRelease: vi.fn(),
+  handleLogout: vi.fn(),
+  ...overrides,
+})
+
+/** Drives the page with the real controller, so routing is exercised end to end. */
+function OnboardingHarness() {
+  const onboarding = useOnboardingController()
+  return <OnboardingPage onboarding={onboarding} />
+}
+
+function renderOnboarding(auth?: Partial<AuthContextValue>) {
+  return render(
+    <AuthContext.Provider value={makeAuthValue(auth)}>
+      <OnboardingHarness />
+    </AuthContext.Provider>
+  )
+}
+
+describe('OnboardingPage', () => {
+  it('opens on Q1 with the three origin answers', () => {
+    renderOnboarding()
+
+    expect(screen.getByText('Do you already have an Evenfire server?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /My team already uses Evenfire/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /I have a server address/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /No, I’m just getting started/ })).toBeTruthy()
+    // The first step is the one with no way back; Q1's second answer is its skip.
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull()
+  })
+
+  it('routes the invited answer to the invitation step with its existing handler', async () => {
+    const user = userEvent.setup()
+    const handleStartDesktopSetup = vi.fn()
+
+    renderOnboarding({ email: 'invited@example.com', handleStartDesktopSetup })
+
+    await user.click(screen.getByRole('button', { name: /My team already uses Evenfire/ }))
+
+    expect(screen.getByLabelText('Email')).toBeTruthy()
+    await user.click(screen.getByRole('button', { name: 'Continue setup' }))
+
+    expect(handleStartDesktopSetup).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes the have-an-address answer straight to the manual environment form', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+
+    await user.click(screen.getByRole('button', { name: /I have a server address/ }))
+
+    expect(screen.getByLabelText('Environment name')).toBeTruthy()
+    expect(screen.getByLabelText('External REST API')).toBeTruthy()
+  })
+
+  it('sends the getting-started answer to the self-hosted step while path A is unavailable', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+
+    // Q2 is skipped entirely rather than offering a choice with one real answer.
+    expect(screen.queryByText('How do you want to run Evenfire?')).toBeNull()
+    expect(screen.getByText('Run Evenfire yourself')).toBeTruthy()
+  })
+
+  it('keeps the self-hosted step neutral about where the server runs', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+
+    const step = screen.getByText('Run Evenfire yourself').closest('section')
+    const copy = step?.textContent || ''
+    // Self-hosting means any cluster the user controls (spec §5.4). No install
+    // command, no RAM figure, no loopback default, no single deployment shape.
+    expect(copy).not.toMatch(/minikube|docker|127\.0\.0\.1|localhost|GB|RAM|your machine/i)
+  })
+
+  it('opens the deployment guide without writing an environment', async () => {
+    const user = userEvent.setup()
+    const handleSaveRuntimeConfig = vi.fn()
+
+    renderOnboarding({ handleSaveRuntimeConfig })
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: 'Open the deployment guide' }))
+
+    expect(openDeploymentDocs).toHaveBeenCalledTimes(1)
+    // No argument: the renderer never names a URL for the main process (spec §6.8).
+    expect(openDeploymentDocs).toHaveBeenCalledWith()
+    expect(handleSaveRuntimeConfig).not.toHaveBeenCalled()
+  })
+
+  it('hands the self-hosted path to the manual environment form', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I have a server — enter its address/ }))
+
+    expect(screen.getByLabelText('Environment name')).toBeTruthy()
+  })
+
+  it('walks back to the previous step, and to Q1 from a two-step path', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I have a server — enter its address/ }))
+
+    expect(screen.getByLabelText('Environment name')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(screen.getByText('Run Evenfire yourself')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(screen.getByText('Do you already have an Evenfire server?')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull()
+  })
+
+  it('offers the local cluster when one answers, and selects the existing option', async () => {
+    const user = userEvent.setup()
+    const handleSelectRuntimeConfig = vi.fn()
+    probeLocalhostReachable.mockResolvedValue(true)
+
+    renderOnboarding({ handleSelectRuntimeConfig })
+    await user.click(screen.getByRole('button', { name: /I have a server address/ }))
+
+    const hint = await screen.findByRole('button', { name: 'Use Localhost' })
+    // The probe takes no URL argument (spec §5.6).
+    expect(probeLocalhostReachable).toHaveBeenCalledWith()
+
+    await user.click(hint)
+
+    // Reuses the built-in Localhost option rather than saving a duplicate
+    // environment that points at the same address.
+    expect(handleSelectRuntimeConfig).toHaveBeenCalledWith(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
+  })
+
+  it('shows no local-cluster hint when nothing answers', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /I have a server address/ }))
+
+    await screen.findByLabelText('Environment name')
+    expect(probeLocalhostReachable).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button', { name: 'Use Localhost' })).toBeNull()
+  })
+
+  it('keeps the Localhost escape hatch reachable from onboarding', async () => {
+    const user = userEvent.setup()
+    const handleSelectRuntimeConfig = vi.fn()
+
+    renderOnboarding({ handleSelectRuntimeConfig })
+
+    await user.click(screen.getByLabelText('Open environment selector'))
+    await user.click(screen.getByRole('button', { name: 'Localhost' }))
+
+    expect(handleSelectRuntimeConfig).toHaveBeenCalledWith(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
+  })
+
+  it('saves through the same submit path as the AuthPage environment form', async () => {
+    const user = userEvent.setup()
+    const handleSaveRuntimeConfig = vi.fn().mockResolvedValue(null)
+
+    renderOnboarding({
+      handleSaveRuntimeConfig,
+      runtimeConfigSetupName: 'Production',
+      runtimeConfigSetupExternalRestApiBaseUrl: 'https://evenfire.example.com',
+    })
+
+    await user.click(screen.getByRole('button', { name: /I have a server address/ }))
+    await user.click(screen.getByRole('button', { name: 'Save environment' }))
+
+    expect(handleSaveRuntimeConfig).toHaveBeenCalledTimes(1)
+  })
+})

--- a/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
@@ -157,6 +157,53 @@ describe('OnboardingPage', () => {
     expect(hosted.textContent).not.toMatch(/free|trial|week|\d+\s*day/i)
   })
 
+  it('offers an undecided answer that compares the two run styles', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I have no idea/ }))
+
+    expect(screen.getByText('Which one is right for you?')).toBeTruthy()
+
+    // Both options are described, each with an upside and a downside — a
+    // comparison that only lists benefits is an advert, not a comparison.
+    const compare = screen.getByText('Which one is right for you?').closest('section')
+    const copy = compare?.textContent || ''
+    expect(copy).toContain('Evenfire hosts it')
+    expect(copy).toContain('You run it yourself')
+    expect(screen.getAllByText('+').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText('−').length).toBe(2)
+  })
+
+  it('makes no cost claims while hosted signup does not exist', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I have no idea/ }))
+
+    const copy = screen.getByText('Which one is right for you?').closest('section')?.textContent
+    expect(copy).not.toMatch(/free|trial|price|pricing|\$|per seat|subscription/i)
+  })
+
+  it('lets the undecided user commit to either run style', async () => {
+    const user = userEvent.setup()
+
+    renderOnboarding()
+    await user.click(screen.getByRole('button', { name: /No, I’m just getting started/ }))
+    await user.click(screen.getByRole('button', { name: /I have no idea/ }))
+    await user.click(screen.getByRole('button', { name: 'I’ll run it myself' }))
+    expect(screen.getByText('Run Evenfire yourself')).toBeTruthy()
+
+    // Back returns to the comparison, not past it to Q2.
+    await user.click(screen.getByRole('button', { name: 'Back' }))
+    expect(screen.getByText('Which one is right for you?')).toBeTruthy()
+
+    await user.click(screen.getByRole('button', { name: 'Evenfire hosts it' }))
+    expect(screen.getByText('Evenfire hosts it for you')).toBeTruthy()
+  })
+
   it('routes the hosted answer to a link-out step with a manual fallback', async () => {
     const user = userEvent.setup()
     const handleSaveRuntimeConfig = vi.fn()

--- a/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
@@ -246,36 +246,44 @@ describe('OnboardingPage', () => {
     renderOnboarding({ handleSelectRuntimeConfig })
     await user.click(screen.getByRole('button', { name: /I have a server address/ }))
 
-    const hint = await screen.findByRole('button', { name: 'Use Localhost' })
+    // Presented as a plain option carrying its address, not a callout banner.
+    const option = await screen.findByRole('button', { name: /Localhost/ })
+    expect(option.textContent).toContain('http://127.0.0.1:8091')
     // The probe takes no URL argument (spec §5.6).
     expect(probeLocalhostReachable).toHaveBeenCalledWith()
 
-    await user.click(hint)
+    await user.click(option)
 
     // Reuses the built-in Localhost option rather than saving a duplicate
     // environment that points at the same address.
     expect(handleSelectRuntimeConfig).toHaveBeenCalledWith(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
   })
 
-  it('shows no local-cluster hint when nothing answers', async () => {
+  it('shows nothing about Localhost anywhere when nothing answers', async () => {
     const user = userEvent.setup()
 
     renderOnboarding()
     await user.click(screen.getByRole('button', { name: /I have a server address/ }))
-
     await screen.findByLabelText('Environment name')
-    expect(probeLocalhostReachable).toHaveBeenCalledTimes(1)
-    expect(screen.queryByRole('button', { name: 'Use Localhost' })).toBeNull()
+
+    expect(probeLocalhostReachable).toHaveBeenCalledWith()
+    expect(screen.queryByRole('button', { name: /Localhost/ })).toBeNull()
+
+    // Not in the environment dock either — the menu must not advertise a
+    // server that isn't running.
+    await user.click(screen.getByLabelText('Open environment selector'))
+    expect(screen.queryByRole('button', { name: /Localhost/ })).toBeNull()
   })
 
-  it('keeps the Localhost escape hatch reachable from onboarding', async () => {
+  it('keeps the Localhost escape hatch in the dock once one is detected', async () => {
     const user = userEvent.setup()
     const handleSelectRuntimeConfig = vi.fn()
+    probeLocalhostReachable.mockResolvedValue(true)
 
     renderOnboarding({ handleSelectRuntimeConfig })
 
     await user.click(screen.getByLabelText('Open environment selector'))
-    await user.click(screen.getByRole('button', { name: 'Localhost' }))
+    await user.click(await screen.findByRole('button', { name: 'Localhost' }))
 
     expect(handleSelectRuntimeConfig).toHaveBeenCalledWith(LOCALHOST_RUNTIME_CONFIG_OPTION_ID)
   })

--- a/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/desktop-app/ui/src/pages/__tests__/OnboardingPage.test.tsx
@@ -216,7 +216,7 @@ describe('OnboardingPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'See hosted Evenfire' }))
     expect(openHostedSignup).toHaveBeenCalledTimes(1)
-    // No argument: the renderer never names a URL for the main process (spec §6.8).
+    // No argument: the renderer never names a URL for the main process.
     expect(openHostedSignup).toHaveBeenCalledWith()
     expect(handleSaveRuntimeConfig).not.toHaveBeenCalled()
 
@@ -233,7 +233,7 @@ describe('OnboardingPage', () => {
 
     const step = screen.getByText('Run Evenfire yourself').closest('section')
     const copy = step?.textContent || ''
-    // Self-hosting means any cluster the user controls (spec §5.4). No install
+    // Self-hosting means any cluster the user controls. No install
     // command, no RAM figure, no loopback default, no single deployment shape.
     expect(copy).not.toMatch(/minikube|docker|127\.0\.0\.1|localhost|GB|RAM|your machine/i)
   })
@@ -248,7 +248,7 @@ describe('OnboardingPage', () => {
     await user.click(screen.getByRole('button', { name: 'Open the deployment guide' }))
 
     expect(openDeploymentDocs).toHaveBeenCalledTimes(1)
-    // No argument: the renderer never names a URL for the main process (spec §6.8).
+    // No argument: the renderer never names a URL for the main process.
     expect(openDeploymentDocs).toHaveBeenCalledWith()
     expect(handleSaveRuntimeConfig).not.toHaveBeenCalled()
   })
@@ -296,7 +296,7 @@ describe('OnboardingPage', () => {
     // Presented as a plain option carrying its address, not a callout banner.
     const option = await screen.findByRole('button', { name: /Localhost/ })
     expect(option.textContent).toContain('http://127.0.0.1:8091')
-    // The probe takes no URL argument (spec §5.6).
+    // The probe takes no URL argument.
     expect(probeLocalhostReachable).toHaveBeenCalledWith()
 
     await user.click(option)

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -9995,43 +9995,15 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
   animation: boot-screen-out var(--boot-exit-duration) ease forwards;
 }
 
+/* The splash carries the same lockup as the auth cards, one step larger since
+   it stands alone on a full-screen backdrop rather than above a form. */
 .boot-brand {
+  --brand-lockup-height: 34px;
+
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2-5);
   opacity: 0;
   animation: boot-brand-in 600ms cubic-bezier(0.2, 0.8, 0.25, 1) both;
-}
-
-.boot-brand-mark {
-  width: 44px;
-  height: 44px;
-  flex: 0 0 auto;
-  object-fit: contain;
-}
-
-.boot-brand-copy {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-  text-align: left;
-}
-
-.boot-brand-title {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-tight);
-  color: var(--text);
-}
-
-.boot-brand-subtitle {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-bold);
-  line-height: 1.15;
-  color: var(--text-muted);
-  letter-spacing: var(--letter-spacing-caps);
-  text-transform: uppercase;
-  white-space: nowrap;
 }
 
 .boot-progress {
@@ -10129,42 +10101,54 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
 .auth-card__header {
   display: grid;
   gap: var(--space-2);
+  justify-items: center;
 }
 
+/* Hairline separating the brand from the form or wizard step below. Its own
+   element rather than a border on the header, so the space above and below is
+   the rule's own margin and can be tuned without touching header padding.
+   Uses the edge token so it tracks the theme instead of pinning one grey. */
+.auth-card__divider {
+  width: 70%;
+  height: 1px;
+  /* No margin — the card's grid gap already spaces this. `justify-self` does
+     the centering instead, so the two never compound. */
+  justify-self: center;
+  background: rgba(var(--edge-rgb), 0.3);
+}
+
+/* One logotype asset carrying mark and wordmark together, the same lockup
+   Control UI's login card and this app's SidebarNav use — not the square mark
+   beside hand-typed text. Shared by every brand surface (auth, onboarding, the
+   boot splash) so they cannot drift apart. The two theme files are swapped by
+   CSS rather than by reading the theme in JS, so the right one paints on the
+   first frame. Height is a variable so a surface can scale the lockup without
+   forking the rule. */
 .auth-brand {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2);
+  margin: var(--space-2) 0;
 }
 
-.auth-brand-mark {
-  width: 42px;
-  height: 42px;
-  flex: 0 0 auto;
+.brand-lockup {
+  display: block;
+  width: 100%;
+  max-width: 200px;
+  max-height: var(--brand-lockup-height, 28px);
   object-fit: contain;
+  background: transparent;
 }
 
-.auth-brand-copy {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
+.brand-lockup--dark {
+  display: none;
 }
 
-.auth-brand-title {
-  font-size: var(--font-size-xl);
-  font-weight: 700;
-  line-height: 1.1;
-  color: var(--text);
+:root[data-theme='dark'] .brand-lockup--light {
+  display: none;
 }
 
-.auth-brand-subtitle {
-  font-size: var(--font-size-xs);
-  font-weight: 700;
-  line-height: 1.15;
-  color: var(--text-muted);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  white-space: nowrap;
+:root[data-theme='dark'] .brand-lockup--dark {
+  display: block;
 }
 
 .auth-flow-card {
@@ -10264,10 +10248,44 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
 /* First-run onboarding (spec §5.2). The wizard reuses the auth card shell and
    the auth form/link primitives; only the answer list is new. */
 
+/* Hold one height across every step so the card stops growing and shrinking as
+   the user moves through the wizard. The body takes the slack and scrolls if a
+   step ever outgrows it, and the footer keeps Back pinned to the bottom so it
+   does not travel with the content above it. Capped against the viewport so a
+   short window scrolls instead of overflowing. */
+/* One card shape shared by every pre-authentication screen — the onboarding
+   wizard and sign-in alike — so the card never resizes as the user moves
+   between steps, or when onboarding hands off to sign-in.
+
+   Sized to the tallest content: the manual environment form with the Localhost
+   option showing, which needs ~500px (two fields, a 72px option, and the brand
+   header). Shorter screens carry the slack as empty space; that is the trade
+   for a card that holds still. Capped against the viewport so a short window
+   scrolls the body instead of overflowing. */
+.auth-card--flow {
+  height: min(540px, 86vh);
+  /* header, divider, body, footer — the body takes the slack. */
+  grid-template-rows: auto auto 1fr auto;
+}
+
+.auth-card__body {
+  display: grid;
+  gap: var(--space-3);
+  align-content: start;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.auth-card__footer {
+  display: flex;
+  align-items: end;
+  min-height: var(--space-5);
+}
+
 /* A bare h1 falls back to the browser's 2em — 32px, which is off the type
    scale entirely and oversized inside a 420px card. Pull it onto the scale,
    above the 18px brand title so the step heading still leads. */
-.onboarding-card h1 {
+.auth-card--flow h1 {
   font-size: var(--font-size-2xl);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-tight);

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -10261,6 +10261,35 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
   align-items: stretch;
 }
 
+/* First-run onboarding (spec §5.2). The wizard reuses the auth card shell and
+   the auth form/link primitives; only the answer list is new. */
+.onboarding-options {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.onboarding-option {
+  display: grid;
+  gap: var(--space-1);
+  justify-items: start;
+  text-align: left;
+  white-space: normal;
+}
+
+.onboarding-option__title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--text);
+}
+
+.onboarding-option__hint {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-regular);
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
 .auth-button-loading {
   display: inline-flex;
   align-items: center;

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -10263,6 +10263,9 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
    for a card that holds still. Capped against the viewport so a short window
    scrolls the body instead of overflowing. */
 .auth-card--flow {
+  /* 20% wider than the base auth card (420px): the wizard carries option rows
+     and the run-style comparison, which read cramped at sign-in's width. */
+  width: min(504px, 94vw);
   height: min(540px, 86vh);
   /* header, divider, body, footer — the body takes the slack. */
   grid-template-rows: auto auto 1fr auto;
@@ -10316,6 +10319,60 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
   font-weight: var(--font-weight-regular);
   line-height: 1.4;
   color: var(--text-muted);
+}
+
+/* Q2's "I have no idea" branch: the two run styles compared. Stacked rather
+   than side-by-side columns, which would be unreadable at the card's width. */
+.onboarding-compare {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.onboarding-compare__group {
+  display: grid;
+  gap: var(--space-1-5);
+}
+
+.onboarding-compare__title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--text);
+}
+
+.onboarding-compare__lead {
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.onboarding-compare__list {
+  display: grid;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.onboarding-compare__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-1-5);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.onboarding-compare__mark {
+  font-weight: var(--font-weight-semibold);
+}
+
+.onboarding-compare__mark--pro {
+  color: var(--success);
+}
+
+.onboarding-compare__mark--con {
+  color: var(--warning);
 }
 
 .auth-button-loading {

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -10263,6 +10263,16 @@ button.page-breadcrumb-link--plain-action:hover:enabled {
 
 /* First-run onboarding (spec §5.2). The wizard reuses the auth card shell and
    the auth form/link primitives; only the answer list is new. */
+
+/* A bare h1 falls back to the browser's 2em — 32px, which is off the type
+   scale entirely and oversized inside a 420px card. Pull it onto the scale,
+   above the 18px brand title so the step heading still leads. */
+.onboarding-card h1 {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+}
+
 .onboarding-options {
   display: grid;
   gap: var(--space-2);


### PR DESCRIPTION
## Why

The desktop app is a client that cannot function without a server, and it had no way to acquire one. A cold install showed a single email field labelled "Continue setup" — which only worked if that address already had an invitation registered with `member-registration-service`. Everyone else hit a dead end with no explanation of what an "Environment" was or where to get one.

## What

A first-run questionnaire that asks at most two questions and routes to one of five paths. Implements PR 1 of `specs/desktop-app-onboarding-spec.md`, plus the hosted link-out.

**Q1 — "Do you already have an Evenfire server?"**
- *My team already uses Evenfire* → invitation flow (existing handlers, new home)
- *I have a server address* → manual environment form (also the one-click skip)
- *No, I'm just getting started* → Q2

**Q2 — "How do you want to run Evenfire?"**
- *Evenfire hosts it for me* → links to the Evenfire site, falls back to the manual form
- *I'll run it myself* → links to the deployment guide, falls back to the manual form
- *I have no idea* → a comparison of the two, framed around the requirements that force the decision

`AuthPage` becomes sign-in-only. Its environment dock moves to a shared `RuntimeConfigDock` rendered by both pages, because a cold install no longer renders `AuthPage` at all and the Localhost escape hatch lives there.

## Notable decisions

**Self-hosting means any cluster the user controls — remote or local.** The spec originally scripted a minikube install with a `127.0.0.1` default and a 10GB Docker prerequisite, which quietly redefined self-hosting as "on this laptop". `docker-compose.yml` settled it: 43 lines, `mcp-host` + `channel-reader` only, `CLERUM_ENABLE_AUTH: "false"` — no external-rest-api, so it cannot produce a `DesktopRuntimeConfig` target at all. Path B now links to documentation covering both shapes and shows no prerequisites, no install command, and no default address.

**No cost claims.** Hosted signup does not exist yet — no tenant provisioning, no `evenfire://desktop-environment` handoff — so the hosted path is a link-out, not an in-app signup, and the copy promises no trial or price. Two tests assert the absence of `free|trial|price|$|per seat|subscription`, so shipping hosted signup fails them and puts the copy decision in front of a human.

**Every compared option carries a downside.** A comparison listing only upsides is an advert; a test pins the count of downside marks.

## New IPC — three calls, all no-argument

`probeLocalhostReachable`, `openDeploymentDocs`, `openHostedSignup`. All call `assertTrustedSender`, and none take a parameter: the renderer cannot name a URL for the main process to fetch or open. The probe only ever checks the built-in Localhost option.

## Dev switch

`EVENFIRE_ONBOARDING_PREVIEW=true` (default false, only the literal `"true"`) makes the app start genuinely cold so the flow can be reviewed on a configured machine — separate config directory, env runtime config ignored, real environments never read or written. `make local-app-onboarding` wraps it. Verified in both directions: on → `screen: onboarding` on the preview directory; off → `screen: sign-in` on the real one.

## Verification

- Full desktop-app suite: **198 files, 1997 tests** passing
- `npm run style-rules` clean; no new CSS files, no raw hex or font sizes
- Driven by hand in the running app across every step, both themes of the brand lockup, and with the preview flag on and off
- Profile UI handoff confirmed unaffected: both deep-link listeners live in `useAuthController` (mounted app-wide), and the confirmation/success dialogs are siblings of the page switch, so they render over onboarding as they did over sign-in

## Not in this PR

Path A proper (the `state` nonce and waiting screen), path C's `invitation_config_not_found` copy, and the trial pill — PRs 2–4 in the spec's sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DY8Fj2SQ78CNVsaGLvtWw8