### PR TITLE
fix(profile-ui): default internal API to in-namespace Service DNS

### DIFF
--- a/profile-ui/app/constants/serverApi.ts
+++ b/profile-ui/app/constants/serverApi.ts
@@ -1,3 +1,7 @@
 export const EXTERNAL_REST_API_INTERNAL_URL =
   process.env.EXTERNAL_REST_API_INTERNAL_URL ||
-  'http://external-rest-api.profiles.svc.cluster.local:8091'
+  // In-namespace Service name: works in dedicated `profiles` and shared
+  // `profiles-<slug>`. Do not default to `.profiles.svc.cluster.local` —
+  // Next bakes this rewrite at image build, so that FQDN 500s on shared
+  // tenants (ENOTFOUND). Runtime env still wins when Next evaluates it.
+  'http://external-rest-api:8091'

--- a/profile-ui/next.config.js
+++ b/profile-ui/next.config.js
@@ -7,7 +7,7 @@ const nextConfig = {
   async rewrites() {
     const destination =
       process.env.EXTERNAL_REST_API_INTERNAL_URL ||
-      'http://external-rest-api.profiles.svc.cluster.local:8091'
+      'http://external-rest-api:8091'
     // WARNING (see evenfire #287, and RC2 in PR #280): this rewrite routes through
     // Next's internal proxy, which silently truncates request bodies at 10MiB and
     // hard-caps at a 30s proxyTimeout — the exact construct RC2 removed from

--- a/profile-ui/package-lock.json
+++ b/profile-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-profile-ui",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-profile-ui",
-      "version": "0.1.125",
+      "version": "0.1.126",
       "dependencies": {
         "@clerum/desktop-app-links": "file:../packages/desktop-app-links",
         "next": "16.2.11",

--- a/profile-ui/package.json
+++ b/profile-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-profile-ui",
-  "version": "0.1.125",
+  "version": "0.1.126",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/profile-ui/test/internalApiUrl.test.ts
+++ b/profile-ui/test/internalApiUrl.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const ROOT = path.join(process.cwd())
+
+/** In-namespace Service name. Works in dedicated `profiles` and shared `profiles-<slug>`. */
+const IN_NAMESPACE_API = 'http://external-rest-api:8091'
+const DEDICATED_CLUSTER_FQDN = 'external-rest-api.profiles.svc.cluster.local'
+
+test('next.config.js rewrite default is the in-namespace Service, not dedicated FQDN', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'next.config.js'), 'utf8')
+  assert.match(src, new RegExp(IN_NAMESPACE_API.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  assert.doesNotMatch(src, new RegExp(DEDICATED_CLUSTER_FQDN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+})
+
+test('serverApi.ts default is the in-namespace Service, not dedicated FQDN', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'app/constants/serverApi.ts'), 'utf8')
+  assert.match(src, new RegExp(IN_NAMESPACE_API.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  assert.doesNotMatch(src, new RegExp(DEDICATED_CLUSTER_FQDN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+})


### PR DESCRIPTION
## Why

Shared-trial tenant `jose-test` on smoke-8: profile-ui 500s on password set and `/api/v1/me` with

```
Failed to proxy http://external-rest-api.profiles.svc.cluster.local:8091/...
ENOTFOUND external-rest-api.profiles.svc.cluster.local
```

MCC already sets `EXTERNAL_REST_API_INTERNAL_URL` to `profiles-<slug>`. Next **bakes** `rewrites()` at image build, so the dedicated-cluster FQDN is frozen in. SSR invitation GET can still work (runtime env); browser POSTs through `/external-rest-api` do not.

## What

Default the rewrite + `serverApi.ts` to `http://external-rest-api:8091` (in-namespace Service name). That DNS works in dedicated `profiles` **and** shared `profiles-<slug>`. Runtime env still wins when Next evaluates it.

Landing this is not enough for `jose-test` until a new profile-ui image is built (dev `build-publish`) and pinned/rolled by MCC.

## Evidence

- `profile-ui` `npm test`: 58 node:test + 13 vitest passed, including new `internalApiUrl.test.ts`.

**Do not merge until Jose says go.**