### PR TITLE
fix(hcc): skip no-op Deployment/ConfigMap/LlmHook-NP replaces at the remaining writers (#460)

### DIFF
--- a/host-context-controller/README.md
+++ b/host-context-controller/README.md
@@ -380,7 +380,7 @@ a permissive policy — see the NetworkPolicy and GFS tables:
 | `CONTEXT_MAPPER_DESKTOP_RESOURCES_REQUEST_MEMORY` | `256Mi`                          | Desktop memory request.                                                                                                                                                                  |
 | `CONTEXT_MAPPER_DESKTOP_RESOURCES_REQUEST_CPU`    | `250m`                           | Desktop CPU request.                                                                                                                                                                     |
 | `CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_MEMORY`   | `4Gi`                            | Desktop memory limit.                                                                                                                                                                    |
-| `CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_CPU`      | `1000m`                          | Desktop CPU limit.                                                                                                                                                                       |
+| `CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_CPU`      | `1`                              | Desktop CPU limit. Author the apiserver-canonical form (`1`, not `1000m`) so the Deployment no-op gate can match.                                                                        |
 | `CONTEXT_MAPPER_DESKTOP_API_TOKEN`                | `` (empty)                       | Bearer token required by `GET /api/v1/desktop/:hostRef`. **When empty the check is skipped and the endpoint is unauthenticated** — a dev-mode convenience. Set it in any shared cluster. |
 
 ### channel-reader provisioning

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.280",
+      "version": "0.1.281",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.279",
+      "version": "0.1.280",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.273",
+  "version": "0.1.274",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.273",
+      "version": "0.1.274",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.278",
+  "version": "0.1.279",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.278",
+      "version": "0.1.279",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.271",
+  "version": "0.1.272",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.271",
+      "version": "0.1.272",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.283",
+  "version": "0.1.284",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.283",
+      "version": "0.1.284",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.281",
+  "version": "0.1.282",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.281",
+      "version": "0.1.282",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.277",
+  "version": "0.1.278",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.277",
+      "version": "0.1.278",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.282",
+  "version": "0.1.283",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.282",
+      "version": "0.1.283",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.272",
+  "version": "0.1.273",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.272",
+      "version": "0.1.273",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.276",
+  "version": "0.1.277",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.276",
+      "version": "0.1.277",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.274",
+  "version": "0.1.275",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.274",
+      "version": "0.1.275",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package-lock.json
+++ b/host-context-controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.275",
+  "version": "0.1.276",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-host-context-controller",
-      "version": "0.1.275",
+      "version": "0.1.276",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@clerum/codex-catalog-projection": "file:../packages/codex-catalog-projection",

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.279",
+  "version": "0.1.280",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.278",
+  "version": "0.1.279",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.277",
+  "version": "0.1.278",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.273",
+  "version": "0.1.274",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.280",
+  "version": "0.1.281",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.274",
+  "version": "0.1.275",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.275",
+  "version": "0.1.276",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.271",
+  "version": "0.1.272",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.282",
+  "version": "0.1.283",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.281",
+  "version": "0.1.282",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.276",
+  "version": "0.1.277",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.283",
+  "version": "0.1.284",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/package.json
+++ b/host-context-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-host-context-controller",
-  "version": "0.1.272",
+  "version": "0.1.273",
   "description": "Host Context Controller - provides McpServer CRDs to mcp-host via REST API",
   "main": "dist/main.js",
   "engines": {

--- a/host-context-controller/src/__tests__/asApiserverDeployment.ts
+++ b/host-context-controller/src/__tests__/asApiserverDeployment.ts
@@ -8,9 +8,15 @@ import type * as k8s from '@kubernetes/client-node'
  * a field, refresh this blob so the suite goes red until the comparator or
  * builder learns that default (PR G §8).
  *
- * Container `imagePullPolicy` is filled after overlay from kube
- * `DefaultImagePullPolicy` (Always for `:latest` / untagged; IfNotPresent
- * otherwise) because recorded containers are replaced by the desired list.
+ * Desired containers replace the recorded list (arrays overlay by clone).
+ * Top-level omitted container defaults are then copied from the recorded
+ * container — one list, not a hand-written twin of
+ * `normalizeContainerDefaults`. `imagePullPolicy` stays content-dependent
+ * (`DefaultImagePullPolicy`: Always for `:latest` / untagged; IfNotPresent
+ * otherwise). Nested defaults (ports, probes, env.fieldRef) only exist when
+ * those child objects are present and stay synthesized. Refresh the recorded
+ * container from a live GET so a new apiserver default turns the suite red
+ * (PR G §8 / #530).
  */
 const SERVER_TIME = new Date('2026-04-01T00:00:00.000Z')
 const SERVER_UID = '11111111-2222-3333-4444-555555555555'
@@ -70,6 +76,7 @@ export const RECORDED_APPSV1_DEPLOYMENT: k8s.V1Deployment = {
             name: 'recorded',
             image: 'recorded:1',
             imagePullPolicy: 'IfNotPresent',
+            resources: {},
             terminationMessagePath: '/dev/termination-log',
             terminationMessagePolicy: 'File',
           },
@@ -178,16 +185,33 @@ function applyPodSpecDefaults(podSpec: k8s.V1PodSpec | undefined): void {
   for (const volume of podSpec.volumes ?? []) applyVolumeDefaults(volume)
 }
 
+const RECORDED_CONTAINER_AUTHORING = new Set(['name', 'image'])
+const RECORDED_CONTAINER_CONTENT_DEPENDENT = new Set(['imagePullPolicy'])
+
+function recordedContainer(): k8s.V1Container {
+  const container = RECORDED_APPSV1_DEPLOYMENT.spec?.template?.spec?.containers?.[0]
+  if (!container) {
+    throw new Error('RECORDED_APPSV1_DEPLOYMENT is missing a recorded container')
+  }
+  return container
+}
+
 function applyContainerDefaults(container: k8s.V1Container): void {
-  if (container.resources === undefined) container.resources = {}
+  // Top-level omitted keys come from the recorded container so a refreshed
+  // blob (new apiserver default) fills without a parallel if-chain.
+  for (const [key, value] of Object.entries(recordedContainer()) as Array<
+    [keyof k8s.V1Container, unknown]
+  >) {
+    if (RECORDED_CONTAINER_AUTHORING.has(key) || RECORDED_CONTAINER_CONTENT_DEPENDENT.has(key)) {
+      continue
+    }
+    if (value === undefined) continue
+    if (container[key] === undefined) {
+      ;(container as unknown as Record<string, unknown>)[key] = structuredClone(value)
+    }
+  }
   if (container.imagePullPolicy === undefined) {
     container.imagePullPolicy = defaultImagePullPolicy(container.image)
-  }
-  if (container.terminationMessagePath === undefined) {
-    container.terminationMessagePath = '/dev/termination-log'
-  }
-  if (container.terminationMessagePolicy === undefined) {
-    container.terminationMessagePolicy = 'File'
   }
   for (const port of container.ports ?? []) {
     if (port.protocol === undefined) port.protocol = 'TCP'

--- a/host-context-controller/src/__tests__/asApiserverDeployment.ts
+++ b/host-context-controller/src/__tests__/asApiserverDeployment.ts
@@ -119,13 +119,17 @@ const REPLACE_OBJECT_KEYS = new Set([
 /** Defined overlay keys win; omitted keys keep the recorded apiserver default. */
 function overlayDefined(base: unknown, overlay: unknown): unknown {
   if (overlay === undefined) return base
-  if (overlay === null || typeof overlay !== 'object' || Array.isArray(overlay)) return overlay
-  if (base === null || typeof base !== 'object' || Array.isArray(base)) return overlay
+  if (overlay === null || typeof overlay !== 'object' || Array.isArray(overlay)) {
+    return structuredClone(overlay)
+  }
+  if (base === null || typeof base !== 'object' || Array.isArray(base)) {
+    return structuredClone(overlay)
+  }
   const out: Record<string, unknown> = { ...(base as Record<string, unknown>) }
   for (const [key, value] of Object.entries(overlay as Record<string, unknown>)) {
     if (value === undefined) continue
     if (REPLACE_OBJECT_KEYS.has(key) && typeof value === 'object' && !Array.isArray(value)) {
-      out[key] = value
+      out[key] = structuredClone(value)
       continue
     }
     out[key] = overlayDefined((base as Record<string, unknown>)[key], value)
@@ -175,6 +179,7 @@ function applyPodSpecDefaults(podSpec: k8s.V1PodSpec | undefined): void {
 }
 
 function applyContainerDefaults(container: k8s.V1Container): void {
+  if (container.resources === undefined) container.resources = {}
   if (container.imagePullPolicy === undefined) {
     container.imagePullPolicy = defaultImagePullPolicy(container.image)
   }

--- a/host-context-controller/src/__tests__/asApiserverDeployment.ts
+++ b/host-context-controller/src/__tests__/asApiserverDeployment.ts
@@ -4,8 +4,10 @@ import type * as k8s from '@kubernetes/client-node'
  * Apply documented apps/v1 defaulting onto a desired Deployment. Unlike
  * `asApiserverService`, this is not a recorded-blob overlay: it fills fields
  * the apiserver would default-fill, leaving every HCC-authored value intact.
- * Refresh this function when a live `kubectl get deploy -o json` reveals a
- * default the fixture does not model (PR G §8).
+ * Container `imagePullPolicy` follows kube `DefaultImagePullPolicy` (Always
+ * for `:latest` / untagged; IfNotPresent otherwise). Refresh this function
+ * when a live `kubectl get deploy -o json` reveals a default the fixture
+ * does not model (PR G §8).
  */
 const SERVER_TIME = new Date('2026-04-01T00:00:00.000Z')
 const SERVER_UID = '11111111-2222-3333-4444-555555555555'
@@ -96,6 +98,9 @@ function applyPodSpecDefaults(podSpec: k8s.V1PodSpec | undefined): void {
 }
 
 function applyContainerDefaults(container: k8s.V1Container): void {
+  if (container.imagePullPolicy === undefined) {
+    container.imagePullPolicy = defaultImagePullPolicy(container.image)
+  }
   if (container.terminationMessagePath === undefined) {
     container.terminationMessagePath = '/dev/termination-log'
   }
@@ -123,6 +128,21 @@ function applyProbeDefaults(probe: k8s.V1Probe | undefined): void {
   if (probe.successThreshold === undefined) probe.successThreshold = 1
   if (probe.failureThreshold === undefined) probe.failureThreshold = 3
   if (probe.httpGet && probe.httpGet.scheme === undefined) probe.httpGet.scheme = 'HTTP'
+}
+
+/**
+ * Mirror kube `DefaultImagePullPolicy` / `tags.Latest`: Always when the
+ * reference has no tag or the tag is `latest`; IfNotPresent for any other
+ * tag or a digest. This is not a full docker-reference parser.
+ */
+function defaultImagePullPolicy(image: string | undefined): 'Always' | 'IfNotPresent' {
+  if (!image) return 'Always'
+  if (image.includes('@')) return 'IfNotPresent'
+  const slash = image.lastIndexOf('/')
+  const name = slash === -1 ? image : image.slice(slash + 1)
+  const colon = name.lastIndexOf(':')
+  if (colon === -1) return 'Always'
+  return name.slice(colon + 1) === 'latest' ? 'Always' : 'IfNotPresent'
 }
 
 function applyVolumeDefaults(volume: k8s.V1Volume): void {

--- a/host-context-controller/src/__tests__/asApiserverDeployment.ts
+++ b/host-context-controller/src/__tests__/asApiserverDeployment.ts
@@ -1,0 +1,144 @@
+import type * as k8s from '@kubernetes/client-node'
+
+/**
+ * Apply documented apps/v1 defaulting onto a desired Deployment. Unlike
+ * `asApiserverService`, this is not a recorded-blob overlay: it fills fields
+ * the apiserver would default-fill, leaving every HCC-authored value intact.
+ * Refresh this function when a live `kubectl get deploy -o json` reveals a
+ * default the fixture does not model (PR G §8).
+ */
+const SERVER_TIME = new Date('2026-04-01T00:00:00.000Z')
+const SERVER_UID = '11111111-2222-3333-4444-555555555555'
+const SERVER_RESOURCE_VERSION = '1776125'
+
+export function asApiserverDeployment(desired: k8s.V1Deployment): k8s.V1Deployment {
+  const live = structuredClone(desired)
+  applyServerOwnedMetadata(live)
+  applyDeploymentSpecDefaults(live.spec)
+  return live
+}
+
+function applyServerOwnedMetadata(deployment: k8s.V1Deployment): void {
+  const name = deployment.metadata?.name ?? 'unnamed'
+  const namespace = deployment.metadata?.namespace ?? 'default'
+  deployment.metadata = {
+    ...deployment.metadata,
+    annotations: {
+      ...deployment.metadata?.annotations,
+      'deployment.kubernetes.io/revision':
+        deployment.metadata?.annotations?.['deployment.kubernetes.io/revision'] ?? '1',
+    },
+    creationTimestamp: SERVER_TIME,
+    generation: 1,
+    managedFields: [
+      {
+        apiVersion: 'apps/v1',
+        fieldsType: 'FieldsV1',
+        fieldsV1: { 'f:spec': { 'f:template': {} } },
+        manager: 'kube-apiserver',
+        operation: 'Update',
+        time: SERVER_TIME,
+      },
+    ],
+    resourceVersion: SERVER_RESOURCE_VERSION,
+    uid: SERVER_UID,
+    selfLink: `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`,
+  }
+  deployment.status = {
+    observedGeneration: 1,
+    replicas: deployment.spec?.replicas ?? 1,
+    readyReplicas: 0,
+    updatedReplicas: 0,
+    unavailableReplicas: deployment.spec?.replicas ?? 1,
+    conditions: [],
+  }
+}
+
+function applyDeploymentSpecDefaults(spec: k8s.V1Deployment['spec']): void {
+  if (!spec) return
+  if (spec.replicas === undefined) spec.replicas = 1
+  if (spec.progressDeadlineSeconds === undefined) spec.progressDeadlineSeconds = 600
+  if (spec.revisionHistoryLimit === undefined) spec.revisionHistoryLimit = 10
+  if (spec.minReadySeconds === undefined) spec.minReadySeconds = 0
+  if (spec.paused === undefined) spec.paused = false
+  if (!spec.strategy) {
+    spec.strategy = {
+      type: 'RollingUpdate',
+      rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
+    }
+  }
+
+  const template = spec.template
+  if (!template) return
+  if (template.metadata && template.metadata.creationTimestamp === undefined) {
+    template.metadata.creationTimestamp = SERVER_TIME
+  }
+  applyPodSpecDefaults(template.spec)
+}
+
+function applyPodSpecDefaults(podSpec: k8s.V1PodSpec | undefined): void {
+  if (!podSpec) return
+  if (podSpec.restartPolicy === undefined) podSpec.restartPolicy = 'Always'
+  if (podSpec.dnsPolicy === undefined) podSpec.dnsPolicy = 'ClusterFirst'
+  if (podSpec.schedulerName === undefined) podSpec.schedulerName = 'default-scheduler'
+  if (podSpec.terminationGracePeriodSeconds === undefined) {
+    podSpec.terminationGracePeriodSeconds = 30
+  }
+  if (podSpec.enableServiceLinks === undefined) podSpec.enableServiceLinks = true
+  if (podSpec.preemptionPolicy === undefined) podSpec.preemptionPolicy = 'PreemptLowerPriority'
+  if (!podSpec.serviceAccountName) podSpec.serviceAccountName = 'default'
+  if (podSpec.serviceAccount === undefined) podSpec.serviceAccount = podSpec.serviceAccountName
+
+  for (const container of [...(podSpec.initContainers ?? []), ...(podSpec.containers ?? [])]) {
+    applyContainerDefaults(container)
+  }
+  for (const volume of podSpec.volumes ?? []) applyVolumeDefaults(volume)
+}
+
+function applyContainerDefaults(container: k8s.V1Container): void {
+  if (container.terminationMessagePath === undefined) {
+    container.terminationMessagePath = '/dev/termination-log'
+  }
+  if (container.terminationMessagePolicy === undefined) {
+    container.terminationMessagePolicy = 'File'
+  }
+  for (const port of container.ports ?? []) {
+    if (port.protocol === undefined) port.protocol = 'TCP'
+  }
+  applyProbeDefaults(container.startupProbe)
+  applyProbeDefaults(container.livenessProbe)
+  applyProbeDefaults(container.readinessProbe)
+  for (const env of container.env ?? []) {
+    if (env.valueFrom?.fieldRef && env.valueFrom.fieldRef.apiVersion === undefined) {
+      env.valueFrom.fieldRef.apiVersion = 'v1'
+    }
+  }
+}
+
+function applyProbeDefaults(probe: k8s.V1Probe | undefined): void {
+  if (!probe) return
+  if (probe.initialDelaySeconds === undefined) probe.initialDelaySeconds = 0
+  if (probe.timeoutSeconds === undefined) probe.timeoutSeconds = 1
+  if (probe.periodSeconds === undefined) probe.periodSeconds = 10
+  if (probe.successThreshold === undefined) probe.successThreshold = 1
+  if (probe.failureThreshold === undefined) probe.failureThreshold = 3
+  if (probe.httpGet && probe.httpGet.scheme === undefined) probe.httpGet.scheme = 'HTTP'
+}
+
+function applyVolumeDefaults(volume: k8s.V1Volume): void {
+  if (volume.secret && volume.secret.defaultMode === undefined) volume.secret.defaultMode = 420
+  if (volume.secret && volume.secret.optional === undefined) volume.secret.optional = false
+  if (volume.configMap && volume.configMap.defaultMode === undefined) {
+    volume.configMap.defaultMode = 420
+  }
+  if (volume.configMap && volume.configMap.optional === undefined) volume.configMap.optional = false
+  if (volume.downwardAPI && volume.downwardAPI.defaultMode === undefined) {
+    volume.downwardAPI.defaultMode = 420
+  }
+  if (volume.projected && volume.projected.defaultMode === undefined) {
+    volume.projected.defaultMode = 420
+  }
+  if (volume.persistentVolumeClaim && volume.persistentVolumeClaim.readOnly === undefined) {
+    volume.persistentVolumeClaim.readOnly = false
+  }
+}

--- a/host-context-controller/src/__tests__/asApiserverDeployment.ts
+++ b/host-context-controller/src/__tests__/asApiserverDeployment.ts
@@ -1,34 +1,27 @@
 import type * as k8s from '@kubernetes/client-node'
 
 /**
- * Apply documented apps/v1 defaulting onto a desired Deployment. Unlike
- * `asApiserverService`, this is not a recorded-blob overlay: it fills fields
- * the apiserver would default-fill, leaving every HCC-authored value intact.
- * Container `imagePullPolicy` follows kube `DefaultImagePullPolicy` (Always
- * for `:latest` / untagged; IfNotPresent otherwise). Refresh this function
- * when a live `kubectl get deploy -o json` reveals a default the fixture
- * does not model (PR G §8).
+ * Recorded kube-apiserver GET of an apps/v1 Deployment (`kubectl get deploy
+ * -o json` shape), not a field list copied from
+ * `normalizeDeploymentForComparison`. Stamp controller-owned identity and
+ * PodSpec via `asApiserverDeployment`. When a newer apiserver default-fills
+ * a field, refresh this blob so the suite goes red until the comparator or
+ * builder learns that default (PR G §8).
+ *
+ * Container `imagePullPolicy` is filled after overlay from kube
+ * `DefaultImagePullPolicy` (Always for `:latest` / untagged; IfNotPresent
+ * otherwise) because recorded containers are replaced by the desired list.
  */
 const SERVER_TIME = new Date('2026-04-01T00:00:00.000Z')
 const SERVER_UID = '11111111-2222-3333-4444-555555555555'
 const SERVER_RESOURCE_VERSION = '1776125'
 
-export function asApiserverDeployment(desired: k8s.V1Deployment): k8s.V1Deployment {
-  const live = structuredClone(desired)
-  applyServerOwnedMetadata(live)
-  applyDeploymentSpecDefaults(live.spec)
-  return live
-}
-
-function applyServerOwnedMetadata(deployment: k8s.V1Deployment): void {
-  const name = deployment.metadata?.name ?? 'unnamed'
-  const namespace = deployment.metadata?.namespace ?? 'default'
-  deployment.metadata = {
-    ...deployment.metadata,
+export const RECORDED_APPSV1_DEPLOYMENT: k8s.V1Deployment = {
+  apiVersion: 'apps/v1',
+  kind: 'Deployment',
+  metadata: {
     annotations: {
-      ...deployment.metadata?.annotations,
-      'deployment.kubernetes.io/revision':
-        deployment.metadata?.annotations?.['deployment.kubernetes.io/revision'] ?? '1',
+      'deployment.kubernetes.io/revision': '1',
     },
     creationTimestamp: SERVER_TIME,
     generation: 1,
@@ -42,18 +35,102 @@ function applyServerOwnedMetadata(deployment: k8s.V1Deployment): void {
         time: SERVER_TIME,
       },
     ],
+    name: 'recorded-deploy',
+    namespace: 'recorded-ns',
     resourceVersion: SERVER_RESOURCE_VERSION,
     uid: SERVER_UID,
-    selfLink: `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`,
-  }
-  deployment.status = {
+    selfLink: '/apis/apps/v1/namespaces/recorded-ns/deployments/recorded-deploy',
+  },
+  spec: {
+    replicas: 1,
+    progressDeadlineSeconds: 600,
+    revisionHistoryLimit: 10,
+    minReadySeconds: 0,
+    paused: false,
+    selector: { matchLabels: { app: 'recorded' } },
+    strategy: {
+      type: 'RollingUpdate',
+      rollingUpdate: { maxSurge: '25%', maxUnavailable: '25%' },
+    },
+    template: {
+      metadata: {
+        creationTimestamp: SERVER_TIME,
+        labels: { app: 'recorded' },
+      },
+      spec: {
+        restartPolicy: 'Always',
+        dnsPolicy: 'ClusterFirst',
+        schedulerName: 'default-scheduler',
+        terminationGracePeriodSeconds: 30,
+        enableServiceLinks: true,
+        preemptionPolicy: 'PreemptLowerPriority',
+        serviceAccountName: 'default',
+        containers: [
+          {
+            name: 'recorded',
+            image: 'recorded:1',
+            imagePullPolicy: 'IfNotPresent',
+            terminationMessagePath: '/dev/termination-log',
+            terminationMessagePolicy: 'File',
+          },
+        ],
+      },
+    },
+  },
+  status: {
     observedGeneration: 1,
-    replicas: deployment.spec?.replicas ?? 1,
+    replicas: 1,
     readyReplicas: 0,
     updatedReplicas: 0,
-    unavailableReplicas: deployment.spec?.replicas ?? 1,
+    unavailableReplicas: 1,
     conditions: [],
+  },
+}
+
+export function asApiserverDeployment(desired: k8s.V1Deployment): k8s.V1Deployment {
+  const live = overlayDefined(
+    structuredClone(RECORDED_APPSV1_DEPLOYMENT),
+    desired
+  ) as k8s.V1Deployment
+  const name = desired.metadata?.name ?? live.metadata?.name ?? 'unnamed'
+  const namespace = desired.metadata?.namespace ?? live.metadata?.namespace ?? 'default'
+  live.metadata = {
+    ...live.metadata,
+    selfLink: `/apis/apps/v1/namespaces/${namespace}/deployments/${name}`,
   }
+  const replicas = live.spec?.replicas ?? 1
+  live.status = {
+    ...RECORDED_APPSV1_DEPLOYMENT.status,
+    replicas,
+    unavailableReplicas: replicas,
+  }
+  applyDeploymentSpecDefaults(live.spec)
+  return live
+}
+
+const REPLACE_OBJECT_KEYS = new Set([
+  'selector',
+  'labels',
+  'matchLabels',
+  'matchExpressions',
+  'strategy',
+])
+
+/** Defined overlay keys win; omitted keys keep the recorded apiserver default. */
+function overlayDefined(base: unknown, overlay: unknown): unknown {
+  if (overlay === undefined) return base
+  if (overlay === null || typeof overlay !== 'object' || Array.isArray(overlay)) return overlay
+  if (base === null || typeof base !== 'object' || Array.isArray(base)) return overlay
+  const out: Record<string, unknown> = { ...(base as Record<string, unknown>) }
+  for (const [key, value] of Object.entries(overlay as Record<string, unknown>)) {
+    if (value === undefined) continue
+    if (REPLACE_OBJECT_KEYS.has(key) && typeof value === 'object' && !Array.isArray(value)) {
+      out[key] = value
+      continue
+    }
+    out[key] = overlayDefined((base as Record<string, unknown>)[key], value)
+  }
+  return out
 }
 
 function applyDeploymentSpecDefaults(spec: k8s.V1Deployment['spec']): void {
@@ -89,7 +166,7 @@ function applyPodSpecDefaults(podSpec: k8s.V1PodSpec | undefined): void {
   if (podSpec.enableServiceLinks === undefined) podSpec.enableServiceLinks = true
   if (podSpec.preemptionPolicy === undefined) podSpec.preemptionPolicy = 'PreemptLowerPriority'
   if (!podSpec.serviceAccountName) podSpec.serviceAccountName = 'default'
-  if (podSpec.serviceAccount === undefined) podSpec.serviceAccount = podSpec.serviceAccountName
+  podSpec.serviceAccount = podSpec.serviceAccountName
 
   for (const container of [...(podSpec.initContainers ?? []), ...(podSpec.containers ?? [])]) {
     applyContainerDefaults(container)

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as k8s from '@kubernetes/client-node'
+import {
+  asAppsApi,
+  asCoreApi,
+  asNetworkingApi,
+  asRbacApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockNetworkingApi,
+  createMockRbacApi,
+} from '../../test/__fixtures__/testMocks'
+import { HostReconciler } from '../hostReconciler'
+import type { HostCRD } from '../types'
+import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
+import { asApiserverDeployment } from './asApiserverDeployment'
+import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+
+vi.mock('../config', () => ({
+  config: {
+    hostNamespace: 'mcp-host',
+    hostWorkspaceStorageClassName: 'standard',
+    hostWorkspaceStorageSize: '1Gi',
+    hostWorkspacePath: '/workspace',
+    hostImage: 'clerum/mcp-host:test',
+    desktopImage: 'clerum/mcp-host-desktop:test',
+    hostImagePullPolicy: 'IfNotPresent',
+    hostImagePullSecretName: '',
+    hostPort: 8080,
+    hostConfigMapName: 'mcp-host-config',
+    hostServiceAccountName: 'mcp-host',
+    gfsNamespace: 'gfs',
+    gfscPort: 8087,
+    desktopPort: 3000,
+    rpcProxyNamespace: 'rpc-proxy',
+    channelsNamespace: 'channels',
+    channelReaderImage: 'clerum/channel-reader:test',
+    channelReaderImagePullPolicy: 'IfNotPresent',
+    channelReaderHandoffPort: 8091,
+    hostK8sRequestTimeoutMs: 30_000,
+    hostFullReconcileConcurrency: 2,
+    mcpHostGatewayUrl: 'http://mcp-host-gateway',
+    hostResources: {
+      requests: { memory: '128Mi', cpu: '50m' },
+      limits: { memory: '256Mi', cpu: '200m' },
+    },
+    desktopResources: {
+      requests: { memory: '256Mi', cpu: '100m' },
+      limits: { memory: '512Mi', cpu: '500m' },
+    },
+  },
+}))
+
+function sparseDeployment(): k8s.V1Deployment {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: { name: 'sparse', namespace: 'ns' },
+    spec: {
+      selector: { matchLabels: { app: 'sparse' } },
+      template: {
+        metadata: { labels: { app: 'sparse' } },
+        spec: {
+          containers: [{ name: 'c', image: 'img:1', ports: [{ containerPort: 80 }] }],
+        },
+      },
+    },
+  }
+}
+
+function makeHost(name = 'alpha-host'): HostCRD {
+  return {
+    name,
+    namespace: 'mcp-host',
+    uid: 'uid-alpha-host',
+    spec: {
+      host: name,
+      contextRef: 'ctx1',
+      secretRef: 'llm-secret',
+    },
+  }
+}
+
+function createReconciler(): HostReconciler {
+  return new HostReconciler({} as k8s.KubeConfig, {
+    appsApi: asAppsApi(createMockAppsApi()),
+    coreApi: asCoreApi(createMockCoreApi()),
+    networkingApi: asNetworkingApi(createMockNetworkingApi()),
+    rbacApi: asRbacApi(createMockRbacApi()),
+    countCommunicationChannels: () => 1,
+    isCommunicationChannelCacheSynced: () => true,
+  })
+}
+
+/** Mirror replaceWithConflictRetry: merge after stamping the live resourceVersion. */
+function mergedForCompare(desired: k8s.V1Deployment, existing: k8s.V1Deployment): k8s.V1Deployment {
+  return preserveDeploymentAnnotations(
+    {
+      ...desired,
+      metadata: { ...desired.metadata, resourceVersion: existing.metadata?.resourceVersion },
+    },
+    existing
+  )
+}
+
+function expectSweepDetectsEveryLeaf(desired: k8s.V1Deployment, existing: k8s.V1Deployment): void {
+  const undetectable: string[] = []
+  for (const path of collectLeafPaths(desired)) {
+    const mutated = cloneAndMutateLeaf(desired, path) as k8s.V1Deployment
+    if (deploymentMatchesDesired(mergedForCompare(mutated, existing), existing)) {
+      undetectable.push(formatLeafPath(path))
+    }
+  }
+  expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+}
+
+describe('asApiserverDeployment', () => {
+  it('FIXTURE-1: default-fills a sparse Deployment so it differs structurally', () => {
+    const desired = sparseDeployment()
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('FIXTURE-1: Host builder output differs from the default-filled live object', () => {
+    const desired = createReconciler().buildDeployment(makeHost())
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('FIXTURE-1: channel-reader builder output differs from the default-filled live object', () => {
+    const desired = (createReconciler() as any).buildChannelReaderDeployment(
+      makeHost(),
+      'rev-abc'
+    ) as k8s.V1Deployment
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+})
+
+describe('deploymentMatchesDesired', () => {
+  it('returns false when either spec is missing (fail-open-to-write)', () => {
+    const desired = sparseDeployment()
+    expect(deploymentMatchesDesired(undefined, desired)).toBe(false)
+    expect(deploymentMatchesDesired(desired, undefined)).toBe(false)
+    expect(deploymentMatchesDesired({ metadata: { name: 'x' } }, desired)).toBe(false)
+    expect(deploymentMatchesDesired(desired, { metadata: { name: 'x' } })).toBe(false)
+  })
+
+  it('Host builder vs fixture is a no-op after merge', () => {
+    const desired = createReconciler().buildDeployment(makeHost())
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('channel-reader builder vs fixture is a no-op after merge', () => {
+    const desired = (createReconciler() as any).buildChannelReaderDeployment(
+      makeHost(),
+      'rev-abc'
+    ) as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('Host mutation sweep: every desired leaf is detectable', () => {
+    const desired = createReconciler().buildDeployment(makeHost())
+    expectSweepDetectsEveryLeaf(desired, asApiserverDeployment(desired))
+  })
+
+  it('channel-reader mutation sweep: every desired leaf is detectable', () => {
+    const desired = (createReconciler() as any).buildChannelReaderDeployment(
+      makeHost(),
+      'rev-abc'
+    ) as k8s.V1Deployment
+    expectSweepDetectsEveryLeaf(desired, asApiserverDeployment(desired))
+  })
+})

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -136,6 +136,29 @@ describe('asApiserverDeployment', () => {
     ) as k8s.V1Deployment
     expect(asApiserverDeployment(desired)).not.toEqual(desired)
   })
+
+  it('FIXTURE-1: fills omitted imagePullPolicy the way apps/v1 defaults it', () => {
+    const containerOf = (desired: k8s.V1Deployment) =>
+      asApiserverDeployment(desired).spec?.template?.spec?.containers?.[0]
+
+    expect(containerOf(sparseDeployment())?.imagePullPolicy).toBe('IfNotPresent')
+
+    const latest = sparseDeployment()
+    latest.spec!.template.spec!.containers![0].image = 'img:latest'
+    expect(containerOf(latest)?.imagePullPolicy).toBe('Always')
+
+    const untagged = sparseDeployment()
+    untagged.spec!.template.spec!.containers![0].image = 'img'
+    expect(containerOf(untagged)?.imagePullPolicy).toBe('Always')
+
+    const digested = sparseDeployment()
+    digested.spec!.template.spec!.containers![0].image = 'img@sha256:aaaaaaaa'
+    expect(containerOf(digested)?.imagePullPolicy).toBe('IfNotPresent')
+
+    const authored = sparseDeployment()
+    authored.spec!.template.spec!.containers![0].imagePullPolicy = 'Never'
+    expect(containerOf(authored)?.imagePullPolicy).toBe('Never')
+  })
 })
 
 type CanonicalPodSpec = {
@@ -168,6 +191,7 @@ function deploymentWithProbe(
             {
               name: 'c',
               image: 'img:1',
+              imagePullPolicy: 'IfNotPresent',
               livenessProbe: {
                 httpGet: { path: '/live', port: 80 },
                 periodSeconds: 5,
@@ -223,6 +247,13 @@ describe('safe-strip lemma equality guards', () => {
 })
 
 describe('deploymentMatchesDesired', () => {
+  it('omitted imagePullPolicy is not a no-op against the apiserver default-fill', () => {
+    const desired = sparseDeployment()
+    const existing = asApiserverDeployment(desired)
+    expect(existing.spec?.template?.spec?.containers?.[0]?.imagePullPolicy).toBe('IfNotPresent')
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(false)
+  })
+
   it('returns false when either spec is missing (fail-open-to-write)', () => {
     const desired = sparseDeployment()
     expect(deploymentMatchesDesired(undefined, desired)).toBe(false)

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -17,7 +17,7 @@ import {
   normalizeDeploymentForComparison,
   preserveDeploymentAnnotations,
 } from '../utils'
-import { asApiserverDeployment } from './asApiserverDeployment'
+import { RECORDED_APPSV1_DEPLOYMENT, asApiserverDeployment } from './asApiserverDeployment'
 import {
   cloneAndMutateLeaf,
   collectLeafPaths,
@@ -176,6 +176,45 @@ describe('asApiserverDeployment', () => {
     expect(existing.spec?.template?.spec?.restartPolicy).toBe('Always')
   })
 
+  it('FIXTURE-1: top-level container defaults come from the recorded container', () => {
+    const recorded = RECORDED_APPSV1_DEPLOYMENT.spec?.template?.spec?.containers?.[0]
+    expect(recorded).toBeDefined()
+    const desired = sparseDeployment()
+    delete desired.spec!.template.spec!.containers![0].ports
+    const synthesized = asApiserverDeployment(desired).spec?.template?.spec?.containers?.[0]
+    expect(synthesized).toBeDefined()
+
+    const topLevelDefaults = (container: k8s.V1Container) => {
+      const rest: Record<string, unknown> = { ...container }
+      delete rest.name
+      delete rest.image
+      delete rest.imagePullPolicy
+      return rest
+    }
+    expect(topLevelDefaults(synthesized!)).toEqual(topLevelDefaults(recorded!))
+    expect(recorded?.resources).toEqual({})
+    expect(synthesized?.resources).toEqual({})
+  })
+
+  it('FIXTURE-1: recorded container defaults that the lemma strips still strip; IPP does not', () => {
+    const recorded = RECORDED_APPSV1_DEPLOYMENT.spec?.template?.spec?.containers?.[0]
+    expect(recorded).toBeDefined()
+    const desired = sparseDeployment()
+    desired.spec!.template.spec!.containers![0] = {
+      name: 'c',
+      image: 'img:1',
+      imagePullPolicy: recorded!.imagePullPolicy,
+      resources: structuredClone(recorded!.resources),
+      terminationMessagePath: recorded!.terminationMessagePath,
+      terminationMessagePolicy: recorded!.terminationMessagePolicy,
+    }
+    const container = canonicalPodSpec(normalizeDeploymentForComparison(desired))?.containers?.[0]
+    expect(container?.resources).toBeUndefined()
+    expect(container?.terminationMessagePath).toBeUndefined()
+    expect(container?.terminationMessagePolicy).toBeUndefined()
+    expect(container?.imagePullPolicy).toBe('IfNotPresent')
+  })
+
   it('FIXTURE-1: fills omitted imagePullPolicy the way apps/v1 defaults it', () => {
     const containerOf = (desired: k8s.V1Deployment) =>
       asApiserverDeployment(desired).spec?.template?.spec?.containers?.[0]
@@ -204,6 +243,9 @@ type CanonicalPodSpec = {
   serviceAccountName?: string
   containers?: Array<{
     resources?: unknown
+    imagePullPolicy?: string
+    terminationMessagePath?: string
+    terminationMessagePolicy?: string
     livenessProbe?: { timeoutSeconds?: number; failureThreshold?: number }
   }>
 }

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -160,6 +160,13 @@ describe('asApiserverDeployment', () => {
     expect(asApiserverDeployment(desired)).not.toEqual(desired)
   })
 
+  it('FIXTURE-1: asApiserverDeployment does not mutate the caller desired object', () => {
+    const desired = sparseDeployment()
+    const before = structuredClone(desired)
+    asApiserverDeployment(desired)
+    expect(desired).toEqual(before)
+  })
+
   it('FIXTURE-1: omitted Deployment spec fields come from the recorded blob', () => {
     const desired = sparseDeployment()
     const existing = asApiserverDeployment(desired)
@@ -196,6 +203,7 @@ describe('asApiserverDeployment', () => {
 type CanonicalPodSpec = {
   serviceAccountName?: string
   containers?: Array<{
+    resources?: unknown
     livenessProbe?: { timeoutSeconds?: number; failureThreshold?: number }
   }>
 }
@@ -275,6 +283,35 @@ describe('safe-strip lemma equality guards', () => {
     const desired = deploymentWithProbe({ periodSeconds: 5 })
     const existing = asApiserverDeployment(desired)
     expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('strips empty resources {} and keeps a non-empty request', () => {
+    const empty = deploymentWithProbe({ periodSeconds: 5 })
+    empty.spec!.template.spec!.containers![0].resources = {}
+    const kept = deploymentWithProbe({ periodSeconds: 5 })
+    kept.spec!.template.spec!.containers![0].resources = { requests: { cpu: '50m' } }
+    expect(
+      canonicalPodSpec(normalizeDeploymentForComparison(empty))?.containers?.[0]?.resources
+    ).toBeUndefined()
+    expect(
+      canonicalPodSpec(normalizeDeploymentForComparison(kept))?.containers?.[0]?.resources
+    ).toEqual({ requests: { cpu: '50m' } })
+  })
+
+  it('omitted container resources match a live empty resources object', () => {
+    const desired = deploymentWithProbe({ periodSeconds: 5 })
+    const existing = asApiserverDeployment(desired)
+    expect(existing.spec?.template?.spec?.containers?.[0]?.resources).toEqual({})
+    expect(desired.spec?.template?.spec?.containers?.[0]?.resources).toBeUndefined()
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('does not treat 1000m and 1 as the same cpu quantity', () => {
+    const milli = deploymentWithProbe({ periodSeconds: 5 })
+    milli.spec!.template.spec!.containers![0].resources = { limits: { cpu: '1000m' } }
+    const canonical = deploymentWithProbe({ periodSeconds: 5 })
+    canonical.spec!.template.spec!.containers![0].resources = { limits: { cpu: '1' } }
+    expect(deploymentMatchesDesired(milli, canonical)).toBe(false)
   })
 })
 

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -12,7 +12,11 @@ import {
 } from '../../test/__fixtures__/testMocks'
 import { HostReconciler } from '../hostReconciler'
 import type { HostCRD } from '../types'
-import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
+import {
+  deploymentMatchesDesired,
+  normalizeDeploymentForComparison,
+  preserveDeploymentAnnotations,
+} from '../utils'
 import { asApiserverDeployment } from './asApiserverDeployment'
 import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
 
@@ -131,6 +135,90 @@ describe('asApiserverDeployment', () => {
       'rev-abc'
     ) as k8s.V1Deployment
     expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+})
+
+type CanonicalPodSpec = {
+  serviceAccountName?: string
+  containers?: Array<{
+    livenessProbe?: { timeoutSeconds?: number; failureThreshold?: number }
+  }>
+}
+
+function canonicalPodSpec(normalized: unknown): CanonicalPodSpec | undefined {
+  return (normalized as { spec?: { template?: { spec?: CanonicalPodSpec } } }).spec?.template?.spec
+}
+
+function deploymentWithProbe(
+  probe: Partial<k8s.V1Probe>,
+  serviceAccountName?: string
+): k8s.V1Deployment {
+  return {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: { name: 'probe-guard', namespace: 'ns' },
+    spec: {
+      replicas: 1,
+      selector: { matchLabels: { app: 'probe-guard' } },
+      template: {
+        metadata: { labels: { app: 'probe-guard' } },
+        spec: {
+          ...(serviceAccountName !== undefined ? { serviceAccountName } : {}),
+          containers: [
+            {
+              name: 'c',
+              image: 'img:1',
+              livenessProbe: {
+                httpGet: { path: '/live', port: 80 },
+                periodSeconds: 5,
+                ...probe,
+              },
+            },
+          ],
+        },
+      },
+    },
+  }
+}
+
+describe('safe-strip lemma equality guards', () => {
+  it('strips timeoutSeconds === 1 and keeps a non-default 2', () => {
+    const stripped = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({ timeoutSeconds: 1 }))
+    )
+    const kept = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({ timeoutSeconds: 2 }))
+    )
+    expect(stripped?.containers?.[0]?.livenessProbe?.timeoutSeconds).toBeUndefined()
+    expect(kept?.containers?.[0]?.livenessProbe?.timeoutSeconds).toBe(2)
+  })
+
+  it('strips failureThreshold === 3 and keeps a non-default 6', () => {
+    const stripped = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({ failureThreshold: 3 }))
+    )
+    const kept = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({ failureThreshold: 6 }))
+    )
+    expect(stripped?.containers?.[0]?.livenessProbe?.failureThreshold).toBeUndefined()
+    expect(kept?.containers?.[0]?.livenessProbe?.failureThreshold).toBe(6)
+  })
+
+  it("strips serviceAccountName === 'default' and keeps a non-default name", () => {
+    const stripped = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({}, 'default'))
+    )
+    const kept = canonicalPodSpec(
+      normalizeDeploymentForComparison(deploymentWithProbe({}, 'clerum-x'))
+    )
+    expect(stripped?.serviceAccountName).toBeUndefined()
+    expect(kept?.serviceAccountName).toBe('clerum-x')
+  })
+
+  it('omitted probe timeout/failure and SA match the apiserver defaults after merge', () => {
+    const desired = deploymentWithProbe({ periodSeconds: 5 })
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
   })
 })
 

--- a/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
+++ b/host-context-controller/src/__tests__/deploymentMatchesDesired.test.ts
@@ -18,7 +18,12 @@ import {
   preserveDeploymentAnnotations,
 } from '../utils'
 import { asApiserverDeployment } from './asApiserverDeployment'
-import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+import {
+  cloneAndMutateLeaf,
+  collectLeafPaths,
+  collectLiveOnlySpecLeaves,
+  formatLeafPath,
+} from './mutateJsonLeaves'
 
 vi.mock('../config', () => ({
   config: {
@@ -118,6 +123,24 @@ function expectSweepDetectsEveryLeaf(desired: k8s.V1Deployment, existing: k8s.V1
   expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
 }
 
+function expectSweepDetectsLiveOnlySpecLeaves(
+  desired: k8s.V1Deployment,
+  existing: k8s.V1Deployment
+): void {
+  const liveOnly = collectLiveOnlySpecLeaves(desired, existing)
+  expect(liveOnly.length, 'fixture added no spec-only leaves').toBeGreaterThan(0)
+  const undetectable: string[] = []
+  for (const path of liveOnly) {
+    const mutatedExisting = cloneAndMutateLeaf(existing, path) as k8s.V1Deployment
+    if (deploymentMatchesDesired(mergedForCompare(desired, mutatedExisting), mutatedExisting)) {
+      undetectable.push(formatLeafPath(path))
+    }
+  }
+  expect(undetectable, `undetectable live-only spec path(s): ${undetectable.join(', ')}`).toEqual(
+    []
+  )
+}
+
 describe('asApiserverDeployment', () => {
   it('FIXTURE-1: default-fills a sparse Deployment so it differs structurally', () => {
     const desired = sparseDeployment()
@@ -135,6 +158,15 @@ describe('asApiserverDeployment', () => {
       'rev-abc'
     ) as k8s.V1Deployment
     expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('FIXTURE-1: omitted Deployment spec fields come from the recorded blob', () => {
+    const desired = sparseDeployment()
+    const existing = asApiserverDeployment(desired)
+    expect(existing.spec?.progressDeadlineSeconds).toBe(600)
+    expect(existing.spec?.revisionHistoryLimit).toBe(10)
+    expect(existing.spec?.template?.spec?.dnsPolicy).toBe('ClusterFirst')
+    expect(existing.spec?.template?.spec?.restartPolicy).toBe('Always')
   })
 
   it('FIXTURE-1: fills omitted imagePullPolicy the way apps/v1 defaults it', () => {
@@ -282,11 +314,24 @@ describe('deploymentMatchesDesired', () => {
     expectSweepDetectsEveryLeaf(desired, asApiserverDeployment(desired))
   })
 
+  it('Host mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = createReconciler().buildDeployment(makeHost())
+    expectSweepDetectsLiveOnlySpecLeaves(desired, asApiserverDeployment(desired))
+  })
+
   it('channel-reader mutation sweep: every desired leaf is detectable', () => {
     const desired = (createReconciler() as any).buildChannelReaderDeployment(
       makeHost(),
       'rev-abc'
     ) as k8s.V1Deployment
     expectSweepDetectsEveryLeaf(desired, asApiserverDeployment(desired))
+  })
+
+  it('channel-reader mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = (createReconciler() as any).buildChannelReaderDeployment(
+      makeHost(),
+      'rev-abc'
+    ) as k8s.V1Deployment
+    expectSweepDetectsLiveOnlySpecLeaves(desired, asApiserverDeployment(desired))
   })
 })

--- a/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
+++ b/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
@@ -13,7 +13,8 @@ const GATED = new Set([
 
 const EXEMPT = new Set(['k8s/gfsK8sApi.ts', 'statelessLifecycleExecutor.ts'])
 
-const CALL = /replaceNamespacedDeployment\s*\(\s*\{/g
+/** Any call, including `replace(params)` — not only inline `({ ... })`. */
+const CALL = /replaceNamespacedDeployment\s*\(/g
 
 function productionTsFiles(dir: string): string[] {
   const out: string[] = []
@@ -29,39 +30,93 @@ function productionTsFiles(dir: string): string[] {
   return out
 }
 
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim()
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+}
+
+function lineAt(source: string, index: number): string {
+  const start = source.lastIndexOf('\n', index - 1) + 1
+  const end = source.indexOf('\n', index)
+  return source.slice(start, end === -1 ? source.length : end)
+}
+
+function callSiteIndexes(source: string): number[] {
+  const indexes: number[] = []
+  for (const match of source.matchAll(CALL)) {
+    if (match.index === undefined) continue
+    if (isCommentLine(lineAt(source, match.index))) continue
+    indexes.push(match.index)
+  }
+  return indexes
+}
+
+function enclosingReplaceRetryBlock(source: string, callIndex: number): string | null {
+  let searchFrom = 0
+  let lastStart = -1
+  while (true) {
+    const idx = source.indexOf('replaceWithConflictRetry', searchFrom)
+    if (idx === -1 || idx > callIndex) break
+    lastStart = idx
+    searchFrom = idx + 1
+  }
+  if (lastStart === -1) return null
+  const paren = source.indexOf('(', lastStart)
+  if (paren === -1 || paren > callIndex) return null
+  let depth = 0
+  for (let i = paren; i < source.length; i++) {
+    if (source[i] === '(') depth += 1
+    else if (source[i] === ')') {
+      depth -= 1
+      if (depth === 0) {
+        if (i < callIndex) return null
+        return source.slice(lastStart, i + 1)
+      }
+    }
+  }
+  return null
+}
+
+function isDeploymentGated(block: string): boolean {
+  return /isUpToDate:/.test(block) && /deploymentMatchesDesired/.test(block)
+}
+
 describe('Deployment writer inventory', () => {
   it('every replaceNamespacedDeployment call is gated or explicitly exempt', () => {
     const hits: Array<{ rel: string; count: number; gated: boolean }> = []
     for (const file of productionTsFiles(SRC_ROOT)) {
       const rel = relative(SRC_ROOT, file).replaceAll('\\', '/')
       const source = readFileSync(file, 'utf8')
-      const count = source.match(CALL)?.length ?? 0
-      if (count === 0) continue
+      const sites = callSiteIndexes(source)
+      if (sites.length === 0) continue
       const isGated = GATED.has(rel)
       const isExempt = EXEMPT.has(rel)
       expect(
         isGated || isExempt,
-        `${rel} calls replaceNamespacedDeployment ${count} time(s) but is on neither the gated nor the exempt list`
+        `${rel} calls replaceNamespacedDeployment ${sites.length} time(s) but is on neither the gated nor the exempt list`
       ).toBe(true)
-      if (isGated) {
-        expect(
-          source.includes('deploymentMatchesDesired'),
-          `${rel} is gated but does not reference deploymentMatchesDesired`
-        ).toBe(true)
-        const directGates = source.match(/isUpToDate:\s*deploymentMatchesDesired\b/g)?.length ?? 0
-        const wrapperGates = source.match(/return deploymentMatchesDesired\s*\(/g)?.length ?? 0
-        expect(
-          directGates + wrapperGates,
-          `${rel} has ${count} Deployment replace(s) but ${directGates + wrapperGates} isUpToDate gate(s)`
-        ).toBe(count)
+
+      for (const index of sites) {
+        const block = enclosingReplaceRetryBlock(source, index)
+        if (isGated) {
+          expect(
+            block,
+            `${rel} call at index ${index} is not inside replaceWithConflictRetry`
+          ).not.toBeNull()
+          expect(
+            isDeploymentGated(block ?? ''),
+            `${rel} call at index ${index} is missing an isUpToDate deploymentMatchesDesired gate`
+          ).toBe(true)
+        }
+        if (isExempt) {
+          expect(
+            block !== null && isDeploymentGated(block),
+            `${rel} is exempt and must not wire the Deployment no-op gate`
+          ).toBe(false)
+        }
       }
-      if (isExempt) {
-        expect(
-          source.includes('isUpToDate: deploymentMatchesDesired'),
-          `${rel} is exempt and must not wire the Deployment no-op gate`
-        ).toBe(false)
-      }
-      hits.push({ rel, count, gated: isGated })
+
+      hits.push({ rel, count: sites.length, gated: isGated })
     }
 
     expect(hits.map(h => h.rel).sort()).toEqual([...GATED, ...EXEMPT].sort())

--- a/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
+++ b/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const SRC_ROOT = join(__dirname, '..')
+
+const GATED = new Set([
+  'hostReconciler.ts',
+  'reconciler.ts',
+  'sharedFileSystemReconciler.ts',
+  'llmHookReconciler.ts',
+])
+
+const EXEMPT = new Set(['k8s/gfsK8sApi.ts', 'statelessLifecycleExecutor.ts'])
+
+const CALL = /replaceNamespacedDeployment\s*\(\s*\{/g
+
+function productionTsFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === '__tests__' || entry.endsWith('.test.ts')) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...productionTsFiles(full))
+      continue
+    }
+    if (entry.endsWith('.ts')) out.push(full)
+  }
+  return out
+}
+
+describe('Deployment writer inventory', () => {
+  it('every replaceNamespacedDeployment call is gated or explicitly exempt', () => {
+    const hits: Array<{ rel: string; count: number; gated: boolean }> = []
+    for (const file of productionTsFiles(SRC_ROOT)) {
+      const rel = relative(SRC_ROOT, file).replaceAll('\\', '/')
+      const source = readFileSync(file, 'utf8')
+      const count = source.match(CALL)?.length ?? 0
+      if (count === 0) continue
+      const isGated = GATED.has(rel)
+      const isExempt = EXEMPT.has(rel)
+      expect(
+        isGated || isExempt,
+        `${rel} calls replaceNamespacedDeployment ${count} time(s) but is on neither the gated nor the exempt list`
+      ).toBe(true)
+      if (isGated) {
+        expect(
+          source.includes('deploymentMatchesDesired'),
+          `${rel} is gated but does not reference deploymentMatchesDesired`
+        ).toBe(true)
+      }
+      if (isExempt) {
+        expect(
+          source.includes('isUpToDate: deploymentMatchesDesired'),
+          `${rel} is exempt and must not wire the Deployment no-op gate`
+        ).toBe(false)
+      }
+      hits.push({ rel, count, gated: isGated })
+    }
+
+    expect(hits.map(h => h.rel).sort()).toEqual([...GATED, ...EXEMPT].sort())
+    expect(hits.reduce((sum, h) => sum + h.count, 0)).toBe(8)
+    expect(
+      hits
+        .filter(h => h.gated)
+        .map(h => h.rel)
+        .sort()
+    ).toEqual([...GATED].sort())
+  })
+})

--- a/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
+++ b/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
@@ -78,7 +78,10 @@ function enclosingReplaceRetryBlock(source: string, callIndex: number): string |
 }
 
 function isDeploymentGated(block: string): boolean {
-  return /isUpToDate:/.test(block) && /deploymentMatchesDesired/.test(block)
+  return (
+    /isUpToDate:\s*deploymentMatchesDesired\b/.test(block) ||
+    /return deploymentMatchesDesired\s*\(/.test(block)
+  )
 }
 
 describe('Deployment writer inventory', () => {
@@ -127,5 +130,44 @@ describe('Deployment writer inventory', () => {
         .map(h => h.rel)
         .sort()
     ).toEqual([...GATED].sort())
+  })
+
+  it('every replaceNamespacedConfigMap call is gated per call-site', () => {
+    const CONFIGMAP_GATED = new Set(['reconciler.ts'])
+    const CONFIGMAP_CALL = /replaceNamespacedConfigMap\s*\(/g
+    const hits: Array<{ rel: string; count: number }> = []
+
+    for (const file of productionTsFiles(SRC_ROOT)) {
+      const rel = relative(SRC_ROOT, file).replaceAll('\\', '/')
+      const source = readFileSync(file, 'utf8')
+      const sites: number[] = []
+      for (const match of source.matchAll(CONFIGMAP_CALL)) {
+        if (match.index === undefined) continue
+        if (isCommentLine(lineAt(source, match.index))) continue
+        sites.push(match.index)
+      }
+      if (sites.length === 0) continue
+
+      expect(
+        CONFIGMAP_GATED.has(rel),
+        `${rel} calls replaceNamespacedConfigMap ${sites.length} time(s) but is not on the ConfigMap gated list`
+      ).toBe(true)
+
+      for (const index of sites) {
+        const block = enclosingReplaceRetryBlock(source, index)
+        expect(
+          block,
+          `${rel} ConfigMap call at index ${index} is not inside replaceWithConflictRetry`
+        ).not.toBeNull()
+        expect(
+          /isUpToDate:\s*configMapMatchesDesired\b/.test(block ?? ''),
+          `${rel} ConfigMap call at index ${index} is missing isUpToDate: configMapMatchesDesired`
+        ).toBe(true)
+      }
+      hits.push({ rel, count: sites.length })
+    }
+
+    expect(hits.map(h => h.rel).sort()).toEqual([...CONFIGMAP_GATED].sort())
+    expect(hits.reduce((sum, h) => sum + h.count, 0)).toBe(1)
   })
 })

--- a/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
+++ b/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
@@ -91,7 +91,20 @@ describe('Deployment writer inventory', () => {
       const rel = relative(SRC_ROOT, file).replaceAll('\\', '/')
       const source = readFileSync(file, 'utf8')
       const sites = callSiteIndexes(source)
-      if (sites.length === 0) continue
+      const identCount = [...source.matchAll(/replaceNamespacedDeployment\b/g)].filter(
+        match => match.index !== undefined && !isCommentLine(lineAt(source, match.index))
+      ).length
+      if (sites.length === 0) {
+        expect(
+          identCount,
+          `${rel} mentions replaceNamespacedDeployment but has no call; an alias/bind form is invisible to the call regex`
+        ).toBe(0)
+        continue
+      }
+      expect(
+        identCount,
+        `${rel} has ${identCount} replaceNamespacedDeployment identifier(s) but ${sites.length} call(s); an alias/bind form is invisible to the call regex`
+      ).toBe(sites.length)
       const isGated = GATED.has(rel)
       const isExempt = EXEMPT.has(rel)
       expect(

--- a/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
+++ b/host-context-controller/src/__tests__/deploymentWriterInventory.test.ts
@@ -48,6 +48,12 @@ describe('Deployment writer inventory', () => {
           source.includes('deploymentMatchesDesired'),
           `${rel} is gated but does not reference deploymentMatchesDesired`
         ).toBe(true)
+        const directGates = source.match(/isUpToDate:\s*deploymentMatchesDesired\b/g)?.length ?? 0
+        const wrapperGates = source.match(/return deploymentMatchesDesired\s*\(/g)?.length ?? 0
+        expect(
+          directGates + wrapperGates,
+          `${rel} has ${count} Deployment replace(s) but ${directGates + wrapperGates} isUpToDate gate(s)`
+        ).toBe(count)
       }
       if (isExempt) {
         expect(

--- a/host-context-controller/src/__tests__/llmHookDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/llmHookDeploymentNoopGate.test.ts
@@ -16,7 +16,13 @@ import { LlmHookReconciler, computePodKey } from '../llmHookReconciler'
 import type { HostCRD, LlmHookCRD } from '../types'
 import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
 import { asApiserverDeployment } from './asApiserverDeployment'
-import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+import {
+  cloneAndMutateLeaf,
+  collectLeafPaths,
+  collectLiveOnlySpecLeaves,
+  formatLeafPath,
+  undetectableLiveOnlySpecLeaves,
+} from './mutateJsonLeaves'
 
 vi.mock('../config', () => ({
   config: {
@@ -109,6 +115,24 @@ describe('LlmHook ensureDeployment no-op gate', () => {
       }
     }
     expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('LlmHook mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(
+      podKey,
+      members,
+      'rev-1'
+    ) as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(collectLiveOnlySpecLeaves(desired, existing).length).toBeGreaterThan(0)
+    expect(
+      undetectableLiveOnlySpecLeaves(desired, existing, mutated =>
+        deploymentMatchesDesired(
+          mergedForCompare(desired, mutated as k8s.V1Deployment),
+          mutated as k8s.V1Deployment
+        )
+      )
+    ).toEqual([])
   })
 
   it('NOOP-LLMDEP-1: equivalent Deployment skips replace and Updated logs', async () => {

--- a/host-context-controller/src/__tests__/llmHookDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/llmHookDeploymentNoopGate.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import {
+  type MockAppsApi,
+  asAppsApi,
+  asCoreApi,
+  asCustomApi,
+  asNetworkingApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockCustomApi,
+  createMockNetworkingApi,
+} from '../../test/__fixtures__/testMocks'
+import { updatedLogs } from '../../test/__fixtures__/updatedLogs'
+import { LlmHookReconciler, computePodKey } from '../llmHookReconciler'
+import type { HostCRD, LlmHookCRD } from '../types'
+import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
+import { asApiserverDeployment } from './asApiserverDeployment'
+import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+
+vi.mock('../config', () => ({
+  config: {
+    llmHooksNamespace: 'llm-hooks',
+    hostNamespace: 'mcp-host',
+    mcpServerImagePullPolicy: 'IfNotPresent',
+  },
+}))
+
+const IMG = 'registry.example.com/hook@sha256:' + 'a'.repeat(64)
+const CREDENTIALS_REVISION_ANNOTATION = 'clerum.io/credentials-revision'
+
+function makeHook(): LlmHookCRD {
+  return {
+    name: 'pre-hook',
+    namespace: 'llm-hooks',
+    generation: 1,
+    spec: {
+      target: { image: { ref: IMG, port: 8080 } },
+      path: '/',
+      lifecyclePoints: ['preCall'],
+    },
+  }
+}
+
+function mergedForCompare(desired: k8s.V1Deployment, existing: k8s.V1Deployment): k8s.V1Deployment {
+  return preserveDeploymentAnnotations(
+    {
+      ...desired,
+      metadata: { ...desired.metadata, resourceVersion: existing.metadata?.resourceVersion },
+    },
+    existing
+  )
+}
+
+describe('LlmHook ensureDeployment no-op gate', () => {
+  let appsApi: MockAppsApi
+  let reconciler: LlmHookReconciler
+  const hook = makeHook()
+  const podKey = computePodKey(hook)!
+  const members = [hook]
+
+  beforeEach(() => {
+    appsApi = createMockAppsApi()
+    reconciler = new LlmHookReconciler(
+      {} as k8s.KubeConfig,
+      new Map<string, LlmHookCRD>(),
+      new Map<string, HostCRD>(),
+      {
+        appsApi: asAppsApi(appsApi),
+        coreApi: asCoreApi(createMockCoreApi()),
+        customApi: asCustomApi(createMockCustomApi()),
+        networkingApi: asNetworkingApi(createMockNetworkingApi()),
+      }
+    )
+    appsApi.createNamespacedDeployment.mockRejectedValue({ code: 409 })
+  })
+
+  it('FIXTURE-1: LlmHook builder output differs from the default-filled live object', () => {
+    const desired = (reconciler as any).buildDeployment(
+      podKey,
+      members,
+      'rev-1'
+    ) as k8s.V1Deployment
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('predicate: merged builder vs fixture is a no-op', () => {
+    const desired = (reconciler as any).buildDeployment(
+      podKey,
+      members,
+      'rev-1'
+    ) as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('LlmHook mutation sweep: every desired leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(
+      podKey,
+      members,
+      'rev-1'
+    ) as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    const undetectable: string[] = []
+    for (const path of collectLeafPaths(desired)) {
+      const mutated = cloneAndMutateLeaf(desired, path) as k8s.V1Deployment
+      if (deploymentMatchesDesired(mergedForCompare(mutated, existing), existing)) {
+        undetectable.push(formatLeafPath(path))
+      }
+    }
+    expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('NOOP-LLMDEP-1: equivalent Deployment skips replace and Updated logs', async () => {
+    const desired = (reconciler as any).buildDeployment(
+      podKey,
+      members,
+      'rev-1'
+    ) as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(desired))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureDeployment(podKey, members, 'rev-1')
+      expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+      expect(updatedLogs(log, 'Updated', 'Deployment')).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('ROTATE-LLMDEP-1: credentials revision change replaces once', async () => {
+    const live = (reconciler as any).buildDeployment(podKey, members, 'rev-old') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    await (reconciler as any).ensureDeployment(podKey, members, 'rev-new')
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+    const body = (
+      appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+    ).body
+    expect(body.spec?.template?.metadata?.annotations?.[CREDENTIALS_REVISION_ANNOTATION]).toBe(
+      'rev-new'
+    )
+  })
+
+  it('IMAGE-LLMDEP-1: image.ref bump replaces once', async () => {
+    const live = (reconciler as any).buildDeployment(podKey, members, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    const bumped = makeHook()
+    bumped.spec.target.image!.ref = 'registry.example.com/hook@sha256:' + 'b'.repeat(64)
+    const newKey = computePodKey(bumped)!
+    await (reconciler as any).ensureDeployment(newKey, [bumped], 'rev-1')
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+    const body = (
+      appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+    ).body
+    expect(body.spec?.template?.spec?.containers?.[0]?.image).toBe(bumped.spec.target.image!.ref)
+  })
+})

--- a/host-context-controller/src/__tests__/llmHookNetworkPolicyNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/llmHookNetworkPolicyNoopGate.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import {
+  type MockCoreApi,
+  type MockNetworkingApi,
+  asAppsApi,
+  asCoreApi,
+  asCustomApi,
+  asNetworkingApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockCustomApi,
+  createMockNetworkingApi,
+} from '../../test/__fixtures__/testMocks'
+import { updatedLogs } from '../../test/__fixtures__/updatedLogs'
+import {
+  HOST_LABEL,
+  LLMHOOK_LABEL,
+  MANAGED_BY_LABEL,
+  MANAGED_BY_VALUE,
+  POLICY_TYPE_LABEL,
+} from '../constants'
+import { LlmHookReconciler, computePodKey, serviceTargetNpName } from '../llmHookReconciler'
+import type { HostCRD, LlmHookCRD } from '../types'
+import { asApiserverNetworkPolicy, updatedPolicyLogs } from './asApiserverNetworkPolicy'
+
+vi.mock('../config', () => ({
+  config: {
+    llmHooksNamespace: 'llm-hooks',
+    hostNamespace: 'mcp-host',
+    mcpServerImagePullPolicy: 'IfNotPresent',
+  },
+}))
+
+const IMG = 'registry.example.com/hook@sha256:' + 'a'.repeat(64)
+
+function makeImageHook(): LlmHookCRD {
+  return {
+    name: 'pre-hook',
+    namespace: 'llm-hooks',
+    generation: 1,
+    spec: {
+      target: { image: { ref: IMG, port: 8080 } },
+      path: '/',
+      lifecyclePoints: ['preCall'],
+    },
+  }
+}
+
+function makeServiceHook(): LlmHookCRD {
+  return {
+    name: 'svc-hook',
+    namespace: 'llm-hooks',
+    generation: 1,
+    spec: {
+      target: { service: { name: 'hook-svc', namespace: 'llm-hooks', port: 8080 } },
+      path: '/',
+      lifecyclePoints: ['preCall'],
+    },
+  }
+}
+
+function makeHost(hookId: string): HostCRD {
+  return {
+    name: 'chatllm',
+    namespace: 'mcp-host',
+    spec: {
+      host: 'chatllm',
+      contextRef: 'ctx',
+      secretRef: 'secret',
+      guardrails: { hooks: { preCall: [{ id: hookId }] } },
+    },
+  }
+}
+
+describe('LlmHook NetworkPolicy no-op gate', () => {
+  let networkingApi: MockNetworkingApi
+  let coreApi: MockCoreApi
+  let reconciler: LlmHookReconciler
+  let hooks: Map<string, LlmHookCRD>
+  let hosts: Map<string, HostCRD>
+
+  beforeEach(() => {
+    networkingApi = createMockNetworkingApi()
+    coreApi = createMockCoreApi()
+    hooks = new Map()
+    hosts = new Map()
+    reconciler = new LlmHookReconciler({} as k8s.KubeConfig, hooks, hosts, {
+      appsApi: asAppsApi(createMockAppsApi()),
+      coreApi: asCoreApi(coreApi),
+      customApi: asCustomApi(createMockCustomApi()),
+      networkingApi: asNetworkingApi(networkingApi),
+    })
+    networkingApi.createNamespacedNetworkPolicy.mockRejectedValue({ code: 409 })
+  })
+
+  it('NOOP-LLMNP-1: image-hook policy (caller :811) skips replace', async () => {
+    const hook = makeImageHook()
+    const podKey = computePodKey(hook)!
+    const desired = (reconciler as any).buildNetworkPolicy(
+      podKey,
+      [hook],
+      []
+    ) as k8s.V1NetworkPolicy
+    networkingApi.readNamespacedNetworkPolicy.mockResolvedValue(asApiserverNetworkPolicy(desired))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureNetworkPolicy(podKey, [hook], [])
+      expect(networkingApi.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
+      expect(updatedPolicyLogs(log, `NetworkPolicy "${desired.metadata?.name}"`)).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('NOOP-LLMNP-2: service-target policy (caller :889) skips replace', async () => {
+    const hook = makeServiceHook()
+    coreApi.readNamespacedService.mockResolvedValue({
+      spec: { selector: { app: 'hook-svc' } },
+    })
+    const desired: k8s.V1NetworkPolicy = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: {
+        name: serviceTargetNpName(hook.name),
+        namespace: 'llm-hooks',
+        labels: {
+          [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
+          [POLICY_TYPE_LABEL]: 'service-hook-ingress',
+          [LLMHOOK_LABEL]: hook.name,
+        },
+      },
+      spec: {
+        podSelector: { matchLabels: { app: 'hook-svc' } },
+        policyTypes: ['Ingress'],
+        ingress: [],
+      },
+    }
+    networkingApi.readNamespacedNetworkPolicy.mockResolvedValue(asApiserverNetworkPolicy(desired))
+    await (reconciler as any).ensureServiceTargetNetworkPolicy(hook)
+    expect(networkingApi.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
+  })
+
+  it('NOOP-LLMNP-3: host-egress policy (caller :964) skips replace', async () => {
+    const hook = makeImageHook()
+    const host = makeHost(hook.name)
+    hooks.set(hook.name, hook)
+    hosts.set(host.name, host)
+    const rules = (await (reconciler as any).buildHostEgressRules(
+      host
+    )) as k8s.V1NetworkPolicyEgressRule[]
+    expect(rules.length).toBeGreaterThan(0)
+    const desired: k8s.V1NetworkPolicy = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: {
+        name: `mcp-host-${host.name}-egress-llm-hooks`,
+        namespace: 'mcp-host',
+        labels: {
+          [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
+          [HOST_LABEL]: host.name,
+          [POLICY_TYPE_LABEL]: 'llm-hooks-egress',
+        },
+      },
+      spec: {
+        podSelector: {
+          matchLabels: { [HOST_LABEL]: host.name, [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
+        },
+        policyTypes: ['Egress'],
+        egress: rules,
+      },
+    }
+    networkingApi.readNamespacedNetworkPolicy.mockResolvedValue(asApiserverNetworkPolicy(desired))
+    await (reconciler as any).ensureHostEgressNetworkPolicy(host)
+    expect(networkingApi.replaceNamespacedNetworkPolicy).not.toHaveBeenCalled()
+  })
+
+  it('WRITE-LLMNP-1: added egress rule replaces once', async () => {
+    const hook = makeImageHook()
+    const podKey = computePodKey(hook)!
+    const empty = (reconciler as any).buildNetworkPolicy(podKey, [hook], []) as k8s.V1NetworkPolicy
+    networkingApi.readNamespacedNetworkPolicy.mockResolvedValue(asApiserverNetworkPolicy(empty))
+    const extra: k8s.V1NetworkPolicyEgressRule[] = [
+      { to: [{ ipBlock: { cidr: '1.2.3.4/32' } }], ports: [{ port: 443, protocol: 'TCP' }] },
+    ]
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureNetworkPolicy(podKey, [hook], extra)
+      expect(networkingApi.replaceNamespacedNetworkPolicy).toHaveBeenCalledOnce()
+      expect(updatedLogs(log, 'Updated', 'NetworkPolicy')).toEqual([
+        `[LlmHook] Updated NetworkPolicy "${empty.metadata?.name}"`,
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+})

--- a/host-context-controller/src/__tests__/mcpServerConfigMapNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/mcpServerConfigMapNoopGate.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import {
+  type MockCoreApi,
+  asAppsApi,
+  asCoreApi,
+  asCustomApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockCustomApi,
+} from '../../test/__fixtures__/testMocks'
+import { updatedLogs } from '../../test/__fixtures__/updatedLogs'
+import { McpServerReconciler } from '../reconciler'
+import type { McpServerCRD } from '../types'
+import { configMapMatchesDesired } from '../utils'
+
+vi.mock('../config', () => ({
+  config: {
+    devMode: false,
+    port: 8081,
+    namespace: 'mcp-server',
+    hostNamespace: 'mcp-host',
+    mcpServerImagePullPolicy: 'IfNotPresent',
+    egressProxyImage: 'clerum/nginx-egress-proxy:0.1.0',
+    stdioBridgeImage: 'clerum/stdio-bridge:test',
+    stdioBridgeResources: {
+      requests: { cpu: '50m', memory: '64Mi' },
+      limits: { cpu: '200m', memory: '128Mi' },
+    },
+    devMcpServers: [],
+    devContexts: [],
+    devAuthTokens: new Map(),
+  },
+}))
+
+function makeRemoteServer(): McpServerCRD {
+  return {
+    name: 'mcp-sentry-remote',
+    namespace: 'mcp-server',
+    uid: 'test-uid-123',
+    spec: {
+      contextRef: 'context1',
+      image: 'clerum/nginx-egress-proxy:0.1.0',
+      transport: { type: 'streamableHttp', port: 3000 },
+      remote: { baseUrl: 'https://mcp.sentry.io/sse' },
+    },
+  }
+}
+
+function asApiserverConfigMap(
+  desired: k8s.V1ConfigMap,
+  drift?: { template?: string }
+): k8s.V1ConfigMap {
+  return {
+    ...desired,
+    metadata: {
+      ...desired.metadata,
+      resourceVersion: '42',
+      uid: 'cm-uid',
+      creationTimestamp: new Date('2026-04-01T00:00:00.000Z'),
+    },
+    data: {
+      ...desired.data,
+      ...(drift?.template !== undefined ? { 'default.conf.template': drift.template } : {}),
+    },
+  }
+}
+
+describe('McpServer nginx ConfigMap no-op gate', () => {
+  let coreApi: MockCoreApi
+  let reconciler: McpServerReconciler
+  const server = makeRemoteServer()
+
+  beforeEach(() => {
+    coreApi = createMockCoreApi()
+    reconciler = new McpServerReconciler({} as k8s.KubeConfig, {
+      assumeInventoryAuthorityWhenUnconfigured: true,
+      appsApi: asAppsApi(createMockAppsApi()),
+      coreApi: asCoreApi(coreApi),
+      customApi: asCustomApi(createMockCustomApi()),
+    })
+    coreApi.createNamespacedConfigMap.mockRejectedValue({ code: 409 })
+  })
+
+  it('returns false when either ConfigMap is missing (fail-open-to-write)', () => {
+    const desired = (reconciler as any).buildNginxConfigMap(server) as k8s.V1ConfigMap
+    expect(configMapMatchesDesired(undefined, desired)).toBe(false)
+    expect(configMapMatchesDesired(desired, undefined)).toBe(false)
+  })
+
+  it('CM-1: identical conf skips replace and Updated logs', async () => {
+    const desired = (reconciler as any).buildNginxConfigMap(server) as k8s.V1ConfigMap
+    coreApi.readNamespacedConfigMap.mockResolvedValue(asApiserverConfigMap(desired))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureConfigMap(server)
+      expect(coreApi.replaceNamespacedConfigMap).not.toHaveBeenCalled()
+      expect(updatedLogs(log, 'Updated', 'nginx ConfigMap')).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('CM-2: a byte change in default.conf.template replaces once', async () => {
+    const desired = (reconciler as any).buildNginxConfigMap(server) as k8s.V1ConfigMap
+    coreApi.readNamespacedConfigMap.mockResolvedValue(
+      asApiserverConfigMap(desired, { template: '# drifted\n' })
+    )
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureConfigMap(server)
+      expect(coreApi.replaceNamespacedConfigMap).toHaveBeenCalledOnce()
+      const body = (
+        coreApi.replaceNamespacedConfigMap.mock.calls[0][0] as { body: k8s.V1ConfigMap }
+      ).body
+      expect(body.data?.['default.conf.template']).toBe(desired.data?.['default.conf.template'])
+      expect(updatedLogs(log, 'Updated', 'nginx ConfigMap')).toEqual([
+        '[Reconciler] Updated nginx ConfigMap "mcp-sentry-remote-nginx-conf"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('CM-3: replace 409 retries and succeeds', async () => {
+    const desired = (reconciler as any).buildNginxConfigMap(server) as k8s.V1ConfigMap
+    const drifted = asApiserverConfigMap(desired, { template: '# drifted\n' })
+    coreApi.readNamespacedConfigMap
+      .mockResolvedValueOnce({
+        ...drifted,
+        metadata: { ...drifted.metadata, resourceVersion: '42' },
+      })
+      .mockResolvedValueOnce({
+        ...drifted,
+        metadata: { ...drifted.metadata, resourceVersion: '43' },
+      })
+    coreApi.replaceNamespacedConfigMap
+      .mockRejectedValueOnce({ code: 409 })
+      .mockResolvedValueOnce({})
+
+    await (reconciler as any).ensureConfigMap(server)
+
+    expect(coreApi.replaceNamespacedConfigMap).toHaveBeenCalledTimes(2)
+    expect(
+      (coreApi.replaceNamespacedConfigMap.mock.calls[0][0] as { body: k8s.V1ConfigMap }).body
+        .metadata?.resourceVersion
+    ).toBe('42')
+    expect(
+      (coreApi.replaceNamespacedConfigMap.mock.calls[1][0] as { body: k8s.V1ConfigMap }).body
+        .metadata?.resourceVersion
+    ).toBe('43')
+  })
+
+  it('CM-4: isCurrent false skips replace after the gate', async () => {
+    const desired = (reconciler as any).buildNginxConfigMap(server) as k8s.V1ConfigMap
+    coreApi.readNamespacedConfigMap.mockResolvedValue(
+      asApiserverConfigMap(desired, { template: '# drifted\n' })
+    )
+    const isCurrent = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+
+    await (reconciler as any).ensureConfigMap(server, isCurrent)
+
+    expect(coreApi.replaceNamespacedConfigMap).not.toHaveBeenCalled()
+    expect(isCurrent).toHaveBeenCalled()
+  })
+})

--- a/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
@@ -14,7 +14,13 @@ import { McpServerReconciler } from '../reconciler'
 import type { McpServerCRD } from '../types'
 import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
 import { asApiserverDeployment } from './asApiserverDeployment'
-import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+import {
+  cloneAndMutateLeaf,
+  collectLeafPaths,
+  collectLiveOnlySpecLeaves,
+  formatLeafPath,
+  undetectableLiveOnlySpecLeaves,
+} from './mutateJsonLeaves'
 
 vi.mock('../config', () => ({
   config: {
@@ -118,6 +124,20 @@ describe('McpServer ensureDeployment no-op gate', () => {
     expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
   })
 
+  it('McpServer mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(collectLiveOnlySpecLeaves(desired, existing).length).toBeGreaterThan(0)
+    expect(
+      undetectableLiveOnlySpecLeaves(desired, existing, mutated =>
+        deploymentMatchesDesired(
+          mergedForCompare(desired, mutated as k8s.V1Deployment),
+          mutated as k8s.V1Deployment
+        )
+      )
+    ).toEqual([])
+  })
+
   it('NOOP-MCPDEP-1: equivalent Deployment skips replace and Updated logs', async () => {
     const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
     appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(desired))
@@ -219,6 +239,20 @@ describe('McpServer stdio ensureDeployment no-op gate', () => {
       }
     }
     expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('McpServer stdio mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(collectLiveOnlySpecLeaves(desired, existing).length).toBeGreaterThan(0)
+    expect(
+      undetectableLiveOnlySpecLeaves(desired, existing, mutated =>
+        deploymentMatchesDesired(
+          mergedForCompare(desired, mutated as k8s.V1Deployment),
+          mutated as k8s.V1Deployment
+        )
+      )
+    ).toEqual([])
   })
 
   it('NOOP-MCPDEP-STDIO-1: equivalent stdio Deployment skips replace and Updated logs', async () => {

--- a/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
@@ -54,6 +54,20 @@ function makeServer(): McpServerCRD {
   }
 }
 
+function makeStdioServer(): McpServerCRD {
+  return {
+    name: 'test-mcp',
+    namespace: 'mcp-server',
+    uid: 'uid-test-1234',
+    spec: {
+      contextRef: 'ctx1',
+      image: 'my-mcp-server:v1',
+      transport: { type: 'stdio', port: 3000 },
+      command: ['/mcp-bin/mcp-server'],
+    },
+  }
+}
+
 function mergedForCompare(desired: k8s.V1Deployment, existing: k8s.V1Deployment): k8s.V1Deployment {
   return preserveDeploymentAnnotations(
     {
@@ -162,5 +176,77 @@ describe('McpServer ensureDeployment no-op gate', () => {
 
     expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
     expect(isCurrent).toHaveBeenCalled()
+  })
+})
+
+describe('McpServer stdio ensureDeployment no-op gate', () => {
+  let appsApi: MockAppsApi
+  let reconciler: McpServerReconciler
+  const server = makeStdioServer()
+
+  beforeEach(() => {
+    appsApi = createMockAppsApi()
+    reconciler = new McpServerReconciler({} as k8s.KubeConfig, {
+      assumeInventoryAuthorityWhenUnconfigured: true,
+      appsApi: asAppsApi(appsApi),
+      coreApi: asCoreApi(createMockCoreApi()),
+      customApi: asCustomApi(createMockCustomApi()),
+    })
+    appsApi.createNamespacedDeployment.mockRejectedValue({ code: 409 })
+  })
+
+  it('stdio-bridge authors imagePullPolicy so the live default-fill is a no-op', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const podSpec = desired.spec?.template?.spec
+    expect(podSpec?.initContainers?.find(c => c.name === 'copy-mcp-app')?.imagePullPolicy).toBe(
+      'IfNotPresent'
+    )
+    expect(podSpec?.containers?.find(c => c.name === 'stdio-bridge')?.imagePullPolicy).toBe(
+      'IfNotPresent'
+    )
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('McpServer stdio mutation sweep: every desired leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    const undetectable: string[] = []
+    for (const path of collectLeafPaths(desired)) {
+      const mutated = cloneAndMutateLeaf(desired, path) as k8s.V1Deployment
+      if (deploymentMatchesDesired(mergedForCompare(mutated, existing), existing)) {
+        undetectable.push(formatLeafPath(path))
+      }
+    }
+    expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('NOOP-MCPDEP-STDIO-1: equivalent stdio Deployment skips replace and Updated logs', async () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(desired))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureDeployment(server, 'rev-1')
+      expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+      expect(updatedLogs(log, 'Updated', 'Deployment "test-mcp"')).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('IMAGE-MCPDEP-STDIO-1: image bump replaces the copy init container once', async () => {
+    const live = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    const bumped = makeStdioServer()
+    bumped.spec.image = 'my-mcp-server:v2'
+    await (reconciler as any).ensureDeployment(bumped, 'rev-1')
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+    const body = (
+      appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+    ).body
+    const copyImage = body.spec?.template?.spec?.initContainers?.find(
+      c => c.name === 'copy-mcp-app'
+    )?.image
+    expect(copyImage).toBe('my-mcp-server:v2')
   })
 })

--- a/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/mcpServerDeploymentNoopGate.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import {
+  type MockAppsApi,
+  asAppsApi,
+  asCoreApi,
+  asCustomApi,
+  createMockAppsApi,
+  createMockCoreApi,
+  createMockCustomApi,
+} from '../../test/__fixtures__/testMocks'
+import { updatedLogs } from '../../test/__fixtures__/updatedLogs'
+import { McpServerReconciler } from '../reconciler'
+import type { McpServerCRD } from '../types'
+import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
+import { asApiserverDeployment } from './asApiserverDeployment'
+import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+
+vi.mock('../config', () => ({
+  config: {
+    devMode: false,
+    port: 8081,
+    namespace: 'mcp-server',
+    hostNamespace: 'mcp-host',
+    mcpServerImagePullPolicy: 'IfNotPresent',
+    egressProxyImage: 'clerum/nginx-egress-proxy:0.1.0',
+    stdioBridgeImage: 'clerum/stdio-bridge:test',
+    stdioBridgeResources: {
+      requests: { cpu: '50m', memory: '64Mi' },
+      limits: { cpu: '200m', memory: '128Mi' },
+    },
+    devMcpServers: [],
+    devContexts: [],
+    devAuthTokens: new Map(),
+  },
+}))
+
+const CREDENTIALS_REVISION_ANNOTATION = 'clerum.io/credentials-revision'
+
+function makeServer(): McpServerCRD {
+  return {
+    name: 'test-mcp',
+    namespace: 'mcp-server',
+    uid: 'uid-test-1234',
+    spec: {
+      contextRef: 'ctx1',
+      image: 'my-mcp-server:v1',
+      transport: { type: 'streamableHttp', port: 3000, url: 'http://test.mcp-server.svc:3000/mcp' },
+      envSecret: {
+        name: 'test-mcp-credentials',
+        keys: [{ secretKey: 'api-key', envVar: 'API_KEY' }],
+      },
+    },
+  }
+}
+
+function mergedForCompare(desired: k8s.V1Deployment, existing: k8s.V1Deployment): k8s.V1Deployment {
+  return preserveDeploymentAnnotations(
+    {
+      ...desired,
+      metadata: { ...desired.metadata, resourceVersion: existing.metadata?.resourceVersion },
+    },
+    existing
+  )
+}
+
+describe('McpServer ensureDeployment no-op gate', () => {
+  let appsApi: MockAppsApi
+  let reconciler: McpServerReconciler
+  const server = makeServer()
+
+  beforeEach(() => {
+    appsApi = createMockAppsApi()
+    reconciler = new McpServerReconciler({} as k8s.KubeConfig, {
+      assumeInventoryAuthorityWhenUnconfigured: true,
+      appsApi: asAppsApi(appsApi),
+      coreApi: asCoreApi(createMockCoreApi()),
+      customApi: asCustomApi(createMockCustomApi()),
+    })
+    appsApi.createNamespacedDeployment.mockRejectedValue({ code: 409 })
+  })
+
+  it('FIXTURE-1: McpServer builder output differs from the default-filled live object', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('predicate: merged builder vs fixture is a no-op', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('McpServer mutation sweep: every desired leaf is detectable', () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    const existing = asApiserverDeployment(desired)
+    const undetectable: string[] = []
+    for (const path of collectLeafPaths(desired)) {
+      const mutated = cloneAndMutateLeaf(desired, path) as k8s.V1Deployment
+      if (deploymentMatchesDesired(mergedForCompare(mutated, existing), existing)) {
+        undetectable.push(formatLeafPath(path))
+      }
+    }
+    expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('NOOP-MCPDEP-1: equivalent Deployment skips replace and Updated logs', async () => {
+    const desired = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(desired))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureDeployment(server, 'rev-1')
+      expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+      expect(updatedLogs(log, 'Updated', 'Deployment "test-mcp"')).toEqual([])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('ROTATE-MCPDEP-1: credentials revision change replaces once with the new annotation', async () => {
+    const live = (reconciler as any).buildDeployment(server, 'rev-old') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    const log = vi.spyOn(console, 'log')
+    try {
+      await (reconciler as any).ensureDeployment(server, 'rev-new')
+      expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+      const body = (
+        appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+      ).body
+      expect(body.spec?.template?.metadata?.annotations?.[CREDENTIALS_REVISION_ANNOTATION]).toBe(
+        'rev-new'
+      )
+      expect(updatedLogs(log, 'Updated', 'Deployment "test-mcp"')).toEqual([
+        '[Reconciler] Updated Deployment "test-mcp"',
+      ])
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('IMAGE-MCPDEP-1: image bump replaces once', async () => {
+    const live = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    const bumped = makeServer()
+    bumped.spec.image = 'my-mcp-server:v2'
+    await (reconciler as any).ensureDeployment(bumped, 'rev-1')
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+    const body = (
+      appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+    ).body
+    expect(body.spec?.template?.spec?.containers?.[0]?.image).toBe('my-mcp-server:v2')
+  })
+
+  it('GATE-MCPDEP-1: drift plus isCurrent false skips replace after the gate', async () => {
+    const live = (reconciler as any).buildDeployment(server, 'rev-1') as k8s.V1Deployment
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(live))
+    const isCurrent = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+    const bumped = makeServer()
+    bumped.spec.image = 'my-mcp-server:v2'
+
+    await (reconciler as any).ensureDeployment(bumped, 'rev-1', isCurrent)
+
+    expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+    expect(isCurrent).toHaveBeenCalled()
+  })
+})

--- a/host-context-controller/src/__tests__/mutateJsonLeaves.ts
+++ b/host-context-controller/src/__tests__/mutateJsonLeaves.ts
@@ -1,0 +1,53 @@
+/** Collect every JSON leaf path: primitives and arrays (arrays also recurse). */
+export function collectLeafPaths(value: unknown, prefix: string[] = []): string[][] {
+  if (value === undefined || value === null) return []
+  if (Array.isArray(value)) {
+    const nested = value.flatMap((item, index) =>
+      collectLeafPaths(item, [...prefix, String(index)])
+    )
+    return [prefix, ...nested]
+  }
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, entry]) =>
+      collectLeafPaths(entry, [...prefix, key])
+    )
+  }
+  return [prefix]
+}
+
+export function getAtPath(root: unknown, path: string[]): unknown {
+  let cursor: unknown = root
+  for (const key of path) {
+    if (cursor === null || typeof cursor !== 'object') return undefined
+    cursor = (cursor as Record<string, unknown>)[key]
+  }
+  return cursor
+}
+
+export function setAtPath(root: unknown, path: string[], next: unknown): void {
+  if (path.length === 0) return
+  let cursor: Record<string, unknown> = root as Record<string, unknown>
+  for (let i = 0; i < path.length - 1; i++) {
+    cursor = cursor[path[i]] as Record<string, unknown>
+  }
+  cursor[path[path.length - 1]] = next
+}
+
+/** Spec §7.2(a): string +'-x', number +1, boolean flip, array drop one element. */
+export function mutateLeaf(value: unknown): unknown {
+  if (typeof value === 'string') return `${value}-x`
+  if (typeof value === 'number') return value + 1
+  if (typeof value === 'boolean') return !value
+  if (Array.isArray(value)) return value.length === 0 ? ['_sweep'] : value.slice(0, -1)
+  return value
+}
+
+export function cloneAndMutateLeaf(root: unknown, path: string[]): unknown {
+  const clone = structuredClone(root)
+  setAtPath(clone, path, mutateLeaf(getAtPath(clone, path)))
+  return clone
+}
+
+export function formatLeafPath(path: string[]): string {
+  return path.length === 0 ? '(root)' : path.join('.')
+}

--- a/host-context-controller/src/__tests__/mutateJsonLeaves.ts
+++ b/host-context-controller/src/__tests__/mutateJsonLeaves.ts
@@ -51,3 +51,25 @@ export function cloneAndMutateLeaf(root: unknown, path: string[]): unknown {
 export function formatLeafPath(path: string[]): string {
   return path.length === 0 ? '(root)' : path.join('.')
 }
+
+/**
+ * Spec leaves the apiserver/fixture added that `desired` omitted.
+ * `creationTimestamp` is stripped unconditionally by the comparator.
+ */
+export function collectLiveOnlySpecLeaves(desired: unknown, existing: unknown): string[][] {
+  return collectLeafPaths(existing).filter(path => {
+    if (path[0] !== 'spec') return false
+    if (path.includes('creationTimestamp')) return false
+    return getAtPath(desired, path) === undefined
+  })
+}
+
+export function undetectableLiveOnlySpecLeaves(
+  desired: unknown,
+  existing: unknown,
+  isStillNoOp: (mutatedExisting: unknown) => boolean
+): string[] {
+  return collectLiveOnlySpecLeaves(desired, existing)
+    .filter(path => isStillNoOp(cloneAndMutateLeaf(existing, path)))
+    .map(formatLeafPath)
+}

--- a/host-context-controller/src/__tests__/reconciler.sanitize.test.ts
+++ b/host-context-controller/src/__tests__/reconciler.sanitize.test.ts
@@ -284,6 +284,7 @@ describe('CRD Field Injection Prevention (sanitizeCrdSpec)', () => {
       const copyContainer = capturedInitContainer(appsApi, 'copy-mcp-app')
       const bridgeContainer = capturedContainer(appsApi, 'stdio-bridge')
       for (const container of [copyContainer, bridgeContainer]) {
+        expect(container.imagePullPolicy).toBe('IfNotPresent')
         expect(container.securityContext?.allowPrivilegeEscalation).toBe(false)
         expect(container.securityContext?.capabilities?.drop).toEqual(['ALL'])
         expect(container.securityContext?.capabilities?.add).toBeUndefined()

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -331,6 +331,7 @@ describe('replaceWithConflictRetry order and retry', () => {
   it('WRITE-2: isUpToDate skip and read-404 do not increment', async () => {
     const replace = vi.fn()
     const before = await readWritesTotal('Service')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     await replaceWithConflictRetry({
       description: 'Service "svc"',
@@ -354,6 +355,31 @@ describe('replaceWithConflictRetry order and retry', () => {
 
     expect(replace).not.toHaveBeenCalled()
     expect(await readWritesTotal('Service')).toBe(before)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/disappeared \(404\); skipping replace/)
+    )
+    warn.mockRestore()
+  })
+
+  it('SKIP-3: isUpToDate skip with mutationAllowed false does not increment writes or skips', async () => {
+    const replace = vi.fn()
+    const beforeWrites = await readWritesTotal('Service')
+    const beforeSkips = await readWriteSkipsTotal('Service')
+
+    await replaceWithConflictRetry({
+      description: 'Service "svc"',
+      logPrefix: '[Test]',
+      body: desired,
+      mergeExisting: preserveServiceAssignedFields,
+      isUpToDate: () => true,
+      mutationAllowed: () => false,
+      read: async () => existing,
+      replace,
+    })
+
+    expect(replace).not.toHaveBeenCalled()
+    expect(await readWritesTotal('Service')).toBe(beforeWrites)
+    expect(await readWriteSkipsTotal('Service')).toBe(beforeSkips)
   })
 
   it('SKIP-1: isUpToDate skip increments clerum_hcc_write_skips_total{kind=Service}', async () => {

--- a/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
+++ b/host-context-controller/src/__tests__/replaceWithConflictRetryOrder.test.ts
@@ -8,11 +8,19 @@ import {
   serviceMatchesDesired,
 } from '../utils'
 
-async function readWritesTotal(kind: string): Promise<number> {
-  const metric = registry.getSingleMetric('clerum_hcc_writes_total')
-  if (!metric) throw new Error('clerum_hcc_writes_total is not registered')
+async function readLabeledCounter(name: string, kind: string): Promise<number> {
+  const metric = registry.getSingleMetric(name)
+  if (!metric) throw new Error(`${name} is not registered`)
   const snapshot = await metric.get()
   return snapshot.values.find(entry => entry.labels.kind === kind)?.value ?? 0
+}
+
+async function readWritesTotal(kind: string): Promise<number> {
+  return readLabeledCounter('clerum_hcc_writes_total', kind)
+}
+
+async function readWriteSkipsTotal(kind: string): Promise<number> {
+  return readLabeledCounter('clerum_hcc_write_skips_total', kind)
 }
 
 function apiException(code: number): ApiException<unknown> {
@@ -346,6 +354,56 @@ describe('replaceWithConflictRetry order and retry', () => {
 
     expect(replace).not.toHaveBeenCalled()
     expect(await readWritesTotal('Service')).toBe(before)
+  })
+
+  it('SKIP-1: isUpToDate skip increments clerum_hcc_write_skips_total{kind=Service}', async () => {
+    const replace = vi.fn()
+    const beforeWrites = await readWritesTotal('Service')
+    const beforeSkips = await readWriteSkipsTotal('Service')
+
+    await replaceWithConflictRetry({
+      description: 'Service "svc"',
+      logPrefix: '[Test]',
+      body: desired,
+      mergeExisting: preserveServiceAssignedFields,
+      isUpToDate: () => true,
+      read: async () => existing,
+      replace,
+    })
+
+    expect(replace).not.toHaveBeenCalled()
+    expect(await readWritesTotal('Service')).toBe(beforeWrites)
+    expect(await readWriteSkipsTotal('Service')).toBe(beforeSkips + 1)
+    expect(await registry.metrics()).toContain('clerum_hcc_write_skips_total')
+  })
+
+  it('SKIP-2: successful replace and read-404 do not increment write skips', async () => {
+    const replace = vi.fn().mockResolvedValue({})
+    const beforeSkips = await readWriteSkipsTotal('Service')
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await replaceWithConflictRetry({
+      description: 'Service "svc"',
+      logPrefix: '[Test]',
+      body: desired,
+      mergeExisting: preserveServiceAssignedFields,
+      isUpToDate: () => false,
+      read: async () => existing,
+      replace,
+    })
+
+    await replaceWithConflictRetry({
+      description: 'Service "svc"',
+      logPrefix: '[Test]',
+      body: desired,
+      read: async () => {
+        throw { code: 404 }
+      },
+      replace,
+    })
+
+    expect(await readWriteSkipsTotal('Service')).toBe(beforeSkips)
+    log.mockRestore()
   })
 
   it('WRITE-3: 409 then successful replace increments once, not per attempt', async () => {

--- a/host-context-controller/src/__tests__/sfsDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/sfsDeploymentNoopGate.test.ts
@@ -5,7 +5,13 @@ import { SharedFileSystemReconciler } from '../sharedFileSystemReconciler'
 import type { SharedFileSystemCRD } from '../types'
 import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
 import { asApiserverDeployment } from './asApiserverDeployment'
-import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+import {
+  cloneAndMutateLeaf,
+  collectLeafPaths,
+  collectLiveOnlySpecLeaves,
+  formatLeafPath,
+  undetectableLiveOnlySpecLeaves,
+} from './mutateJsonLeaves'
 
 const RESTARTED_AT = 'kubectl.kubernetes.io/restartedAt'
 const RESTART_STAMP = '2026-08-31T10:00:00Z'
@@ -116,6 +122,20 @@ describe('SFS Deployment no-op gate', () => {
       }
     }
     expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('SFS mutation sweep: every live-only spec leaf is detectable', () => {
+    const desired = buildDeployment(sfs, factoryConfig)
+    const existing = asApiserverDeployment(desired)
+    expect(collectLiveOnlySpecLeaves(desired, existing).length).toBeGreaterThan(0)
+    expect(
+      undetectableLiveOnlySpecLeaves(desired, existing, mutated =>
+        deploymentMatchesDesired(
+          mergedForCompare(desired, mutated as k8s.V1Deployment),
+          mutated as k8s.V1Deployment
+        )
+      )
+    ).toEqual([])
   })
 
   it('NOOP-SFS-1: equivalent Deployment skips replace', async () => {

--- a/host-context-controller/src/__tests__/sfsDeploymentNoopGate.test.ts
+++ b/host-context-controller/src/__tests__/sfsDeploymentNoopGate.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as k8s from '@kubernetes/client-node'
+import { type SharedFileSystemFactoryConfig, buildDeployment } from '../k8s/sharedFileSystemFactory'
+import { SharedFileSystemReconciler } from '../sharedFileSystemReconciler'
+import type { SharedFileSystemCRD } from '../types'
+import { deploymentMatchesDesired, preserveDeploymentAnnotations } from '../utils'
+import { asApiserverDeployment } from './asApiserverDeployment'
+import { cloneAndMutateLeaf, collectLeafPaths, formatLeafPath } from './mutateJsonLeaves'
+
+const RESTARTED_AT = 'kubectl.kubernetes.io/restartedAt'
+const RESTART_STAMP = '2026-08-31T10:00:00Z'
+
+const factoryConfig: SharedFileSystemFactoryConfig = {
+  hostNamespace: 'mcp-host',
+  controlPlaneNamespace: 'control-plane',
+  wfcImage: 'registry.example/clerum/workspace-files-controller:0.1.0',
+  wfcImagePullPolicy: 'IfNotPresent',
+  wfcImagePullSecretName: 'clerum',
+  wfcPort: 8086,
+  wfcInitImage: 'busybox:1.36',
+  wfcResources: {
+    requests: { memory: '64Mi', cpu: '50m' },
+    limits: { memory: '128Mi', cpu: '200m' },
+  },
+  wfcJwtPublicKeyConfigMapName: 'mcp-host-config',
+  wfcJwtPublicKeyConfigMapKey: 'CLERUM_AUTH_JWT_PUBLIC_KEY',
+  wfcMaxUploadBytes: 100 * 1024 * 1024,
+  wfcMaxListEntries: 5000,
+  wfcMaxPathDepth: 32,
+}
+
+function makeSfs(): SharedFileSystemCRD {
+  return {
+    name: 'team-mission',
+    namespace: 'mcp-host',
+    spec: {
+      size: '5Gi',
+      directories: ['docs', 'runbooks'],
+      security: { runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 },
+    },
+  }
+}
+
+function mergedForCompare(desired: k8s.V1Deployment, existing: k8s.V1Deployment): k8s.V1Deployment {
+  return preserveDeploymentAnnotations(
+    {
+      ...desired,
+      metadata: { ...desired.metadata, resourceVersion: existing.metadata?.resourceVersion },
+    },
+    existing
+  )
+}
+
+function withRestartedAt(deployment: k8s.V1Deployment, stamp = RESTART_STAMP): k8s.V1Deployment {
+  const live = structuredClone(deployment)
+  const templateMeta = live.spec?.template?.metadata
+  if (!templateMeta) throw new Error('expected pod template metadata')
+  templateMeta.annotations = {
+    ...templateMeta.annotations,
+    [RESTARTED_AT]: stamp,
+  }
+  return live
+}
+
+describe('SFS Deployment no-op gate', () => {
+  const sfs = makeSfs()
+  let appsApi: {
+    createNamespacedDeployment: ReturnType<typeof vi.fn>
+    readNamespacedDeployment: ReturnType<typeof vi.fn>
+    replaceNamespacedDeployment: ReturnType<typeof vi.fn>
+  }
+
+  function makeReconciler(cfg: SharedFileSystemFactoryConfig = factoryConfig) {
+    appsApi = {
+      createNamespacedDeployment: vi.fn().mockRejectedValue({ code: 409 }),
+      readNamespacedDeployment: vi.fn(),
+      replaceNamespacedDeployment: vi.fn().mockResolvedValue({}),
+    }
+    return new SharedFileSystemReconciler(null, {
+      appsApi: appsApi as never,
+      coreApi: {} as never,
+      batchApi: {} as never,
+      networkingApi: {} as never,
+      customApi: {} as never,
+      factoryConfig: cfg,
+    })
+  }
+
+  beforeEach(() => {
+    appsApi = {
+      createNamespacedDeployment: vi.fn(),
+      readNamespacedDeployment: vi.fn(),
+      replaceNamespacedDeployment: vi.fn(),
+    }
+  })
+
+  it('FIXTURE-1: SFS builder output differs from the default-filled live object', () => {
+    const desired = buildDeployment(sfs, factoryConfig)
+    expect(asApiserverDeployment(desired)).not.toEqual(desired)
+  })
+
+  it('predicate: merged builder vs fixture is a no-op', () => {
+    const desired = buildDeployment(sfs, factoryConfig)
+    const existing = asApiserverDeployment(desired)
+    expect(deploymentMatchesDesired(mergedForCompare(desired, existing), existing)).toBe(true)
+  })
+
+  it('SFS mutation sweep: every desired leaf is detectable', () => {
+    const desired = buildDeployment(sfs, factoryConfig)
+    const existing = asApiserverDeployment(desired)
+    const undetectable: string[] = []
+    for (const path of collectLeafPaths(desired)) {
+      const mutated = cloneAndMutateLeaf(desired, path) as k8s.V1Deployment
+      if (deploymentMatchesDesired(mergedForCompare(mutated, existing), existing)) {
+        undetectable.push(formatLeafPath(path))
+      }
+    }
+    expect(undetectable, `undetectable leaf path(s): ${undetectable.join(', ')}`).toEqual([])
+  })
+
+  it('NOOP-SFS-1: equivalent Deployment skips replace', async () => {
+    const reconciler = makeReconciler()
+    const desired = buildDeployment(sfs, factoryConfig)
+    appsApi.readNamespacedDeployment.mockResolvedValue(asApiserverDeployment(desired))
+    await (reconciler as any).ensureDeployment(sfs)
+    expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+  })
+
+  it('SFS-3: live restartedAt plus identical desired skips without clearing the marker', async () => {
+    const reconciler = makeReconciler()
+    const desired = buildDeployment(sfs, factoryConfig)
+    const live = withRestartedAt(asApiserverDeployment(desired))
+    appsApi.readNamespacedDeployment.mockResolvedValue(live)
+    await (reconciler as any).ensureDeployment(sfs)
+    expect(appsApi.replaceNamespacedDeployment).not.toHaveBeenCalled()
+  })
+
+  it('SFS-3: a real change replaces once and keeps restartedAt', async () => {
+    const oldConfig = { ...factoryConfig, wfcImage: 'wfc:old' }
+    const newConfig = { ...factoryConfig, wfcImage: 'wfc:new' }
+    const live = withRestartedAt(asApiserverDeployment(buildDeployment(sfs, oldConfig)))
+    const reconciler = makeReconciler(newConfig)
+    appsApi.readNamespacedDeployment.mockResolvedValue(live)
+    await (reconciler as any).ensureDeployment(sfs)
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+    const body = (
+      appsApi.replaceNamespacedDeployment.mock.calls[0][0] as { body: k8s.V1Deployment }
+    ).body
+    expect(body.spec?.template?.spec?.containers?.[0]?.image).toBe('wfc:new')
+    expect(body.spec?.template?.metadata?.annotations?.[RESTARTED_AT]).toBe(RESTART_STAMP)
+  })
+
+  it('IMAGE-SFS-1: wfcImage bump replaces once', async () => {
+    const live = asApiserverDeployment(
+      buildDeployment(sfs, { ...factoryConfig, wfcImage: 'wfc:old' })
+    )
+    const reconciler = makeReconciler({ ...factoryConfig, wfcImage: 'wfc:new' })
+    appsApi.readNamespacedDeployment.mockResolvedValue(live)
+    await (reconciler as any).ensureDeployment(sfs)
+    expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
+  })
+})

--- a/host-context-controller/src/config.ts
+++ b/host-context-controller/src/config.ts
@@ -716,7 +716,7 @@ export const config: Config = {
     },
     limits: {
       memory: getEnv('CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_MEMORY', '4Gi')!,
-      cpu: getEnv('CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_CPU', '1000m')!,
+      cpu: getEnv('CONTEXT_MAPPER_DESKTOP_RESOURCES_LIMIT_CPU', '1')!,
     },
   },
 

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -76,6 +76,7 @@ import {
   applyNetworkPolicy,
   canonicalStringify,
   canonicalizeValue,
+  deploymentMatchesDesired,
   getErrorCode,
   preserveDeploymentAnnotations,
   preserveServiceAssignedFields,
@@ -5068,22 +5069,6 @@ function roleMatchesDesired(desired: k8s.V1Role, existing: k8s.V1Role): boolean 
 }
 
 /**
- * Kubernetes persists server metadata and defaulted Deployment/PodSpec fields
- * that HCC does not author. Remove only those known fields before comparing
- * the objects; every HCC-authored field stays exact so an intentional removal
- * or change still causes a rollout. Keep this allowlist conservative: an
- * unknown admission mutation must compare as drift rather than be silently
- * ignored. Pod-template annotations are merged by preserveDeploymentAnnotations
- * before this comparison.
- */
-function deploymentMatchesDesired(desired: k8s.V1Deployment, existing: k8s.V1Deployment): boolean {
-  return (
-    JSON.stringify(normalizeDeploymentForComparison(desired)) ===
-    JSON.stringify(normalizeDeploymentForComparison(existing))
-  )
-}
-
-/**
  * Preserve operational pod-template annotations (kubectl restart markers,
  * operator edits) while keeping CONTROLLER-OWNED ones authoritative: a key in
  * `controllerOwned` that the desired template omits is REMOVED from the merge
@@ -5151,86 +5136,4 @@ function preserveChannelReaderDeploymentAnnotations(
   existing: k8s.V1Deployment
 ): k8s.V1Deployment {
   return preserveDeploymentAnnotationsExcept(desired, existing, ['clerum.io/credentials-revision'])
-}
-
-function normalizeDeploymentForComparison(deployment: k8s.V1Deployment): unknown {
-  const normalized = structuredClone(deployment)
-  delete normalized.status
-  delete normalized.metadata?.resourceVersion
-  delete normalized.metadata?.uid
-  delete normalized.metadata?.generation
-  delete normalized.metadata?.creationTimestamp
-  delete normalized.metadata?.managedFields
-  delete normalized.metadata?.selfLink
-
-  const spec = normalized.spec
-  if (spec) {
-    if (spec.progressDeadlineSeconds === 600) delete spec.progressDeadlineSeconds
-    if (spec.revisionHistoryLimit === 10) delete spec.revisionHistoryLimit
-    if (spec.minReadySeconds === 0) delete spec.minReadySeconds
-    if (spec.paused === false) delete spec.paused
-    if (
-      spec.strategy?.type === 'RollingUpdate' &&
-      spec.strategy.rollingUpdate?.maxSurge === '25%' &&
-      spec.strategy.rollingUpdate.maxUnavailable === '25%'
-    ) {
-      delete spec.strategy
-    }
-    const template = spec.template
-    if (template) {
-      delete template.metadata?.creationTimestamp
-
-      const podSpec = template.spec
-      if (podSpec) {
-        if (podSpec.restartPolicy === 'Always') delete podSpec.restartPolicy
-        if (podSpec.dnsPolicy === 'ClusterFirst') delete podSpec.dnsPolicy
-        if (podSpec.schedulerName === 'default-scheduler') delete podSpec.schedulerName
-        if (podSpec.terminationGracePeriodSeconds === 30)
-          delete podSpec.terminationGracePeriodSeconds
-        if (podSpec.enableServiceLinks === true) delete podSpec.enableServiceLinks
-        if (podSpec.preemptionPolicy === 'PreemptLowerPriority') delete podSpec.preemptionPolicy
-        if (podSpec.serviceAccount === podSpec.serviceAccountName) delete podSpec.serviceAccount
-        if (Object.keys(podSpec.securityContext ?? {}).length === 0) delete podSpec.securityContext
-        for (const container of [
-          ...(podSpec.initContainers ?? []),
-          ...(podSpec.containers ?? []),
-        ]) {
-          normalizeContainerDefaults(container)
-        }
-        for (const volume of podSpec.volumes ?? []) normalizeVolumeDefaults(volume)
-      }
-    }
-  }
-
-  return canonicalizeValue(normalized)
-}
-
-function normalizeContainerDefaults(container: k8s.V1Container): void {
-  if (container.terminationMessagePath === '/dev/termination-log') {
-    delete container.terminationMessagePath
-  }
-  if (container.terminationMessagePolicy === 'File') delete container.terminationMessagePolicy
-  for (const probe of [container.startupProbe, container.livenessProbe, container.readinessProbe]) {
-    if (!probe) continue
-    if (probe.initialDelaySeconds === 0) delete probe.initialDelaySeconds
-    if (probe.successThreshold === 1) delete probe.successThreshold
-    if (probe.httpGet?.scheme === 'HTTP') delete probe.httpGet.scheme
-  }
-  for (const env of container.env ?? []) {
-    if (env.valueFrom?.fieldRef?.apiVersion === 'v1') {
-      delete env.valueFrom.fieldRef.apiVersion
-    }
-  }
-}
-
-function normalizeVolumeDefaults(volume: k8s.V1Volume): void {
-  if (volume.secret?.defaultMode === 420) delete volume.secret.defaultMode
-  if (volume.secret?.optional === false) delete volume.secret.optional
-  if (volume.configMap?.defaultMode === 420) delete volume.configMap.defaultMode
-  if (volume.configMap?.optional === false) delete volume.configMap.optional
-  if (volume.downwardAPI?.defaultMode === 420) delete volume.downwardAPI.defaultMode
-  if (volume.projected?.defaultMode === 420) delete volume.projected.defaultMode
-  if (volume.persistentVolumeClaim?.readOnly === false) {
-    delete volume.persistentVolumeClaim.readOnly
-  }
 }

--- a/host-context-controller/src/hostReconciler.ts
+++ b/host-context-controller/src/hostReconciler.ts
@@ -2534,7 +2534,9 @@ export class HostReconciler {
    * - On 409 from create, compares a fresh, server-normalized Deployment and
    *   replaces only meaningful drift. Conflict retries rebuild against the
    *   latest live replica count. A Deployment owned by a different host is
-   *   never overwritten.
+   *   never overwritten: the initial read skips, and a retry-time ownership
+   *   change throws so write_skips_total does not count the refusal as a
+   *   healthy no-op.
    */
   private async reconcileChannelReaderDeployment(host: HostCRD): Promise<void> {
     const name = `channel-reader-${host.name}`
@@ -2601,12 +2603,18 @@ export class HostReconciler {
             }
             return preserveChannelReaderDeploymentAnnotations(desiredWithLiveReplicas, fresh)
           },
-          isUpToDate: (next, fresh) => {
+          validateExisting: fresh => {
             const freshOwnerHost = fresh.metadata?.labels?.[HOST_LABEL]
             // Never replace an object whose ownership changed during a retry.
-            if (freshOwnerHost && freshOwnerHost !== host.name) return true
-            return deploymentMatchesDesired(next, fresh)
+            // Veto here — not via isUpToDate — so write_skips_total stays a
+            // genuine no-op count.
+            if (freshOwnerHost && freshOwnerHost !== host.name) {
+              throw new Error(
+                `channel-reader Deployment ownership changed to host "${freshOwnerHost}"; refusing replace`
+              )
+            }
           },
+          isUpToDate: deploymentMatchesDesired,
         })
       } catch (replaceErr) {
         console.error(`[HostReconciler] Failed to update channel-reader "${name}":`, replaceErr)

--- a/host-context-controller/src/llmHookReconciler.ts
+++ b/host-context-controller/src/llmHookReconciler.ts
@@ -38,7 +38,9 @@ import {
 import { isAllowedExternalEgressCidr, isPublicDnsHostname } from './networkPolicyReconciler'
 import { HostCRD, LlmHookCRD, LlmHookCondition, LlmHookImageTarget, LlmHookStatus } from './types'
 import {
+  deploymentMatchesDesired,
   getErrorCode,
+  networkPolicyMatchesDesired,
   preserveDeploymentAnnotations,
   preserveObjectAnnotations,
   preserveServiceAssignedFields,
@@ -767,6 +769,7 @@ export class LlmHookReconciler {
       logPrefix: LOG,
       body: deployment,
       mergeExisting: preserveDeploymentAnnotations,
+      isUpToDate: deploymentMatchesDesired,
       read: () =>
         this.appsApi.readNamespacedDeployment({ name, namespace: config.llmHooksNamespace }),
       replace: body =>
@@ -827,6 +830,7 @@ export class LlmHookReconciler {
       logPrefix: LOG,
       body: policy,
       mergeExisting: preserveObjectAnnotations,
+      isUpToDate: networkPolicyMatchesDesired,
       read: () => this.networkingApi.readNamespacedNetworkPolicy({ name, namespace }),
       replace: body => this.networkingApi.replaceNamespacedNetworkPolicy({ name, namespace, body }),
     })

--- a/host-context-controller/src/metrics.ts
+++ b/host-context-controller/src/metrics.ts
@@ -301,6 +301,15 @@ export const writesTotal = counter({
   labelNames: ['kind'] as const,
 })
 
+// Twin of writesTotal. Incremented when isUpToDate returns true, before the
+// helper returns without replace(). Label set is {kind} only — policy_type
+// belongs to #526.
+export const writeSkipsTotal = counter({
+  name: 'clerum_hcc_write_skips_total',
+  help: 'No-op Kubernetes replaces skipped by replaceWithConflictRetry because the merged object was already up to date, by object kind.',
+  labelNames: ['kind'] as const,
+})
+
 export const hostCleanupDeferredTotal = counter({
   name: 'clerum_hcc_host_cleanup_deferred_total',
   help: 'Orphan Host cleanup deferrals by bounded reason.',

--- a/host-context-controller/src/networkPolicyReconciler.egressFailStatic.test.ts
+++ b/host-context-controller/src/networkPolicyReconciler.egressFailStatic.test.ts
@@ -49,6 +49,7 @@ vi.mock('./metrics', () => ({
   networkPolicySafetyPassDurationSeconds: { observe: vi.fn() },
   networkPolicySafetyPassPoliciesTotal: { inc: vi.fn() },
   writesTotal: { inc: vi.fn() },
+  writeSkipsTotal: { inc: vi.fn() },
 }))
 
 function makeMockNetworkingApi() {

--- a/host-context-controller/src/networkPolicyReconciler.orphanSweep.test.ts
+++ b/host-context-controller/src/networkPolicyReconciler.orphanSweep.test.ts
@@ -37,6 +37,7 @@ vi.mock('./metrics', () => ({
   netPolOrphansDeletedTotal: { inc: vi.fn() },
   netPolOrphanSweepCappedTotal: { inc: vi.fn() },
   writesTotal: { inc: vi.fn() },
+  writeSkipsTotal: { inc: vi.fn() },
 }))
 function makeMockNetworkingApi() {
   return {

--- a/host-context-controller/src/networkPolicyReconciler.test.ts
+++ b/host-context-controller/src/networkPolicyReconciler.test.ts
@@ -80,6 +80,7 @@ vi.mock('./metrics', () => ({
   netPolOrphansDeletedTotal: { inc: vi.fn() },
   netPolOrphanSweepCappedTotal: { inc: vi.fn() },
   writesTotal: { inc: vi.fn() },
+  writeSkipsTotal: { inc: vi.fn() },
 }))
 
 function makeMockNetworkingApi() {

--- a/host-context-controller/src/reconciler.test.ts
+++ b/host-context-controller/src/reconciler.test.ts
@@ -935,7 +935,7 @@ describe('PR-B B1 — writeStatusCondition', () => {
         reason: 'ok',
         message: 'ok',
       })
-    ).resolves.toBeUndefined()
+    ).resolves.toBe(false)
 
     expect(customApi.patchNamespacedCustomObjectStatus).not.toHaveBeenCalled()
   })
@@ -1868,6 +1868,43 @@ describe('updateStatusConditions', () => {
     expect(types).toContain('SecretResolved')
     expect(types).toContain('NetworkReady')
     expect(types).toContain('DeploymentReady')
+  })
+
+  it('does not log Updated status conditions when both writes were skipped', async () => {
+    const server = makeServer({ name: 'pg' })
+    const identical = {
+      status: {
+        conditions: [
+          {
+            type: 'NetworkReady',
+            status: 'True',
+            reason: 'NetworkPoliciesApplied',
+            message: 'NetworkPolicies and Service created',
+            lastTransitionTime: '2020-01-02T00:00:00.000Z',
+          },
+          {
+            type: 'DeploymentReady',
+            status: 'True',
+            reason: 'ReplicasAvailable',
+            message: 'Deployment has ready replicas',
+            lastTransitionTime: '2020-01-02T00:00:00.000Z',
+          },
+        ],
+      },
+    }
+    customApi.getNamespacedCustomObjectStatus.mockResolvedValue(identical)
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    try {
+      await (
+        reconciler as unknown as {
+          updateStatusConditions(server: McpServerCRD, deploymentReady: boolean): Promise<void>
+        }
+      ).updateStatusConditions(server, true)
+      expect(customApi.patchNamespacedCustomObjectStatus).not.toHaveBeenCalled()
+      expect(log.mock.calls.flat().join('\n')).not.toContain('Updated status conditions')
+    } finally {
+      log.mockRestore()
+    }
   })
 })
 

--- a/host-context-controller/src/reconciler.test.ts
+++ b/host-context-controller/src/reconciler.test.ts
@@ -1872,34 +1872,46 @@ describe('updateStatusConditions', () => {
 
   it('does not log Updated status conditions when both writes were skipped', async () => {
     const server = makeServer({ name: 'pg' })
-    const identical = {
-      status: {
-        conditions: [
-          {
-            type: 'NetworkReady',
-            status: 'True',
-            reason: 'NetworkPoliciesApplied',
-            message: 'NetworkPolicies and Service created',
-            lastTransitionTime: '2020-01-02T00:00:00.000Z',
-          },
-          {
-            type: 'DeploymentReady',
-            status: 'True',
-            reason: 'ReplicasAvailable',
-            message: 'Deployment has ready replicas',
-            lastTransitionTime: '2020-01-02T00:00:00.000Z',
-          },
-        ],
-      },
-    }
-    customApi.getNamespacedCustomObjectStatus.mockResolvedValue(identical)
+    let liveStatus: { conditions?: unknown[] } | undefined
+    customApi.getNamespacedCustomObjectStatus.mockImplementation(async () => ({
+      metadata: { resourceVersion: '1' },
+      ...(liveStatus ? { status: liveStatus } : {}),
+    }))
+    customApi.patchNamespacedCustomObjectStatus.mockImplementation(
+      async (req: { body: Array<{ op?: string; path?: string; value?: unknown }> }) => {
+        const op = req.body.find(
+          candidate =>
+            candidate.op === 'add' &&
+            (candidate.path === '/status' || candidate.path === '/status/conditions')
+        )
+        if (!op) throw new Error('status condition add operation was not emitted')
+        liveStatus =
+          op.path === '/status'
+            ? (op.value as { conditions?: unknown[] })
+            : { conditions: op.value as unknown[] }
+        return {}
+      }
+    )
+
+    const updateStatusConditions = (
+      reconciler as unknown as {
+        updateStatusConditions(server: McpServerCRD, deploymentReady: boolean): Promise<void>
+      }
+    ).updateStatusConditions.bind(reconciler)
+
+    await updateStatusConditions(server, true)
+    expect(customApi.patchNamespacedCustomObjectStatus).toHaveBeenCalled()
+    expect(liveStatus?.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'NetworkReady' }),
+        expect.objectContaining({ type: 'DeploymentReady' }),
+      ])
+    )
+
+    customApi.patchNamespacedCustomObjectStatus.mockClear()
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
     try {
-      await (
-        reconciler as unknown as {
-          updateStatusConditions(server: McpServerCRD, deploymentReady: boolean): Promise<void>
-        }
-      ).updateStatusConditions(server, true)
+      await updateStatusConditions(server, true)
       expect(customApi.patchNamespacedCustomObjectStatus).not.toHaveBeenCalled()
       expect(log.mock.calls.flat().join('\n')).not.toContain('Updated status conditions')
     } finally {

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -29,6 +29,7 @@ import { mcpserverMissingSecret } from './metrics'
 import { McpServerCRD, McpServerStatus } from './types'
 import {
   canonicalStringify,
+  deploymentMatchesDesired,
   getErrorCode,
   preserveDeploymentAnnotations,
   preserveObjectAnnotations,
@@ -1510,6 +1511,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
         logPrefix: '[Reconciler]',
         body: deployment,
         mergeExisting: preserveDeploymentAnnotations,
+        isUpToDate: deploymentMatchesDesired,
         read: () =>
           this.appsApi.readNamespacedDeployment({
             name: server.name,

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -1270,8 +1270,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
                     {
                       name: 'copy-mcp-app',
                       image: server.spec.image,
-                      imagePullPolicy:
-                        server.spec.imagePullPolicy || config.mcpServerImagePullPolicy,
+                      imagePullPolicy: config.mcpServerImagePullPolicy,
                       command: [
                         'sh',
                         '-c',
@@ -1332,8 +1331,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
                     {
                       name: 'mcp-server',
                       image: server.spec.image,
-                      imagePullPolicy:
-                        server.spec.imagePullPolicy || config.mcpServerImagePullPolicy,
+                      imagePullPolicy: config.mcpServerImagePullPolicy,
                       command: server.spec.command || undefined,
                       args: server.spec.args || undefined,
                       ports,
@@ -1370,8 +1368,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
                     {
                       name: 'stdio-bridge',
                       image: config.stdioBridgeImage, // G10: configurable bridge image
-                      imagePullPolicy:
-                        server.spec.imagePullPolicy || config.mcpServerImagePullPolicy,
+                      imagePullPolicy: config.mcpServerImagePullPolicy,
                       env: [
                         {
                           name: 'STDIO_COMMAND',

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -1845,7 +1845,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
     isCurrent: () => boolean = () => true
   ): Promise<void> {
     try {
-      await this.writeStatusCondition(
+      const networkWrote = await this.writeStatusCondition(
         server,
         {
           type: 'NetworkReady',
@@ -1855,7 +1855,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
         },
         isCurrent
       )
-      await this.writeStatusCondition(
+      const deploymentWrote = await this.writeStatusCondition(
         server,
         {
           type: 'DeploymentReady',
@@ -1873,9 +1873,11 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
         },
         isCurrent
       )
-      console.log(
-        `[Reconciler] Updated status conditions on "${server.name}" (DeploymentReady=${deploymentReady})`
-      )
+      if (networkWrote || deploymentWrote) {
+        console.log(
+          `[Reconciler] Updated status conditions on "${server.name}" (DeploymentReady=${deploymentReady})`
+        )
+      }
     } catch (error) {
       // Status subresource may not exist yet — log but don't fail reconciliation
       console.warn(`[Reconciler] Failed to update status conditions on "${server.name}":`, error)
@@ -1904,8 +1906,8 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
     server: McpServerCRD,
     condition: Omit<McpServerCondition, 'lastTransitionTime'>,
     isCurrent: () => boolean = () => true
-  ): Promise<void> {
-    if (!isCurrent()) return
+  ): Promise<boolean> {
+    if (!isCurrent()) return false
     const now = new Date().toISOString()
 
     // Update the missing-secret gauge for SecretResolved conditions.
@@ -1930,7 +1932,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
     // if anything changed since our read; we then re-read and retry, so no
     // writer's condition is lost.
     for (let attempt = 1; attempt <= STATUS_CONDITION_WRITE_MAX_ATTEMPTS; attempt += 1) {
-      if (!isCurrent()) return
+      if (!isCurrent()) return false
       // Re-read on every optimistic-conflict retry. Merging against the
       // latest resourceVersion preserves conditions written by peer
       // controllers between our read and patch.
@@ -1956,15 +1958,15 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
           console.warn(
             `[Reconciler] McpServer "${server.name}" deleted mid-reconcile — skipping status update`
           )
-          return
+          return false
         }
         console.warn(
           `[Reconciler] Failed to read status for "${server.name}" — skipping status update for type "${condition.type}" to avoid clobbering other status fields:`,
           error
         )
-        return
+        return false
       }
-      if (!isCurrent()) return
+      if (!isCurrent()) return false
 
       const prior = existingConditions.find(c => c.type === condition.type)
       const observedGeneration = condition.observedGeneration ?? server.generation
@@ -1981,7 +1983,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
       // reconcile — a tight self-loop that also amplifies NetworkPolicy
       // optimistic-lock contention downstream.
       if (unchanged) {
-        return
+        return false
       }
 
       const lastTransitionTime =
@@ -2035,7 +2037,7 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
         // The generated client prefers JSON Patch for this endpoint. Send an
         // actual patch document so status writes keep working across client
         // upgrades instead of relying on merge-patch object bodies.
-        if (!isCurrent()) return
+        if (!isCurrent()) return false
         await this.customApi.patchNamespacedCustomObjectStatus({
           group: 'clerum.io',
           version: 'v1alpha1',
@@ -2044,14 +2046,14 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
           name: server.name,
           body: statusPatch,
         })
-        return
+        return true
       } catch (error) {
         const errorCode = getErrorCode(error)
         if (errorCode === 404) {
           console.warn(
             `[Reconciler] McpServer "${server.name}" deleted mid-reconcile — status patch skipped`
           )
-          return
+          return false
         }
         // 409 (Conflict) or 422 (a `test` op failed) mean a concurrent writer
         // won the race. Re-read and retry rather than lose our condition. Any
@@ -2067,9 +2069,10 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
           `[Reconciler] Failed to write status condition ${condition.type}=${condition.status} on "${server.name}" (attempt ${attempt}/${STATUS_CONDITION_WRITE_MAX_ATTEMPTS}):`,
           error
         )
-        return
+        return false
       }
     }
+    return false
   }
 
   // ─── Public API ─────────────────────────────────────────────────────

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -1370,6 +1370,8 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
                     {
                       name: 'stdio-bridge',
                       image: config.stdioBridgeImage, // G10: configurable bridge image
+                      imagePullPolicy:
+                        server.spec.imagePullPolicy || config.mcpServerImagePullPolicy,
                       env: [
                         {
                           name: 'STDIO_COMMAND',

--- a/host-context-controller/src/reconciler.ts
+++ b/host-context-controller/src/reconciler.ts
@@ -29,6 +29,7 @@ import { mcpserverMissingSecret } from './metrics'
 import { McpServerCRD, McpServerStatus } from './types'
 import {
   canonicalStringify,
+  configMapMatchesDesired,
   deploymentMatchesDesired,
   getErrorCode,
   preserveDeploymentAnnotations,
@@ -947,39 +948,28 @@ ${authHeaderLines ? '\n        # ── Credential auth headers (envsubst-resolv
   ): Promise<void> {
     const cm = this.buildNginxConfigMap(server)
     if (!isCurrent()) return
+    const name = `${server.name}-nginx-conf`
+    const namespace = server.namespace
     try {
       await this.coreApi.createNamespacedConfigMap({
-        namespace: server.namespace,
+        namespace,
         body: cm,
       })
-      console.log(`[Reconciler] Created nginx ConfigMap "${server.name}-nginx-conf"`)
+      console.log(`[Reconciler] Created nginx ConfigMap "${name}"`)
     } catch (error: unknown) {
-      if (getErrorCode(error) === 409) {
-        const existing = await this.coreApi.readNamespacedConfigMap({
-          name: `${server.name}-nginx-conf`,
-          namespace: server.namespace,
-        })
-        if (!isCurrent()) return
-        const next = preserveObjectAnnotations(
-          {
-            ...cm,
-            metadata: {
-              ...cm.metadata,
-              resourceVersion: existing.metadata?.resourceVersion,
-            },
-          },
-          existing
-        )
-        if (!isCurrent()) return
-        await this.coreApi.replaceNamespacedConfigMap({
-          name: `${server.name}-nginx-conf`,
-          namespace: server.namespace,
-          body: next,
-        })
-        console.log(`[Reconciler] Updated nginx ConfigMap "${server.name}-nginx-conf"`)
-      } else {
+      if (getErrorCode(error) !== 409) {
         throw error
       }
+      await replaceWithConflictRetry({
+        description: `nginx ConfigMap "${name}"`,
+        logPrefix: '[Reconciler]',
+        body: cm,
+        mergeExisting: preserveObjectAnnotations,
+        isUpToDate: configMapMatchesDesired,
+        mutationAllowed: isCurrent,
+        read: () => this.coreApi.readNamespacedConfigMap({ name, namespace }),
+        replace: body => this.coreApi.replaceNamespacedConfigMap({ name, namespace, body }),
+      })
     }
   }
 

--- a/host-context-controller/src/sharedFileSystemReconciler.ts
+++ b/host-context-controller/src/sharedFileSystemReconciler.ts
@@ -46,6 +46,7 @@ import type {
 } from './types'
 import {
   applyNetworkPolicy,
+  deploymentMatchesDesired,
   getErrorCode,
   preserveDeploymentAnnotations,
   replaceWithConflictRetry,
@@ -366,6 +367,7 @@ export class SharedFileSystemReconciler {
         // otherwise HCC would immediately create a second Recreate outage and
         // defeat the reconciler's one-rollout contract.
         mergeExisting: preserveDeploymentAnnotations,
+        isUpToDate: deploymentMatchesDesired,
         replace: body =>
           this.appsApi.replaceNamespacedDeployment({
             namespace: this.factoryConfig.hostNamespace,

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -61,7 +61,10 @@ export async function replaceWithConflictRetry<
     try {
       existing = await read()
     } catch (err) {
-      if (getErrorCode(err) === 404) return
+      if (getErrorCode(err) === 404) {
+        console.warn(`${logPrefix} ${description} disappeared (404); skipping replace`)
+        return
+      }
       throw err
     }
     validateExisting?.(existing)
@@ -72,6 +75,7 @@ export async function replaceWithConflictRetry<
     }
     const next = mergeExisting ? mergeExisting(base, existing) : base
     if (isUpToDate?.(next, existing)) {
+      if (mutationAllowed && !mutationAllowed()) return
       writeSkipsTotal.inc({ kind: next.kind ?? 'unknown' })
       return
     }
@@ -247,8 +251,10 @@ function normalizeServiceForComparison(service: k8s.V1Service): unknown {
 /**
  * True when the merged desired ConfigMap is equivalent to the live object.
  * ConfigMaps have no apps/v1-style spec defaulting, so comparison is the
- * whole object after stripping server-owned metadata. Doubt or a malformed
- * object returns false (fail-open-to-write).
+ * whole object after stripping server-owned metadata. Labels, finalizers,
+ * and ownerReferences are compared in full (mergeExisting keeps annotations
+ * only), so a foreign stamp there is permanent write churn, not a skip.
+ * Doubt or a malformed object returns false (fail-open-to-write).
  */
 export function configMapMatchesDesired(
   desired: k8s.V1ConfigMap | undefined,
@@ -330,7 +336,10 @@ function normalizeNetworkPolicyForComparison(policy: k8s.V1NetworkPolicy): unkno
  * must compare as drift rather than be silently ignored.
  *
  * Pod-template annotations are merged by preserveDeploymentAnnotations before
- * this comparison. Doubt or a malformed object returns false
+ * this comparison. Labels, finalizers, and ownerReferences are compared in
+ * full: a third-party stamp on those fields is drift and keeps the gate
+ * writing (fail-open), because mergeExisting does not absorb them.
+ * Doubt or a malformed object returns false
  * (fail-open-to-write), matching serviceMatchesDesired / networkPolicyMatchesDesired.
  */
 export function deploymentMatchesDesired(
@@ -378,6 +387,9 @@ export function normalizeDeploymentForComparison(deployment: k8s.V1Deployment): 
           delete podSpec.terminationGracePeriodSeconds
         if (podSpec.enableServiceLinks === true) delete podSpec.enableServiceLinks
         if (podSpec.preemptionPolicy === 'PreemptLowerPriority') delete podSpec.preemptionPolicy
+        // Cross-field default: kube mirrors serviceAccount from serviceAccountName.
+        // Delete the deprecated alias first; then strip SA === 'default'. Swapping
+        // these two lines would leave a dangling alias and force a write every pass.
         if (podSpec.serviceAccount === podSpec.serviceAccountName) delete podSpec.serviceAccount
         if (podSpec.serviceAccountName === 'default') delete podSpec.serviceAccountName
         if (Object.keys(podSpec.securityContext ?? {}).length === 0) delete podSpec.securityContext
@@ -396,6 +408,7 @@ export function normalizeDeploymentForComparison(deployment: k8s.V1Deployment): 
 }
 
 export function normalizeContainerDefaults(container: k8s.V1Container): void {
+  if (Object.keys(container.resources ?? {}).length === 0) delete container.resources
   if (container.terminationMessagePath === '/dev/termination-log') {
     delete container.terminationMessagePath
   }

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -245,6 +245,33 @@ function normalizeServiceForComparison(service: k8s.V1Service): unknown {
 }
 
 /**
+ * True when the merged desired ConfigMap is equivalent to the live object.
+ * ConfigMaps have no apps/v1-style spec defaulting, so comparison is the
+ * whole object after stripping server-owned metadata. Doubt or a malformed
+ * object returns false (fail-open-to-write).
+ */
+export function configMapMatchesDesired(
+  desired: k8s.V1ConfigMap | undefined,
+  existing: k8s.V1ConfigMap | undefined
+): boolean {
+  try {
+    if (!desired || !existing) return false
+    return (
+      JSON.stringify(normalizeConfigMapForComparison(desired)) ===
+      JSON.stringify(normalizeConfigMapForComparison(existing))
+    )
+  } catch {
+    return false
+  }
+}
+
+function normalizeConfigMapForComparison(configMap: k8s.V1ConfigMap): unknown {
+  const normalized = structuredClone(configMap)
+  stripServerOwnedMetadata(normalized)
+  return canonicalizeValue(normalized)
+}
+
+/**
  * True when the desired NetworkPolicy is equivalent to the live object, so a
  * replace would be a no-op. Canonicalize first: the apiserver default-fills
  * policyTypes and ports[].protocol=TCP, and key order is not stable (#307).

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -285,6 +285,115 @@ function normalizeNetworkPolicyForComparison(policy: k8s.V1NetworkPolicy): unkno
   return canonicalizeValue(normalized)
 }
 
+/**
+ * True when the merged desired Deployment is equivalent to the live object.
+ * Kubernetes persists server metadata and defaulted Deployment/PodSpec fields
+ * that HCC does not author. Remove only those known fields before comparing;
+ * every HCC-authored field stays exact so an intentional removal or change
+ * still causes a rollout.
+ *
+ * Safe-strip lemma: a normalizer mutation of the form "delete field X iff
+ * X === documented-default, applied identically to both sides" cannot hide
+ * any real change for any consumer. Anything outside that form — unconditional
+ * deletes, value normalisation, per-writer branches — can hide changes and is
+ * forbidden. Keep this allowlist conservative: an unknown admission mutation
+ * must compare as drift rather than be silently ignored.
+ *
+ * Pod-template annotations are merged by preserveDeploymentAnnotations before
+ * this comparison. Doubt or a malformed object returns false
+ * (fail-open-to-write), matching serviceMatchesDesired / networkPolicyMatchesDesired.
+ */
+export function deploymentMatchesDesired(
+  desired: k8s.V1Deployment | undefined,
+  existing: k8s.V1Deployment | undefined
+): boolean {
+  try {
+    if (!desired?.spec || !existing?.spec) return false
+    return (
+      JSON.stringify(normalizeDeploymentForComparison(desired)) ===
+      JSON.stringify(normalizeDeploymentForComparison(existing))
+    )
+  } catch {
+    return false
+  }
+}
+
+export function normalizeDeploymentForComparison(deployment: k8s.V1Deployment): unknown {
+  const normalized = structuredClone(deployment)
+  stripServerOwnedMetadata(normalized)
+
+  const spec = normalized.spec
+  if (spec) {
+    if (spec.progressDeadlineSeconds === 600) delete spec.progressDeadlineSeconds
+    if (spec.revisionHistoryLimit === 10) delete spec.revisionHistoryLimit
+    if (spec.minReadySeconds === 0) delete spec.minReadySeconds
+    if (spec.paused === false) delete spec.paused
+    if (
+      spec.strategy?.type === 'RollingUpdate' &&
+      spec.strategy.rollingUpdate?.maxSurge === '25%' &&
+      spec.strategy.rollingUpdate.maxUnavailable === '25%'
+    ) {
+      delete spec.strategy
+    }
+    const template = spec.template
+    if (template) {
+      delete template.metadata?.creationTimestamp
+
+      const podSpec = template.spec
+      if (podSpec) {
+        if (podSpec.restartPolicy === 'Always') delete podSpec.restartPolicy
+        if (podSpec.dnsPolicy === 'ClusterFirst') delete podSpec.dnsPolicy
+        if (podSpec.schedulerName === 'default-scheduler') delete podSpec.schedulerName
+        if (podSpec.terminationGracePeriodSeconds === 30)
+          delete podSpec.terminationGracePeriodSeconds
+        if (podSpec.enableServiceLinks === true) delete podSpec.enableServiceLinks
+        if (podSpec.preemptionPolicy === 'PreemptLowerPriority') delete podSpec.preemptionPolicy
+        if (podSpec.serviceAccount === podSpec.serviceAccountName) delete podSpec.serviceAccount
+        if (Object.keys(podSpec.securityContext ?? {}).length === 0) delete podSpec.securityContext
+        for (const container of [
+          ...(podSpec.initContainers ?? []),
+          ...(podSpec.containers ?? []),
+        ]) {
+          normalizeContainerDefaults(container)
+        }
+        for (const volume of podSpec.volumes ?? []) normalizeVolumeDefaults(volume)
+      }
+    }
+  }
+
+  return canonicalizeValue(normalized)
+}
+
+export function normalizeContainerDefaults(container: k8s.V1Container): void {
+  if (container.terminationMessagePath === '/dev/termination-log') {
+    delete container.terminationMessagePath
+  }
+  if (container.terminationMessagePolicy === 'File') delete container.terminationMessagePolicy
+  for (const probe of [container.startupProbe, container.livenessProbe, container.readinessProbe]) {
+    if (!probe) continue
+    if (probe.initialDelaySeconds === 0) delete probe.initialDelaySeconds
+    if (probe.successThreshold === 1) delete probe.successThreshold
+    if (probe.httpGet?.scheme === 'HTTP') delete probe.httpGet.scheme
+  }
+  for (const env of container.env ?? []) {
+    if (env.valueFrom?.fieldRef?.apiVersion === 'v1') {
+      delete env.valueFrom.fieldRef.apiVersion
+    }
+  }
+}
+
+export function normalizeVolumeDefaults(volume: k8s.V1Volume): void {
+  if (volume.secret?.defaultMode === 420) delete volume.secret.defaultMode
+  if (volume.secret?.optional === false) delete volume.secret.optional
+  if (volume.configMap?.defaultMode === 420) delete volume.configMap.defaultMode
+  if (volume.configMap?.optional === false) delete volume.configMap.optional
+  if (volume.downwardAPI?.defaultMode === 420) delete volume.downwardAPI.defaultMode
+  if (volume.projected?.defaultMode === 420) delete volume.projected.defaultMode
+  if (volume.persistentVolumeClaim?.readOnly === false) {
+    delete volume.persistentVolumeClaim.readOnly
+  }
+}
+
 /** Create-or-replace a NetworkPolicy (409 catch → conflict-retry replace). */
 export async function applyNetworkPolicy(
   api: k8s.NetworkingV1Api,

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -349,6 +349,7 @@ export function normalizeDeploymentForComparison(deployment: k8s.V1Deployment): 
         if (podSpec.enableServiceLinks === true) delete podSpec.enableServiceLinks
         if (podSpec.preemptionPolicy === 'PreemptLowerPriority') delete podSpec.preemptionPolicy
         if (podSpec.serviceAccount === podSpec.serviceAccountName) delete podSpec.serviceAccount
+        if (podSpec.serviceAccountName === 'default') delete podSpec.serviceAccountName
         if (Object.keys(podSpec.securityContext ?? {}).length === 0) delete podSpec.securityContext
         for (const container of [
           ...(podSpec.initContainers ?? []),
@@ -372,7 +373,9 @@ export function normalizeContainerDefaults(container: k8s.V1Container): void {
   for (const probe of [container.startupProbe, container.livenessProbe, container.readinessProbe]) {
     if (!probe) continue
     if (probe.initialDelaySeconds === 0) delete probe.initialDelaySeconds
+    if (probe.timeoutSeconds === 1) delete probe.timeoutSeconds
     if (probe.successThreshold === 1) delete probe.successThreshold
+    if (probe.failureThreshold === 3) delete probe.failureThreshold
     if (probe.httpGet?.scheme === 'HTTP') delete probe.httpGet.scheme
   }
   for (const env of container.env ?? []) {

--- a/host-context-controller/src/utils.ts
+++ b/host-context-controller/src/utils.ts
@@ -1,5 +1,5 @@
 import * as k8s from '@kubernetes/client-node'
-import { writesTotal } from './metrics'
+import { writeSkipsTotal, writesTotal } from './metrics'
 
 /** Extract HTTP status code from a K8s client error (handles both error formats). */
 export function getErrorCode(error: unknown): number | undefined {
@@ -71,7 +71,10 @@ export async function replaceWithConflictRetry<
       metadata: { ...desired.metadata, resourceVersion: existing.metadata?.resourceVersion },
     }
     const next = mergeExisting ? mergeExisting(base, existing) : base
-    if (isUpToDate?.(next, existing)) return
+    if (isUpToDate?.(next, existing)) {
+      writeSkipsTotal.inc({ kind: next.kind ?? 'unknown' })
+      return
+    }
     if (mutationAllowed && !mutationAllowed()) return
     try {
       await replace(next)

--- a/host-context-controller/test/hostReconciler.test.ts
+++ b/host-context-controller/test/hostReconciler.test.ts
@@ -56,7 +56,7 @@ vi.mock('../src/config', () => ({
     desktopPort: 3000,
     desktopResources: {
       requests: { memory: '256Mi', cpu: '250m' },
-      limits: { memory: '4Gi', cpu: '1000m' },
+      limits: { memory: '4Gi', cpu: '1' },
     },
     devMcpServers: [],
     devContexts: [],
@@ -814,7 +814,7 @@ describe('HostReconciler — desktop support', () => {
     expect(resources.requests.memory).toBe('256Mi')
     expect(resources.requests.cpu).toBe('250m')
     expect(resources.limits.memory).toBe('4Gi')
-    expect(resources.limits.cpu).toBe('1000m')
+    expect(resources.limits.cpu).toBe('1')
   })
 
   it('creates desktop NetworkPolicy when desktop enabled', async () => {
@@ -1488,7 +1488,9 @@ describe('reconcileChannelReaderDeployment', () => {
     appsApi.replaceNamespacedDeployment.mockRejectedValueOnce({ code: 409 })
     coreApi.readNamespacedSecret.mockRejectedValue({ code: 404 })
 
-    await (reconciler as any).reconcileChannelReaderDeployment(host)
+    await expect((reconciler as any).reconcileChannelReaderDeployment(host)).rejects.toThrow(
+      /ownership changed to host "other-host"/
+    )
 
     expect(appsApi.replaceNamespacedDeployment).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
## Summary
- Implements [#527](https://github.com/evenfire-ai/evenfire/issues/527) / [#460](https://github.com/evenfire-ai/evenfire/issues/460): the remaining HCC writers that still replaced Deployments, the nginx ConfigMap, and LlmHook NetworkPolicies on every pass now go through `replaceWithConflictRetry` with a no-op predicate.
- Shared `deploymentMatchesDesired` lives in `utils.ts`. Safe-strip lemma only: delete field X iff X === documented default, applied identically on both sides. The strips that keep McpServer/LlmHook/SFS builders from leaving the gate inert are `timeoutSeconds===1`, `failureThreshold===3`, `serviceAccountName==='default'`, and empty `container.resources === {}` (kube always emits the key; mirrors the existing empty `securityContext` strip). No `periodSeconds===10`. No `imagePullPolicy` strip.
- New `clerum_hcc_write_skips_total{kind}` increments only when `isUpToDate` is true **and** `mutationAllowed()` (if set) is true, before return. `writesTotal` still increments only after a successful `replace()`. GFS and the stateless lifecycle writer stay ungated. LlmHook keeps its private NetworkPolicy helper (`mergeExisting: preserveObjectAnnotations`).
- Channel-reader retry-time ownership veto lives on `validateExisting` (throws) so an adoption race is not counted as a healthy skip.
- `writeStatusCondition` returns boolean and logs `Updated status conditions` only when a status patch actually happened.

**Base:** `origin/dev` `24d749d0` (includes #525). HCC image `0.1.271` → `0.1.284` via the src/ hook.

Closes #527

## Test plan
- [x] Host / channel-reader / McpServer / SFS / LlmHook: fixture ≠ desired (FIXTURE-1) and merged builder vs fixture is a no-op
- [x] `asApiserverDeployment` does not mutate the caller `desired` object
- [x] Leaf sweeps fail if any desired path is undetectable (desired + live-only spec)
- [x] Equality guards keep non-default timeout / failureThreshold / serviceAccountName; empty `resources: {}` matches omitted; `1000m` ≠ `1`
- [x] `NOOP-*` suites assert `replace` is not called; `IMAGE-*` / `ROTATE-*` / `CM-2` write once
- [x] SFS-3: live `restartedAt` skips; real image change keeps the marker
- [x] LlmHook NP: three callers skip; added egress writes once
- [x] Inventory: 8 `replaceNamespacedDeployment(` call-sites across 6 files — 5 gated / 3 exempt — plus 1 gated `replaceNamespacedConfigMap(`; identifier count must equal call count per file
- [x] SKIP-1 / SKIP-2 / SKIP-3 for `writeSkipsTotal` (skip increments; write and read-404 do not; stale `mutationAllowed` does not)
- [x] T0: `scripts/minikube/t0.sh` — 2012 HCC tests, `tsc -p tsconfig.build.json`, plus T0 contract/handoff scripts

Out of this PR: live apiserver §8 fixture diff (no Minikube); GFS Deployment gates; `policy_type` on skip metrics (#526); moving LlmHook NP onto shared `applyNetworkPolicy`; general Kubernetes quantity canonicalization (`1024Mi` vs `1Gi`). Residual lows from the independent review are tracked in [#530](https://github.com/evenfire-ai/evenfire/issues/530).

Made with [Cursor](https://cursor.com)


