### PR TITLE
fix(control-ui): correct four defects found in a browser sweep

### DIFF
--- a/control-ui/app/globals.css
+++ b/control-ui/app/globals.css
@@ -8761,14 +8761,41 @@ textarea.cu-input {
   text-align: right;
 }
 
+/* A sortable header is a header first. It previously carried `cu-link--sm`,
+   which rendered it at 13px sentence-case against the 11px uppercase static
+   `th` beside it, so the interactive columns read as less important than the
+   static ones. Sorting is signalled by the arrow, the colour and the weight. */
 .cu-table__sort-link {
-  color: var(--cu-text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cu-space-05);
+  padding: 0;
+  border: 0;
+  background: none;
+  font: inherit;
+  font-size: var(--cu-font-size-2xs);
+  font-weight: var(--cu-font-weight-semibold);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: inherit;
   white-space: nowrap;
+  cursor: pointer;
+  transition: color var(--cu-motion-base);
+}
+
+.cu-table__sort-link:hover:not(:disabled) {
+  color: var(--cu-text);
+}
+
+.cu-table__sort-link:focus-visible {
+  outline: 2px solid var(--cu-focus);
+  outline-offset: 2px;
+  border-radius: var(--cu-radius-xs);
 }
 
 .cu-table__sort-link.is-active {
   color: var(--cu-text);
-  font-weight: var(--font-weight-medium, 500);
+  font-weight: var(--cu-font-weight-bold);
 }
 
 .cu-row-actions {
@@ -9608,7 +9635,10 @@ textarea.cu-input {
   position: sticky;
   top: 0;
   height: 100vh;
-  overflow-y: auto;
+  /* The shell itself must not scroll: when it did, expanding a nav group
+     pushed Settings and Log out below the fold instead of keeping them
+     pinned. Only the destination list scrolls. */
+  overflow: hidden;
 }
 
 .cu-sidebar__brand,
@@ -9688,6 +9718,9 @@ textarea.cu-input {
   flex-direction: column;
   gap: 0.35rem;
   margin-bottom: 0.5rem;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .cu-sidebar__item {
@@ -9762,6 +9795,7 @@ textarea.cu-input {
   margin-top: auto;
   display: grid;
   gap: var(--cu-space-1);
+  flex: 0 0 auto;
 }
 
 .cu-sidebar__footer + .cu-sidebar__footer {
@@ -10701,7 +10735,7 @@ textarea.cu-input {
 }
 
 .cu-tb-name {
-  font-weight: var(--font-weight-semibold, 600);
+  font-weight: var(--cu-font-weight-semibold);
 }
 
 .cu-tb-scope {
@@ -10805,7 +10839,7 @@ textarea.cu-input {
 
 .cu-tb-progress__spent--over {
   color: var(--cu-danger);
-  font-weight: var(--font-weight-semibold, 600);
+  font-weight: var(--cu-font-weight-semibold);
 }
 
 .cu-tb-progress__sep {
@@ -10869,7 +10903,7 @@ textarea.cu-input {
 }
 
 .cu-tb-dim__label {
-  font-weight: var(--font-weight-medium, 500);
+  font-weight: var(--cu-font-weight-medium);
   color: var(--cu-text);
 }
 

--- a/control-ui/components/HostTable.tsx
+++ b/control-ui/components/HostTable.tsx
@@ -7,6 +7,7 @@ import { LlmProviderIcon } from './LlmProviderIcon'
 import { SectionSearchInput } from './SectionSearchInput'
 import { IconRobot } from './Sidebar/icons'
 import { SkeletonTableRows } from './SkeletonTableRows'
+import { TableEmptyRow } from './TableEmptyRow'
 import { TableHeaderRow } from './TableHeaderRow'
 import type { TableHeaderColumn } from './TableHeaderRow/types'
 import { TablePanelHeader } from './TablePanelHeader'
@@ -199,8 +200,23 @@ export function HostTable({
           </table>
         </div>
       ) : filteredRows.length === 0 ? (
-        <div className="cu-empty">
-          {normalizedSearch ? 'No agents match this search.' : 'No agents found.'}
+        <div className="cu-table-wrap">
+          <table className="cu-table cu-table--header-band">
+            <thead>
+              <TableHeaderRow columns={HOST_COLUMNS} />
+            </thead>
+            <tbody>
+              <TableEmptyRow
+                colSpan={HOST_COLUMNS.length}
+                message={normalizedSearch ? 'No agents match this search.' : 'No agents found.'}
+                action={
+                  normalizedSearch
+                    ? { label: 'Clear search', onSelect: () => setSearchQuery('') }
+                    : undefined
+                }
+              />
+            </tbody>
+          </table>
         </div>
       ) : (
         <div className="cu-table-wrap">

--- a/control-ui/components/MarketplaceOrgArea/index.tsx
+++ b/control-ui/components/MarketplaceOrgArea/index.tsx
@@ -111,7 +111,7 @@ export function MarketplaceOrgArea({ activeTab }: { activeTab: OrgAreaTab }) {
             )
           ) : null}
 
-          {activeTab === 'credentials' ? <RegistryApiKeysPanel /> : null}
+          {activeTab === 'credentials' ? <RegistryApiKeysPanel embedded /> : null}
 
           {activeTab === 'connection' ? <RegistryConnectPanel /> : null}
         </div>

--- a/control-ui/components/McpServerTable.tsx
+++ b/control-ui/components/McpServerTable.tsx
@@ -365,7 +365,7 @@ export function McpServerTable({
     return (
       <button
         type="button"
-        className={`cu-link cu-link--sm cu-table__sort-link${isActive ? ' is-active' : ''}`}
+        className={`cu-table__sort-link${isActive ? ' is-active' : ''}`}
         onClick={() => toggleSort(key)}
         aria-label={`Sort by ${label.toLowerCase()} ${nextDirection}`}
         aria-pressed={isActive}

--- a/control-ui/components/ProfileAdminHome.tsx
+++ b/control-ui/components/ProfileAdminHome.tsx
@@ -837,7 +837,7 @@ export function ProfileAdminHome({ activeTab, highlightedAdminId = '' }: Profile
                             <th className="cu-table__col-count">
                               <button
                                 type="button"
-                                className="cu-link cu-link--sm cu-table__sort-link"
+                                className="cu-table__sort-link"
                                 onClick={() =>
                                   setMemberTeamsSortDir(prev => (prev === 'asc' ? 'desc' : 'asc'))
                                 }

--- a/control-ui/components/RegistryApiKeysPanel.tsx
+++ b/control-ui/components/RegistryApiKeysPanel.tsx
@@ -14,6 +14,7 @@ import {
 } from '../lib/api'
 import { useConfirmDialog } from './ConfirmDialog'
 import CreateApiKeyModal from './CreateApiKeyModal'
+import type { RegistryApiKeysPanelProps } from './RegistryApiKeysPanel.types'
 import RevealApiKeyModal from './RevealApiKeyModal'
 import { SectionLoadingSkeleton } from './SectionLoadingSkeleton'
 import { TableHeaderRow } from './TableHeaderRow'
@@ -52,7 +53,7 @@ function fmtExpiry(v: string | null): string {
   return d.getTime() < Date.now() ? `Expired ${d.toLocaleDateString()}` : d.toLocaleString()
 }
 
-export default function RegistryApiKeysPanel() {
+export default function RegistryApiKeysPanel({ embedded = false }: RegistryApiKeysPanelProps) {
   const { showToast } = useToast()
   const { confirm, confirmDialog } = useConfirmDialog()
   const [view, setView] = useState<View>({ kind: 'loading' })
@@ -238,7 +239,7 @@ export default function RegistryApiKeysPanel() {
 
   return (
     <section>
-      <div className="cu-card cu-card--viewport-fill">{content}</div>
+      {embedded ? content : <div className="cu-card cu-card--viewport-fill">{content}</div>}
       {creating ? (
         <CreateApiKeyModal onCreate={handleCreate} onCancel={() => setCreating(false)} />
       ) : null}

--- a/control-ui/components/RegistryApiKeysPanel.types.ts
+++ b/control-ui/components/RegistryApiKeysPanel.types.ts
@@ -1,0 +1,8 @@
+export type RegistryApiKeysPanelProps = {
+  /**
+   * Set when the panel is rendered inside a host card. `cu-card--viewport-fill`
+   * means "fill the viewport"; nesting two of them produced the card-in-card
+   * double border on the Marketplace org area.
+   */
+  embedded?: boolean
+}

--- a/control-ui/components/RegistryCatalog.tsx
+++ b/control-ui/components/RegistryCatalog.tsx
@@ -183,7 +183,7 @@ export default function RegistryCatalog() {
     return (
       <button
         type="button"
-        className={`cu-link cu-link--sm cu-table__sort-link${isActive ? ' is-active' : ''}`}
+        className={`cu-table__sort-link${isActive ? ' is-active' : ''}`}
         onClick={() => toggleSort(key)}
         aria-label={`Sort by ${label.toLowerCase()} ${nextDirection}`}
         aria-pressed={isActive}

--- a/control-ui/components/TableEmptyRow/index.tsx
+++ b/control-ui/components/TableEmptyRow/index.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { Button } from '@components/ui'
+import type { TableEmptyRowProps } from './types'
+
+/**
+ * The empty state for a route table. It is a row, not a replacement for the
+ * table, so the column headers stay mounted: unmounting them strands the user
+ * with a line of text and no structure to orient against.
+ */
+export function TableEmptyRow({ action, colSpan, message }: TableEmptyRowProps) {
+  return (
+    <tr>
+      <td className="cu-empty" colSpan={colSpan}>
+        {message}
+        {action ? (
+          <Button className="cu-empty__action" onClick={action.onSelect} size="sm" variant="ghost">
+            {action.label}
+          </Button>
+        ) : null}
+      </td>
+    </tr>
+  )
+}

--- a/control-ui/components/TableEmptyRow/types.ts
+++ b/control-ui/components/TableEmptyRow/types.ts
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react'
+
+export type TableEmptyRowProps = {
+  /** Number of columns to span. Must match the table's header row. */
+  colSpan: number
+  message: ReactNode
+  /** Offer this when the empty state is the result of a filter the user can undo. */
+  action?: {
+    label: string
+    onSelect: () => void
+  }
+}

--- a/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
+++ b/control-ui/components/__tests__/RegistryApiKeysPanel.test.tsx
@@ -237,4 +237,22 @@ describe('RegistryApiKeysPanel', () => {
     expect(cells[0]).toHaveTextContent('efrk_new')
     expect(cells[1]).toHaveTextContent('efrk_old')
   })
+
+  it('owns its card when it is the whole page', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockResolvedValue({ org: 'acme', keys: [] })
+    const view = render(<RegistryApiKeysPanel />)
+    await waitFor(() => expect(api.listRegistryApiKeys).toHaveBeenCalled())
+
+    expect(view.container.querySelector('.cu-card--viewport-fill')).toBeInTheDocument()
+  })
+
+  it('drops its card when embedded, so it does not nest inside the host card', async () => {
+    vi.mocked(api.listRegistryApiKeys).mockResolvedValue({ org: 'acme', keys: [] })
+    const view = render(<RegistryApiKeysPanel embedded />)
+    await waitFor(() => expect(api.listRegistryApiKeys).toHaveBeenCalled())
+
+    // cu-card--viewport-fill means "fill the viewport". Two of them nested
+    // produced the visible card-in-card border on the Marketplace org area.
+    expect(view.container.querySelector('.cu-card--viewport-fill')).not.toBeInTheDocument()
+  })
 })

--- a/control-ui/components/__tests__/TableEmptyRow.test.tsx
+++ b/control-ui/components/__tests__/TableEmptyRow.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TableEmptyRow } from '../TableEmptyRow'
+
+afterEach(cleanup)
+
+function renderInTable(node: React.ReactNode) {
+  return render(
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Context</th>
+        </tr>
+      </thead>
+      <tbody>{node}</tbody>
+    </table>
+  )
+}
+
+describe('TableEmptyRow', () => {
+  it('keeps the column headers visible and spans them with the message', () => {
+    const view = renderInTable(<TableEmptyRow colSpan={2} message="No agents match this search." />)
+
+    // The header row is the point: an empty result must not unmount the table.
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toBeInTheDocument()
+    expect(screen.getByText('No agents match this search.')).toBeInTheDocument()
+    expect(view.container.querySelector('td')).toHaveAttribute('colspan', '2')
+  })
+
+  it('offers a way out when the empty state came from a filter', async () => {
+    const onSelect = vi.fn()
+    renderInTable(
+      <TableEmptyRow
+        colSpan={2}
+        message="No agents match this search."
+        action={{ label: 'Clear search', onSelect }}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+
+    expect(onSelect).toHaveBeenCalledOnce()
+  })
+})

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.459",
+  "version": "0.1.460",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.459",
+      "version": "0.1.460",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.459",
+  "version": "0.1.460",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
## Summary

**Stacked on #475 → #474 → #468.** Merge order: #468 → #474 → #475 → this.

Four defects an 18-route pass over the running dev app turned up, none of which a static audit of the stylesheet could see.

### 1. Sortable column headers were styled as body links

`.cu-table__sort-link` set only `color` and `white-space`; everything else came from `cu-link--sm`, giving **13px sentence-case** against the **11px uppercase** static `th` beside it. On LLM Models both appear in one header row, 17px apart vertically, so the four *interactive* columns read as less important than the three static ones.

The sort link now carries the header treatment and drops `cu-link--sm`. Sorting is signalled by the arrow, the colour and the weight.

While in there: its `.is-active` rule referenced `var(--font-weight-medium, 500)`, a **Desktop** token name that does not exist in control-ui. It fell back to 500 and rendered the *active* sort column **lighter** than its neighbours. Fixed, along with the three other Desktop-token references falling back the same way.

**This is the widest-blast-radius change in the whole stack** — one rule touching every sortable header in the app.

### 2. The sidebar clipped Log out

The shell itself scrolled, so expanding either nav group pushed the footer past the fold: 976px of content in an 820px viewport put *Log out* at y=952. Now the shell does not scroll, the destination list does, and the footer is pinned. Sign-out and Settings are reachable at any height with any group expanded.

### 3. Two opposite empty states

Agents replaced its **whole table, column headers included**, with one line of muted text when a search matched nothing, leaving ~700px of void. Agent Outputs did the opposite and kept its header with ghost rows.

New `TableEmptyRow` keeps the table and header mounted and offers **Clear search**. Applied to Agents here; the other tables become a one-line conversion.

### 4. Nested viewport-fill cards

The Marketplace org area nested two `cu-card--viewport-fill` elements (measured 1046px and 1001px), producing the visible card-in-card double border. That modifier means "fill the viewport".

`RegistryApiKeysPanel` is also used standalone at `/registry/keys`, so its card is legitimate and cannot just be deleted. It now takes an `embedded` prop, and the org area passes it. Its props type moves to `RegistryApiKeysPanel.types.ts` rather than sitting in the implementation file.

## Testing

- [x] `npm test` passes for changed services — 4 new tests written test-first for the two testable defects. 1711 passed, up from 1707, no regressions. The 13 `lib/__tests__/gfsFileUpload.test.ts` failures are pre-existing and identical to `origin/dev`.
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Prettier clean

## Not verified: defects 1 and 2

Both are **pure CSS with no assertable output**, and the dev deployment runs the released image rather than this branch, so I could not confirm them in a browser. Tests cannot cover them either — jsdom has no real cascade.

**Both need an eyeball before merge**, and defect 1 especially, given it changes every sortable header at once. Concretely, worth checking:

- LLM Models, Marketplace and Installed connectors: sortable headers now match the static ones, and the active sort column reads heavier rather than lighter.
- Sidebar with Files and Cost & Usage both expanded at a short viewport: Settings and Log out stay pinned and the destination list scrolls.

I would rather flag this than let the checklist imply a verification I did not do.

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)