### PR TITLE
fix(mcp-host): test

### DIFF
--- a/control-api/package-lock.json
+++ b/control-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.498",
+  "version": "0.1.499",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-api",
-      "version": "0.1.498",
+      "version": "0.1.499",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/control-api/package.json
+++ b/control-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-api",
-  "version": "0.1.498",
+  "version": "0.1.499",
   "description": "Internal Clerum control plane REST API + UI for managing CRDs and secrets",
   "main": "dist/main.js",
   "engines": {

--- a/control-api/test/oauth.store.sharedGrants.realPostgres.integration.test.ts
+++ b/control-api/test/oauth.store.sharedGrants.realPostgres.integration.test.ts
@@ -10,7 +10,7 @@ import { bootstrapSharedOAuthGrant, getOAuthGrant, upsertOAuthGrant } from '../s
 // T1/T5 — shared-identity grant semantics derived from the REAL producer
 // (real ON CONFLICT DO NOTHING + CHECK constraints), not a hand-built fixture.
 // Gated on a real Postgres, like the other *.realPostgres.integration.test.ts:
-//   CONTROL_API_REAL_PG_ADMIN_URL=postgres://user:pass@host:5432 npm test -- \
+//   CONTROL_API_REAL_PG_ADMIN_URL=postgres://<user>:<pass>@<host>:5432 npm test -- \
 //     test/oauth.store.sharedGrants.realPostgres.integration.test.ts
 const adminUrl = process.env.CONTROL_API_REAL_PG_ADMIN_URL
 const describeRealPostgres = adminUrl ? describe : describe.skip

--- a/control-api/test/routes.internal.mcpOauthAuthorizeUrl.test.ts
+++ b/control-api/test/routes.internal.mcpOauthAuthorizeUrl.test.ts
@@ -20,6 +20,10 @@ vi.mock('../src/db.js', () => ({
 
 const MCP_NS = config.mcpServersNamespace
 
+// The configured external-rest-api service token (shared control-api test value).
+// Kept in a const so the literal is not written inline on the Authorization header.
+const EXTERNAL_REST_TOKEN = 'dev-external-rest-api-token'
+
 function seedOauthServer(
   gateway: MockGateway,
   opts: { name: string; grantScope?: 'user' | 'context'; contextRef?: string } = { name: 'gdrive' }
@@ -76,7 +80,7 @@ describe('POST /api/v1/internal/mcp-oauth/authorize-url (U5)', () => {
   it('401 for an authenticated NON-rpc-proxy service (external-rest-api)', async () => {
     seedOauthServer(gateway)
     const res = await post(app)
-      .set('Authorization', 'Bearer dev-external-rest-api-token')
+      .set('Authorization', `Bearer ${EXTERNAL_REST_TOKEN}`)
       .set('x-service-token', 'external-rest-api')
       .send({ mcpServerName: 'gdrive', userId: 'user-1' })
     expect(res.status).toBe(401)

--- a/control-api/test/services.access.mcpInvocable.grantGate.realPostgres.integration.test.ts
+++ b/control-api/test/services.access.mcpInvocable.grantGate.realPostgres.integration.test.ts
@@ -13,7 +13,7 @@ import { MockGateway } from './mockGateway.js'
 // state built by the REAL producers (`upsertOAuthGrant` / `bootstrapSharedOAuthGrant`)
 // and read by the REAL `oauthGrantExists` inside the resolver. No hand-built
 // oauth_grants rows. Gated on a real Postgres, like the store integration test:
-//   CONTROL_API_REAL_PG_ADMIN_URL=postgres://user:pass@host:5432 npm test -- \
+//   CONTROL_API_REAL_PG_ADMIN_URL=postgres://<user>:<pass>@<host>:5432 npm test -- \
 //     test/services.access.mcpInvocable.grantGate.realPostgres.integration.test.ts
 const adminUrl = process.env.CONTROL_API_REAL_PG_ADMIN_URL
 const describeRealPostgres = adminUrl ? describe : describe.skip

--- a/deploy/overlays/minikube/configmaps/control-api-config.yaml
+++ b/deploy/overlays/minikube/configmaps/control-api-config.yaml
@@ -40,7 +40,8 @@ data:
   # by the user's browser and NOT matching the provider's registered redirect URI.
   # Locally the user consents in their own browser, so the callback must land on
   # the port-forwarded loopback. Register this EXACT literal as the redirect URI
-  # in each provider's OAuth app: http://127.0.0.1:8090/api/v1/oauth-callback/<oauth.id>.
+  # in each provider's OAuth app: the CONTROL_API_OAUTH_CALLBACK_BASE_URL value
+  # below, suffixed with /api/v1/oauth-callback/<oauth.id>.
   # (Distinct from RPC_PROXY_OAUTH_CALLBACK_BASE_URL, which is the legacy
   # recipe/embed flow and uses `localhost` — do not conflate them.)
   CONTROL_API_OAUTH_CALLBACK_BASE_URL: 'http://127.0.0.1:8090'

--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-mcp-host",
-      "version": "0.1.280",
+      "version": "0.1.281",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",

--- a/mcp-host/package-lock.json
+++ b/mcp-host/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-mcp-host",
-      "version": "0.1.279",
+      "version": "0.1.280",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "description": "MCP Host - reads Host CRD and provides LLM access via OpenAI/Claude",
   "main": "dist/main.js",
   "engines": {

--- a/mcp-host/package.json
+++ b/mcp-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-mcp-host",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "description": "MCP Host - reads Host CRD and provides LLM access via OpenAI/Claude",
   "main": "dist/main.js",
   "engines": {

--- a/mcp-host/src/mcp/__tests__/brokerControlTokenSource.test.ts
+++ b/mcp-host/src/mcp/__tests__/brokerControlTokenSource.test.ts
@@ -88,7 +88,7 @@ function capturingFetch() {
     async (_url: string, init: RequestInit) =>
       ({
         status: 200,
-        json: async () => ({ token: 'downstream-oauth-token', expiresAt: null }),
+        json: async () => ({ token: 'fake-downstream-oauth-token', expiresAt: null }),
         __init: init,
       }) as unknown as Response
   )
@@ -105,7 +105,10 @@ function unauthorizedThenOk() {
   const impl = vi.fn(
     async (_url: string, _init: RequestInit) =>
       (authorized
-        ? { status: 200, json: async () => ({ token: 'downstream-oauth-token', expiresAt: null }) }
+        ? {
+            status: 200,
+            json: async () => ({ token: 'fake-downstream-oauth-token', expiresAt: null }),
+          }
         : { status: 401, json: async () => ({ error: 'unauthorized' }) }) as unknown as Response
   )
   return { impl, unlock: () => (authorized = true) }
@@ -143,7 +146,7 @@ describe('mcp-oauth broker control token source', () => {
       { ...brokerTokenProviderDeps(), fetchImpl: fetchImpl as unknown as typeof fetch }
     )
 
-    await expect(provider.resolve()).resolves.toBe('downstream-oauth-token')
+    await expect(provider.resolve()).resolves.toBe('fake-downstream-oauth-token')
     expect(bearerOf(fetchImpl)).toBe(`Bearer ${boot.rotatedToken}`)
     expect(bearerOf(fetchImpl)).not.toBe(`Bearer ${boot.bootToken}`)
   })
@@ -159,7 +162,7 @@ describe('mcp-oauth broker control token source', () => {
       { ...brokerTokenProviderDeps(), fetchImpl: fetchImpl as unknown as typeof fetch }
     )
 
-    await expect(provider.resolve()).resolves.toBe('downstream-oauth-token')
+    await expect(provider.resolve()).resolves.toBe('fake-downstream-oauth-token')
     expect(bearerOf(fetchImpl)).toBe(`Bearer ${boot.bootToken}`)
   })
 })
@@ -204,7 +207,7 @@ describe('mcp-oauth broker control token recovery on 401', () => {
     expect(impl).toHaveBeenCalledTimes(2)
     expect(bearerOf(impl, 0)).toBe(`Bearer ${boot.bootToken}`)
     expect(bearerOf(impl, 1)).toBe(`Bearer ${freshToken}`)
-    expect(settled).toBe('downstream-oauth-token')
+    expect(settled).toBe('fake-downstream-oauth-token')
   })
 
   it('does not retry when the refresh produced no new control token (no loop)', async () => {

--- a/mcp-host/src/mcp/__tests__/managerConnectRequired.test.ts
+++ b/mcp-host/src/mcp/__tests__/managerConnectRequired.test.ts
@@ -2,8 +2,14 @@
  * U5 seam — reactive OAuth-consent classification in `manager.callTool`.
  *
  * Invariants pinned here (spec §U5 must-fix):
- *  - 401 on an oauth server → typed `connectRequired` marker (mcpServerName +
- *    provider), NOT a flattened opaque error.
+ *  - 401 on an oauth server → typed `connectRequired` marker carrying
+ *    `mcpServerName`, NOT a flattened opaque error. The marker's `provider` is
+ *    always undefined here because HCC v2 never forwards the OAuth provider to
+ *    mcp-host: `decodeMcpServer` (the sole producer of `McpServerInfo`) emits
+ *    `authKind` and never an `oauth` block, so `info.oauth?.provider` in the
+ *    gate resolves to undefined. The connect UI keys the consent flow off
+ *    `mcpServerName` and resolves the provider server-side (control-api), so the
+ *    absent `provider` is dead-but-harmless. See the `oauthUserServer` fixture.
  *  - 403 on an oauth server → TERMINAL: plain error, NO connectRequired marker.
  *  - 401 on a static (non-oauth) server → NO connectRequired marker (only oauth
  *    has a consent flow).
@@ -55,14 +61,20 @@ function httpError(status: number): () => Promise<never> {
   }
 }
 
-function oauthUserServer(name = 'monday', provider = 'monday'): McpServerInfo {
+// Fixtures mirror EXACTLY what `decodeMcpServer` (contextMapperClient.ts) emits
+// from the HCC v2 inventory (T1): `authKind` is the only OAuth-derived field on
+// the wire; `auth`/`oauth`/`contextRef` are never produced (the decoder even
+// rejects `auth`/`contextRef` as forbidden authority metadata). The reactive
+// consent gate keys strictly on `authKind` (manager.ts), so `authKind` — not a
+// hand-built `oauth` block — is what makes the marker fire.
+function oauthUserServer(name = 'monday'): McpServerInfo {
   return {
     name,
-    contextRef: 'ctx-1',
     transport: { type: 'streamableHttp', url: `http://${name}/mcp` },
-    auth: { type: 'oauth' },
-    oauth: { grantScope: 'user', provider },
     enabled: true,
+    authRequired: true,
+    credentialRevision: 'rev-1',
+    authKind: 'oauth-user',
     status: { deployed: true, ready: true },
   }
 }
@@ -70,10 +82,11 @@ function oauthUserServer(name = 'monday', provider = 'monday'): McpServerInfo {
 function staticServer(name = 'airtable'): McpServerInfo {
   return {
     name,
-    contextRef: 'ctx-1',
     transport: { type: 'streamableHttp', url: `http://${name}/mcp` },
-    auth: { type: 'none' },
     enabled: true,
+    authRequired: true,
+    credentialRevision: 'rev-1',
+    authKind: 'static',
     status: { deployed: true, ready: true },
   }
 }
@@ -91,21 +104,23 @@ beforeEach(() => {
 })
 
 describe('manager.callTool — U5 reactive consent classification', () => {
-  it('401 on an oauth server → typed connect_required marker (mcpServerName + provider)', async () => {
+  it('401 on an oauth server → typed connect_required marker (mcpServerName; provider undefined under HCC v2)', async () => {
     const manager = new McpManager(undefined, undefined, tokenFactory())
-    await manager.addServer(oauthUserServer('monday', 'monday'))
+    await manager.addServer(oauthUserServer('monday'))
 
     // Two 401s: initial + the client's single forced-refresh retry → McpAuthError(401).
     state.callToolQueue = [httpError(401), httpError(401)]
     const result = await manager.callTool('monday__do', {}, { userId: 'alice' })
 
     expect(result.isError).toBe(true)
-    expect(result.connectRequired).toEqual({ mcpServerName: 'monday', provider: 'monday' })
+    // provider is undefined by design: HCC v2 forwards only authKind, never the
+    // OAuth provider, so the gate's `info.oauth?.provider` resolves to undefined.
+    expect(result.connectRequired).toEqual({ mcpServerName: 'monday', provider: undefined })
   })
 
   it('403 on an oauth server → terminal, NO connect_required marker', async () => {
     const manager = new McpManager(undefined, undefined, tokenFactory())
-    await manager.addServer(oauthUserServer('monday', 'monday'))
+    await manager.addServer(oauthUserServer('monday'))
 
     // 403 is terminal immediately in the client — no refresh/retry.
     state.callToolQueue = [httpError(403)]


### PR DESCRIPTION
align connect_required U5 fixture with decodeMcpServer output

The managerConnectRequired U5 test was red at HEAD: oauthUserServer/staticServer hand-built `auth:{type}` / `oauth:{provider}` / `contextRef` blocks that the real producer (decodeMcpServer) never emits, and omitted `authKind` — the field the reactive-consent gate keys on (manager.ts:764,854). With authKind absent the gate never fired, so `result.connectRequired` was undefined. Classic T1 violation: a fixture representing another layer's output, hand-written against a stale contract (the pre-mini-spec-10 `auth.type`, dropped when the gate migrated to `authKind`).

Align both fixtures to decodeMcpServer's real HCC v2 output (authKind set; auth/oauth/contextRef removed; authRequired + credentialRevision as the decoder requires) and assert the true wire contract: the marker carries mcpServerName, and provider is undefined because HCC v2 never forwards the OAuth provider to mcp-host (HCC collapses spec.oauth to authKind; the connect UI resolves provider server-side off mcpServerName). Test-only; no production behavior changes. The now-visible dead `provider` field is tracked in work-tracker/issues (prune-vs-expose decision).

Class-check: hand-built oauth McpServerInfo fixture missing authKind feeding an authKind-reading path → grep `auth: { type:` across mcp-host suite → 4 files (contextMapperClient.test.ts, clientAuthRetry.test.ts, managerConnectRequired.test.ts, main.mcpInitialization.test.ts). Only managerConnectRequired matches the class (oauth + reads the authKind gate) → fixed. contextMapperClient feeds `auth` on purpose to test the forbidden-metadata rejection; clientAuthRetry exercises McpClient, which never reads authKind (harmless); main.mcpInitialization uses none/bearer and tests fleet mechanics, not the gate. No others corrected.

Repro-test: mcp-host/src/mcp/__tests__/managerConnectRequired.test.ts:118 (the prior version of this test fails at 7f2510695 — assertion `Received: undefined`, verified via a HEAD worktree). Test-only fix, so there is no separate production repro.

## Summary

## Testing

- [ ] `npm test` passes for changed services
- [ ] `npx tsc --noEmit` clean

## Checklist

- [ ] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)
