### PR TITLE
fix(control-ui): stop the image build type-checking test files

### DIFF
--- a/control-ui/tsconfig.json
+++ b/control-ui/tsconfig.json
@@ -35,5 +35,5 @@
     "**/*.tsx",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## The bug

The `control-ui` image has not built since **2026-07-21**. `next build` type-checks everything `tsconfig.json` includes, and that spanned the package's test files. Ten of them import repo-root fixtures:

```ts
// control-ui/e2e/support/gfs-normal-workflow-state.test.ts
import { ... } from '../../../tests/e2e/gfsUiFixtures'
```

`control-ui/Dockerfile` copies `packages/*`, `scripts/qa-recorder` and `control-ui` — never `tests/`. From `/app/control-ui/e2e/support`, that `../../../tests/` resolves to `/app/tests`, which the build context does not contain. Result: 8 × `TS2307`, both arches, deterministic.

```
e2e/support/gfs-normal-workflow-state.test.ts(2,66): error TS2307:
  Cannot find module '../../../tests/e2e/gfsUiFixtures' or its corresponding type declarations.
...
Failed to type check.
ERROR: failed to build: process "/bin/sh -c npm run build" did not complete successfully
```

## Why CI never caught it

`ci-public.yml`'s `Build (control-ui)` runs the *same* `npm run build`, but against a **full checkout**, where `tests/e2e/*` exists and every import resolves. The failure is specific to the image build context, and nothing in CI builds the image.

## The fix

Exclude `e2e/` and the test globs from the type-check. The production image build has no business compiling tests.

```diff
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "e2e", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
```

## Tradeoff — stated, not hidden

`next build` was `control-ui`'s **only** type-check in CI. These files lose type coverage.

They do **not** lose behavioural coverage: `vitest.config.ts` carries its own `include` list and does not read this `exclude`, so `npm test` collects and runs exactly what it did before.

The alternative considered was copying `tests/` into the builder stage, which preserves type coverage at the cost of one more `COPY`. Excluding was chosen deliberately. If the type coverage turns out to matter, the follow-up is a dedicated `tsc -p` step over the test files rather than reverting this.

## Verification

Positive — the builder stage now completes locally, with `npm run build` genuinely executing (not a cache hit; the Next route table is in the output):

```
docker build -f control-ui/Dockerfile --target builder .
#16 DONE 11.7s
#17 exporting to image ... DONE 15.8s
exit=0
```

Negative — [run 34665418782](https://github.com/evenfire-ai/evenfire/actions/runs/34665418782) (`build_all=true`, this Dockerfile unchanged) failed on `control-ui-amd64` **and** `control-ui-arm64` with the errors above. The fix is load-bearing, not decorative.

## How this surfaced

The v0.8.0 release rehearsal refused to promote:

```
control-ui: source changed after the published image (4d6311440c2bdab1b73d205fbd52f7fb8e8ab8b1).
Push to dev and let build-publish run before tagging.
```

`ghcr.io/evenfire-ai/control-ui:latest` and `:sha-4d63114` resolve to the same digest, and no tag exists for any dev commit since. The release cut is blocked on this.

Separately, `build-publish` reported this broken build as **green** for ~7 weeks — filed as #621. That is why a deterministic build failure went unnoticed; this PR does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EYMyoBhdTSZ3hRzb14zQE
