### PR TITLE
fix(hcc): skip no-op Host Role replaces

### DIFF
--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.260",
+  "version": "0.1.261",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.260",
+      "version": "0.1.261",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.255",
+  "version": "0.1.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.255",
+      "version": "0.1.256",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.256",
+      "version": "0.1.257",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.257",
+      "version": "0.1.258",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.258",
+  "version": "0.1.259",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.258",
+      "version": "0.1.259",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.259",
+  "version": "0.1.260",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.259",
+      "version": "0.1.260",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/image-policy": "file:../packages/image-policy",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.258",
+  "version": "0.1.259",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.259",
+  "version": "0.1.260",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.260",
+  "version": "0.1.261",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.257",
+  "version": "0.1.258",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.255",
+  "version": "0.1.256",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.256",
+  "version": "0.1.257",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/__tests__/asApiserverRole.ts
+++ b/host-context-controller/src/__tests__/asApiserverRole.ts
@@ -5,9 +5,9 @@ import type * as k8s from '@kubernetes/client-node'
  * Recorded kube-apiserver GET of a namespaced Role (`kubectl get role -o json`
  * shape), not a field list copied from the comparator. Stamp
  * controller-owned name/labels/rules via `asApiserverRole`. Label keys are
- * inserted in reverse author order so a byte-identical fixture cannot hide a
- * missing canonicalize. Do not reconstruct rules from desired alone when
- * asserting the read carried `rules` — the skip must see them or it fail-opens.
+ * inserted in reverse author order, and each rule is rebuilt in
+ * V1PolicyRule.attributeTypeMap order, so a byte-identical fixture cannot hide
+ * a missing canonicalize. The skip must still see `rules` or it fail-opens.
  */
 export const RECORDED_ROLE: k8s.V1Role = {
   apiVersion: 'rbac.authorization.k8s.io/v1',
@@ -49,6 +49,20 @@ function shuffleLabelKeys(labels: Record<string, string>): Record<string, string
   return shuffled
 }
 
+/**
+ * Rebuild a rule in client-node ObjectSerializer / V1PolicyRule.attributeTypeMap
+ * order so a missing key-canonicalize cannot hide behind a cloned builder object.
+ */
+export function asApiserverPolicyRule(rule: k8s.V1PolicyRule): k8s.V1PolicyRule {
+  const live: Record<string, unknown> = {}
+  if (rule.apiGroups !== undefined) live.apiGroups = rule.apiGroups
+  if (rule.nonResourceURLs !== undefined) live.nonResourceURLs = rule.nonResourceURLs
+  if (rule.resourceNames !== undefined) live.resourceNames = rule.resourceNames
+  if (rule.resources !== undefined) live.resources = rule.resources
+  if (rule.verbs !== undefined) live.verbs = rule.verbs
+  return live as unknown as k8s.V1PolicyRule
+}
+
 export function asApiserverRole(desired: k8s.V1Role): k8s.V1Role {
   const recorded = structuredClone(RECORDED_ROLE)
   const labels = desired.metadata?.labels ?? {}
@@ -66,7 +80,7 @@ export function asApiserverRole(desired: k8s.V1Role): k8s.V1Role {
       ownerReferences: desired.metadata?.ownerReferences,
       selfLink: `/apis/rbac.authorization.k8s.io/v1/namespaces/${desired.metadata?.namespace}/roles/${desired.metadata?.name}`,
     },
-    rules: structuredClone(desired.rules ?? []),
+    rules: (desired.rules ?? []).map(asApiserverPolicyRule),
   }
 }
 

--- a/host-context-controller/src/__tests__/asApiserverRole.ts
+++ b/host-context-controller/src/__tests__/asApiserverRole.ts
@@ -52,6 +52,7 @@ function shuffleLabelKeys(labels: Record<string, string>): Record<string, string
 /**
  * Rebuild a rule in client-node ObjectSerializer / V1PolicyRule.attributeTypeMap
  * order so a missing key-canonicalize cannot hide behind a cloned builder object.
+ * FIXTURE-ROLE-1 pins this order against the live client-node class.
  */
 export function asApiserverPolicyRule(rule: k8s.V1PolicyRule): k8s.V1PolicyRule {
   const live: Record<string, unknown> = {}

--- a/host-context-controller/src/__tests__/asApiserverRole.ts
+++ b/host-context-controller/src/__tests__/asApiserverRole.ts
@@ -1,0 +1,77 @@
+import { vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+
+/**
+ * Recorded kube-apiserver GET of a namespaced Role (`kubectl get role -o json`
+ * shape), not a field list copied from the comparator. Stamp
+ * controller-owned name/labels/rules via `asApiserverRole`. Label keys are
+ * inserted in reverse author order so a byte-identical fixture cannot hide a
+ * missing canonicalize. Do not reconstruct rules from desired alone when
+ * asserting the read carried `rules` — the skip must see them or it fail-opens.
+ */
+export const RECORDED_ROLE: k8s.V1Role = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'Role',
+  metadata: {
+    annotations: {
+      'kubectl.kubernetes.io/last-applied-configuration': '{}',
+    },
+    creationTimestamp: new Date('2026-04-01T00:00:00.000Z'),
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: { 'f:rules': {} },
+        manager: 'kube-apiserver',
+        operation: 'Update',
+        time: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ],
+    name: 'recorded-role',
+    namespace: 'recorded-ns',
+    resourceVersion: '1784167',
+    uid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    selfLink: '/apis/rbac.authorization.k8s.io/v1/namespaces/recorded-ns/roles/recorded-role',
+    labels: {
+      'clerum.io/host': 'recorded',
+      'clerum.io/managed-by': 'host-context-controller',
+    },
+  },
+  rules: [],
+}
+
+function shuffleLabelKeys(labels: Record<string, string>): Record<string, string> {
+  const shuffled: Record<string, string> = {}
+  for (const key of Object.keys(labels).reverse()) {
+    shuffled[key] = labels[key]
+  }
+  return shuffled
+}
+
+export function asApiserverRole(desired: k8s.V1Role): k8s.V1Role {
+  const recorded = structuredClone(RECORDED_ROLE)
+  const labels = desired.metadata?.labels ?? {}
+  return {
+    ...recorded,
+    metadata: {
+      ...recorded.metadata,
+      name: desired.metadata?.name,
+      namespace: desired.metadata?.namespace,
+      labels: shuffleLabelKeys({ ...labels }),
+      annotations: {
+        ...recorded.metadata?.annotations,
+        ...desired.metadata?.annotations,
+      },
+      ownerReferences: desired.metadata?.ownerReferences,
+      selfLink: `/apis/rbac.authorization.k8s.io/v1/namespaces/${desired.metadata?.namespace}/roles/${desired.metadata?.name}`,
+    },
+    rules: structuredClone(desired.rules ?? []),
+  }
+}
+
+export function updatedRoleLogs(log: ReturnType<typeof vi.spyOn>, needle: string): string[] {
+  return log.mock.calls
+    .map((call: unknown[]) => String(call[0]))
+    .filter((line: string) => line.includes('Updated Role') && line.includes(needle))
+}

--- a/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
@@ -165,19 +165,36 @@ describe('Host ensureHostRole no-op gate', () => {
     }
   })
 
-  it('NOOP-ROLE-5: reordered live verbs still replaces once', async () => {
+  it('NOOP-ROLE-5: reordered live verbs replace once then converge', async () => {
     rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
     let existing: k8s.V1Role | undefined
+    let readPass = 0
     rbacApi.readNamespacedRole.mockImplementation(() => {
-      const live = structuredClone(desiredFromCreate(rbacApi))
-      secretGetRule(live).verbs = ['watch', 'get', 'list']
-      existing = asApiserverRole(live)
+      readPass += 1
+      if (readPass === 1) {
+        const live = structuredClone(desiredFromCreate(rbacApi))
+        secretGetRule(live).verbs = ['watch', 'get', 'list']
+        existing = asApiserverRole(live)
+        return Promise.resolve(existing)
+      }
+      const written = rbacApi.replaceNamespacedRole.mock.calls[0]?.[0].body as
+        | k8s.V1Role
+        | undefined
+      if (!written) throw new Error('NOOP-ROLE-5: second read expected a written Role body')
+      existing = asApiserverRole(structuredClone(written))
       return Promise.resolve(existing)
     })
     const log = vi.spyOn(console, 'log')
     try {
       await (reconciler as any).ensureHostRole(host)
       expect(secretGetRule(existing!).verbs).toEqual(['watch', 'get', 'list'])
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+
+      await (reconciler as any).ensureHostRole(host)
+      expect(secretGetRule(existing!).verbs).toEqual(['get', 'watch', 'list'])
       expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
       expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
         '[HostReconciler] Updated Role "host-chatllm-config-reader"',

--- a/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
@@ -36,9 +36,7 @@ function makeHost(secretRef = 'secret'): HostCRD {
 }
 
 function desiredFromCreate(rbacApi: MockRbacApi): k8s.V1Role {
-  const body = rbacApi.createNamespacedRole.mock.calls[0][0].body as k8s.V1Role
-  expect(body.rules?.length).toBeGreaterThan(0)
-  return body
+  return rbacApi.createNamespacedRole.mock.calls[0][0].body as k8s.V1Role
 }
 
 describe('Host ensureHostRole no-op gate', () => {
@@ -66,14 +64,23 @@ describe('Host ensureHostRole no-op gate', () => {
 
   it('NOOP-ROLE-1: apiserver-shaped Role with shuffled label keys skips replace', async () => {
     rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
     rbacApi.readNamespacedRole.mockImplementation(() => {
-      const existing = asApiserverRole(desiredFromCreate(rbacApi))
-      expect(existing.rules?.length).toBeGreaterThan(0)
+      existing = asApiserverRole(desiredFromCreate(rbacApi))
       return Promise.resolve(existing)
     })
     const log = vi.spyOn(console, 'log')
     try {
       await (reconciler as any).ensureHostRole(host)
+      expect(rbacApi.readNamespacedRole).toHaveBeenCalledOnce()
+      expect(existing?.rules?.length).toBeGreaterThan(0)
+      expect(Object.keys(existing!.rules![0] ?? {})).toEqual([
+        'apiGroups',
+        'resourceNames',
+        'resources',
+        'verbs',
+      ])
+      expect(desiredFromCreate(rbacApi).rules?.length).toBeGreaterThan(0)
       expect(rbacApi.replaceNamespacedRole).not.toHaveBeenCalled()
       expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([])
     } finally {
@@ -83,20 +90,20 @@ describe('Host ensureHostRole no-op gate', () => {
 
   it('NOOP-ROLE-2: rotated secretRef still replaces once', async () => {
     rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
     rbacApi.readNamespacedRole.mockImplementation(() => {
       const live = structuredClone(desiredFromCreate(rbacApi))
       const secretRule = live.rules?.find(
         (rule: k8s.V1PolicyRule) => rule.resources?.[0] === 'secrets' && rule.verbs?.includes('get')
       )
-      expect(secretRule?.resourceNames?.[0]).toBe('rotated-secret')
       secretRule!.resourceNames![0] = host.spec.secretRef
-      const existing = asApiserverRole(live)
-      expect(existing.rules?.length).toBeGreaterThan(0)
+      existing = asApiserverRole(live)
       return Promise.resolve(existing)
     })
     const log = vi.spyOn(console, 'log')
     try {
       await (reconciler as any).ensureHostRole(makeHost('rotated-secret'))
+      expect(existing?.rules?.length).toBeGreaterThan(0)
       expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
       expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
         '[HostReconciler] Updated Role "host-chatllm-config-reader"',

--- a/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import {
+  type MockRbacApi,
+  asAppsApi,
+  asCoreApi,
+  asCustomApi,
+  asNetworkingApi,
+  asRbacApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockCustomApi,
+  createMockNetworkingApi,
+  createMockRbacApi,
+} from '../../test/__fixtures__/testMocks'
+import { HostReconciler } from '../hostReconciler'
+import type { HostCRD } from '../types'
+import { asApiserverRole, updatedRoleLogs } from './asApiserverRole'
+
+function makeStubKc(): k8s.KubeConfig {
+  const stub = new Proxy({}, { get: () => vi.fn() })
+  return { makeApiClient: () => stub } as unknown as k8s.KubeConfig
+}
+
+function makeHost(secretRef = 'secret'): HostCRD {
+  return {
+    name: 'chatllm',
+    namespace: 'mcp-host',
+    uid: 'chatllm-uid',
+    spec: {
+      host: 'chatllm',
+      contextRef: 'ctx',
+      secretRef,
+    },
+  }
+}
+
+function desiredFromCreate(rbacApi: MockRbacApi): k8s.V1Role {
+  const body = rbacApi.createNamespacedRole.mock.calls[0][0].body as k8s.V1Role
+  expect(body.rules?.length).toBeGreaterThan(0)
+  return body
+}
+
+describe('Host ensureHostRole no-op gate', () => {
+  let rbacApi: MockRbacApi
+  let reconciler: HostReconciler
+  const host = makeHost()
+
+  beforeEach(() => {
+    rbacApi = createMockRbacApi()
+    reconciler = new HostReconciler(makeStubKc(), {
+      coreApi: asCoreApi(createMockCoreApi()),
+      appsApi: asAppsApi(createMockAppsApi()),
+      networkingApi: asNetworkingApi(createMockNetworkingApi()),
+      rbacApi: asRbacApi(rbacApi),
+      customApi: asCustomApi(createMockCustomApi()),
+    })
+  })
+
+  it('CREATE-ROLE-1: successful create never reads or replaces', async () => {
+    await (reconciler as any).ensureHostRole(host)
+    expect(rbacApi.createNamespacedRole).toHaveBeenCalledOnce()
+    expect(rbacApi.readNamespacedRole).not.toHaveBeenCalled()
+    expect(rbacApi.replaceNamespacedRole).not.toHaveBeenCalled()
+  })
+
+  it('NOOP-ROLE-1: apiserver-shaped Role with shuffled label keys skips replace', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const existing = asApiserverRole(desiredFromCreate(rbacApi))
+      expect(existing.rules?.length).toBeGreaterThan(0)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(rbacApi.replaceNamespacedRole).not.toHaveBeenCalled()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-ROLE-2: rotated secretRef still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      const secretRule = live.rules?.find(
+        (rule: k8s.V1PolicyRule) => rule.resources?.[0] === 'secrets' && rule.verbs?.includes('get')
+      )
+      expect(secretRule?.resourceNames?.[0]).toBe('rotated-secret')
+      secretRule!.resourceNames![0] = host.spec.secretRef
+      const existing = asApiserverRole(live)
+      expect(existing.rules?.length).toBeGreaterThan(0)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(makeHost('rotated-secret'))
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+})

--- a/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { V1PolicyRule } from '@kubernetes/client-node'
 import type * as k8s from '@kubernetes/client-node'
 import {
   type MockRbacApi,
@@ -13,9 +14,10 @@ import {
   createMockNetworkingApi,
   createMockRbacApi,
 } from '../../test/__fixtures__/testMocks'
+import { HOST_LABEL } from '../constants'
 import { HostReconciler } from '../hostReconciler'
 import type { HostCRD } from '../types'
-import { asApiserverRole, updatedRoleLogs } from './asApiserverRole'
+import { asApiserverPolicyRule, asApiserverRole, updatedRoleLogs } from './asApiserverRole'
 
 function makeStubKc(): k8s.KubeConfig {
   const stub = new Proxy({}, { get: () => vi.fn() })
@@ -37,6 +39,14 @@ function makeHost(secretRef = 'secret'): HostCRD {
 
 function desiredFromCreate(rbacApi: MockRbacApi): k8s.V1Role {
   return rbacApi.createNamespacedRole.mock.calls[0][0].body as k8s.V1Role
+}
+
+function secretGetRule(role: k8s.V1Role): k8s.V1PolicyRule {
+  const rule = role.rules?.find(
+    (entry: k8s.V1PolicyRule) => entry.resources?.[0] === 'secrets' && entry.verbs?.includes('get')
+  )
+  if (!rule) throw new Error('desired Role is missing the secrets get rule')
+  return rule
 }
 
 describe('Host ensureHostRole no-op gate', () => {
@@ -74,12 +84,12 @@ describe('Host ensureHostRole no-op gate', () => {
       await (reconciler as any).ensureHostRole(host)
       expect(rbacApi.readNamespacedRole).toHaveBeenCalledOnce()
       expect(existing?.rules?.length).toBeGreaterThan(0)
-      expect(Object.keys(existing!.rules![0] ?? {})).toEqual([
-        'apiGroups',
-        'resourceNames',
-        'resources',
-        'verbs',
-      ])
+      const authoredKeys = Object.keys(desiredFromCreate(rbacApi).rules![0] ?? {})
+      const liveKeys = Object.keys(existing!.rules![0] ?? {})
+      // Author order vs client-node attributeTypeMap — canonicalize must run.
+      expect(authoredKeys).toEqual(['apiGroups', 'resources', 'resourceNames', 'verbs'])
+      expect(liveKeys).toEqual(['apiGroups', 'resourceNames', 'resources', 'verbs'])
+      expect(authoredKeys).not.toEqual(liveKeys)
       expect(desiredFromCreate(rbacApi).rules?.length).toBeGreaterThan(0)
       expect(rbacApi.replaceNamespacedRole).not.toHaveBeenCalled()
       expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([])
@@ -93,10 +103,7 @@ describe('Host ensureHostRole no-op gate', () => {
     let existing: k8s.V1Role | undefined
     rbacApi.readNamespacedRole.mockImplementation(() => {
       const live = structuredClone(desiredFromCreate(rbacApi))
-      const secretRule = live.rules?.find(
-        (rule: k8s.V1PolicyRule) => rule.resources?.[0] === 'secrets' && rule.verbs?.includes('get')
-      )
-      secretRule!.resourceNames![0] = host.spec.secretRef
+      secretGetRule(live).resourceNames![0] = host.spec.secretRef
       existing = asApiserverRole(live)
       return Promise.resolve(existing)
     })
@@ -140,10 +147,8 @@ describe('Host ensureHostRole no-op gate', () => {
     let existing: k8s.V1Role | undefined
     rbacApi.readNamespacedRole.mockImplementation(() => {
       const live = structuredClone(desiredFromCreate(rbacApi))
-      const secretRule = live.rules?.find(
-        (rule: k8s.V1PolicyRule) => rule.resources?.[0] === 'secrets' && rule.verbs?.includes('get')
-      )
-      secretRule!.verbs = [...(secretRule!.verbs ?? []), 'update']
+      const secretRule = secretGetRule(live)
+      secretRule.verbs = [...(secretRule.verbs ?? []), 'update']
       existing = asApiserverRole(live)
       return Promise.resolve(existing)
     })
@@ -158,5 +163,115 @@ describe('Host ensureHostRole no-op gate', () => {
     } finally {
       log.mockRestore()
     }
+  })
+
+  it('NOOP-ROLE-5: reordered live verbs still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      secretGetRule(live).verbs = ['watch', 'get', 'list']
+      existing = asApiserverRole(live)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(secretGetRule(existing!).verbs).toEqual(['watch', 'get', 'list'])
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-ROLE-6: tampered live host label still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      existing = asApiserverRole(desiredFromCreate(rbacApi))
+      existing.metadata!.labels![HOST_LABEL] = 'other-host'
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(existing?.metadata?.labels?.[HOST_LABEL]).toBe('other-host')
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-ROLE-7: removed live rule still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      live.rules = (live.rules ?? []).filter(rule => rule.resources?.[0] !== 'configmaps')
+      existing = asApiserverRole(live)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(existing?.rules?.some(rule => rule.resources?.[0] === 'configmaps')).toBe(false)
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-ROLE-8: removed live secret resourceName still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      const secretRule = secretGetRule(live)
+      secretRule.resourceNames = (secretRule.resourceNames ?? []).filter((_, index) => index !== 1)
+      existing = asApiserverRole(live)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(secretGetRule(existing!).resourceNames).toHaveLength(
+        (secretGetRule(desiredFromCreate(rbacApi)).resourceNames?.length ?? 0) - 1
+      )
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('FIXTURE-ROLE-1: asApiserverPolicyRule follows V1PolicyRule.attributeTypeMap', () => {
+    expect(V1PolicyRule.getAttributeTypeMap().map(entry => entry.name)).toEqual([
+      'apiGroups',
+      'nonResourceURLs',
+      'resourceNames',
+      'resources',
+      'verbs',
+    ])
+    expect(
+      Object.keys(
+        asApiserverPolicyRule({
+          apiGroups: [''],
+          resources: ['secrets'],
+          resourceNames: ['x'],
+          verbs: ['get'],
+        })
+      )
+    ).toEqual(['apiGroups', 'resourceNames', 'resources', 'verbs'])
   })
 })

--- a/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/hostRoleNoopGate.test.ts
@@ -112,4 +112,51 @@ describe('Host ensureHostRole no-op gate', () => {
       log.mockRestore()
     }
   })
+
+  it('NOOP-ROLE-3: extra live rule still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      live.rules = [...(live.rules ?? []), { apiGroups: [''], resources: ['pods'], verbs: ['get'] }]
+      existing = asApiserverRole(live)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(existing?.rules?.length).toBe((desiredFromCreate(rbacApi).rules?.length ?? 0) + 1)
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-ROLE-4: extra live secret verb still replaces once', async () => {
+    rbacApi.createNamespacedRole.mockRejectedValue({ code: 409 })
+    let existing: k8s.V1Role | undefined
+    rbacApi.readNamespacedRole.mockImplementation(() => {
+      const live = structuredClone(desiredFromCreate(rbacApi))
+      const secretRule = live.rules?.find(
+        (rule: k8s.V1PolicyRule) => rule.resources?.[0] === 'secrets' && rule.verbs?.includes('get')
+      )
+      secretRule!.verbs = [...(secretRule!.verbs ?? []), 'update']
+      existing = asApiserverRole(live)
+      return Promise.resolve(existing)
+    })
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureHostRole(host)
+      expect(existing?.rules?.some(rule => rule.verbs?.includes('update'))).toBe(true)
+      expect(rbacApi.replaceNamespacedRole).toHaveBeenCalledOnce()
+      expect(updatedRoleLogs(log, '"host-chatllm-config-reader"')).toEqual([
+        '[HostReconciler] Updated Role "host-chatllm-config-reader"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
 })

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -4652,9 +4652,12 @@ export class HostReconciler {
  * True when the desired Role matches the live object on the fields HCC authors:
  * `rbacLabels` and `rules` in author order. Server metadata and annotations are
  * ignored — the builder does not write annotations, and comparing them would
- * force a PUT. Label keys are canonicalized; rules, verbs, and resourceNames
- * are not sorted. Missing rules or labels, or any compare failure, returns
- * false (fail-open-to-write, #307).
+ * force a PUT. Label keys are canonicalized. Object keys inside each rule are
+ * also canonicalized: client-node rebuilds V1PolicyRule in attributeTypeMap
+ * order (resourceNames before resources), so a raw JSON.stringify never matches
+ * a live GET (#307). Rule arrays, verbs, and resourceNames stay in author order.
+ * Missing rules or labels, or any compare failure, returns false
+ * (fail-open-to-write).
  */
 function roleMatchesDesired(desired: k8s.V1Role, existing: k8s.V1Role): boolean {
   try {
@@ -4666,7 +4669,10 @@ function roleMatchesDesired(desired: k8s.V1Role, existing: k8s.V1Role): boolean 
     ) {
       return false
     }
-    return JSON.stringify(desired.rules) === JSON.stringify(existing.rules)
+    return (
+      JSON.stringify(canonicalizeRoleValue(desired.rules)) ===
+      JSON.stringify(canonicalizeRoleValue(existing.rules))
+    )
   } catch {
     return false
   }
@@ -4676,6 +4682,18 @@ function canonicalizeLabelKeys(labels: Record<string, string>): Record<string, s
   const canonical: Record<string, string> = {}
   for (const key of Object.keys(labels).sort()) {
     canonical[key] = labels[key]
+  }
+  return canonical
+}
+
+/** Sort object keys recursively. Arrays keep author order. */
+function canonicalizeRoleValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeRoleValue)
+  if (typeof value !== 'object' || value === null) return value
+  const canonical: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    const entry = (value as Record<string, unknown>)[key]
+    if (entry !== undefined) canonical[key] = canonicalizeRoleValue(entry)
   }
   return canonical
 }

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -4649,15 +4649,6 @@ export class HostReconciler {
 }
 
 /**
- * Kubernetes persists server metadata and defaulted Deployment/PodSpec fields
- * that HCC does not author. Remove only those known fields before comparing
- * the objects; every HCC-authored field stays exact so an intentional removal
- * or change still causes a rollout. Keep this allowlist conservative: an
- * unknown admission mutation must compare as drift rather than be silently
- * ignored. Pod-template annotations are merged by preserveDeploymentAnnotations
- * before this comparison.
- */
-/**
  * True when the desired Role matches the live object on the fields HCC authors:
  * `rbacLabels` and `rules` in author order. Server metadata and annotations are
  * ignored — the builder does not write annotations, and comparing them would
@@ -4689,6 +4680,15 @@ function canonicalizeLabelKeys(labels: Record<string, string>): Record<string, s
   return canonical
 }
 
+/**
+ * Kubernetes persists server metadata and defaulted Deployment/PodSpec fields
+ * that HCC does not author. Remove only those known fields before comparing
+ * the objects; every HCC-authored field stays exact so an intentional removal
+ * or change still causes a rollout. Keep this allowlist conservative: an
+ * unknown admission mutation must compare as drift rather than be silently
+ * ignored. Pod-template annotations are merged by preserveDeploymentAnnotations
+ * before this comparison.
+ */
 function deploymentMatchesDesired(desired: k8s.V1Deployment, existing: k8s.V1Deployment): boolean {
   return (
     JSON.stringify(normalizeDeploymentForComparison(desired)) ===

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -952,6 +952,7 @@ export class HostReconciler {
     // Already exists — replace to pick up rotated secretRef / new resourceNames.
     try {
       const existing = await this.rbacApi.readNamespacedRole({ name, namespace: host.namespace })
+      if (roleMatchesDesired(body, existing)) return
       body.metadata!.resourceVersion = existing.metadata?.resourceVersion
       await this.rbacApi.replaceNamespacedRole({ name, namespace: host.namespace, body })
       console.log(`[HostReconciler] Updated Role "${name}"`)
@@ -4656,6 +4657,38 @@ export class HostReconciler {
  * ignored. Pod-template annotations are merged by preserveDeploymentAnnotations
  * before this comparison.
  */
+/**
+ * True when the desired Role matches the live object on the fields HCC authors:
+ * `rbacLabels` and `rules` in author order. Server metadata and annotations are
+ * ignored — the builder does not write annotations, and comparing them would
+ * force a PUT. Label keys are canonicalized; rules, verbs, and resourceNames
+ * are not sorted. Missing rules or labels, or any compare failure, returns
+ * false (fail-open-to-write, #307).
+ */
+function roleMatchesDesired(desired: k8s.V1Role, existing: k8s.V1Role): boolean {
+  try {
+    if (!desired.rules || !existing.rules) return false
+    if (!desired.metadata?.labels || !existing.metadata?.labels) return false
+    if (
+      JSON.stringify(canonicalizeLabelKeys(desired.metadata.labels)) !==
+      JSON.stringify(canonicalizeLabelKeys(existing.metadata.labels))
+    ) {
+      return false
+    }
+    return JSON.stringify(desired.rules) === JSON.stringify(existing.rules)
+  } catch {
+    return false
+  }
+}
+
+function canonicalizeLabelKeys(labels: Record<string, string>): Record<string, string> {
+  const canonical: Record<string, string> = {}
+  for (const key of Object.keys(labels).sort()) {
+    canonical[key] = labels[key]
+  }
+  return canonical
+}
+
 function deploymentMatchesDesired(desired: k8s.V1Deployment, existing: k8s.V1Deployment): boolean {
   return (
     JSON.stringify(normalizeDeploymentForComparison(desired)) ===


### PR DESCRIPTION
## Summary
- `ensureHostRole` already read the live Role and then always called `replaceNamespacedRole`, logging `Updated Role` on every reconcile (~10–15/min in the field).
- Skip the PUT when authored `rbacLabels` and `rules` already match (label keys canonicalized; rules / verbs / resourceNames stay in author order). Server metadata and annotations are ignored so last-applied noise does not force a write.
- Does **not** migrate onto `replaceWithConflictRetry`. Migrating and unswallowing the fail-quiet update catch stay a follow-up (G5). Does not touch `utils.ts`.

Related to #460 (G5 Role skip).

## Test plan
- [x] NOOP-ROLE-1: create 409 + apiserver-shaped Role (uid/RV/managedFields, shuffled label keys, same rules) → replace ×0 and zero `Updated Role`. Authored rule keys differ from live `attributeTypeMap` order (canonicalize must run).
- [x] NOOP-ROLE-2: existing equivalent, desired `secretRef` rotated → replace ×1 and one `Updated Role`
- [x] NOOP-ROLE-3/4: extra live rule or extra secrets `update` verb → replace ×1
- [x] NOOP-ROLE-5: reordered live verbs → replace ×1 (converge, do not oscillate)
- [x] NOOP-ROLE-6: tampered `clerum.io/host` label value → replace ×1
- [x] NOOP-ROLE-7/8: removed live rule or removed secret resourceName → replace ×1
- [x] FIXTURE-ROLE-1: `asApiserverPolicyRule` key order matches `V1PolicyRule.attributeTypeMap`
- [x] KEEP `test/hostReconciler.test.ts` (`rewrites Role resourceNames when spec.secretRef changes`): read without `rules` still replaces
- [x] KEEP `hostDeploymentAnnotationMerge.test.ts` unchanged
- [x] `npx tsc --noEmit` and `npm test` in `host-context-controller` (1857 tests)