### PR TITLE
feat(desktop-ui): collapse global search and tune header/panel spacing

### DIFF
--- a/desktop-app/test/browser/responsiveUtilityGutter.browser.test.ts
+++ b/desktop-app/test/browser/responsiveUtilityGutter.browser.test.ts
@@ -22,12 +22,16 @@ function launchOptions() {
   return { headless: true }
 }
 
-async function headerGeometry(width: number, drawerOpen = false): Promise<HeaderGeometry> {
+async function headerGeometry(
+  width: number,
+  drawerOpen = false,
+  searchOpen = false
+): Promise<HeaderGeometry> {
   if (!browser) throw new Error('Browser must launch before measuring responsive utility geometry')
   const page = await browser.newPage({ viewport: { width, height: 800 } })
   await page.setContent(`
     <div class="content-panel${drawerOpen ? ' content-panel--app-notification-drawer-open' : ''}">
-      <div class="top-bar"><div class="header-left"><div class="global-search"></div></div></div>
+      <div class="top-bar"><div class="header-left"><div class="global-search${searchOpen ? ' is-open' : ''}"></div></div></div>
       <section class="page">
         <header class="apps-page-header">Apps</header>
         <header class="sandbox-ui-mounted-header"><button>Back</button></header>
@@ -62,8 +66,14 @@ describe('responsive utility gutter', () => {
   it('uses the compact closed-header reservation at tablet widths and retains drawer-open space', async () => {
     const closed = await headerGeometry(1100)
     const open = await headerGeometry(1100, true)
+    const searchExpanded = await headerGeometry(1100, false, true)
 
-    expect(closed.searchWidth).toBe(352)
+    // Idle, the global-search collapses to the 40px magnifier; it grows to its
+    // tablet expanded width (clamp(160px, 32vw, …) = 352px at 1100) only on
+    // focus/open. The utility gutter still reserves for the *expanded* search
+    // (352 + space-2 + 36 = 398) so expansion never collides with page content.
+    expect(closed.searchWidth).toBe(40)
+    expect(searchExpanded.searchWidth).toBe(352)
     expect(closed.mountedPaddingRight).toBe(398)
     expect(closed.mountedPaddingRight).toBeLessThan(open.pagePaddingRight)
     expect(open.mountedPaddingRight).toBe(0)

--- a/desktop-app/ui/src/components/AppHeader/__tests__/searchCollapse.test.tsx
+++ b/desktop-app/ui/src/components/AppHeader/__tests__/searchCollapse.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AppHeader } from '../index'
+
+// The collapsed idle contract: `.global-search` may only carry `is-open` while
+// there is query/result state. Focusing an empty field or typing-then-clearing
+// must leave the container without `is-open` once idle — the CSS `:focus-within`
+// rule handles the transient expansion during focus, `is-open` does not.
+
+vi.mock('@hooks/domain/useAgentsDataController', () => ({
+  useAgentsDataController: () => ({ accessCatalog: null }),
+}))
+
+vi.mock('@hooks/domain/useContextsDataController', () => ({
+  useContextsDataController: () => ({ contextIds: [] }),
+}))
+
+vi.mock('@hooks/domain/useMcpServersDataController', () => ({
+  useMcpServersDataController: () => ({ globalMcpServers: [], mcpServersByAgent: {} }),
+}))
+
+vi.mock('@hooks/domain/useSearchPluginsAppsController', () => ({
+  useSearchPluginsAppsController: () => ({
+    plugins: [],
+    apps: [],
+    loading: false,
+    error: null,
+    ensureLoaded: vi.fn(async () => undefined),
+  }),
+}))
+
+vi.mock('@hooks/domain/useTeamsDataController', () => ({
+  useTeamsDataController: () => ({
+    teams: [],
+    teamMembers: [],
+    teamDirectory: {},
+    loading: false,
+    teamDirectoryHydrated: true,
+    currentTeamId: '',
+    ensureHydrated: vi.fn(async () => undefined),
+  }),
+}))
+
+vi.mock('@contexts/NavigationContext', () => ({
+  useNavigationContext: () => ({
+    navItem: 'apps',
+    handleNavSelect: vi.fn(),
+    handleOpenContextDetails: vi.fn(),
+    handleOpenTeamDetails: vi.fn(),
+  }),
+}))
+
+vi.mock('@contexts/NotificationsContext', () => ({
+  useNotificationsContext: () => ({
+    notifications: [],
+    unreadNotificationCount: 0,
+    notificationActionById: {},
+    pendingApprovals: [],
+    pendingApprovalsLoading: false,
+    pendingApprovalActionId: null,
+    markNotificationsRead: vi.fn(),
+    clearNotifications: vi.fn(),
+    removeNotification: vi.fn(),
+    handleOpenNotification: vi.fn(),
+    handleApproveNotification: vi.fn(),
+    handleDenyNotification: vi.fn(),
+    handleRefreshPendingApprovals: vi.fn(async () => undefined),
+    handleDecidePendingApproval: vi.fn(),
+  }),
+}))
+
+// Mock click-outside so the collapse can only come from the query-state model,
+// not from a synthetic mousedown — a keyboard user never fires that path.
+vi.mock('@hooks/useClickOutside', () => ({ useClickOutside: vi.fn() }))
+
+describe('AppHeader global search idle collapse', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('does not keep is-open after focusing an empty field and tabbing out', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<AppHeader />)
+    const search = container.querySelector('.global-search')
+    expect(search).not.toBeNull()
+
+    await user.click(screen.getByRole('textbox', { name: 'Search' }))
+    expect(search?.classList.contains('is-open')).toBe(false)
+
+    await user.tab()
+    expect(document.activeElement).not.toBe(screen.getByRole('textbox', { name: 'Search' }))
+    expect(search?.classList.contains('is-open')).toBe(false)
+  })
+
+  it('drops is-open once the typed query is cleared', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<AppHeader />)
+    const search = container.querySelector('.global-search')
+    const input = screen.getByRole('textbox', { name: 'Search' })
+
+    await user.type(input, 'agent')
+    expect(search?.classList.contains('is-open')).toBe(true)
+
+    await user.clear(input)
+    expect(search?.classList.contains('is-open')).toBe(false)
+  })
+})

--- a/desktop-app/ui/src/components/AppHeader/index.tsx
+++ b/desktop-app/ui/src/components/AppHeader/index.tsx
@@ -167,7 +167,11 @@ export const AppHeader = React.memo(function AppHeader({
   useEffect(() => {
     if (searchFocusRequestId <= 0) return
     setNotificationsOpen(false)
-    setSearchOpen(true)
+    // Open based on query presence rather than delegating to the input's
+    // onFocus: when the field is already focused (e.g. Escape then re-triggering
+    // the shortcut) focus() is a no-op and onFocus would not re-fire. Read the
+    // live input value so this stays keyed only on the request id.
+    setSearchOpen((searchInputRef.current?.value ?? '').trim().length > 0)
     searchInputRef.current?.focus()
   }, [searchFocusRequestId])
 
@@ -634,9 +638,9 @@ export const AppHeader = React.memo(function AppHeader({
             value={searchQuery}
             onChange={event => {
               setSearchQuery(event.target.value)
-              setSearchOpen(true)
+              setSearchOpen(event.target.value.trim().length > 0)
             }}
-            onFocus={() => setSearchOpen(true)}
+            onFocus={() => setSearchOpen(searchQuery.trim().length > 0)}
             onKeyDown={event => {
               if (event.key === 'Escape') {
                 setSearchOpen(false)

--- a/desktop-app/ui/src/components/AppHeader/index.tsx
+++ b/desktop-app/ui/src/components/AppHeader/index.tsx
@@ -623,7 +623,7 @@ export const AppHeader = React.memo(function AppHeader({
   return (
     <header className="top-bar">
       <div className="header-left">
-        <div className="global-search" ref={searchRef}>
+        <div className={`global-search${searchOpen ? ' is-open' : ''}`} ref={searchRef}>
           <TextInput
             ref={searchInputRef}
             type="text"

--- a/desktop-app/ui/src/styles.css
+++ b/desktop-app/ui/src/styles.css
@@ -100,25 +100,63 @@ h3 {
 
 .global-search {
   position: relative;
-  width: var(--app-notification-drawer-width);
-  min-width: 220px;
+  /* Collapsed to just the magnifier until focused, then expands to the full
+     search width. The expanded size is carried in custom props so each
+     breakpoint retunes it without re-declaring the collapsed state. Collapsed
+     width matches the 40px input height so the icon sits in a square. */
+  --global-search-expanded: var(--app-notification-drawer-width);
+  --global-search-expanded-min: 220px;
+  width: 40px;
+  min-width: 40px;
   max-width: 100%;
+  /* Collapsed, the 40px pill sits one gap from the notification bell, whose
+     hover fill would otherwise crowd it — add a gap's worth of separation,
+     dropped back to 0 once expanded (the wide field already reads clear of it). */
+  margin-right: var(--space-2);
+  transition:
+    width var(--motion-medium),
+    min-width var(--motion-medium),
+    margin-right var(--motion-medium);
 }
 
+/* Stay expanded whenever the field is focused OR the results are open, so the
+   collapse is tied to "closed", not merely "unfocused": tabbing out while the
+   dropdown is still open must not hide the typed query behind the 40px box. */
+.global-search:focus-within,
+.global-search.is-open {
+  width: var(--global-search-expanded);
+  min-width: var(--global-search-expanded-min);
+  margin-right: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .global-search {
+    transition: none;
+  }
+}
+
+/* Collapsed: the glyph fills the square and is centered both axes, so it reads
+   as a balanced icon button instead of a small mark with dead space beside it. */
 .global-search::before {
   content: '⌕';
   position: absolute;
-  left: 12px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 16px;
-  height: 16px;
+  inset: 0;
+  display: grid;
+  place-items: center;
   background-image: none;
   color: var(--text-dim);
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-xl);
   font-weight: 600;
   line-height: 1;
   pointer-events: none;
+}
+
+/* Expanded: pin the glyph to the left edge (ahead of the input's 40px left pad)
+   and drop back to the in-field size so it aligns with the typed text. */
+.global-search:focus-within::before,
+.global-search.is-open::before {
+  inset: 0 auto 0 12px;
+  font-size: var(--font-size-lg);
 }
 
 .search-input {
@@ -1034,7 +1072,7 @@ h3 {
   width: 328px;
   min-width: 328px;
   max-width: 328px;
-  padding: var(--space-2);
+  padding: 0 var(--space-2) var(--space-2);
   display: flex;
   flex-direction: column;
   background: var(--sidebar-gradient);
@@ -1130,7 +1168,7 @@ h3 {
   align-items: center;
   gap: var(--space-2-5);
   padding: var(--sidebar-logo-pad-top) var(--space-1) var(--space-2);
-  margin-bottom: var(--space-2);
+  margin-bottom: var(--space-1);
   min-height: 56px;
 }
 
@@ -2207,8 +2245,18 @@ h3 {
   overflow: hidden;
   min-height: 0;
   height: 100vh;
-  padding: var(--space-4) var(--space-4) 0 calc(var(--space-4) / 2);
+  /* Top pad clears the absolute top-bar: its space-2 top offset + the header's
+     own height + a bit of gap below it. space-2 * 5 is the smallest step of the
+     spacing scale that covers that stack; the other three sides are just space-2. */
+  padding: calc(var(--space-2) * 5) var(--space-2) var(--space-2) var(--space-2);
   gap: 0;
+}
+
+/* The absolute top-bar aligns to the panel's own space-2 edges here (the panel
+   owns the extra top breathing room via its padding, not the header). */
+.content-panel.content-panel--agent-chat > .top-bar {
+  top: var(--space-2);
+  right: var(--space-2);
 }
 
 .content-panel.content-panel--agent-chat > .agent-page {
@@ -10784,6 +10832,12 @@ pre {
     grid-template-rows: auto minmax(0, 1fr);
   }
 
+  /* Sidebar is gone and the aside spans the full top, so the extra top
+     breathing room (space-2 * 5) is no longer needed — drop it to space-2. */
+  .content-panel.content-panel--agent-chat {
+    padding-top: var(--space-2);
+  }
+
   .left-nav {
     position: sticky;
     top: 0;
@@ -10793,6 +10847,7 @@ pre {
     height: auto;
     min-height: 0;
     max-height: none;
+    padding-top: var(--space-2);
     border-right: 0;
     border-bottom: 1px solid rgba(var(--edge-rgb), 0.38);
     overflow: visible;
@@ -10981,9 +11036,21 @@ pre {
   }
 
   .global-search {
+    /* Header is a full-width row here — the search fills it and never
+       collapses; expanded props match so :focus-within keeps it at 100%. */
     width: 100%;
     min-width: 0;
     max-width: none;
+    margin-right: 0;
+    --global-search-expanded: 100%;
+    --global-search-expanded-min: 0;
+  }
+
+  /* Never collapses here, so the icon stays left-pinned even when unfocused —
+     without this the centered collapsed-state glyph floats mid-bar. */
+  .global-search::before {
+    inset: 0 auto 0 12px;
+    font-size: var(--font-size-lg);
   }
 
   .page-header,
@@ -12642,7 +12709,7 @@ pre {
 }
 
 .content-panel:has(.sandbox-ui-mounted-header) {
-  padding: var(--space-4) 0 0;
+  padding: var(--space-2) 0 0;
   align-content: stretch;
 }
 
@@ -12669,7 +12736,7 @@ pre {
    drawer-open states are mutually exclusive (see App.tsx notificationTrayUsesDrawer),
    so this higher-specificity override is unambiguous. */
 .content-panel.content-panel--chat-drawer-open {
-  --app-header-utilities-width: calc(var(--chat-drawer-width) + var(--space-2) + 36px);
+  --app-header-utilities-width: calc(var(--chat-drawer-width) + var(--space-2) + 16px);
 }
 
 .content-panel.content-panel--chat-drawer-open > .page:has(.sandbox-ui-mounted-header) {
@@ -12961,8 +13028,8 @@ pre {
   }
 
   .global-search {
-    width: clamp(160px, 32vw, var(--app-notification-drawer-width));
-    min-width: 160px;
+    --global-search-expanded: clamp(160px, 32vw, var(--app-notification-drawer-width));
+    --global-search-expanded-min: 160px;
   }
 
   .apps-page-header {
@@ -15633,7 +15700,6 @@ pre {
   border-color: var(--chat-view-selected-border);
   border-style: solid;
   border-width: 0 1px 1px;
-  border-radius: 0 var(--radius-sm) 0 0;
   display: flex;
   flex: 1 1 0;
   flex-direction: column;


### PR DESCRIPTION
## What

Header and layout polish for the desktop renderer (`desktop-app/ui`).

### Collapsible global search
- The header global-search now collapses to a 40px magnifier icon and expands to the full field on focus **or** while its results dropdown is open.
- `is-open` state on `AppHeader` means "there is a query / open results", not merely "was focused". Focus-time expansion comes from `.global-search:focus-within` (independent of `is-open`); `is-open` only keeps the field expanded while a query/results dropdown is present. Focusing an empty field, or clearing the query, collapses back to the 40px idle box even for a keyboard user who tabs away (no outside `mousedown` fires).
- Collapsed glyph is centered in the square; expanded glyph pins left and drops back to the in-field size.
- `prefers-reduced-motion: reduce` disables the width transition.
- Responsive variants: in the full-width header row the field never collapses (icon stays left-pinned); narrow breakpoint retunes the expanded width via custom props.

### Surrounding spacing
- `left-nav` padding and logo `margin-bottom` tightened.
- `content-panel--agent-chat`: top padding restructured to clear the absolute top-bar, with matching top-bar `top`/`right` offsets and a mobile fallback.
- `content-panel` with an open app: top padding `--space-4` → `--space-2`.
- `content-panel--chat-drawer-open`: utilities-width gutter `36px` → `16px`.
- Removed a stray `border-radius` on a selected chat-view element.

## Scope
- 1 service (`desktop-app/ui`), 4 files: 2 implementation files (`AppHeader/index.tsx`, `styles.css`) plus 2 test files (`responsiveUtilityGutter.browser.test.ts`, `AppHeader/__tests__/searchCollapse.test.tsx`) — within the PR budget.
- CSS + JSX state logic in `AppHeader`. No CRD, no API, no security surface.

## Verification
- Pre-commit passed: prettier, commitlint, `style-rules` (`da-*`) clean.
- `AppHeader` vitest suite green (13 tests incl. `searchCollapse.test.tsx`); the new regression tests fail against the pre-fix head, confirming they cover the collapse bug rather than shield it.
- The two spacing values (`--space-2` sandbox padding, `16px` chat-drawer gutter) and the search state change were run through `code-reviewer` + `security-reviewer`: no blockers, SAFE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
