### PR TITLE
feat(desktop-app): shrink chat-view session tabs Chrome-style

### DIFF
--- a/desktop-app/test/native/chat-workspace-geometry.fixture.cjs
+++ b/desktop-app/test/native/chat-workspace-geometry.fixture.cjs
@@ -17,12 +17,16 @@ async function geometry(window) {
     const workspace = document.querySelector('.chat-view-workspace').getBoundingClientRect()
     const tabs = document.querySelector('.chat-view-tabs').getBoundingClientRect()
     const active = document.querySelector('.chat-view-tab.is-active').getBoundingClientRect()
+    const inactive = document.querySelector('.chat-view-tab:not(.is-active)').getBoundingClientRect()
     const scroller = document.querySelector('.chat-view-tabs__scroller')
     const surface = document.querySelector('.chat-view-surface').getBoundingClientRect()
     const surfaceStyle = getComputedStyle(document.querySelector('.chat-view-surface'))
     const activeTab = document.querySelector('.chat-view-tab.is-active')
     const activeStyle = getComputedStyle(activeTab)
-    const listSeamStyle = getComputedStyle(document.querySelector('.chat-view-tabs__list'), '::after')
+    // The bottom shelf now lives on the non-scrolling .chat-view-tabs container
+    // (::after) so it stays under the whole visible strip when the tabs
+    // overflow and scroll — it used to live on the scrolling list.
+    const seamStyle = getComputedStyle(document.querySelector('.chat-view-tabs'), '::after')
     const inactiveStyle = getComputedStyle(document.querySelector('.chat-view-tab:not(.is-active)'))
     const inactiveBorderReferenceStyle = getComputedStyle(
       document.querySelector('[data-inactive-tab-border-reference]')
@@ -35,6 +39,7 @@ async function geometry(window) {
     )
     return {
       activeBottom: active.bottom,
+      activeWidth: active.width,
       activeBackground: activeStyle.backgroundColor,
       activeBackgroundImage: activeStyle.backgroundImage,
       activeBorderBottom: activeStyle.borderBottomColor,
@@ -42,19 +47,26 @@ async function geometry(window) {
       activeBorderBottomWidth: activeStyle.borderBottomWidth,
       activeBorderTop: activeStyle.borderTopColor,
       activeBorderTopStyle: activeStyle.borderTopStyle,
+      activeFlexShrink: activeStyle.flexShrink,
       activeCloseBackground: activeCloseStyle.backgroundColor,
       activeSelectBackground: activeSelectStyle.backgroundColor,
       inactiveBackground: inactiveStyle.backgroundColor,
+      inactiveWidth: inactive.width,
+      inactiveBorderBottom: inactiveStyle.borderBottomColor,
       inactiveBorderBottomStyle: inactiveStyle.borderBottomStyle,
       inactiveBorderBottomWidth: inactiveStyle.borderBottomWidth,
       inactiveBorderTop: inactiveStyle.borderTopColor,
       inactiveBorderReferenceTop: inactiveBorderReferenceStyle.borderTopColor,
+      inactiveFlexShrink: inactiveStyle.flexShrink,
+      inactiveMinWidth: inactiveStyle.minWidth,
+      inactiveMaxWidth: inactiveStyle.maxWidth,
       listClientWidth: scroller.clientWidth,
       listOverflowX: getComputedStyle(scroller).overflowX,
-      listSeamBackground: listSeamStyle.backgroundColor,
-      listSeamBottom: listSeamStyle.bottom,
-      listSeamHeight: listSeamStyle.height,
-      listSeamPosition: listSeamStyle.position,
+      seamBackground: seamStyle.backgroundColor,
+      seamBottom: seamStyle.bottom,
+      seamHeight: seamStyle.height,
+      seamPosition: seamStyle.position,
+      seamZIndex: seamStyle.zIndex,
       listScrollWidth: scroller.scrollWidth,
       panelPaddingLeft: panelStyle.paddingLeft,
       surfaceBackground: surfaceStyle.backgroundColor,
@@ -140,13 +152,18 @@ function assertTabTreatment(state, theme) {
   )
   assert.equal(
     state.inactiveBorderBottomStyle,
-    'none',
-    `${theme} inactive tabs have no bottom border`
+    'solid',
+    `${theme} inactive tabs draw a bottom border to complete the shared seam`
   )
   assert.equal(
     state.inactiveBorderBottomWidth,
-    '0px',
-    `${theme} inactive tabs have no bottom-border width`
+    '1px',
+    `${theme} inactive tabs draw a one-pixel bottom border`
+  )
+  assert.equal(
+    state.inactiveBorderBottom,
+    state.surfaceBorderTop,
+    `${theme} inactive bottom border uses the selected surface border treatment`
   )
   assert.equal(
     state.inactiveBorderTop,
@@ -229,13 +246,39 @@ app.whenReady().then(async () => {
       colorDistance(darkPaint.outsideBorder, darkPaint.outsideFill) >= 5,
       'surface border remains visibly painted outside the selected tab'
     )
-    assert.equal(wide.listSeamPosition, 'absolute', 'tab list owns the shared surface seam')
-    assert.equal(wide.listSeamBottom, '0px', 'shared seam occupies the tab row lower edge')
-    assert.equal(wide.listSeamHeight, '1px', 'shared seam paints exactly one border row')
     assert.equal(
-      wide.listSeamBackground,
+      wide.seamPosition,
+      'absolute',
+      'the non-scrolling tab strip owns the shared surface seam'
+    )
+    assert.equal(wide.seamBottom, '0px', 'shared seam occupies the tab strip lower edge')
+    assert.equal(wide.seamHeight, '1px', 'shared seam paints exactly one border row')
+    assert.equal(
+      wide.seamZIndex,
+      '-1',
+      'shared seam sits behind the opaque tabs so it only shows through their gaps'
+    )
+    assert.equal(
+      wide.seamBackground,
       wide.surfaceBorderTop,
       'shared seam uses the selected surface border treatment'
+    )
+    // Elastic tab sizing: tokens anchor a 220px ceiling and a 96px floor, and
+    // with only four tabs in a wide window each tab measures at the ceiling.
+    assert.equal(wide.inactiveMaxWidth, '220px', 'tabs cap at the --chat-tab-max ceiling')
+    assert.equal(wide.inactiveMinWidth, '96px', 'tabs never shrink below the --chat-tab-min floor')
+    assert.ok(
+      Math.abs(wide.inactiveWidth - 220) <= 1,
+      'a wide window with few tabs holds each tab at the 220px ceiling'
+    )
+    assert.ok(
+      Math.abs(wide.activeWidth - 220) <= 1,
+      'the active tab also sits at the 220px ceiling when there is room'
+    )
+    assert.equal(wide.inactiveFlexShrink, '1', 'inactive tabs shrink at the default rate')
+    assert.ok(
+      Number(wide.activeFlexShrink) < Number(wide.inactiveFlexShrink),
+      'the active tab is configured to shrink slower than inactive tabs'
     )
     await window.webContents.executeJavaScript(
       "document.documentElement.setAttribute('data-theme', 'light')"
@@ -249,7 +292,7 @@ app.whenReady().then(async () => {
       'light active tab shares the surface border'
     )
     assert.equal(
-      light.listSeamBackground,
+      light.seamBackground,
       light.surfaceBorderTop,
       'light shared seam uses the selected surface border treatment'
     )
@@ -293,12 +336,45 @@ app.whenReady().then(async () => {
       'the label remains transparent over the complete tab hover fill'
     )
 
+    // Intermediate width: tabs have shrunk below the ceiling but the strip has
+    // not overflowed yet — proving the tabs give up width before the scroller
+    // ever scrolls.
+    window.setSize(700, 700)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const mid = await geometry(window)
+    assert.ok(
+      mid.listScrollWidth <= mid.listClientWidth + 1,
+      'at an intermediate width the tab strip shrinks instead of overflowing'
+    )
+    assert.ok(
+      mid.inactiveWidth > 96 && mid.inactiveWidth < 220,
+      'at an intermediate width inactive tabs sit between the 96px floor and 220px ceiling'
+    )
+    assert.ok(
+      mid.activeWidth > 96 && mid.activeWidth < 220,
+      'at an intermediate width the active tab is also between floor and ceiling'
+    )
+    assert.ok(
+      mid.activeWidth > mid.inactiveWidth,
+      'while shrinking, the active tab stays wider than an inactive one'
+    )
+
     window.setSize(420, 700)
     await new Promise(resolve => setTimeout(resolve, 50))
     const narrow = await geometry(window)
     const narrowPaint = await paintedSeam(window)
     assert.equal(narrow.listOverflowX, 'auto', 'only the tab list owns horizontal overflow')
     assert.ok(narrow.listScrollWidth > narrow.listClientWidth, 'long narrow tabs remain scrollable')
+    // Overflow only begins once even the slowest-shrinking (active) tab has
+    // bottomed out at the 96px floor — the scroller does not appear before then.
+    assert.ok(
+      Math.abs(narrow.inactiveWidth - 96) <= 1,
+      'once the strip overflows, inactive tabs rest at the 96px floor'
+    )
+    assert.ok(
+      Math.abs(narrow.activeWidth - 96) <= 1,
+      'once the strip overflows, the active tab has also reached the 96px floor'
+    )
     assert.ok(
       Math.abs(narrow.surfaceWidth - narrow.workspaceWidth) <= 1,
       'narrow surface stays full width'
@@ -318,6 +394,47 @@ app.whenReady().then(async () => {
     )
     assert.equal(narrow.surfaceBorderLeftStyle, 'solid', 'narrow surface keeps its left border')
     assert.equal(narrow.surfaceBorderRightStyle, 'solid', 'narrow surface keeps its right border')
+
+    // With the strip actually scrolled, the shelf must stay put and the active
+    // tab's notch must still mask the surface border beneath it. This is the
+    // reason the shelf was moved onto the non-scrolling container: a shelf on
+    // the scrolling list would slide out from under the visible tabs here.
+    window.setSize(360, 700)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    const appliedScroll = await window.webContents.executeJavaScript(`(() => {
+      const scroller = document.querySelector('.chat-view-tabs__scroller')
+      scroller.scrollLeft = Math.floor((scroller.scrollWidth - scroller.clientWidth) / 2)
+      return scroller.scrollLeft
+    })()`)
+    await new Promise(resolve => setTimeout(resolve, 50))
+    assert.ok(appliedScroll > 0, 'the overflowing strip actually scrolls horizontally')
+    const scrolled = await geometry(window)
+    const scrolledPaint = await paintedSeam(window)
+    assert.equal(
+      scrolled.seamPosition,
+      'absolute',
+      'the shelf stays anchored to the non-scrolling container after scrolling'
+    )
+    assert.equal(scrolled.seamBottom, '0px', 'the scrolled shelf still hugs the strip lower edge')
+    assert.equal(scrolled.seamHeight, '1px', 'the scrolled shelf still paints exactly one row')
+    assert.equal(
+      scrolled.seamBackground,
+      scrolled.surfaceBorderTop,
+      'the scrolled shelf keeps the selected surface border treatment'
+    )
+    assert.ok(
+      Math.abs(scrolled.surfaceTop - scrolled.activeBottom) <= 1,
+      'the scrolled active tab and surface still share one border row'
+    )
+    assert.ok(
+      colorDistance(scrolledPaint.selectedSeam, scrolledPaint.selectedFill) <
+        colorDistance(scrolledPaint.outsideBorder, scrolledPaint.outsideFill) / 2,
+      'the scrolled active tab still masks the surface border beneath its own span'
+    )
+    assert.ok(
+      colorDistance(scrolledPaint.outsideBorder, scrolledPaint.outsideFill) >= 5,
+      'the shelf remains visibly painted outside the scrolled active tab'
+    )
 
     console.log('chat workspace native geometry fixture: PASS')
     app.exit(0)

--- a/desktop-app/ui/src/components/ChatTabs/ChatTabs.test.tsx
+++ b/desktop-app/ui/src/components/ChatTabs/ChatTabs.test.tsx
@@ -60,9 +60,18 @@ describe('ChatTabs', () => {
     const styles = readFileSync(path.join(process.cwd(), 'ui', 'src', 'styles.css'), 'utf8')
     expect(styles).toMatch(/\.chat-view-tabs\s*\{[^}]*padding:\s*var\(--space-2\) 0 0;/s)
     expect(styles).toMatch(/\.chat-view-tabs__scroller\s*\{[^}]*width:\s*100%;/s)
-    expect(styles).toMatch(/\.chat-view-tabs__list\s*\{[^}]*width:\s*max-content;/s)
-    expect(styles).toMatch(/\.chat-view-tab\s*\{[^}]*flex:\s*0 0 220px;/s)
-    expect(styles).toMatch(/\.chat-view-tab\s*\{[^}]*width:\s*220px;/s)
+    expect(styles).toMatch(/\.chat-view-tabs__list\s*\{[^}]*width:\s*100%;/s)
+    expect(styles).toMatch(/\.chat-view-tab\s*\{[^}]*flex:\s*1 1 var\(--chat-tab-max\);/s)
+    expect(styles).toMatch(/\.chat-view-tab\s*\{[^}]*max-width:\s*var\(--chat-tab-max\);/s)
+    expect(styles).toMatch(/\.chat-view-tab\s*\{[^}]*min-width:\s*var\(--chat-tab-min\);/s)
+    // The active tab shrinks slower than the others so it stays legible when crowded.
+    expect(styles).toMatch(/\.chat-view-tab\.is-active\s*\{[^}]*flex-shrink:\s*0\.4;/s)
+    // The bottom shelf lives on the non-scrolling container so it survives horizontal
+    // scroll of the overflowing tabs (a shelf on the list would slide away).
+    expect(styles).toMatch(/\.chat-view-tabs::after\s*\{[^}]*z-index:\s*-1;/s)
+    expect(styles).toMatch(
+      /\.chat-view-tab:not\(\.is-active\)\s*\{[^}]*border-bottom:\s*1px solid var\(--chat-view-selected-border\);/s
+    )
     expect(styles).toMatch(/\.chat-view-tab__select\s*\{[^}]*flex:\s*1 1 auto;/s)
     expect(styles).toMatch(/\.chat-view-tab__label\s*\{[^}]*text-overflow:\s*ellipsis;/s)
   })

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -15520,6 +15520,25 @@ pre {
   z-index: 1;
 }
 
+/* Bottom shelf of the tab strip. It lives on the non-scrolling container (not
+   the scroller/list) so it stays under the whole visible strip when the tabs
+   overflow and scroll — a shelf on the scrolling list only spans the initial
+   viewport and slides away on scroll. z-index:-1 keeps it below the opaque
+   tabs (so it only shows through the gaps between them); each inactive tab
+   draws its own matching bottom border, and the active tab omits it to notch
+   through and merge with the surface below. */
+.chat-view-tabs::after {
+  background: var(--chat-view-selected-border);
+  bottom: 0;
+  content: '';
+  height: 1px;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  z-index: -1;
+}
+
 .chat-view-tabs__scroller {
   min-width: 0;
   overflow-x: auto;
@@ -15534,18 +15553,7 @@ pre {
   min-width: 100%;
   position: relative;
   transform: rotateX(180deg);
-  width: max-content;
-}
-
-.chat-view-tabs__list::after {
-  background: var(--chat-view-selected-border);
-  bottom: 0;
-  content: '';
-  height: 1px;
-  left: 0;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
+  width: 100%;
 }
 
 .chat-view-tab {
@@ -15554,21 +15562,24 @@ pre {
   border: 1px solid var(--border-soft);
   border-radius: var(--radius-sm) var(--radius-sm) 0 0;
   display: flex;
-  flex: 0 0 220px;
-  min-width: 0;
+  flex: 1 1 var(--chat-tab-max);
+  min-width: var(--chat-tab-min);
+  max-width: var(--chat-tab-max);
   transition: background var(--motion-fast);
-  width: 220px;
 }
 
 .chat-view-tab:not(.is-active) {
-  border-bottom: 0;
-  border-color: color-mix(in srgb, var(--border-soft) 25%, transparent);
+  border-bottom: 1px solid var(--chat-view-selected-border);
+  border-left-color: color-mix(in srgb, var(--border-soft) 25%, transparent);
+  border-right-color: color-mix(in srgb, var(--border-soft) 25%, transparent);
+  border-top-color: color-mix(in srgb, var(--border-soft) 25%, transparent);
 }
 
 .chat-view-tab.is-active {
   background: linear-gradient(var(--surface-strong), var(--surface-strong)), var(--panel);
   border-color: var(--chat-view-selected-border);
   border-bottom: 0;
+  flex-shrink: 0.4;
   position: relative;
   z-index: 1;
 }

--- a/desktop-app/ui/src/styles/tokens.css
+++ b/desktop-app/ui/src/styles/tokens.css
@@ -151,6 +151,10 @@
   /* Layout */
   --search-bar-min-width: 320px;
   --avatar-size: 40px;
+
+  /* chat-view session tabs (Chrome-style: shrink to a floor, cap at a ceiling) */
+  --chat-tab-max: 220px;
+  --chat-tab-min: 96px;
   --control-bg: var(--surface-soft);
   --control-bg-strong: rgba(var(--panel-rgb), 0.78);
   --control-border: rgba(var(--edge-rgb), 0.56);


### PR DESCRIPTION
## What
The full-screen chat tab strip pinned every session tab at a fixed 220px and let the row overflow into horizontal scroll as sessions piled up. The tabs now behave like Chrome: they share the available width and shrink together from a 220px ceiling down to a 96px floor, and only past that floor does the existing horizontal scroll take over.

## Why
With many open sessions the fixed-width strip forced horizontal scrolling almost immediately, making it hard to see and reach tabs. Shrinking-to-fit keeps far more tabs visible and navigable before scroll is ever needed, matching the behavior users already expect from browsers.

## How
- `.chat-view-tab` switches from `flex: 0 0 220px` / fixed `width` to `flex: 1 1 var(--chat-tab-max)` bounded by `min-width: var(--chat-tab-min)` (96px floor) and `max-width: var(--chat-tab-max)` (220px ceiling); the list drops `width: max-content` for `width: 100%` so the tabs shrink within the viewport instead of expanding the row.
- The active tab shrinks slower (`flex-shrink: 0.4`) so it stays legible when the strip is crowded.
- Sizing lives in two layout tokens, `--chat-tab-max` / `--chat-tab-min`, next to the existing single-use layout tokens in `tokens.css`.
- The strip's bottom shelf moves off the scrolling list onto the non-scrolling `.chat-view-tabs` container (`z-index: -1`, showing through the gaps between tabs) so it no longer slides away when the overflowing tabs scroll. Each inactive tab now draws its own matching bottom border and the active tab omits it to notch through into the surface below.
- The chat drawer's session switcher is a dropdown (`ChatSwitcher`), a different surface that does not compete for width, and is left untouched.

## Testing
- `ChatTabs` unit tests (3) and `ChatViewWorkspace` tests (5): all pass. The style-contract assertions were updated to the new flex/min/max model and now also pin the active-tab `flex-shrink`, the relocated shelf, and the inactive-tab bottom border.
- Native chat-workspace geometry validation: `cd desktop-app && npm run test:native:chat-workspace-geometry` passes. The native Electron fixture was updated for the elastic tabs and now covers, through measured Chromium geometry/computed style, the 220px ceiling, the 96px floor, tabs shrinking to fit before the strip overflows, horizontal scroll starting only after even the active tab reaches the floor, the active tab's slower shrink, and the non-scrolling shelf/notch treatment staying correct with `scrollLeft` applied. Verified it fails against the pre-PR CSS (merge base `47b191c`) and passes on head, so it genuinely guards the new contract.
- Repo style-rules checker: passes (exit 0, no findings).

## Risks / Follow-ups
- Purely presentational (CSS + tokens + style-contract tests); no logic, auth, or data paths touched. Live visual confirmation in the running Electron app is recommended as a final check of the shelf/notch across scroll positions.
