### PR TITLE
feat(release): schema v3 footprint + portability catalog

### DIFF
--- a/deploy/release/portability-catalog.json
+++ b/deploy/release/portability-catalog.json
@@ -1,0 +1,86 @@
+{
+  "catalogVersion": "pc-v1-trial",
+  "kinds": [
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "Host",
+      "order": 10,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "Context",
+      "order": 20,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "GlobalFileSystem",
+      "order": 30,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "SharedFileSystem",
+      "order": 40,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "CommunicationChannel",
+      "order": 50,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "WorkflowRecipePolicy",
+      "order": 60,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "WorkflowRecipe",
+      "order": 70,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "McpServer",
+      "order": 80,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    },
+    {
+      "apiVersion": "clerum.io/v1alpha1",
+      "kind": "LlmHook",
+      "order": 90,
+      "restoreTransform": "unsupported",
+      "quiescenceHook": "unsupported",
+      "credentialTransition": "unsupported",
+      "verificationProbe": "unsupported"
+    }
+  ]
+}

--- a/deploy/release/shared-footprint.json
+++ b/deploy/release/shared-footprint.json
@@ -1,0 +1,21 @@
+{
+  "footprintVersion": "fp-v1-trial",
+  "baseline": {
+    "cpuMillis": 2000,
+    "memoryMib": 4096,
+    "storageGib": 10,
+    "ephemeralStorageGib": 4,
+    "pods": 24,
+    "pvcs": 3
+  },
+  "plans": {
+    "trial": {
+      "cpuMillis": 1000,
+      "memoryMib": 2048,
+      "storageGib": 5,
+      "ephemeralStorageGib": 2,
+      "pods": 12,
+      "pvcs": 2
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Producer JSON for MCC schemaVersion 3. Does not cut a release.

- `deploy/release/shared-footprint.json` — `fp-v1-trial`, baseline 2000/4096/10/4/24/3, `plans.trial` 1000/2048/5/2/12/2 (matches MCC `makeReleaseV3()`).
- `deploy/release/portability-catalog.json` — `pc-v1-trial`, all nine `charts/clerum-crds/crds` kinds including `LlmHook`. Every hook string is the literal `unsupported`.

Validated against MCC TypeBox `SharedFootprint` / `PortabilityCatalog` (`additionalProperties: false`).

**Merge-commit only, never squash.** Ask before merge. Orchestrator will attach these files to the next platform GitHub release after `/promote` — not this PR.

## Testing

- [x] TypeBox `Value.Check` against MCC `@evenfire/mcc-shared` dist: `ok`
- [ ] `npm test` passes for changed services (JSON assets only)
- [ ] `npx tsc --noEmit` clean (JSON assets only)

## Checklist

- [x] This is not a new third-party MCP server / WorkflowRecipe (those go to the registry)