### PR TITLE
fix: close the subscription modal after finishing setup

### DIFF
--- a/control-ui/components/CodexSubscriptionHub/index.tsx
+++ b/control-ui/components/CodexSubscriptionHub/index.tsx
@@ -204,6 +204,7 @@ export function CodexSubscriptionHub() {
 
   function closeEdit() {
     connectEpoch.current += 1
+    setCreating(false)
     setEditing(null)
     setEditName('')
     setEditDefault('')

--- a/control-ui/components/__tests__/CodexSubscriptionHub.test.tsx
+++ b/control-ui/components/__tests__/CodexSubscriptionHub.test.tsx
@@ -147,6 +147,9 @@ describe('CodexSubscriptionHub', () => {
         defaultModel: null,
       })
     })
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
     expect(revokeCodexSubscription).not.toHaveBeenCalled()
   })
 

--- a/control-ui/package-lock.json
+++ b/control-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.485",
+  "version": "0.1.486",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clerum-control-ui",
-      "version": "0.1.485",
+      "version": "0.1.486",
       "dependencies": {
         "@clerum/display-field": "file:../packages/display-field",
         "@clerum/llm-providers": "file:../packages/llm-providers",

--- a/control-ui/package.json
+++ b/control-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clerum-control-ui",
-  "version": "0.1.485",
+  "version": "0.1.486",
   "private": true,
   "scripts": {
     "dev": "NEXT_IGNORE_INCORRECT_LOCKFILE=1 next dev",


### PR DESCRIPTION
Fix the modal remaining open after successful subscription 
