### PR TITLE
fix(hcc): treat a 404 on conflict-retry read as gone, not fatal (#472)

### DIFF
--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.255",
+  "version": "0.1.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.255",
+      "version": "0.1.256",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.256",
+      "version": "0.1.257",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.257",
+      "version": "0.1.258",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.258",
+  "version": "0.1.259",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.258",
+      "version": "0.1.259",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.258",
+  "version": "0.1.259",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.255",
+  "version": "0.1.256",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/__tests__/applyNetworkPolicyNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/applyNetworkPolicyNoopGate.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ApiException } from '@kubernetes/client-node'
 import type * as k8s from '@kubernetes/client-node'
 import { applyNetworkPolicy, networkPolicyMatchesDesired } from '../utils'
 import { asApiserverNetworkPolicy, updatedPolicyLogs } from './asApiserverNetworkPolicy'
+
+function apiException(code: number): ApiException<unknown> {
+  return new ApiException(code, 'test', {}, {})
+}
 
 function desiredPolicy(): k8s.V1NetworkPolicy {
   return {
@@ -99,7 +104,7 @@ describe('applyNetworkPolicy no-op gate', () => {
   })
 
   it.each([
-    { form: 'code', error: { code: 404 } },
+    { form: 'ApiException', error: apiException(404) },
     { form: 'statusCode', error: { response: { statusCode: 404 } } },
   ])('TOCTOU-NP-1: create 409 + read 404 ($form) returns without replace', async ({ error }) => {
     const api = fakeNetworkingApi()
@@ -116,11 +121,11 @@ describe('applyNetworkPolicy no-op gate', () => {
   })
 
   it.each([
-    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'ApiException', error: apiException(403) },
     { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
-    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'ApiException', error: apiException(500) },
     { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
-  ])('TOCTOU-NP-2: create 409 + read $status ($form) still throws', async ({ error }) => {
+  ])('TOCTOU-NP-2-APPLY: create 409 + read $status ($form) still throws', async ({ error }) => {
     const api = fakeNetworkingApi()
     api.createNamespacedNetworkPolicy.mockRejectedValue({ code: 409 })
     api.readNamespacedNetworkPolicy.mockRejectedValue(error)

--- a/host-context-controller/src/__tests__/applyNetworkPolicyNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/applyNetworkPolicyNoopGate.test.ts
@@ -98,6 +98,42 @@ describe('applyNetworkPolicy no-op gate', () => {
     expect(api.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
   })
 
+  it.each([
+    { form: 'code', error: { code: 404 } },
+    { form: 'statusCode', error: { response: { statusCode: 404 } } },
+  ])('TOCTOU-NP-1: create 409 + read 404 ($form) returns without replace', async ({ error }) => {
+    const api = fakeNetworkingApi()
+    api.createNamespacedNetworkPolicy.mockRejectedValue({ code: 409 })
+    api.readNamespacedNetworkPolicy.mockRejectedValue(error)
+
+    await expect(
+      applyNetworkPolicy(api as unknown as k8s.NetworkingV1Api, 'np', 'ns', desiredPolicy())
+    ).resolves.toBeUndefined()
+
+    expect(api.createNamespacedNetworkPolicy).toHaveBeenCalledOnce()
+    expect(api.readNamespacedNetworkPolicy).toHaveBeenCalledOnce()
+    expect(api.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
+    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
+  ])('TOCTOU-NP-2: create 409 + read $status ($form) still throws', async ({ error }) => {
+    const api = fakeNetworkingApi()
+    api.createNamespacedNetworkPolicy.mockRejectedValue({ code: 409 })
+    api.readNamespacedNetworkPolicy.mockRejectedValue(error)
+
+    await expect(
+      applyNetworkPolicy(api as unknown as k8s.NetworkingV1Api, 'np', 'ns', desiredPolicy())
+    ).rejects.toBe(error)
+
+    expect(api.createNamespacedNetworkPolicy).toHaveBeenCalledOnce()
+    expect(api.readNamespacedNetworkPolicy).toHaveBeenCalledOnce()
+    expect(api.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
+  })
+
   it('GATE-NP-1: mutationAllowed false after create-409 skips replace on drift', async () => {
     const desired = desiredPolicy()
     const drifted = asApiserverNetworkPolicy(desired, { port: 9090 })

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
+import { ApiException } from '@kubernetes/client-node'
 import type * as k8s from '@kubernetes/client-node'
 import {
   preserveServiceAssignedFields,
   replaceWithConflictRetry,
   serviceMatchesDesired,
 } from '../utils'
+
+function apiException(code: number): ApiException<unknown> {
+  return new ApiException(code, 'test', {}, {})
+}
 
 const desired: k8s.V1Service = {
   apiVersion: 'v1',
@@ -95,9 +100,9 @@ describe('replaceWithConflictRetry order and retry', () => {
   })
 
   it.each([
-    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'ApiException', error: apiException(403) },
     { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
-    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'ApiException', error: apiException(500) },
     { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
   ])('TOCTOU-NP-2: helper read $status ($form) still throws', async ({ error }) => {
     const replace = vi.fn()
@@ -123,7 +128,7 @@ describe('replaceWithConflictRetry order and retry', () => {
   })
 
   it.each([
-    { form: 'code', error: { code: 404 } },
+    { form: 'ApiException', error: apiException(404) },
     { form: 'statusCode', error: { response: { statusCode: 404 } } },
   ])(
     'TOCTOU-NP-3: replace 409 then second read 404 ($form) returns without a third replace',
@@ -177,7 +182,7 @@ describe('replaceWithConflictRetry order and retry', () => {
   })
 
   it.each([
-    { form: 'code', error: { code: 404 } },
+    { form: 'ApiException', error: apiException(404) },
     { form: 'statusCode', error: { response: { statusCode: 404 } } },
   ])('TOCTOU-NP-5: helper replace 404 ($form) still throws', async ({ error }) => {
     const read = vi.fn().mockResolvedValue(existing)
@@ -200,9 +205,9 @@ describe('replaceWithConflictRetry order and retry', () => {
   })
 
   it.each([
-    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'ApiException', error: apiException(403) },
     { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
-    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'ApiException', error: apiException(500) },
     { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
   ])(
     'TOCTOU-NP-6: replace 409 then second read $status ($form) still throws',

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -94,6 +94,82 @@ describe('replaceWithConflictRetry order and retry', () => {
     }
   })
 
+  it.each([
+    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
+    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
+  ])('TOCTOU-NP-2: helper read $status ($form) still throws', async ({ error }) => {
+    const replace = vi.fn()
+    const validateExisting = vi.fn()
+    const read = vi.fn().mockRejectedValue(error)
+
+    await expect(
+      replaceWithConflictRetry({
+        description: 'Service "svc"',
+        logPrefix: '[Test]',
+        body: desired,
+        mergeExisting: preserveServiceAssignedFields,
+        isUpToDate: serviceMatchesDesired,
+        validateExisting,
+        read,
+        replace,
+      })
+    ).rejects.toBe(error)
+
+    expect(read).toHaveBeenCalledOnce()
+    expect(validateExisting).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
+  it('TOCTOU-NP-3: replace 409 then second read 404 returns without a third replace', async () => {
+    const read = vi.fn().mockResolvedValueOnce(existing).mockRejectedValueOnce({ code: 404 })
+    const replace = vi.fn().mockRejectedValueOnce({ code: 409 })
+    const validateExisting = vi.fn()
+
+    await expect(
+      replaceWithConflictRetry({
+        description: 'Service "svc"',
+        logPrefix: '[Test]',
+        body: desired,
+        mergeExisting: preserveServiceAssignedFields,
+        isUpToDate: () => false,
+        validateExisting,
+        read,
+        replace,
+      })
+    ).resolves.toBeUndefined()
+
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(validateExisting).toHaveBeenCalledOnce()
+    expect(replace).toHaveBeenCalledOnce()
+    expect(replace.mock.calls[0][0].metadata?.resourceVersion).toBe('9')
+  })
+
+  it('TOCTOU-NP-4: network Error without code is rethrown', async () => {
+    const networkErr = new Error('socket hang up')
+    const replace = vi.fn()
+    const validateExisting = vi.fn()
+    const read = vi.fn().mockRejectedValue(networkErr)
+
+    await expect(
+      replaceWithConflictRetry({
+        description: 'Service "svc"',
+        logPrefix: '[Test]',
+        body: desired,
+        mergeExisting: preserveServiceAssignedFields,
+        isUpToDate: serviceMatchesDesired,
+        validateExisting,
+        read,
+        replace,
+      })
+    ).rejects.toBe(networkErr)
+
+    expect(read).toHaveBeenCalledOnce()
+    expect(validateExisting).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+  })
+
   it('RETRY-SVC-2: post-409 re-read that matches skips the second replace', async () => {
     const drifted: k8s.V1Service = {
       ...existing,

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -199,6 +199,62 @@ describe('replaceWithConflictRetry order and retry', () => {
     expect(replace).toHaveBeenCalledOnce()
   })
 
+  it.each([
+    { status: 403, form: 'code', error: { code: 403 } },
+    { status: 403, form: 'statusCode', error: { response: { statusCode: 403 } } },
+    { status: 500, form: 'code', error: { code: 500 } },
+    { status: 500, form: 'statusCode', error: { response: { statusCode: 500 } } },
+  ])(
+    'TOCTOU-NP-6: replace 409 then second read $status ($form) still throws',
+    async ({ error }) => {
+      const read = vi.fn().mockResolvedValueOnce(existing).mockRejectedValueOnce(error)
+      const replace = vi.fn().mockRejectedValueOnce({ code: 409 })
+      const validateExisting = vi.fn()
+
+      await expect(
+        replaceWithConflictRetry({
+          description: 'Service "svc"',
+          logPrefix: '[Test]',
+          body: desired,
+          mergeExisting: preserveServiceAssignedFields,
+          isUpToDate: () => false,
+          validateExisting,
+          read,
+          replace,
+        })
+      ).rejects.toBe(error)
+
+      expect(read).toHaveBeenCalledTimes(2)
+      expect(validateExisting).toHaveBeenCalledOnce()
+      expect(replace).toHaveBeenCalledOnce()
+      expect(replace.mock.calls[0][0].metadata?.resourceVersion).toBe('9')
+    }
+  )
+
+  it('TOCTOU-NP-7: replace 409 then second-read network Error is rethrown', async () => {
+    const networkErr = new Error('socket hang up')
+    const read = vi.fn().mockResolvedValueOnce(existing).mockRejectedValueOnce(networkErr)
+    const replace = vi.fn().mockRejectedValueOnce({ code: 409 })
+    const validateExisting = vi.fn()
+
+    await expect(
+      replaceWithConflictRetry({
+        description: 'Service "svc"',
+        logPrefix: '[Test]',
+        body: desired,
+        mergeExisting: preserveServiceAssignedFields,
+        isUpToDate: () => false,
+        validateExisting,
+        read,
+        replace,
+      })
+    ).rejects.toBe(networkErr)
+
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(validateExisting).toHaveBeenCalledOnce()
+    expect(replace).toHaveBeenCalledOnce()
+  })
+
   it('RETRY-SVC-2: post-409 re-read that matches skips the second replace', async () => {
     const drifted: k8s.V1Service = {
       ...existing,

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -122,29 +122,35 @@ describe('replaceWithConflictRetry order and retry', () => {
     expect(replace).not.toHaveBeenCalled()
   })
 
-  it('TOCTOU-NP-3: replace 409 then second read 404 returns without a third replace', async () => {
-    const read = vi.fn().mockResolvedValueOnce(existing).mockRejectedValueOnce({ code: 404 })
-    const replace = vi.fn().mockRejectedValueOnce({ code: 409 })
-    const validateExisting = vi.fn()
+  it.each([
+    { form: 'code', error: { code: 404 } },
+    { form: 'statusCode', error: { response: { statusCode: 404 } } },
+  ])(
+    'TOCTOU-NP-3: replace 409 then second read 404 ($form) returns without a third replace',
+    async ({ error }) => {
+      const read = vi.fn().mockResolvedValueOnce(existing).mockRejectedValueOnce(error)
+      const replace = vi.fn().mockRejectedValueOnce({ code: 409 })
+      const validateExisting = vi.fn()
 
-    await expect(
-      replaceWithConflictRetry({
-        description: 'Service "svc"',
-        logPrefix: '[Test]',
-        body: desired,
-        mergeExisting: preserveServiceAssignedFields,
-        isUpToDate: () => false,
-        validateExisting,
-        read,
-        replace,
-      })
-    ).resolves.toBeUndefined()
+      await expect(
+        replaceWithConflictRetry({
+          description: 'Service "svc"',
+          logPrefix: '[Test]',
+          body: desired,
+          mergeExisting: preserveServiceAssignedFields,
+          isUpToDate: () => false,
+          validateExisting,
+          read,
+          replace,
+        })
+      ).resolves.toBeUndefined()
 
-    expect(read).toHaveBeenCalledTimes(2)
-    expect(validateExisting).toHaveBeenCalledOnce()
-    expect(replace).toHaveBeenCalledOnce()
-    expect(replace.mock.calls[0][0].metadata?.resourceVersion).toBe('9')
-  })
+      expect(read).toHaveBeenCalledTimes(2)
+      expect(validateExisting).toHaveBeenCalledOnce()
+      expect(replace).toHaveBeenCalledOnce()
+      expect(replace.mock.calls[0][0].metadata?.resourceVersion).toBe('9')
+    }
+  )
 
   it('TOCTOU-NP-4: network Error without code is rethrown', async () => {
     const networkErr = new Error('socket hang up')
@@ -168,6 +174,29 @@ describe('replaceWithConflictRetry order and retry', () => {
     expect(read).toHaveBeenCalledOnce()
     expect(validateExisting).not.toHaveBeenCalled()
     expect(replace).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { form: 'code', error: { code: 404 } },
+    { form: 'statusCode', error: { response: { statusCode: 404 } } },
+  ])('TOCTOU-NP-5: helper replace 404 ($form) still throws', async ({ error }) => {
+    const read = vi.fn().mockResolvedValue(existing)
+    const replace = vi.fn().mockRejectedValue(error)
+
+    await expect(
+      replaceWithConflictRetry({
+        description: 'Service "svc"',
+        logPrefix: '[Test]',
+        body: desired,
+        mergeExisting: preserveServiceAssignedFields,
+        isUpToDate: () => false,
+        read,
+        replace,
+      })
+    ).rejects.toBe(error)
+
+    expect(read).toHaveBeenCalledOnce()
+    expect(replace).toHaveBeenCalledOnce()
   })
 
   it('RETRY-SVC-2: post-409 re-read that matches skips the second replace', async () => {

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -2287,6 +2287,10 @@ export class HostReconciler {
         )
         return
       }
+      // The outer read above treats 404 as a transient throw so this Host
+      // reconcile requeues and recreates. The helper read below is the #472
+      // contract: 404 means gone, return, and the next Host reconcile
+      // recreates. Same object, two 404 policies — accepted, not a bug.
       try {
         await replaceWithConflictRetry({
           description: `channel-reader Deployment "${name}"`,

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -56,7 +56,13 @@ export async function replaceWithConflictRetry<
     maxAttempts = 3,
   } = opts
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const existing = await read()
+    let existing: T
+    try {
+      existing = await read()
+    } catch (err) {
+      if (getErrorCode(err) === 404) return
+      throw err
+    }
     validateExisting?.(existing)
     const desired = resolveBody ? await resolveBody() : body
     const base: T = {


### PR DESCRIPTION
## Summary
- `replaceWithConflictRetry` treated a 404 from `read()` as fatal because that call sat outside the replace `try`. After `create` returns 409, a delete in the gap aborted the whole NetPol certification pass (`AggregateError`).
- Wrap only `read()`: a 404 returns cleanly (object is gone; the next pass / #467 watchdog recreates). 403, 500, and network errors without a status still throw — including on the post-409 re-read (TOCTOU-NP-6/7).
- Does not retry `create` in the same call (anti-flapper). Does not change the #471 `isUpToDate` gate or the #480 409 retry ladder.

**Read-404 on deny-all (R1-L1):** if `deny-all-<ns>` is deleted in the create-409→read window, this pass can certify readiness while that deny-all is still absent. The *network* state matches base (the object is gone either way). Only the fail-closed certification signal is suppressed; the next resync / #467 watchdog recreates it. Conscious call: ≤1-pass self-heal. This PR does not special-case the deny path.

Closes #472 except same-call recreate; next pass / #467 watchdog recreates.

## Test plan
- [x] TOCTOU-NP-1: create 409 + read 404 (`ApiException` and `response.statusCode`) → no throw; create ×1; read ×1; replace ×0
- [x] TOCTOU-NP-2: helper read 403/500 still throw
- [x] TOCTOU-NP-2-APPLY: `applyNetworkPolicy` create 409 + read 403/500 still throw
- [x] TOCTOU-NP-3: replace 409 then second read 404 → return; no third replace
- [x] TOCTOU-NP-4: network `Error` without `code` is rethrown
- [x] TOCTOU-NP-5: helper replace 404 still throws
- [x] TOCTOU-NP-6/7: replace 409 then second-read 403/500/network still throw
- [x] Existing NOOP-NP-1/2 and ORDER-1 stay green
- [x] `npx tsc --noEmit` and `npm test` in `host-context-controller`