### PR TITLE
feat(hcc): clerum-dev NetworkPolicy orphan-census wrapper

### DIFF
--- a/.github/workflows/ci-public.yml
+++ b/.github/workflows/ci-public.yml
@@ -416,6 +416,12 @@ jobs:
       - name: Test HCC rollout readiness guards (executable, cluster-free)
         run: bash scripts/tests/test-hcc-rollout-readiness-guards.sh
 
+      - name: Test HCC netpol orphan-census guards (executable, cluster-free)
+        run: bash scripts/tests/test-hcc-netpol-orphan-census-guards.sh
+
+      - name: Test HCC netpol orphan-census verdict adjudication (fixtures, cluster-free)
+        run: bash scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
+
       - name: Test HCC API gateway readiness separation
         run: bash scripts/tests/test-hcc-api-gateway-readiness.sh
 

--- a/scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh
+++ b/scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh
@@ -21,5 +21,24 @@ umask 077
 CONTEXT=gke_your-gcp-project_us-central1-a_example-dev
 export CONTEXT
 
-ROOT="$(cd "$(dirname "$0")" && pwd)"
+# Resolve this file, including PATH invocation and a symlink, so exec
+# finds the sibling generic script. dirname "$0" is "." when the
+# wrapper is invoked by name off PATH (R1-L4).
+_self="${BASH_SOURCE[0]:-$0}"
+if [[ "${_self}" != /* && "$(dirname "${_self}")" == "." ]]; then
+  _found="$(command -v -- "$(basename "${_self}")" 2>/dev/null || true)"
+  if [[ -n "${_found}" ]]; then
+    _self="${_found}"
+  fi
+fi
+while [[ -L "${_self}" ]]; do
+  _dir="$(cd "$(dirname "${_self}")" && pwd)"
+  _link="$(readlink "${_self}")"
+  if [[ "${_link}" == /* ]]; then
+    _self="${_link}"
+  else
+    _self="${_dir}/${_link}"
+  fi
+done
+ROOT="$(cd "$(dirname "${_self}")" && pwd)"
 exec "${ROOT}/hcc-netpol-orphan-census.sh"

--- a/scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh
+++ b/scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Public entry point for the HCC NetworkPolicy orphan census.
+#
+# k8s-context-guard-v2 requires a static context name in this file.
+# The token below is the sanctioned public placeholder used by every other
+# script in this repo. The live GKE project/cluster name is not committed
+# here — leak-guards forbid it. Supply the real context from evenfire-infra
+# or a local kubeconfig alias, never from this tree.
+#
+# kubectl --context=gke_your-gcp-project_us-central1-a_example-dev
+#
+# Classification lives in hcc-netpol-orphan-census.sh. Do not duplicate it.
+# Feeds #478 (census series) and #484 (census↔controller parity).
+#
+# Usage:
+#   ./scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh
+
+set -euo pipefail
+umask 077
+
+CONTEXT=gke_your-gcp-project_us-central1-a_example-dev
+export CONTEXT
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+exec "${ROOT}/hcc-netpol-orphan-census.sh"

--- a/scripts/ops/hcc-netpol-orphan-census.sh
+++ b/scripts/ops/hcc-netpol-orphan-census.sh
@@ -3,11 +3,12 @@
 #
 # get/list only — never create, patch, replace, or delete.
 # Classifies by clerum.io/policy-type in {context-allow, rpc-proxy-egress,
-# external-egress}, plus the controller's `repairable` class: managed-by
-# present, policy-type absent, reserved name (ctx-/rpc-egress-/ext-egress-).
-# That last set is what a policy-type-strip corruption looks like; omitting
-# it can print VERDICT=CLEAN while the controller counts those objects and
-# may trip the cap. This is not the full four-lane classifier (reserved
+# external-egress} when managed-by is absent or host-context-controller
+# (#484: exclude only present-and-foreign), plus both controller
+# `repairable` one-marker arms: (1) managed-by present, policy-type absent,
+# reserved name; (2) policy-type present, managed-by absent. Omitting either
+# can print VERDICT=CLEAN while the controller still counts those objects
+# and may trip the cap. This is not the full four-lane classifier (reserved
 # names without owner labels can over-count vs the controller).
 #
 # CONTEXT_MAPPER_* knobs are read from the live host-context-controller
@@ -35,8 +36,10 @@
 # host-context-controller/src/networkPolicyReconciler.ts and the compiled
 # defaults in host-context-controller/src/config.ts (absolute 10, percent
 # 20, rpc-proxy namespace). If you change either side, change this script.
-# Typed membership requires clerum.io/managed-by=host-context-controller
-# so a foreign-owned typed policy cannot inflate listed/orphans (#484).
+# Typed membership excludes clerum.io/managed-by when it is present and
+# not host-context-controller so a foreign-owned typed policy cannot
+# inflate listed/orphans (#484). A typed policy with managed-by absent
+# stays eligible — that is the controller's other repairable arm.
 #
 # Double-samples 90s apart. Adjudicates only when the desired Context +
 # McpServer identity set is identical across samples; otherwise
@@ -126,17 +129,19 @@ require_namespace "${MAPPER_NS}"
 require_namespace "${HOST_NS}"
 require_namespace "${RPC_NS}"
 
-# Typed policy-type membership, plus the reserved-name repairable class
-# (managed-by present, policy-type absent). Shared by listed + orphan filters.
+# Typed membership (type in set and managed-by null-or-HCC) plus the
+# reserved-name untyped repairable class (managed-by present, type absent).
+# Shared by listed + orphan filters.
 CENSUS_MANAGED_JQ='
   def policy_type: .metadata.labels["clerum.io/policy-type"];
+  def managed_by: .metadata.labels["clerum.io/managed-by"];
   def is_typed:
-    .metadata.labels["clerum.io/managed-by"] == "host-context-controller"
-    and (
+    (
       policy_type == "context-allow"
       or policy_type == "rpc-proxy-egress"
       or policy_type == "external-egress"
-    );
+    )
+    and (managed_by == null or managed_by == "host-context-controller");
   def is_untyped_repairable:
     .metadata.labels["clerum.io/managed-by"] == "host-context-controller"
     and (policy_type == null)

--- a/scripts/ops/hcc-netpol-orphan-census.sh
+++ b/scripts/ops/hcc-netpol-orphan-census.sh
@@ -31,6 +31,13 @@
 # reserved-name repairable approximation, not the controller's current
 # pass authority gate.
 #
+# Cap formula must stay aligned with evaluateNetPolOrphanSweepCap in
+# host-context-controller/src/networkPolicyReconciler.ts and the compiled
+# defaults in host-context-controller/src/config.ts (absolute 10, percent
+# 20, rpc-proxy namespace). If you change either side, change this script.
+# Typed membership requires clerum.io/managed-by=host-context-controller
+# so a foreign-owned typed policy cannot inflate listed/orphans (#484).
+#
 # Double-samples 90s apart. Adjudicates only when the desired Context +
 # McpServer identity set is identical across samples; otherwise
 # INCONCLUSIVE_RERUN. A sample that listed zero managed policies is
@@ -61,7 +68,7 @@ deployment_env() {
   local key="$1"
   local value
   local rc=0
-  value="$(kc -n "${HCC_NS}" get deploy "${HCC_DEPLOYMENT}" -o "jsonpath={.spec.template.spec.containers[0].env[?(@.name==\"${key}\")].value}")" || rc=$?
+  value="$(kc -n "${HCC_NS}" get deployments "${HCC_DEPLOYMENT}" -o "jsonpath={.spec.template.spec.containers[0].env[?(@.name==\"${key}\")].value}")" || rc=$?
   if [[ "${rc}" -ne 0 ]]; then
     echo "[census] FATAL: kubectl failed reading ${key} from ${HCC_NS}/${HCC_DEPLOYMENT} (exit ${rc})" >&2
     exit 2
@@ -106,14 +113,30 @@ if [[ "${RPC_NS}" == "UNSET" ]]; then
   RPC_NS="${COMPILED_RPC_NS_DEFAULT}"
 fi
 
+# Fail loud on a missing namespace. An empty list from a typo must never
+# print VERDICT=CLEAN (zero-tests-is-never-success).
+require_namespace() {
+  local ns="$1"
+  if ! kc get namespaces "${ns}" -o name >/dev/null; then
+    echo "[census] FATAL: namespace ${ns} does not exist; refusing to sample an empty inventory" >&2
+    exit 2
+  fi
+}
+require_namespace "${MAPPER_NS}"
+require_namespace "${HOST_NS}"
+require_namespace "${RPC_NS}"
+
 # Typed policy-type membership, plus the reserved-name repairable class
 # (managed-by present, policy-type absent). Shared by listed + orphan filters.
 CENSUS_MANAGED_JQ='
   def policy_type: .metadata.labels["clerum.io/policy-type"];
   def is_typed:
-    policy_type == "context-allow"
-    or policy_type == "rpc-proxy-egress"
-    or policy_type == "external-egress";
+    .metadata.labels["clerum.io/managed-by"] == "host-context-controller"
+    and (
+      policy_type == "context-allow"
+      or policy_type == "rpc-proxy-egress"
+      or policy_type == "external-egress"
+    );
   def is_untyped_repairable:
     .metadata.labels["clerum.io/managed-by"] == "host-context-controller"
     and (policy_type == null)

--- a/scripts/ops/hcc-netpol-orphan-census.sh
+++ b/scripts/ops/hcc-netpol-orphan-census.sh
@@ -29,8 +29,13 @@
 # compiled default. Do not declare the key in deploy/ to unblock the job.
 #
 # This census reflects on-cluster orphans by policy-type plus the
-# reserved-name repairable approximation, not the controller's current
-# pass authority gate.
+# reserved-name repairable approximation. It is not the full pass
+# authority gate, but one abort-shaped class is reported:
+# VERDICT=AMBIGUOUS_PRESENT (exit 5) when a foreign managed-by,
+# typed, reserved-name policy also carries an owner label. That
+# object stays out of listed/orphans (#484) and must not print CLEAN
+# — classifySafetyInventoryPolicy tags it ambiguous and the
+# controller aborts the pass. Other ambiguous arms stay out of scope.
 #
 # Cap formula must stay aligned with evaluateNetPolOrphanSweepCap in
 # host-context-controller/src/networkPolicyReconciler.ts and the compiled
@@ -43,8 +48,8 @@
 #
 # Double-samples 90s apart. Adjudicates only when the desired Context +
 # McpServer identity set is identical across samples; otherwise
-# INCONCLUSIVE_RERUN. A sample that listed zero managed policies is
-# INCONCLUSIVE_EMPTY, never CLEAN.
+# INCONCLUSIVE_RERUN. A sample that listed zero managed policies and
+# zero ambiguous-foreign objects is INCONCLUSIVE_EMPTY, never CLEAN.
 #
 # Usage:
 #   CONTEXT=<kube-context> ./scripts/ops/hcc-netpol-orphan-census.sh
@@ -151,6 +156,23 @@ CENSUS_MANAGED_JQ='
       or (.metadata.name // "" | startswith("ext-egress-"))
     );
   def is_census_managed: is_typed or is_untyped_repairable;
+  def is_reserved:
+    (.metadata.name // "" | startswith("ctx-"))
+    or (.metadata.name // "" | startswith("rpc-egress-"))
+    or (.metadata.name // "" | startswith("ext-egress-"));
+  def has_owner:
+    (.metadata.labels["clerum.io/context"] != null)
+    or (.metadata.labels["clerum.io/mcpserver"] != null);
+  def is_ambiguous_foreign:
+    managed_by != null
+    and managed_by != "host-context-controller"
+    and (
+      policy_type == "context-allow"
+      or policy_type == "rpc-proxy-egress"
+      or policy_type == "external-egress"
+    )
+    and is_reserved
+    and has_owner;
   def census_lane:
     if policy_type == "external-egress"
        or (policy_type == null and (.metadata.name // "" | startswith("ext-egress-")))
@@ -171,6 +193,7 @@ sample_state() {
   )"
 
   local desired_contexts desired_servers listed untyped orphans orphan_count
+  local ambiguous ambiguous_count
   desired_contexts="$(printf "%s" "${contexts_json}" | jq -r '[.items[]?.spec.contextId // empty] | unique | sort | join(",")')"
   desired_servers="$(printf "%s" "${servers_json}" | jq -r '[.items[]?.metadata.name // empty] | unique | sort | join(",")')"
   listed="$(printf "%s" "${np_json}" | jq -r "${CENSUS_MANAGED_JQ} [.items[] | select(is_census_managed)] | length")"
@@ -200,13 +223,34 @@ sample_state() {
     orphan_count="$(printf "%s\n" "${orphans}" | awk 'NF { n++ } END { print n+0 }')"
   fi
 
+  ambiguous="$(printf "%s" "${np_json}" | jq -r "${CENSUS_MANAGED_JQ}"'
+    .items[]
+    | select(is_ambiguous_foreign)
+    | [
+        .metadata.namespace,
+        .metadata.name,
+        (.metadata.labels["clerum.io/policy-type"] // "none"),
+        (.metadata.labels["clerum.io/managed-by"] // "")
+      ]
+    | @tsv
+  ')"
+  if [[ -z "${ambiguous}" ]]; then
+    ambiguous_count=0
+  else
+    ambiguous_count="$(printf "%s\n" "${ambiguous}" | awk 'NF { n++ } END { print n+0 }')"
+  fi
+
   printf "DESIRED_CONTEXTS=%s\n" "${desired_contexts}"
   printf "DESIRED_SERVERS=%s\n" "${desired_servers}"
   printf "LISTED_MANAGED=%s\n" "${listed}"
   printf "REPAIRABLE_UNTYPED=%s\n" "${untyped}"
   printf "ORPHAN_COUNT=%s\n" "${orphan_count}"
+  printf "AMBIGUOUS_COUNT=%s\n" "${ambiguous_count}"
   printf "ORPHANS<<EOF\n"
   printf "%s\n" "${orphans}"
+  printf "EOF\n"
+  printf "AMBIGUOUS<<EOF\n"
+  printf "%s\n" "${ambiguous}"
   printf "EOF\n"
 }
 
@@ -217,14 +261,14 @@ parse_field() {
 
 echo "[census] sample 1"
 SAMPLE1="$(sample_state)"
-echo "${SAMPLE1}" | sed "/^ORPHANS<<EOF/,/^EOF/d"
+echo "${SAMPLE1}" | sed -e "/^ORPHANS<<EOF/,/^EOF/d" -e "/^AMBIGUOUS<<EOF/,/^EOF/d"
 
 echo "[census] waiting ${SAMPLE_GAP_SEC}s for second sample"
 sleep "${SAMPLE_GAP_SEC}"
 
 echo "[census] sample 2"
 SAMPLE2="$(sample_state)"
-echo "${SAMPLE2}" | sed "/^ORPHANS<<EOF/,/^EOF/d"
+echo "${SAMPLE2}" | sed -e "/^ORPHANS<<EOF/,/^EOF/d" -e "/^AMBIGUOUS<<EOF/,/^EOF/d"
 
 CTX1="$(parse_field "${SAMPLE1}" DESIRED_CONTEXTS)"
 SRV1="$(parse_field "${SAMPLE1}" DESIRED_SERVERS)"
@@ -244,10 +288,13 @@ fi
 ORPHAN_COUNT="$(parse_field "${SAMPLE2}" ORPHAN_COUNT)"
 LISTED="$(parse_field "${SAMPLE2}" LISTED_MANAGED)"
 REPAIRABLE_UNTYPED="$(parse_field "${SAMPLE2}" REPAIRABLE_UNTYPED)"
+AMBIGUOUS_COUNT="$(parse_field "${SAMPLE2}" AMBIGUOUS_COUNT)"
 echo "[census] desired set identical across samples"
-echo "[census] listed_managed=${LISTED} repairable_untyped=${REPAIRABLE_UNTYPED} orphan_count=${ORPHAN_COUNT}"
+echo "[census] listed_managed=${LISTED} repairable_untyped=${REPAIRABLE_UNTYPED} orphan_count=${ORPHAN_COUNT} ambiguous_count=${AMBIGUOUS_COUNT}"
 echo "[census] orphans (namespace name policy-type):"
 printf "%s" "${SAMPLE2}" | sed -n "/^ORPHANS<<EOF/,/^EOF/{ /^ORPHANS<<EOF/d; /^EOF/d; p; }"
+echo "[census] ambiguous (namespace name policy-type managed-by):"
+printf "%s" "${SAMPLE2}" | sed -n "/^AMBIGUOUS<<EOF/,/^EOF/{ /^AMBIGUOUS<<EOF/d; /^EOF/d; p; }"
 
 # Controller compiled defaults (config.ts). Used only for
 # controller_cap_would_trip, never as a substitute for live env.
@@ -321,11 +368,21 @@ CONTROLLER_CAP_REASON="$(cap_would_trip "${ORPHAN_COUNT}" "${LISTED}" "${CONTROL
 echo "[census] live_cap_would_trip=${CAP_REASON}"
 echo "[census] compiled_default_absolute=${COMPILED_ABS_DEFAULT} compiled_default_percent=${COMPILED_PCT_DEFAULT}"
 echo "[census] controller_cap_would_trip=${CONTROLLER_CAP_REASON} (live env, else compiled defaults)"
-if [[ "${LISTED}" -eq 0 ]]; then
+if ! is_uint "${AMBIGUOUS_COUNT}"; then
+  echo "[census] VERDICT=INCONCLUSIVE_EMPTY"
+  echo "[census] ambiguous_count is not an unsigned integer; do not treat this as CLEAN" >&2
+  exit 4
+fi
+if [[ "${LISTED}" -eq 0 && "${AMBIGUOUS_COUNT}" -eq 0 ]]; then
   echo "[census] VERDICT=INCONCLUSIVE_EMPTY"
   echo "[census] listed zero managed NetworkPolicies; \"found nothing\" is not CLEAN"
   echo "[census] hint: re-check CONTEXT, CONTEXT_MAPPER_RPC_PROXY_NAMESPACE, and kubectl connectivity"
   exit 4
+fi
+if [[ "${AMBIGUOUS_COUNT}" -gt 0 ]]; then
+  echo "[census] VERDICT=AMBIGUOUS_PRESENT"
+  echo "[census] foreign typed reserved+owner policy present; controller aborts the pass — not CLEAN"
+  exit 5
 fi
 if [[ "${ORPHAN_COUNT}" -eq 0 ]]; then
   echo "[census] VERDICT=CLEAN"

--- a/scripts/tests/test-hcc-netpol-orphan-census-guards.sh
+++ b/scripts/tests/test-hcc-netpol-orphan-census-guards.sh
@@ -212,16 +212,8 @@ fi
 run_census "$GENERIC" CONTEXT="$TEST_CTX"
 if ! grep -Fq 'UNSET (controller applies compiled default: rpc-proxy)' <<<"$OUT"; then
   fail "UNSET rpc-proxy is two-tier — missing live label"
-elif ! grep -Fq 'get networkpolicy -n rpc-proxy' "$CASE_LOG" &&
-  ! grep -Fq 'get networkpolicy --namespace rpc-proxy' "$CASE_LOG" &&
-  ! grep -Eq -- '-n rpc-proxy get networkpolicy|get networkpolicy -n rpc-proxy' "$CASE_LOG"; then
-  # kubectl is invoked as: --context X -n rpc-proxy get networkpolicy -o json
-  # logged as the raw argv string from $*.
-  if ! grep -Fq -- '-n rpc-proxy' "$CASE_LOG" || ! grep -Fq 'networkpolicy' "$CASE_LOG"; then
-    fail "UNSET rpc-proxy is two-tier — did not sample rpc-proxy; got: $(tr '\n' '|' <"$CASE_LOG")"
-  else
-    pass "UNSET rpc-proxy namespace is labelled two-tier and sampled with the compiled default"
-  fi
+elif ! grep -Fq -- '-n rpc-proxy' "$CASE_LOG" || ! grep -Fq 'networkpolicy' "$CASE_LOG"; then
+  fail "UNSET rpc-proxy is two-tier — did not sample rpc-proxy; got: $(tr '\n' '|' <"$CASE_LOG")"
 else
   pass "UNSET rpc-proxy namespace is labelled two-tier and sampled with the compiled default"
 fi
@@ -240,10 +232,47 @@ fi
 # G8
 if grep -Fxq "CONTEXT=${PLACEHOLDER}" "$WRAPPER" &&
   ! grep -Eq 'CONTEXT=.*:-|\$\{CONTEXT:-' "$WRAPPER" &&
-  grep -Eq 'exec .*hcc-netpol-orphan-census\.sh' "$WRAPPER"; then
+  grep -Eq 'exec .*hcc-netpol-orphan-census\.sh' "$WRAPPER" &&
+  grep -Fq 'BASH_SOURCE[0]' "$WRAPPER"; then
   pass "wrapper source pins: unconditional assignment + exec of the generic census"
 else
-  fail "wrapper source pins — unconditional CONTEXT= or exec of the generic census is missing"
+  fail "wrapper source pins — unconditional CONTEXT=, BASH_SOURCE resolve, or exec of the generic census is missing"
+fi
+
+# G9: PATH + symlink invocation must still exec the sibling generic.
+ln -sf "$WRAPPER" "${STUB_BIN}/hcc-netpol-orphan-census-clerum-dev.sh"
+: >"$CASE_LOG"
+_g9_pwd="$(pwd)"
+cd "$WORKDIR"
+OUT="$(
+  env -i \
+    HOME="$HOME" \
+    TMPDIR="$WORKDIR" \
+    KUBECONFIG="$FAKE_KUBECONFIG" \
+    PATH="${STUB_BIN}:${PATH}" \
+    CENSUS_STUB_LOG="$CASE_LOG" \
+    SAMPLE_GAP_SEC=0 \
+    CONTEXT=gke_evil_inherited_ctx \
+    STUB_FAIL_ENV_READ=1 \
+    STUB_ENV_CONTEXT_MAPPER_NAMESPACE="$MAPPER_NS" \
+    STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE="$HOST_NS" \
+    STUB_CONTEXTS_FIXTURE="${WORKDIR}/contexts.json" \
+    STUB_SERVERS_FIXTURE="${WORKDIR}/servers.json" \
+    STUB_NP_MAPPER_FIXTURE="${WORKDIR}/empty-np.json" \
+    STUB_NP_HOST_FIXTURE="${WORKDIR}/empty-np.json" \
+    STUB_NP_RPC_FIXTURE="${WORKDIR}/empty-np.json" \
+    bash -c 'hcc-netpol-orphan-census-clerum-dev.sh' 2>&1
+)"
+RC=$?
+cd "$_g9_pwd"
+cat "$CASE_LOG" >>"$ALL_LOG"
+if ! grep -Fq -- "--context ${PLACEHOLDER}" "$CASE_LOG" &&
+  ! grep -Fq -- "--context=${PLACEHOLDER}" "$CASE_LOG"; then
+  fail "wrapper PATH/symlink resolve — placeholder missing from argv; got: $(tr '\n' '|' <"$CASE_LOG")"
+elif grep -Fq 'gke_evil_inherited_ctx' "$CASE_LOG" || grep -Fq 'gke_evil_inherited_ctx' <<<"$OUT"; then
+  fail "wrapper PATH/symlink resolve — hostile inherited context leaked"
+else
+  pass "wrapper PATH/symlink invocation still execs the sibling generic and pins CONTEXT"
 fi
 
 if grep -Eq '(^|[[:space:]])(set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose)([[:space:]]|$)' "$ALL_LOG"; then

--- a/scripts/tests/test-hcc-netpol-orphan-census-guards.sh
+++ b/scripts/tests/test-hcc-netpol-orphan-census-guards.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Executable, cluster-free guard tests for the HCC NetworkPolicy orphan census
+# (#495). Proves the route (argv, fail-loud ordering, wrapper CONTEXT pin),
+# not a live CLEAN destination. Never contacts a real cluster.
+#
+# Sibling: test-hcc-netpol-orphan-census-verdicts.sh (adjudication).
+set -u
+FAIL=0
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERIC="${ROOT}/scripts/ops/hcc-netpol-orphan-census.sh"
+WRAPPER="${ROOT}/scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh"
+PLACEHOLDER='gke_your-gcp-project_us-central1-a_example-dev'
+TEST_CTX='census-hermetic-ctx'
+MAPPER_NS='mcp-server'
+HOST_NS='mcp-host'
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1"
+  FAIL=1
+}
+
+command -v jq >/dev/null 2>&1 || {
+  echo "FAIL: this harness requires jq on PATH" >&2
+  exit 1
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/hcc-census-guards.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+FAKE_KUBECONFIG="${WORKDIR}/empty-kubeconfig"
+: >"$FAKE_KUBECONFIG"
+STUB_BIN="${WORKDIR}/stub-bin"
+mkdir -p "$STUB_BIN"
+ALL_LOG="${WORKDIR}/all-kubectl.log"
+: >"$ALL_LOG"
+CASE_LOG="${WORKDIR}/kubectl.log"
+
+cat >"${STUB_BIN}/kubectl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CENSUS_STUB_LOG:?}"
+ctx=""
+ns=""
+output=""
+args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --context) ctx="$2"; shift 2 ;;
+    --context=*) ctx="${1#--context=}"; shift ;;
+    -n|--namespace) ns="$2"; shift 2 ;;
+    -n=*|--namespace=*) ns="${1#*=}"; shift ;;
+    -o|--output) output="$2"; shift 2 ;;
+    -o=*|--output=*) output="${1#*=}"; shift ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+verb="${args[0]:-}"
+resource="${args[1]:-}"
+name="${args[2]:-}"
+case "$verb" in
+  set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose|autoscale|cordon|uncordon|taint)
+    echo "fake-kubectl: refusing mutating verb ${verb}" >&2
+    exit 2
+    ;;
+esac
+if [ "$verb" != get ]; then
+  echo "fake-kubectl: unexpected invocation verb=${verb} argv=${args[*]}" >&2
+  exit 2
+fi
+if [ "$resource" = deployments ]; then
+  if [ "${STUB_FAIL_ENV_READ:-0}" = 1 ]; then
+    exit 1
+  fi
+  key=""
+  if [[ "$output" == *'@.name=="'* ]]; then
+    key="${output#*@.name==\"}"
+    key="${key%%\"*}"
+  fi
+  varname="STUB_ENV_${key}"
+  printf '%s' "${!varname-}"
+  exit 0
+fi
+if [ "$resource" = deploy ]; then
+  echo "fake-kubectl: unexpected invocation resource=deploy (want deployments)" >&2
+  exit 2
+fi
+if [ "$resource" = namespaces ]; then
+  if [ -n "${STUB_MISSING_NS:-}" ] && [ "$name" = "$STUB_MISSING_NS" ]; then
+    echo "Error from server (NotFound): namespaces \"${name}\" not found" >&2
+    exit 1
+  fi
+  echo "namespace/${name}"
+  exit 0
+fi
+if [ "$resource" = contexts.clerum.io ]; then
+  cat "${STUB_CONTEXTS_FIXTURE:?}"
+  exit 0
+fi
+if [ "$resource" = mcpservers.clerum.io ]; then
+  cat "${STUB_SERVERS_FIXTURE:?}"
+  exit 0
+fi
+if [ "$resource" = networkpolicy ] || [ "$resource" = networkpolicies ]; then
+  case "$ns" in
+    "${STUB_ENV_CONTEXT_MAPPER_NAMESPACE:-mcp-server}") cat "${STUB_NP_MAPPER_FIXTURE:?}" ;;
+    "${STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE:-mcp-host}") cat "${STUB_NP_HOST_FIXTURE:?}" ;;
+    rpc-proxy|"${STUB_ENV_CONTEXT_MAPPER_RPC_PROXY_NAMESPACE:-}") cat "${STUB_NP_RPC_FIXTURE:?}" ;;
+    *)
+      echo "fake-kubectl: unexpected networkpolicy namespace ${ns}" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+echo "fake-kubectl: unexpected invocation ctx=${ctx} argv=${args[*]}" >&2
+exit 2
+STUB
+chmod +x "${STUB_BIN}/kubectl"
+
+printf '%s\n' '{"items":[{"spec":{"contextId":"ctx-alpha"}}]}' >"${WORKDIR}/contexts.json"
+printf '%s\n' '{"items":[{"metadata":{"name":"srv-a"}}]}' >"${WORKDIR}/servers.json"
+printf '%s\n' '{"items":[]}' >"${WORKDIR}/empty-np.json"
+
+run_census() {
+  local script="$1"
+  shift
+  : >"$CASE_LOG"
+  OUT="$(
+    env -i \
+      HOME="$HOME" \
+      TMPDIR="$WORKDIR" \
+      KUBECONFIG="$FAKE_KUBECONFIG" \
+      PATH="${STUB_BIN}:${PATH}" \
+      CENSUS_STUB_LOG="$CASE_LOG" \
+      SAMPLE_GAP_SEC=0 \
+      STUB_ENV_CONTEXT_MAPPER_NAMESPACE="$MAPPER_NS" \
+      STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE="$HOST_NS" \
+      STUB_CONTEXTS_FIXTURE="${WORKDIR}/contexts.json" \
+      STUB_SERVERS_FIXTURE="${WORKDIR}/servers.json" \
+      STUB_NP_MAPPER_FIXTURE="${WORKDIR}/empty-np.json" \
+      STUB_NP_HOST_FIXTURE="${WORKDIR}/empty-np.json" \
+      STUB_NP_RPC_FIXTURE="${WORKDIR}/empty-np.json" \
+      "$@" \
+      bash "$script" 2>&1
+  )"
+  RC=$?
+  cat "$CASE_LOG" >>"$ALL_LOG"
+}
+
+# G1
+run_census "$GENERIC"
+if [ "${RC:-0}" -eq 0 ]; then
+  fail "refuses when CONTEXT is unset — exited 0"
+elif ! grep -Fq 'must set CONTEXT' <<<"$OUT"; then
+  fail "refuses when CONTEXT is unset — missing needle; got: $(head -c 300 <<<"$OUT")"
+elif [ -s "$CASE_LOG" ]; then
+  fail "refuses when CONTEXT is unset — kubectl ran before the guard"
+else
+  pass "refuses when CONTEXT is unset"
+fi
+
+# G2
+run_census "$GENERIC" CONTEXT="$TEST_CTX"
+if ! grep -Fq 'get deployments' "$CASE_LOG"; then
+  fail "deployment read uses get deployments — log missing token; got: $(tr '\n' '|' <"$CASE_LOG")"
+elif grep -Eq '(^|[[:space:]])get deploy([[:space:]]|$)' "$CASE_LOG"; then
+  fail "deployment read uses get deployments — found abbreviated get deploy"
+else
+  pass "deployment read uses get deployments on the explicit context"
+fi
+
+# G3
+run_census "$GENERIC" CONTEXT="$TEST_CTX" STUB_FAIL_ENV_READ=1
+if [ "$RC" -ne 2 ]; then
+  fail "kubectl failure reading Deployment env is FATAL — exit ${RC}, want 2"
+elif ! grep -Fq 'FATAL: kubectl failed reading' <<<"$OUT"; then
+  fail "kubectl failure reading Deployment env is FATAL — missing needle"
+elif grep -Fq 'VERDICT=' <<<"$OUT"; then
+  fail "kubectl failure reading Deployment env is FATAL — printed a verdict"
+else
+  pass "kubectl failure reading Deployment env is FATAL, not UNSET"
+fi
+
+# G4
+run_census "$GENERIC" CONTEXT="$TEST_CTX" \
+  STUB_ENV_CONTEXT_MAPPER_NAMESPACE= \
+  STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE=
+if [ "$RC" -ne 2 ]; then
+  fail "refuses UNSET mapper/host namespaces — exit ${RC}, want 2"
+elif ! grep -Fq 'refusing to invent defaults' <<<"$OUT"; then
+  fail "refuses UNSET mapper/host namespaces — missing needle"
+elif grep -Fq 'contexts.clerum.io' "$CASE_LOG"; then
+  fail "refuses UNSET mapper/host namespaces — sampled anyway"
+else
+  pass "refuses when mapper/host namespaces are UNSET on the Deployment"
+fi
+
+# G5
+run_census "$GENERIC" CONTEXT="$TEST_CTX" STUB_MISSING_NS="$MAPPER_NS"
+if [ "$RC" -ne 2 ]; then
+  fail "missing namespace exits 2 — exit ${RC}, want 2"
+elif ! grep -Fq 'refusing to sample an empty inventory' <<<"$OUT"; then
+  fail "missing namespace exits 2 — missing FATAL needle"
+elif grep -Fq 'VERDICT=' <<<"$OUT"; then
+  fail "missing namespace exits 2 — printed a verdict"
+elif grep -Fq 'contexts.clerum.io' "$CASE_LOG"; then
+  fail "missing namespace exits 2 — sampled before refusing"
+else
+  pass "missing namespace exits 2 and NEVER prints VERDICT=CLEAN"
+fi
+
+# G6
+run_census "$GENERIC" CONTEXT="$TEST_CTX"
+if ! grep -Fq 'UNSET (controller applies compiled default: rpc-proxy)' <<<"$OUT"; then
+  fail "UNSET rpc-proxy is two-tier — missing live label"
+elif ! grep -Fq 'get networkpolicy -n rpc-proxy' "$CASE_LOG" &&
+  ! grep -Fq 'get networkpolicy --namespace rpc-proxy' "$CASE_LOG" &&
+  ! grep -Eq -- '-n rpc-proxy get networkpolicy|get networkpolicy -n rpc-proxy' "$CASE_LOG"; then
+  # kubectl is invoked as: --context X -n rpc-proxy get networkpolicy -o json
+  # logged as the raw argv string from $*.
+  if ! grep -Fq -- '-n rpc-proxy' "$CASE_LOG" || ! grep -Fq 'networkpolicy' "$CASE_LOG"; then
+    fail "UNSET rpc-proxy is two-tier — did not sample rpc-proxy; got: $(tr '\n' '|' <"$CASE_LOG")"
+  else
+    pass "UNSET rpc-proxy namespace is labelled two-tier and sampled with the compiled default"
+  fi
+else
+  pass "UNSET rpc-proxy namespace is labelled two-tier and sampled with the compiled default"
+fi
+
+# G7
+run_census "$WRAPPER" CONTEXT=gke_evil_inherited_ctx STUB_FAIL_ENV_READ=1
+if ! grep -Fq -- "--context ${PLACEHOLDER}" "$CASE_LOG" &&
+  ! grep -Fq -- "--context=${PLACEHOLDER}" "$CASE_LOG"; then
+  fail "wrapper pins CONTEXT unconditionally — placeholder missing from argv; got: $(tr '\n' '|' <"$CASE_LOG")"
+elif grep -Fq 'gke_evil_inherited_ctx' "$CASE_LOG" || grep -Fq 'gke_evil_inherited_ctx' <<<"$OUT"; then
+  fail "wrapper pins CONTEXT unconditionally — hostile inherited context leaked"
+else
+  pass "wrapper pins CONTEXT unconditionally over a hostile inherited value"
+fi
+
+# G8
+if grep -Fxq "CONTEXT=${PLACEHOLDER}" "$WRAPPER" &&
+  ! grep -Eq 'CONTEXT=.*:-|\$\{CONTEXT:-' "$WRAPPER" &&
+  grep -Eq 'exec .*hcc-netpol-orphan-census\.sh' "$WRAPPER"; then
+  pass "wrapper source pins: unconditional assignment + exec of the generic census"
+else
+  fail "wrapper source pins — unconditional CONTEXT= or exec of the generic census is missing"
+fi
+
+if grep -Eq '(^|[[:space:]])(set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose)([[:space:]]|$)' "$ALL_LOG"; then
+  fail "census stayed read-only — mutating verb recorded; got: $(tr '\n' '|' <"$ALL_LOG")"
+else
+  pass "fake kubectl saw only get verbs (no mutation)"
+fi
+
+exit "$FAIL"

--- a/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
+++ b/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# Executable, cluster-free verdict tests for the HCC NetworkPolicy orphan
+# census (#495 / #484). Fixtures + SAMPLE_GAP_SEC=0 — never a 90s sleep,
+# never a real cluster. Proves membership and adjudication, not a live CLEAN.
+set -u
+FAIL=0
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GENERIC="${ROOT}/scripts/ops/hcc-netpol-orphan-census.sh"
+TEST_CTX='census-hermetic-ctx'
+MAPPER_NS='mcp-server'
+HOST_NS='mcp-host'
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1"
+  FAIL=1
+}
+
+command -v jq >/dev/null 2>&1 || {
+  echo "FAIL: this harness requires jq on PATH" >&2
+  exit 1
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/hcc-census-verdicts.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+FAKE_KUBECONFIG="${WORKDIR}/empty-kubeconfig"
+: >"$FAKE_KUBECONFIG"
+STUB_BIN="${WORKDIR}/stub-bin"
+mkdir -p "$STUB_BIN"
+ALL_LOG="${WORKDIR}/all-kubectl.log"
+: >"$ALL_LOG"
+CASE_LOG="${WORKDIR}/kubectl.log"
+
+cat >"${STUB_BIN}/kubectl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CENSUS_STUB_LOG:?}"
+ctx=""
+ns=""
+output=""
+args=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --context) ctx="$2"; shift 2 ;;
+    --context=*) ctx="${1#--context=}"; shift ;;
+    -n|--namespace) ns="$2"; shift 2 ;;
+    -n=*|--namespace=*) ns="${1#*=}"; shift ;;
+    -o|--output) output="$2"; shift 2 ;;
+    -o=*|--output=*) output="${1#*=}"; shift ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+verb="${args[0]:-}"
+resource="${args[1]:-}"
+name="${args[2]:-}"
+case "$verb" in
+  set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose|autoscale|cordon|uncordon|taint)
+    echo "fake-kubectl: refusing mutating verb ${verb}" >&2
+    exit 2
+    ;;
+esac
+if [ "$verb" != get ]; then
+  echo "fake-kubectl: unexpected invocation verb=${verb} argv=${args[*]}" >&2
+  exit 2
+fi
+if [ "$resource" = deployments ]; then
+  key=""
+  if [[ "$output" == *'@.name=="'* ]]; then
+    key="${output#*@.name==\"}"
+    key="${key%%\"*}"
+  fi
+  varname="STUB_ENV_${key}"
+  printf '%s' "${!varname-}"
+  exit 0
+fi
+if [ "$resource" = namespaces ]; then
+  echo "namespace/${name}"
+  exit 0
+fi
+if [ "$resource" = contexts.clerum.io ]; then
+  count_file="${CENSUS_STUB_DIR:?}/call-count-contexts"
+  n=0
+  if [ -f "$count_file" ]; then
+    n="$(cat "$count_file")"
+  fi
+  n=$((n + 1))
+  printf '%s\n' "$n" >"$count_file"
+  if [ "$n" -ge 2 ] && [ -n "${STUB_CONTEXTS_FIXTURE_2:-}" ]; then
+    cat "${STUB_CONTEXTS_FIXTURE_2}"
+  else
+    cat "${STUB_CONTEXTS_FIXTURE:?}"
+  fi
+  exit 0
+fi
+if [ "$resource" = mcpservers.clerum.io ]; then
+  cat "${STUB_SERVERS_FIXTURE:?}"
+  exit 0
+fi
+if [ "$resource" = networkpolicy ] || [ "$resource" = networkpolicies ]; then
+  case "$ns" in
+    "${STUB_ENV_CONTEXT_MAPPER_NAMESPACE:-mcp-server}") cat "${STUB_NP_MAPPER_FIXTURE:?}" ;;
+    "${STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE:-mcp-host}") cat "${STUB_NP_HOST_FIXTURE:?}" ;;
+    rpc-proxy) cat "${STUB_NP_RPC_FIXTURE:?}" ;;
+    *)
+      echo "fake-kubectl: unexpected networkpolicy namespace ${ns}" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+echo "fake-kubectl: unexpected invocation ctx=${ctx} argv=${args[*]}" >&2
+exit 2
+STUB
+chmod +x "${STUB_BIN}/kubectl"
+
+printf '%s\n' '{"items":[{"spec":{"contextId":"ctx-alpha"}}]}' >"${WORKDIR}/contexts.json"
+printf '%s\n' '{"items":[{"spec":{"contextId":"ctx-alpha"}},{"spec":{"contextId":"ctx-extra"}}]}' >"${WORKDIR}/contexts-churn.json"
+printf '%s\n' '{"items":[{"metadata":{"name":"srv-a"}}]}' >"${WORKDIR}/servers.json"
+printf '%s\n' '{"items":[]}' >"${WORKDIR}/empty-np.json"
+
+# V1: HCC member + foreign typed policy shaped as a pre-#484 orphan.
+jq -n '{
+  items: [
+    {
+      metadata: {
+        uid: "uid-member",
+        namespace: "mcp-server",
+        name: "ctx-alpha-allow",
+        labels: {
+          "clerum.io/managed-by": "host-context-controller",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-alpha"
+        }
+      }
+    },
+    {
+      metadata: {
+        uid: "uid-foreign",
+        namespace: "mcp-server",
+        name: "ctx-ghost-allow",
+        labels: {
+          "clerum.io/managed-by": "someone-else",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-ghost"
+        }
+      }
+    }
+  ]
+}' >"${WORKDIR}/np-v1.json"
+
+# V4: member + typed orphan + untyped repairable orphan.
+jq -n '{
+  items: [
+    {
+      metadata: {
+        uid: "uid-member",
+        namespace: "mcp-server",
+        name: "ctx-alpha-allow",
+        labels: {
+          "clerum.io/managed-by": "host-context-controller",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-alpha"
+        }
+      }
+    },
+    {
+      metadata: {
+        uid: "uid-typed-orphan",
+        namespace: "mcp-server",
+        name: "ctx-gone-allow",
+        labels: {
+          "clerum.io/managed-by": "host-context-controller",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-gone"
+        }
+      }
+    },
+    {
+      metadata: {
+        uid: "uid-repairable",
+        namespace: "mcp-server",
+        name: "ctx-orphaned-thing",
+        labels: {
+          "clerum.io/managed-by": "host-context-controller"
+        }
+      }
+    }
+  ]
+}' >"${WORKDIR}/np-v4.json"
+
+# V5: 1 member + 11 typed orphans (listed=12, orphans=11 > compiled abs 10).
+jq -n '
+  {
+    items: (
+      [range(0; 11) | {
+        metadata: {
+          uid: ("uid-orphan-" + tostring),
+          namespace: "mcp-server",
+          name: ("ctx-gone-allow-" + tostring),
+          labels: {
+            "clerum.io/managed-by": "host-context-controller",
+            "clerum.io/policy-type": "context-allow",
+            "clerum.io/context": "ctx-gone"
+          }
+        }
+      }]
+      + [{
+        metadata: {
+          uid: "uid-member",
+          namespace: "mcp-server",
+          name: "ctx-alpha-allow",
+          labels: {
+            "clerum.io/managed-by": "host-context-controller",
+            "clerum.io/policy-type": "context-allow",
+            "clerum.io/context": "ctx-alpha"
+          }
+        }
+      }]
+    )
+  }
+' >"${WORKDIR}/np-v5.json"
+
+run_census() {
+  : >"$CASE_LOG"
+  rm -f "${WORKDIR}/call-count-contexts"
+  OUT="$(
+    env -i \
+      HOME="$HOME" \
+      TMPDIR="$WORKDIR" \
+      KUBECONFIG="$FAKE_KUBECONFIG" \
+      PATH="${STUB_BIN}:${PATH}" \
+      CENSUS_STUB_LOG="$CASE_LOG" \
+      CENSUS_STUB_DIR="$WORKDIR" \
+      SAMPLE_GAP_SEC=0 \
+      CONTEXT="$TEST_CTX" \
+      STUB_ENV_CONTEXT_MAPPER_NAMESPACE="$MAPPER_NS" \
+      STUB_ENV_CONTEXT_MAPPER_HOST_NAMESPACE="$HOST_NS" \
+      STUB_CONTEXTS_FIXTURE="${WORKDIR}/contexts.json" \
+      STUB_SERVERS_FIXTURE="${WORKDIR}/servers.json" \
+      STUB_NP_MAPPER_FIXTURE="${WORKDIR}/empty-np.json" \
+      STUB_NP_HOST_FIXTURE="${WORKDIR}/empty-np.json" \
+      STUB_NP_RPC_FIXTURE="${WORKDIR}/empty-np.json" \
+      "$@" \
+      bash "$GENERIC" 2>&1
+  )"
+  RC=$?
+  cat "$CASE_LOG" >>"$ALL_LOG"
+}
+
+# V1
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v1.json"
+if [ "$RC" -ne 0 ]; then
+  fail "foreign-owned typed policy is excluded — exit ${RC}; got: $(head -c 400 <<<"$OUT")"
+elif ! grep -Fq 'listed_managed=1' <<<"$OUT" || ! grep -Fq 'orphan_count=0' <<<"$OUT"; then
+  fail "foreign-owned typed policy is excluded — listed/orphan mismatch; got: $(head -c 400 <<<"$OUT")"
+elif ! grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
+  fail "foreign-owned typed policy is excluded — missing CLEAN"
+else
+  pass "foreign-owned typed policy is excluded from listed and orphans (#484)"
+fi
+
+# V2
+run_census
+if [ "$RC" -ne 4 ]; then
+  fail "zero managed policies is INCONCLUSIVE_EMPTY — exit ${RC}, want 4"
+elif ! grep -Fq 'VERDICT=INCONCLUSIVE_EMPTY' <<<"$OUT"; then
+  fail "zero managed policies is INCONCLUSIVE_EMPTY — missing verdict"
+elif ! grep -Fq '"found nothing" is not CLEAN' <<<"$OUT"; then
+  fail "zero managed policies is INCONCLUSIVE_EMPTY — missing found-nothing needle"
+elif grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
+  fail "zero managed policies is INCONCLUSIVE_EMPTY — printed CLEAN"
+else
+  pass "zero managed policies is INCONCLUSIVE_EMPTY, never CLEAN"
+fi
+
+# V3
+run_census STUB_CONTEXTS_FIXTURE_2="${WORKDIR}/contexts-churn.json" \
+  STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v1.json"
+if [ "$RC" -ne 3 ]; then
+  fail "desired-set churn is INCONCLUSIVE_RERUN — exit ${RC}, want 3"
+elif ! grep -Fq 'VERDICT=INCONCLUSIVE_RERUN' <<<"$OUT"; then
+  fail "desired-set churn is INCONCLUSIVE_RERUN — missing verdict"
+elif ! grep -Fq 'desired Context+McpServer set changed between samples' <<<"$OUT"; then
+  fail "desired-set churn is INCONCLUSIVE_RERUN — missing change needle"
+else
+  pass "desired-set churn between samples is INCONCLUSIVE_RERUN"
+fi
+
+# V4
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v4.json"
+if [ "$RC" -ne 0 ]; then
+  fail "genuine orphan and untyped-repairable are counted — exit ${RC}"
+elif ! grep -Fq 'listed_managed=3' <<<"$OUT" ||
+  ! grep -Fq 'repairable_untyped=1' <<<"$OUT" ||
+  ! grep -Fq 'orphan_count=2' <<<"$OUT"; then
+  fail "genuine orphan and untyped-repairable are counted — counters mismatch; got: $(head -c 500 <<<"$OUT")"
+elif ! grep -Fq 'VERDICT=ORPHANS_PRESENT' <<<"$OUT"; then
+  fail "genuine orphan and untyped-repairable are counted — missing ORPHANS_PRESENT"
+elif ! grep -Fq $'mcp-server\tctx-gone-allow\tcontext-allow' <<<"$OUT" ||
+  ! grep -Fq $'mcp-server\tctx-orphaned-thing\trepairable-untyped' <<<"$OUT"; then
+  fail "genuine orphan and untyped-repairable are counted — TSV lines missing; got: $(head -c 500 <<<"$OUT")"
+else
+  pass "genuine orphan and untyped-repairable are counted and reported"
+fi
+
+# V5
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v5.json"
+if [ "$RC" -ne 0 ]; then
+  fail "cap two-tier UNSET vs compiled — exit ${RC}"
+elif ! grep -Fq 'live_cap_would_trip=UNSET' <<<"$OUT"; then
+  fail "cap two-tier UNSET vs compiled — live cap is not UNSET; got: $(grep live_cap <<<"$OUT")"
+elif grep -Fq 'live_cap_would_trip=none' <<<"$OUT"; then
+  fail "cap two-tier UNSET vs compiled — live cap collapsed to none"
+elif ! grep -Fq 'controller_cap_would_trip=absolute' <<<"$OUT"; then
+  fail "cap two-tier UNSET vs compiled — controller trip is not absolute"
+elif ! grep -Fq 'compiled_default_absolute=10 compiled_default_percent=20' <<<"$OUT"; then
+  fail "cap two-tier UNSET vs compiled — compiled defaults line missing"
+elif ! grep -Fq 'VERDICT=ORPHANS_PRESENT' <<<"$OUT"; then
+  fail "cap two-tier UNSET vs compiled — missing ORPHANS_PRESENT"
+else
+  pass "cap two-tier: UNSET live caps report UNSET, controller trip uses compiled defaults"
+fi
+
+# V6
+v6_start="$(date +%s)"
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v1.json"
+v6_elapsed=$(($(date +%s) - v6_start))
+if ! grep -Fq 'waiting 0s for second sample' <<<"$OUT"; then
+  fail "SAMPLE_GAP_SEC is honored — missing waiting 0s needle"
+elif [ "$v6_elapsed" -gt 60 ]; then
+  fail "SAMPLE_GAP_SEC is honored — run took ${v6_elapsed}s (hardcoded sleep?)"
+else
+  pass "SAMPLE_GAP_SEC is honored (no fixed 90s sleep)"
+fi
+
+if grep -Eq '(^|[[:space:]])(set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose)([[:space:]]|$)' "$ALL_LOG"; then
+  fail "census stayed read-only — mutating verb recorded"
+else
+  pass "fake kubectl saw only get verbs (no mutation)"
+fi
+
+exit "$FAIL"

--- a/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
+++ b/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
@@ -219,6 +219,39 @@ jq -n '
   }
 ' >"${WORKDIR}/np-v5.json"
 
+# V7: member + typed reserved orphan without managed-by (controller
+# repairable arm: type present, managed-by absent, reserved + owner).
+# Pre-fix is_typed required managed-by and printed CLEAN (listed=1).
+jq -n '{
+  items: [
+    {
+      metadata: {
+        uid: "uid-member",
+        namespace: "mcp-server",
+        name: "ctx-alpha-allow",
+        labels: {
+          "clerum.io/managed-by": "host-context-controller",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-alpha",
+          "clerum.io/mcpserver": "srv-a"
+        }
+      }
+    },
+    {
+      metadata: {
+        uid: "uid-repairable-typed",
+        namespace: "mcp-server",
+        name: "ctx-gone-allow",
+        labels: {
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-gone",
+          "clerum.io/mcpserver": "srv-gone"
+        }
+      }
+    }
+  ]
+}' >"${WORKDIR}/np-v7.json"
+
 run_census() {
   : >"$CASE_LOG"
   rm -f "${WORKDIR}/call-count-contexts"
@@ -330,6 +363,24 @@ elif [ "$v6_elapsed" -gt 60 ]; then
   fail "SAMPLE_GAP_SEC is honored — run took ${v6_elapsed}s (hardcoded sleep?)"
 else
   pass "SAMPLE_GAP_SEC is honored (no fixed 90s sleep)"
+fi
+
+# V7
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v7.json"
+if [ "$RC" -ne 0 ]; then
+  fail "typed repairable without managed-by is counted — exit ${RC}; got: $(head -c 400 <<<"$OUT")"
+elif ! grep -Fq 'listed_managed=2' <<<"$OUT" ||
+  ! grep -Fq 'repairable_untyped=0' <<<"$OUT" ||
+  ! grep -Fq 'orphan_count=1' <<<"$OUT"; then
+  fail "typed repairable without managed-by is counted — counters mismatch; got: $(head -c 500 <<<"$OUT")"
+elif ! grep -Fq 'VERDICT=ORPHANS_PRESENT' <<<"$OUT"; then
+  fail "typed repairable without managed-by is counted — missing ORPHANS_PRESENT"
+elif grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
+  fail "typed repairable without managed-by is counted — printed CLEAN"
+elif ! grep -Fq $'mcp-server\tctx-gone-allow\tcontext-allow' <<<"$OUT"; then
+  fail "typed repairable without managed-by is counted — TSV line missing; got: $(head -c 500 <<<"$OUT")"
+else
+  pass "typed reserved orphan without managed-by is listed and ORPHANS_PRESENT (RP-495-01)"
 fi
 
 if grep -Eq '(^|[[:space:]])(set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose)([[:space:]]|$)' "$ALL_LOG"; then

--- a/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
+++ b/scripts/tests/test-hcc-netpol-orphan-census-verdicts.sh
@@ -221,7 +221,9 @@ jq -n '
 
 # V7: member + typed reserved orphan without managed-by (controller
 # repairable arm: type present, managed-by absent, reserved + owner).
-# Pre-fix is_typed required managed-by and printed CLEAN (listed=1).
+# Hidden only after the intra-PR #484 tightening (30070fdd), which
+# required managed-by on is_typed and printed CLEAN (listed=1).
+# Against merge-base/dev, type-only is_typed already listed this case.
 jq -n '{
   items: [
     {
@@ -252,6 +254,26 @@ jq -n '{
   ]
 }' >"${WORKDIR}/np-v7.json"
 
+# V8: only the foreign typed reserved+owner shape (no HCC member).
+# listed=0 must not collapse to INCONCLUSIVE_EMPTY / CLEAN.
+jq -n '{
+  items: [
+    {
+      metadata: {
+        uid: "uid-foreign-only",
+        namespace: "mcp-server",
+        name: "ctx-ghost-allow",
+        labels: {
+          "clerum.io/managed-by": "someone-else",
+          "clerum.io/policy-type": "context-allow",
+          "clerum.io/context": "ctx-ghost",
+          "clerum.io/mcpserver": "srv-ghost"
+        }
+      }
+    }
+  ]
+}' >"${WORKDIR}/np-v8.json"
+
 run_census() {
   : >"$CASE_LOG"
   rm -f "${WORKDIR}/call-count-contexts"
@@ -281,14 +303,20 @@ run_census() {
 
 # V1
 run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v1.json"
-if [ "$RC" -ne 0 ]; then
-  fail "foreign-owned typed policy is excluded — exit ${RC}; got: $(head -c 400 <<<"$OUT")"
+if [ "$RC" -ne 5 ]; then
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — exit ${RC}; got: $(head -c 400 <<<"$OUT")"
 elif ! grep -Fq 'listed_managed=1' <<<"$OUT" || ! grep -Fq 'orphan_count=0' <<<"$OUT"; then
-  fail "foreign-owned typed policy is excluded — listed/orphan mismatch; got: $(head -c 400 <<<"$OUT")"
-elif ! grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
-  fail "foreign-owned typed policy is excluded — missing CLEAN"
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — listed/orphan mismatch; got: $(head -c 400 <<<"$OUT")"
+elif ! grep -Fq 'ambiguous_count=1' <<<"$OUT"; then
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — ambiguous_count missing"
+elif ! grep -Fq 'VERDICT=AMBIGUOUS_PRESENT' <<<"$OUT"; then
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — missing verdict"
+elif grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — printed CLEAN"
+elif ! grep -Fq $'mcp-server\tctx-ghost-allow\tcontext-allow\tsomeone-else' <<<"$OUT"; then
+  fail "foreign-owned typed reserved+owner is AMBIGUOUS_PRESENT — TSV missing; got: $(head -c 500 <<<"$OUT")"
 else
-  pass "foreign-owned typed policy is excluded from listed and orphans (#484)"
+  pass "foreign-owned typed reserved+owner stays out of listed/orphans and is AMBIGUOUS_PRESENT (#484 / R1-L1)"
 fi
 
 # V2
@@ -381,6 +409,20 @@ elif ! grep -Fq $'mcp-server\tctx-gone-allow\tcontext-allow' <<<"$OUT"; then
   fail "typed repairable without managed-by is counted — TSV line missing; got: $(head -c 500 <<<"$OUT")"
 else
   pass "typed reserved orphan without managed-by is listed and ORPHANS_PRESENT (RP-495-01)"
+fi
+
+# V8
+run_census STUB_NP_MAPPER_FIXTURE="${WORKDIR}/np-v8.json"
+if [ "$RC" -ne 5 ]; then
+  fail "foreign-only ambiguous is not EMPTY — exit ${RC}; got: $(head -c 400 <<<"$OUT")"
+elif ! grep -Fq 'listed_managed=0' <<<"$OUT" || ! grep -Fq 'ambiguous_count=1' <<<"$OUT"; then
+  fail "foreign-only ambiguous is not EMPTY — counters mismatch; got: $(head -c 500 <<<"$OUT")"
+elif ! grep -Fq 'VERDICT=AMBIGUOUS_PRESENT' <<<"$OUT"; then
+  fail "foreign-only ambiguous is not EMPTY — missing AMBIGUOUS_PRESENT"
+elif grep -Fq 'VERDICT=INCONCLUSIVE_EMPTY' <<<"$OUT" || grep -Fq 'VERDICT=CLEAN' <<<"$OUT"; then
+  fail "foreign-only ambiguous is not EMPTY — printed EMPTY or CLEAN"
+else
+  pass "foreign-only typed reserved+owner is AMBIGUOUS_PRESENT, never EMPTY or CLEAN (R1-L1)"
 fi
 
 if grep -Eq '(^|[[:space:]])(set|delete|apply|patch|rollout|scale|create|replace|annotate|label|exec|drain|edit|expose)([[:space:]]|$)' "$ALL_LOG"; then


### PR DESCRIPTION
## Summary

- Adds `scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh` with a **static** public kubectl context placeholder (`gke_your-gcp-project_us-central1-a_example-dev`) so k8s-context-guard-v2 can inspect a literal `--context=` token. The live GKE project/cluster name is **not** in this repo (leak-guards).
- Reuses `hcc-netpol-orphan-census.sh` (no duplicated classifier).
- Generic script: `deployments` not `deploy`; fail-loud if mapper/host/rpc-proxy namespaces are missing.
- Typed membership: type ∈ {context-allow, rpc-proxy-egress, external-egress} and `managed-by` is null **or** `host-context-controller` (#484 excludes only present-and-foreign). Typed + missing managed-by stays eligible (controller repairable arm).
- Foreign typed reserved-name + owner label is **not** listed/orphaned and prints `VERDICT=AMBIGUOUS_PRESENT` (exit 5), never CLEAN — the controller aborts that pass as `ambiguous`.
- Does **not** build an HCC image. The post-#487 `/metrics` ≥2-tick sample is **not** a merge gate here.

Closes nothing. Feeds #478 (do not close until the series) and #484.

## Test plan

- [x] `bash -n scripts/ops/hcc-netpol-orphan-census.sh`
- [x] `bash -n scripts/ops/hcc-netpol-orphan-census-clerum-dev.sh`
- [x] `bash scripts/ci/check-no-infra-identifiers.sh` is clean
- [x] Wrapper file contains only the sanctioned public placeholder (no interpolated live context)
- [x] Missing namespace exits non-zero (never `VERDICT=CLEAN`)
- [x] Hermetic guards G1–G9 and verdicts V1–V8 (`SAMPLE_GAP_SEC=0`, no cluster)
